### PR TITLE
Optimize some methods in RightsManagementEncryptionTransform, reduce allocs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
@@ -1041,7 +1041,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             Span<byte> guidBytes = stackalloc byte[16];
             Guid.NewGuid().TryWriteBytes(guidBytes);
 
-            return $"{LicenseStreamNamePrefix}{Base32EncodeWithoutPadding(guidBytes, stackalloc char[26])}";
+            return string.Concat(LicenseStreamNamePrefix, Base32EncodeWithoutPadding(guidBytes, stackalloc char[26]));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
@@ -649,11 +649,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// If the RM information in this file cannot be read by the current version of
         /// this class.
         /// </exception>
-        internal void
-        EnumUseLicenseStreams(
-            UseLicenseStreamCallback callback,
-            object param
-            )
+        internal void EnumUseLicenseStreams(UseLicenseStreamCallback callback, object param)
         {
             ArgumentNullException.ThrowIfNull(callback);
 
@@ -662,11 +658,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             foreach (StreamInfo si in _useLicenseStorage.GetStreams())
             {
                 // Stream names: we preserve casing, but do case-insensitive comparison (Native CompoundFile API behavior)
-                if (String.CompareOrdinal(
-                                LicenseStreamNamePrefix.ToUpperInvariant(), 0,
-                                si.Name.ToUpperInvariant(), 0,
-                                LicenseStreamNamePrefixLength
-                                ) == 0)
+                if (si.Name.StartsWith(LicenseStreamNamePrefix, StringComparison.OrdinalIgnoreCase))
                 {
                     callback(this, si, param, ref stop);
                     if (stop)
@@ -1342,7 +1334,6 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         // All use licenses reside in streams whose names begin with this prefix:
         //
         private const string LicenseStreamNamePrefix = "EUL-";
-        private static readonly int    LicenseStreamNamePrefixLength = LicenseStreamNamePrefix.Length;
 
         //
         // The RM version information for the current version of this class.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
@@ -741,9 +741,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             // If the type-prefixed name is not in a valid format, a FileFormatException
             // will be thrown.
             //
-            AuthenticationType authenticationType;
-            string userName;
-            ParseTypePrefixedUserName(typePrefixedUserName, out authenticationType, out userName);
+            ParseTypePrefixedUserName(typePrefixedUserName, out AuthenticationType authenticationType, out string userName);
             user = new ContentUser(userName, authenticationType);
 
             //
@@ -1083,21 +1081,12 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// <param name="userName">
         /// The user's ID.
         /// </param>
-        private static void
-        ParseTypePrefixedUserName(
-            string typePrefixedUserName,
-            out AuthenticationType authenticationType,
-            out string userName
-            )
+        private static void ParseTypePrefixedUserName(string typePrefixedUserName, out AuthenticationType authenticationType, out string userName)
         {
-            //
             // We don't actually know the authentication type yet, and we might find that
             // the type-prefixed user name doesn't even specify a valid authentication
             // type. But we have to assign to authenticationType because it's an out
             // parameter.
-            //
-            authenticationType = AuthenticationType.Windows;
-
             int colonIndex = typePrefixedUserName.IndexOf(':');
             if (colonIndex < 1 || colonIndex >= typePrefixedUserName.Length - 1)
             {
@@ -1107,33 +1096,15 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             // No need to use checked{} here since colonIndex cannot be >= to (max int - 1)
             userName = typePrefixedUserName.Substring(colonIndex + 1);
 
-            string authenticationTypeString = typePrefixedUserName.Substring(0, colonIndex);
-            bool validEnum = false;
+            // Usernames: Case-Insensitive comparison
+            ReadOnlySpan<char> authenticationSpan = typePrefixedUserName.AsSpan(0, colonIndex);
 
-            // user names: case-insensitive comparison
-            if (string.Equals(authenticationTypeString, nameof(AuthenticationType.Windows), StringComparison.OrdinalIgnoreCase))
-            {
+            if (authenticationSpan.Equals(nameof(AuthenticationType.Windows), StringComparison.OrdinalIgnoreCase))
                 authenticationType = AuthenticationType.Windows;
-                validEnum = true;
-            }
-            else if (string.Equals(authenticationTypeString, nameof(AuthenticationType.Passport), StringComparison.OrdinalIgnoreCase))
-            {
+            else if (authenticationSpan.Equals(nameof(AuthenticationType.Passport), StringComparison.OrdinalIgnoreCase))
                 authenticationType = AuthenticationType.Passport;
-                validEnum = true;
-            }
-
-            //
-            // Didn't find a matching enumeration constant.
-            //
-            if (!validEnum)
-            {
-                throw new FileFormatException(
-                                SR.Format(
-                                    SR.InvalidAuthenticationTypeString,
-                                    typePrefixedUserName
-                                    )
-                                );
-            }
+            else // Didn't find a matching enumeration constant.
+                throw new FileFormatException(SR.Format(SR.InvalidAuthenticationTypeString, typePrefixedUserName));
         }
 
         /// <summary>
@@ -1210,9 +1181,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             // If the type-prefixed name is not in a valid format, a FileFormatException
             // will be thrown.
             //
-            AuthenticationType authenticationType;
-            string userName;
-            ParseTypePrefixedUserName(typePrefixedUserName, out authenticationType, out userName);
+            ParseTypePrefixedUserName(typePrefixedUserName, out AuthenticationType authenticationType, out string userName);
             return new ContentUser(userName, authenticationType);
         }
 


### PR DESCRIPTION
## Description

Optimizes some low-hanging fruit in this mostly unused part of WPF to remove some unnecessary allocations.

- `CompareOrdinal` replaced with the most obvious `StartsWith`.
- The Base32 wannabe can be now encoded into a stackallocated buffer if its big enough.
- Parsing authentication type now does it directly off the sliced input string.
- Removed the `LicenseStreamNamePrefixLength`, 4 bytes saved sounds good.

Since I like numbers, here's a benchmark of `MakeUseLicenseStreamName`.

| Method    |Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|---------- |-----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original  |   565.6 ns |    1.71 ns |     1.43 ns | 0.0172 |         260 B |         288 B |
| PR__EDIT2 |  541.0 ns |    2.65 ns |     2.07 ns | 0.0048 |         386 B |          88 B |

## Customer Impact

Decreased allocations, improved performance in this edge-case such as anyone still using this.

## Regression

No.

## Testing

Local build, didn't test the full functionality itself but at least `MakeUseLicenseStreamName` + `Base32EncodeWithoutPadding` outputs have been tested to provide same set of values before and after. However the swaps are pretty much 1:1.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9851)