### PR TITLE
Enable NuGet Audit

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -15,5 +15,9 @@
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
   </packageSources>
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </auditSources>
   <disabledPackageSources />
 </configuration>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,14 +67,14 @@
   <PropertyGroup>
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
-    <!-- 
-        Also in global.json 
-        Used in Wpf.Cpp.PrivateTools.props/targets 
+    <!--
+        Also in global.json
+        Used in Wpf.Cpp.PrivateTools.props/targets
     <MsvcurtC1xxVersion>0.0.1.2</MsvcurtC1xxVersion>
     -->
     <!--
     This is the version of the test infrastructure package is compiled against. This should be
-    removed as part of https://github.com/dotnet/wpf/issues/816 
+    removed as part of https://github.com/dotnet/wpf/issues/816
     -->
     <MicrosoftDotNetWpfTestPackageVersion>1.0.0-beta.19263.1</MicrosoftDotNetWpfTestPackageVersion>
     <!-- These versions are specified in global.json -->
@@ -96,7 +96,7 @@
   </PropertyGroup>
   <!-- Test related -->
   <PropertyGroup>
-    <MoqPackageVersion>4.10.0</MoqPackageVersion>
+    <MoqPackageVersion>4.18.4</MoqPackageVersion>
     <FluentAssertionsVersion>6.11.0</FluentAssertionsVersion>
     <SystemComponentModelTypeConverterTestDataVersion>8.0.0-beta.23107.1</SystemComponentModelTypeConverterTestDataVersion>
     <SystemDrawingCommonTestDataVersion>8.0.0-beta.23107.1</SystemDrawingCommonTestDataVersion>


### PR DESCRIPTION
We want to enable NuGet audit on all the repos that make up the .NET product. https://github.com/dotnet/arcade/issues/15019

The only problems I encountered were due to transitive dependencies brought in by Moq.  I fixed those by upgrading to the same version used in other dotnet repos.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9854)