### PR TITLE
Remove dead code in FontSourceCollection/FontSource (+ hollow CAS remnants)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FamilyCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FamilyCollection.cs
@@ -251,7 +251,6 @@ namespace MS.Internal.FontCache
                         if (_systemCompositeFonts[index] == null)
                         {
                             FontSource fontSource = new FontSource(new Uri(Path.Combine(FamilyCollection.SxSFontsResourcePrefix, _systemCompositeFontsFileNames[index] + Util.CompositeFontExtension), UriKind.RelativeOrAbsolute),
-                                                                   skipDemand:true,
                                                                    isComposite:true,
                                                                    isInternalCompositeFont:true);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FamilyCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FamilyCollection.cs
@@ -90,7 +90,7 @@ namespace MS.Internal.FontCache
             {
                 if (_userCompositeFonts == null)
                 {
-                    _userCompositeFonts = GetCompositeFontList(new FontSourceCollection(_folderUri, false, true));
+                    _userCompositeFonts = GetCompositeFontList(new FontSourceCollection(_folderUri, true));
                 }
                 return _userCompositeFonts;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSource.cs
@@ -81,7 +81,6 @@ namespace MS.Internal.FontCache
         private void Initialize(Uri fontUri, bool skipDemand, bool isComposite, bool isInternalCompositeFont)
         {
             _fontUri = fontUri;
-            _skipDemand = skipDemand;
             _isComposite = isComposite;
             _isInternalCompositeFont = isInternalCompositeFont;
             Invariant.Assert(_isInternalCompositeFont || _fontUri.IsAbsoluteUri);
@@ -432,8 +431,6 @@ namespace MS.Internal.FontCache
         private bool _isInternalCompositeFont;
 
         private Uri     _fontUri;
-
-        private bool    _skipDemand;
 
         private static SizeLimitedCache<Uri, byte[]> _resourceCache = new SizeLimitedCache<Uri, byte[]>(MaximumCacheItems);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSource.cs
@@ -39,7 +39,7 @@ namespace MS.Internal.FontCache
         
         public IFontSource Create(string uriString)
         {
-            return new FontSource(new Uri(uriString), false);
+            return new FontSource(new Uri(uriString));
         }
     }
 
@@ -57,28 +57,27 @@ namespace MS.Internal.FontCache
 
         #region Constructors
 
-        public FontSource(Uri fontUri, bool skipDemand)
+        public FontSource(Uri fontUri)
         {
-            Initialize(fontUri, skipDemand, false, isInternalCompositeFont: false);
+            Initialize(fontUri, false, isInternalCompositeFont: false);
         }
 
-        public FontSource(Uri fontUri, bool skipDemand, bool isComposite)
+        public FontSource(Uri fontUri, bool isComposite)
         {
-            Initialize(fontUri, skipDemand, isComposite, isInternalCompositeFont: false);
+            Initialize(fontUri, isComposite, isInternalCompositeFont: false);
         }
 
         /// <summary>
         /// Allows WPF to construct its internal CompositeFonts from resource URIs.
         /// </summary>
         /// <param name="fontUri"></param>
-        /// <param name="skipDemand"></param>
         /// <param name="isComposite"></param>
-        public FontSource(Uri fontUri, bool skipDemand, bool isComposite, bool isInternalCompositeFont)
+        public FontSource(Uri fontUri, bool isComposite, bool isInternalCompositeFont)
         {
-            Initialize(fontUri, skipDemand, isComposite, isInternalCompositeFont);
+            Initialize(fontUri, isComposite, isInternalCompositeFont);
         }
 
-        private void Initialize(Uri fontUri, bool skipDemand, bool isComposite, bool isInternalCompositeFont)
+        private void Initialize(Uri fontUri, bool isComposite, bool isInternalCompositeFont)
         {
             _fontUri = fontUri;
             _isComposite = isComposite;
@@ -100,7 +99,13 @@ namespace MS.Internal.FontCache
         /// <summary>
         /// Use this to ensure we don't call Uri.IsFile on a relative URI.
         /// </summary>
-        public bool IsFile { get { return !_isInternalCompositeFont && _fontUri.IsFile; } }
+        public bool IsFile
+        {
+            get
+            {
+                return !_isInternalCompositeFont && _fontUri.IsFile;
+            }
+        }
 
         public bool IsComposite
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
@@ -73,7 +73,7 @@ namespace MS.Internal.FontCache
             if (isSingleSupportedFile || !Util.IsEnumerableFontUriScheme(_uri))
             {
                 _fontSources = new List<Text.TextInterface.IFontSource>(1);                
-                _fontSources.Add(new FontSource(_uri, false, isComposite));
+                _fontSources.Add(new FontSource(_uri, isComposite));
             }
             else
             {
@@ -129,7 +129,7 @@ namespace MS.Internal.FontCache
                     {
                         foreach (string file in files)
                         {
-                            fontSources.Add(new FontSource(new Uri(file, UriKind.Absolute), false, true));
+                            fontSources.Add(new FontSource(new Uri(file, UriKind.Absolute), true));
                         }
                     }
                     else
@@ -138,7 +138,7 @@ namespace MS.Internal.FontCache
                         foreach (string file in files)
                         {                            
                             if (Util.IsSupportedFontExtension(Path.GetExtension(file), out isComposite))
-                                fontSources.Add(new FontSource(new Uri(file, UriKind.Absolute), false, isComposite));
+                                fontSources.Add(new FontSource(new Uri(file, UriKind.Absolute), isComposite));
                         }
                     }
                 }
@@ -162,12 +162,12 @@ namespace MS.Internal.FontCache
                             if (String.IsNullOrEmpty(resourceName))
                             {
                                 isComposite = Util.IsCompositeFont(Path.GetExtension(_uri.AbsoluteUri));
-                                fontSources.Add(new FontSource(_uri, false, isComposite));
+                                fontSources.Add(new FontSource(_uri, isComposite));
                             }
                             else
                             {
                                 isComposite = Util.IsCompositeFont(Path.GetExtension(resourceName));
-                                fontSources.Add(new FontSource(new Uri(_uri, resourceName), false, isComposite));
+                                fontSources.Add(new FontSource(new Uri(_uri, resourceName), isComposite));
                             }
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
@@ -126,55 +126,14 @@ namespace MS.Internal.FontCache
                     bool isOnlyCompositeFontFiles = false;
                     if (_isFileSystemFolder)
                     {
-                        if (_isWindowsFonts)
+                        if (_tryGetCompositeFontsOnly)
                         {
-                            if (_tryGetCompositeFontsOnly)
-                            {
-                                files = Directory.GetFiles(_uri.LocalPath, "*" + Util.CompositeFontExtension);
-                                isOnlyCompositeFontFiles = true;
-                            }
-                            else
-                            {
-                                // fontPaths accumulates font file paths obtained from the registry and the file system
-                                // This collection is a set, i.e. only keys matter, not values.
-                                HashSet<string> fontPaths = new HashSet<string>(512, StringComparer.OrdinalIgnoreCase);
-
-                                using (RegistryKey fontsKey = Registry.LocalMachine.OpenSubKey(InstalledWindowsFontsRegistryKey))
-                                {
-                                    // The registry key should be present on a valid Windows installation.
-                                    Invariant.Assert(fontsKey != null);
-
-                                    foreach (string fontValue in fontsKey.GetValueNames())
-                                    {
-                                        string fileName = fontsKey.GetValue(fontValue) as string;
-                                        if (fileName != null)
-                                        {
-                                            // See if the path doesn't contain any directory information.
-                                            // Shell uses the same method to determine whether to prepend the path with %windir%\fonts.
-                                            if (Path.GetFileName(fileName) == fileName)
-                                                fileName = Path.Combine(Util.WindowsFontsLocalPath, fileName);
-
-                                            fontPaths.Add(fileName);
-                                        }
-                                    }
-                                }
-
-                                fontPaths.UnionWith(Directory.EnumerateFiles(_uri.LocalPath));
-
-                                files = fontPaths;
-                            }
-}
+                            files = Directory.GetFiles(_uri.LocalPath, "*" + Util.CompositeFontExtension);
+                            isOnlyCompositeFontFiles = true;                               
+                        }
                         else
                         {
-                            if (_tryGetCompositeFontsOnly)
-                            {
-                                files = Directory.GetFiles(_uri.LocalPath, "*" + Util.CompositeFontExtension);
-                                isOnlyCompositeFontFiles = true;                               
-                            }
-                            else
-                            {
-                                files = Directory.GetFiles(_uri.LocalPath);
-                            }
+                            files = Directory.GetFiles(_uri.LocalPath);
                         }
                     }
                     else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
@@ -62,7 +62,6 @@ namespace MS.Internal.FontCache
         private void Initialize(Uri folderUri, bool isWindowsFonts, bool tryGetCompositeFontsOnly)
         {
             _uri = folderUri;
-            _isWindowsFonts = isWindowsFonts;
             _tryGetCompositeFontsOnly = tryGetCompositeFontsOnly;
 
             bool isComposite = false;
@@ -88,27 +87,11 @@ namespace MS.Internal.FontCache
 
             if (_uri.IsFile)
             {
-                if (_isWindowsFonts)
-                {
-                    if (object.ReferenceEquals(_uri, Util.WindowsFontsUriObject))
-                    {
-                        // We know the local path and that it's a folder
-                        _isFileSystemFolder = true;
-                    }
-                    else
-                    {
-                        // It's a file within the Windows Fonts folder
-                        _isFileSystemFolder = false;
-                    }
-                }
-                else
-                {
-                    // Get the local path
-                    string localPath = _uri.LocalPath;
+                // Get the local path
+                string localPath = _uri.LocalPath;
 
-                    // Decide if it's a file or folder based on syntax, not contents of file system
-                    _isFileSystemFolder = localPath[localPath.Length - 1] == Path.DirectorySeparatorChar;
-                }
+                // Decide if it's a file or folder based on syntax, not contents of file system
+                _isFileSystemFolder = localPath[localPath.Length - 1] == Path.DirectorySeparatorChar;
             }
         }
 
@@ -146,7 +129,7 @@ namespace MS.Internal.FontCache
                     {
                         foreach (string file in files)
                         {
-                            fontSources.Add(new FontSource(new Uri(file, UriKind.Absolute), _isWindowsFonts, true));
+                            fontSources.Add(new FontSource(new Uri(file, UriKind.Absolute), false, true));
                         }
                     }
                     else
@@ -155,7 +138,7 @@ namespace MS.Internal.FontCache
                         foreach (string file in files)
                         {                            
                             if (Util.IsSupportedFontExtension(Path.GetExtension(file), out isComposite))
-                                fontSources.Add(new FontSource(new Uri(file, UriKind.Absolute), _isWindowsFonts, isComposite));
+                                fontSources.Add(new FontSource(new Uri(file, UriKind.Absolute), false, isComposite));
                         }
                     }
                 }
@@ -179,12 +162,12 @@ namespace MS.Internal.FontCache
                             if (String.IsNullOrEmpty(resourceName))
                             {
                                 isComposite = Util.IsCompositeFont(Path.GetExtension(_uri.AbsoluteUri));
-                                fontSources.Add(new FontSource(_uri, _isWindowsFonts, isComposite));
+                                fontSources.Add(new FontSource(_uri, false, isComposite));
                             }
                             else
                             {
                                 isComposite = Util.IsCompositeFont(Path.GetExtension(resourceName));
-                                fontSources.Add(new FontSource(new Uri(_uri, resourceName), _isWindowsFonts, isComposite));
+                                fontSources.Add(new FontSource(new Uri(_uri, resourceName), false, isComposite));
                             }
                         }
                     }
@@ -217,8 +200,6 @@ namespace MS.Internal.FontCache
     
 
         private Uri                         _uri;
-
-        private bool                        _isWindowsFonts;
 
         // _isFileSystemFolder flag makes sense only when _uri.IsFile is set to true.
         private bool                                           _isFileSystemFolder;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
@@ -40,7 +40,7 @@ namespace MS.Internal.FontCache
 
         public IFontSourceCollection Create(string uriString)
         {
-            return new FontSourceCollection(new Uri(uriString), false);
+            return new FontSourceCollection(new Uri(uriString));
         }
     }
 
@@ -49,17 +49,17 @@ namespace MS.Internal.FontCache
     /// </summary>
     internal class FontSourceCollection : IFontSourceCollection
     {
-        public FontSourceCollection(Uri folderUri, bool isWindowsFonts)
+        public FontSourceCollection(Uri folderUri)
         {
-            Initialize(folderUri, isWindowsFonts, false);
+            Initialize(folderUri, false);
         }
 
-        public FontSourceCollection(Uri folderUri, bool isWindowsFonts, bool tryGetCompositeFontsOnly)
+        public FontSourceCollection(Uri folderUri, bool tryGetCompositeFontsOnly)
         {
-            Initialize(folderUri, isWindowsFonts, tryGetCompositeFontsOnly);
+            Initialize(folderUri, tryGetCompositeFontsOnly);
         }
 
-        private void Initialize(Uri folderUri, bool isWindowsFonts, bool tryGetCompositeFontsOnly)
+        private void Initialize(Uri folderUri, bool tryGetCompositeFontsOnly)
         {
             _uri = folderUri;
             _tryGetCompositeFontsOnly = tryGetCompositeFontsOnly;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
@@ -207,9 +207,5 @@ namespace MS.Internal.FontCache
 
         // Flag to indicate that only composite fonts in the provided URI location should be retrieved.        
         private bool                               _tryGetCompositeFontsOnly;
-
-        private const string InstalledWindowsFontsRegistryKey = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts";
-        private const string InstalledWindowsFontsRegistryKeyFullPath = @"HKEY_LOCAL_MACHINE\" + InstalledWindowsFontsRegistryKey;
+    }
 }
-}
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphTypeface.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphTypeface.cs
@@ -104,8 +104,7 @@ namespace System.Windows.Media
             Uri typefaceSource = new Uri(uriPath);
            
             _fontFace = new FontFaceLayoutInfo(font);
-            // We skip permission demands for FontSource because the above line already demands them for the right callers.
-            _fontSource = new FontSource(typefaceSource, true);
+            _fontSource = new FontSource(typefaceSource);
 
             Invariant.Assert(  styleSimulations == StyleSimulations.None 
                             || styleSimulations == StyleSimulations.ItalicSimulation 
@@ -158,8 +157,7 @@ namespace System.Windows.Media
 
             _fontFace = new FontFaceLayoutInfo(_font);
 
-            // We skip permission demands for FontSource because the above line already demands them for the right callers.
-            _fontSource = new FontSource(fontSourceUri, true);
+            _fontSource = new FontSource(fontSourceUri);
 
 
             _initializationState = InitializationState.IsInitialized; // fully initialized


### PR DESCRIPTION
## Description

Removes `skipDemand` from `FontSource` as it is not used for anything anymore, it was used in `NetFx` for figuring out whether to demand permissions.

Also removes `isWindowsFonts` from `FontSourceCollection`, because this is already a dead code in latest `NetFx` as the internal constructor from `FamilyCollection` that allowed `true` has been removed at the same time it stopped deriving from `IFontCacheElement` and it has been replaced by `FamilyCollection.FromWindowsFonts` which uses DirectWrite factory, so it never reaches `FontSourceCollection` on this code path. It is also way faster if you would run it.

## Customer Impact

Smaller code size of `PresentationCore`, cleaner code size for developers, faster JITTing, decreased allocs.

## Regression

No.

## Testing

Local build, app run, work with custom font sources.

## Risk

Low, as it is a dead code. I do not believe anything relies on the original shape of the ctors either.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9838)