### PR TITLE
fix process terminated error when fastly type text with focusing on datagrid using IME

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesHost.cs
@@ -369,21 +369,13 @@ namespace System.Windows.Documents
             textstore.EditSinkCookie = editSinkCookie;
             textstore.EditCookie = editCookie;
 
-            // If Scope of this textstore already has a focus, we need to call SetFocus()
-            // in order to put this DIM on Cicero's focus. TextStore.OnGotFocus() calls
-            // ITfThreadMgr::SetFocus();
-            if (textstore.UiScope.IsKeyboardFocused)
-            {
-                textstore.OnGotFocus();
-            }
-
             _registeredtextstorecount++;
         }
 
         // Deactivate and release ThreadManager.
         private void DeactivateThreadManager()
         {
-            if (_threadManager != null) 
+            if (_threadManager != null)
             {
                 if (_threadManager.Value != null)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
@@ -1638,6 +1638,14 @@ namespace System.Windows.Documents
 
             _textservicesproperty = new TextServicesProperty(this);
 
+            // If Scope of this textstore already has a focus, we need to call SetFocus()
+            // in order to put this DIM on Cicero's focus. TextStore.OnGotFocus() calls
+            // ITfThreadMgr::SetFocus();
+            if (UiScope.IsKeyboardFocused)
+            {
+                OnGotFocus();
+            }
+
             if (IMECompositionTracer.IsEnabled)
             {
                 IMECompositionTracer.ConfigureTracing(this);


### PR DESCRIPTION
Fixes #9829
WPF in .net core 6.0 or 8.0, process terminated error occured and exit program unexpectly when type korean(IME) character fast in DataGrid.

See also : #9805

Main PR

## Description
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

when a DataGrid is first attached while handling an IME, the TextStore.OnFocus() method is executed before any event listeners are set up, giving dispatcher events a chance to be handled. At this time, if the user entered two or more IME characters very quickly, the event is processed at this point, and the consistency check fails in this event and an error occurs.

This commit simply moves the call to the OnFocus() method to after setting up the event listener, giving the dispatcher a chance to handle the event.

## Customer Impact
<!-- What is the impact to customers of not taking this fix? -->
 As a result, when the OnFocus() method is executed, the user's input is processed first, and then selection changed is executed, and the problem of the program being terminated due to quickly entering IME characters is resolved.

## Regression
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
<!-- What kind of testing has been done with the fix. -->
tested with Windows 11 Pro, Korean IME, sample programs not terminated, work well.


## Risk
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
so, it is very simple changes, Since the path where the Attach() method is executed is limited, I think there will be no major problems.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9847)