### PR TITLE
Replace ArrayList/ICollection used for changelog in CollectionView with generic List

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
@@ -1971,7 +1971,7 @@ namespace System.Windows.Data
                 DeferProcessing(unprocessedChanges);
             }
 
-            _tempChangeLog = EmptyArrayList;
+            _tempChangeLog = s_emptyList;
 
             return null;
         }
@@ -2160,8 +2160,9 @@ namespace System.Windows.Data
 
         private readonly Lock _changeLogLock = new();
 
-        List<NotifyCollectionChangedEventArgs> _changeLog = new();
-        List<NotifyCollectionChangedEventArgs> _tempChangeLog = EmptyArrayList;
+        private List<NotifyCollectionChangedEventArgs> _changeLog = new();
+        private List<NotifyCollectionChangedEventArgs> _tempChangeLog = s_emptyList;
+
         DataBindOperation       _databindOperation;
         object                  _vmData;            // view manager's private data
         IEnumerable             _sourceCollection;  // the underlying collection
@@ -2179,7 +2180,8 @@ namespace System.Windows.Data
         object                  _syncObject = new object();
         DataBindEngine          _engine;
         int                     _timestamp;
-        static readonly List<NotifyCollectionChangedEventArgs> EmptyArrayList = new();
+
+        private static readonly List<NotifyCollectionChangedEventArgs> s_emptyList = new();
         static readonly string IEnumerableT = typeof(IEnumerable<>).Name;
         internal static readonly object NoNewItem = new NamedObject("NoNewItem");
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
@@ -1819,7 +1819,7 @@ namespace System.Windows.Data
         ///     processed.
         /// </summary>
         /// <param name="changeLog">
-        ///     ArrayList of NotifyCollectionChangedEventArgs that could not be precessed.
+        ///     List of NotifyCollectionChangedEventArgs that could not be precessed.
         /// </param>
         private void DeferProcessing(List<NotifyCollectionChangedEventArgs> changeLog)
         {
@@ -1829,14 +1829,7 @@ namespace System.Windows.Data
             {
                 lock (_changeLogLock)
                 {
-                    if (_changeLog == null)
-                    {
-                        _changeLog = new List<NotifyCollectionChangedEventArgs>(changeLog);
-                    }
-                    else
-                    {
-                        _changeLog.InsertRange(0, changeLog);
-                    }
+                    _changeLog.InsertRange(0, changeLog);
 
                     if (_databindOperation != null)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
@@ -1827,7 +1827,7 @@ namespace System.Windows.Data
 
             lock (SyncRoot)
             {
-                lock(_changeLogLock)
+                lock (_changeLogLock)
                 {
                     if (_changeLog == null)
                     {
@@ -1863,16 +1863,10 @@ namespace System.Windows.Data
             int currentIndex = 0;
             bool mustDeferProcessing = false;
             long beginTime = DateTime.Now.Ticks;
-            int startCount = changeLog.Count;
 
-            for ( ; currentIndex < changeLog.Count && !(mustDeferProcessing); currentIndex++)
+            for ( ; currentIndex < changeLog.Count && !mustDeferProcessing; currentIndex++)
             {
-                NotifyCollectionChangedEventArgs args = changeLog[currentIndex] as NotifyCollectionChangedEventArgs;
-
-                if (args != null)
-                {
-                    ProcessCollectionChanged(args);
-                }
+                ProcessCollectionChanged(changeLog[currentIndex]);
 
                 if (!processAll)
                 {
@@ -1883,7 +1877,7 @@ namespace System.Windows.Data
             if (mustDeferProcessing && currentIndex < changeLog.Count)
             {
                 // create an unprocessed subset of changeLog
-                changeLog.RemoveRange(0,currentIndex);
+                changeLog.RemoveRange(0, currentIndex);
                 return changeLog;
             }
 


### PR DESCRIPTION
## Description

Replaces `ArrayList` used for tracking changes with `List<NotifyCollectionChangedEventArgs>`. Instead of using `SyncRoot` (object) of the `ArrayList` we will just use the new `Lock` for clarity and slightly improved performance.

Also modifies `ProcessChangeLog` / `DeferProcessing` from `ICollection` to `List<NotifyCollectionChangedEventArgs>` for improved performance.

- The `ProcessChangeLog` null-check was there because of the `as` casting pattern, if the `args` inserted into the `_changeLog` would ever be null, it would blow before it was even added in `PostChange` (the only proc adding into `_changeLog`).
- `DeferProcessing` doesn't need the null-check branch because the only time `_changeLog` is written into is always covered using `_changeLogLock`, so it cannot be NULL, and the ref transfer to `_tempChangeLog` is covered in lock too (`ProcessInvoke`).
- `startCount` variable was removed because it was unused.

## Customer Impact

Improved performance when updating the `CollectionView`, clearer code for developers.

## Regression

No.

## Testing

Local build, testing with CollectionView sample apps, updating from background thread.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9853)