### PR TITLE
Live filtering race condition fix

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
@@ -2584,6 +2584,11 @@ namespace System.Windows.Data
                                                 : (IList)(new ArrayList(size));
                 lsList = localList as LiveShapingList;
 
+                if (lsList != null)
+                {
+                    lsList.LiveShapingDirty += new EventHandler(OnLiveShapingDirty);
+                }
+
                 // filter the collection's array into the local array
                 for (int k = 0; k < size; ++k)
                 {
@@ -2605,11 +2610,6 @@ namespace System.Windows.Data
                 if (ActiveComparer != null)
                 {
                     localList.Sort(ActiveComparer);
-                }
-
-                if (lsList != null)
-                {
-                    lsList.LiveShapingDirty += new EventHandler(OnLiveShapingDirty);
                 }
 
                 _internalList = localList;


### PR DESCRIPTION
Fixes #9454

## Description

When items are added to a filtering collection, changing a live filtering property too fast might result in the collection view becoming out of sync of the data.

This is because the subscription to changes in the list happens after items are added to a private copy of the list, providing a window between the copy and the subscription in which changes can occur unnoticed. This PR fixes it by moving the subscription before creating the copy.

## Customer Impact

By not taking this fix, customers cannot rely on data being correctly filtered during live shaping.

## Regression

No.

## Testing

Tested with provided repro project at https://github.com/VanderlandeWouterPost/CollectionViewSourceFilterAndSortIssue. Verified the issue occurs before the PR but not after.

## Risk

Can't think of any significant risk. When the subscription event occurs, it marks the collection as dirty and queues a dispatcher task to update the view. Both before and after PR, this task executes after the collection is copied.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9849)