### PR TITLE
Suppress SM04191 and SM03722 Binary Formatter CodeQL warnings

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -3086,7 +3086,7 @@ namespace System.Windows
                     try
                     {
                         #pragma warning disable SYSLIB0011 // BinaryFormatter is obsolete 
-                        // CodeQL [SM04191] : This is used to handle necessary clipboard operations and cannot be achieved without BinaryFormatter.
+                        // CodeQL [SM03722, SM04191] : This is used to handle necessary clipboard operations and cannot be achieved without BinaryFormatter.
                         value = formatter.Deserialize(stream);
                         #pragma warning restore SYSLIB0011 // BinaryFormatter is obsolete 
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -3086,6 +3086,7 @@ namespace System.Windows
                     try
                     {
                         #pragma warning disable SYSLIB0011 // BinaryFormatter is obsolete 
+                        // CodeQL [SM04191] : This is used to handle necessary clipboard operations and cannot be achieved without BinaryFormatter.
                         value = formatter.Deserialize(stream);
                         #pragma warning restore SYSLIB0011 // BinaryFormatter is obsolete 
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/DataStreams.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/DataStreams.cs
@@ -273,6 +273,7 @@ namespace MS.Internal.AppModel
                         {
                             dataStream.Position = 0;
                             #pragma warning disable SYSLIB0011 // BinaryFormatter is obsolete 
+                            // CodeQL [SM04191] : This is used to handle necessary navigation operations and cannot be achieved without BinaryFormatter.
                             newValue = this.Formatter.Deserialize(dataStream);
                             #pragma warning restore SYSLIB0011 // BinaryFormatter is obsolete 
                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/DataStreams.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/DataStreams.cs
@@ -273,7 +273,7 @@ namespace MS.Internal.AppModel
                         {
                             dataStream.Position = 0;
                             #pragma warning disable SYSLIB0011 // BinaryFormatter is obsolete 
-                            // CodeQL [SM04191] : This is used to handle necessary navigation operations and cannot be achieved without BinaryFormatter.
+                            // CodeQL [SM03722, SM04191] : This is used to handle necessary navigation operations and cannot be achieved without BinaryFormatter.
                             newValue = this.Formatter.Deserialize(dataStream);
                             #pragma warning restore SYSLIB0011 // BinaryFormatter is obsolete 
                         }

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/BinaryFormatWriterTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/BinaryFormatWriterTests.cs
@@ -27,7 +27,7 @@ public class BinaryFormatWriterTests
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
 #pragma warning restore
-        // CodeQL [SM04191] : This is testing a case around latest implementation of Binary Formatter..
+        // CodeQL [SM03722, SM04191] : This is testing a case around latest implementation of Binary Formatter..
         object deserialized = formatter.Deserialize(stream);
         deserialized.Should().Be(testString);
     }
@@ -44,7 +44,7 @@ public class BinaryFormatWriterTests
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
-        // CodeQL [SM04191] : This is testing a case around latest implementation of Binary Formatter.
+        // CodeQL [SM03722, SM04191] : This is testing a case around latest implementation of Binary Formatter.
         object deserialized = formatter.Deserialize(stream);
 
         if (value is Hashtable hashtable)

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/BinaryFormatWriterTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/BinaryFormatWriterTests.cs
@@ -27,6 +27,7 @@ public class BinaryFormatWriterTests
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
 #pragma warning restore
+        // CodeQL [SM04191] : This is testing a case around latest implementation of Binary Formatter..
         object deserialized = formatter.Deserialize(stream);
         deserialized.Should().Be(testString);
     }
@@ -43,6 +44,7 @@ public class BinaryFormatWriterTests
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
+        // CodeQL [SM04191] : This is testing a case around latest implementation of Binary Formatter.
         object deserialized = formatter.Deserialize(stream);
 
         if (value is Hashtable hashtable)

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/HashTableTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/HashTableTests.cs
@@ -105,7 +105,7 @@ public class HashtableTests
         using var formatterScope = new BinaryFormatterScope(enable: true);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
-        // CodeQL [SM04191] : This is testing a case around latest implementation of Binary Formatter.
+        // CodeQL [SM03722, SM04191] : This is testing a case around latest implementation of Binary Formatter.
         Hashtable deserialized = (Hashtable)formatter.Deserialize(stream);
 #pragma warning restore SYSLIB0011
 

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/HashTableTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/HashTableTests.cs
@@ -105,6 +105,7 @@ public class HashtableTests
         using var formatterScope = new BinaryFormatterScope(enable: true);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
+        // CodeQL [SM04191] : This is testing a case around latest implementation of Binary Formatter.
         Hashtable deserialized = (Hashtable)formatter.Deserialize(stream);
 #pragma warning restore SYSLIB0011
 

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/ListTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/ListTests.cs
@@ -83,7 +83,7 @@ public class ListTests
         using var formatterScope = new BinaryFormatterScope(enable: true);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
-        // CodeQL [SM04191] : This is testing a case around latest implementation of Binary Formatter.
+        // CodeQL [SM03722, SM04191] : This is testing a case around latest implementation of Binary Formatter.
         IList deserialized = (IList)formatter.Deserialize(stream);
 #pragma warning restore SYSLIB0011
 

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/ListTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/ListTests.cs
@@ -83,6 +83,7 @@ public class ListTests
         using var formatterScope = new BinaryFormatterScope(enable: true);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
+        // CodeQL [SM04191] : This is testing a case around latest implementation of Binary Formatter.
         IList deserialized = (IList)formatter.Deserialize(stream);
 #pragma warning restore SYSLIB0011
 

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/PrimitiveTypeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/PrimitiveTypeTests.cs
@@ -100,7 +100,7 @@ public class PrimitiveTypeTests
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
-        // CodeQL [SM04191] : This is testing a case around latest implementation of Binary Formatter.
+        // CodeQL [SM03722, SM04191] : This is testing a case around latest implementation of Binary Formatter.
         object deserialized = formatter.Deserialize(stream);
         deserialized.Should().Be(value);
     }

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/PrimitiveTypeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/PrimitiveTypeTests.cs
@@ -100,6 +100,7 @@ public class PrimitiveTypeTests
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
+        // CodeQL [SM04191] : This is testing a case around latest implementation of Binary Formatter.
         object deserialized = formatter.Deserialize(stream);
         deserialized.Should().Be(value);
     }


### PR DESCRIPTION
## Description
The changes aim to suppress CodeQL warnings around Binary Formatter's deserialize method in code and related tests.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
_None_
<!-- What is the impact to customers of not taking this fix? -->

## Regression
_None_
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
<!-- What kind of testing has been done with the fix. -->

## Risk
Minimal
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9842)