### PR TITLE
Remove AppContextDefaultValues/AccessibilitySwitches values from NetFX (dead code)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Common/src/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/src/System/AppContextDefaultValues.cs
@@ -2,17 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// There are cases where we have multiple assemblies that are going to import this file and 
-// if they are going to also have InternalsVisibleTo between them, there will be a compiler warning
-// that the type is found both in the source and in a referenced assembly. The compiler will prefer 
-// the version of the type defined in the source
-//
-// In order to disable the warning for this type we are disabling this warning for this entire file.
-#pragma warning disable 436
-
-using System;
-using System.Collections.Generic;
-
 namespace System
 {
     internal static partial class AppContextDefaultValues
@@ -182,15 +171,11 @@ namespace System
             return true;
         }
 #endif
-        // This is a partial method. Platforms (such as Desktop) can provide an implementation of it that will read override value
-        // from whatever mechanism is available on that platform. If no implementation is provided, the compiler is going to remove the calls
-        // to it from the code
-        static partial void TryGetSwitchOverridePartial(string switchName, ref bool overrideFound, ref bool overrideValue);
 
+        /// <summary>
         /// This is a partial method. This method is responsible for populating the default values based on a TFM.
         /// It is partial because each library should define this method in their code to contain their defaults.
+        /// </summary> 
         static partial void PopulateDefaultValuesPartial(string platformIdentifier, string profile, int targetFrameworkVersion);
     }
 }
-
-#pragma warning restore 436

--- a/src/Microsoft.DotNet.Wpf/src/Common/src/System/LocalAppContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/src/System/LocalAppContext.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace System
 {
-    internal partial class LocalAppContext
+    internal static class LocalAppContext
     {
         /// <summary>
         /// Holds the switch names and their values. In case it is modified outside <see cref="DefineSwitchDefault"/>,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/BuildTasksAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/BuildTasksAppContextSwitches.cs
@@ -7,11 +7,6 @@ using System.Runtime.CompilerServices;
 
 namespace MS.Internal
 {
-    // WPF's builds are seeing warnings as a result of using LocalAppContext in mutliple assemblies.
-    // that have internalsVisibleTo attribute set between them - which results in the warning.
-    // We don't have a way of suppressing this warning effectively until the shared copies of LocalAppContext and
-    // AppContextDefaultValues have pragmas added to suppress warning 436
-#pragma warning disable 436
     internal static class BuildTasksAppContextSwitches
     {
         #region DoNotUseSha256ForMarkupCompilerChecksumAlgorithm
@@ -30,5 +25,4 @@ namespace MS.Internal
 
         #endregion
     }
-#pragma warning restore 436
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/System/AppContextDefaultValues.cs
@@ -2,45 +2,31 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-using System.Windows;
 using MS.Internal;
 
 namespace System
 {
-    // WPF's builds are seeing warnings as a result of using LocalAppContext in mutliple assemblies.
-    // that have internalsVisibleTo attribute set between them - which results in the warning.
-    // We don't have a way of suppressing this warning effectively until the shared copies of LocalAppContext and
-    // AppContextDefaultValues have pragmas added to suppress warning 436
-#pragma warning disable 436
     internal static partial class AppContextDefaultValues
     {
+        /// <summary>
+        /// This is a partial method. This method is responsible for populating the default values based on a TFM.
+        /// It is partial because each library should define this method in their code to contain their defaults.
+        /// </summary> 
         static partial void PopulateDefaultValuesPartial(string platformIdentifier, string profile, int targetFrameworkVersion)
         {
             switch (platformIdentifier)
             {
                 case ".NETFramework":
+                    if (targetFrameworkVersion <= 40701)
                     {
-                        if (targetFrameworkVersion <= 40701)
-                        {
-                            LocalAppContext.DefineSwitchDefault(BuildTasksAppContextSwitches.DoNotUseSha256ForMarkupCompilerChecksumAlgorithmSwitchName, true);
-                        }
-
-                        break;
+                        LocalAppContext.DefineSwitchDefault(BuildTasksAppContextSwitches.DoNotUseSha256ForMarkupCompilerChecksumAlgorithmSwitchName, true);
                     }
+                    break;
 
                 case ".NETCoreApp":
-                    {
-                        InitializeNetFxSwitchDefaultsForNetCoreRuntime();
-                    }
+                    LocalAppContext.DefineSwitchDefault(BuildTasksAppContextSwitches.DoNotUseSha256ForMarkupCompilerChecksumAlgorithmSwitchName, false);
                     break;
             }
         }
-
-        private static void InitializeNetFxSwitchDefaultsForNetCoreRuntime()
-        {
-            LocalAppContext.DefineSwitchDefault(BuildTasksAppContextSwitches.DoNotUseSha256ForMarkupCompilerChecksumAlgorithmSwitchName, false);
-        }
     }
-#pragma warning restore 436
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
@@ -2,20 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-//
-
 using System;
 using System.Runtime.CompilerServices;
 using System.Windows;
 
 namespace MS.Internal
 {
-    // WPF's builds are seeing new warnings as as result of using LocalAppContext in PresentationFramework, PresentationCore and WindowsBase.
-    // These binaries have internalsVisibleTo attribute set between them - which results in the warning.
-    // We don't have a way of suppressing this warning effectively until the shared copies of LocalAppContext and
-    // AppContextDefaultValues have pragmas added to suppress warning 436
-#pragma warning disable 436
     internal static class CoreAppContextSwitches
     {
         #region DoNotScaleForDpiChanges
@@ -411,5 +403,4 @@ namespace MS.Internal
         #endregion
 
     }
-#pragma warning restore 436
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/AppContextDefaultValues.cs
@@ -2,50 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Windows;
 using MS.Internal;
 
 namespace System
 {
-    // WPF's builds are seeing new warnings as as result of using LocalAppContext in PresentationFramework, PresentationCore and WindowsBase. 
-    // These binaries have internalsVisibleTo attribute set between them - which results in the warning. 
-    // We don't have a way of suppressing this warning effectively until the shared copies of LocalAppContext and 
-    // AppContextDefaultValues have pragmas added to suppress warning 436
-#pragma warning disable 436
     internal static partial class AppContextDefaultValues
     {
+        /// <summary>
+        /// This is a partial method. This method is responsible for populating the default values based on a TFM.
+        /// It is partial because each library should define this method in their code to contain their defaults.
+        /// </summary> 
         static partial void PopulateDefaultValuesPartial(string platformIdentifier, string profile, int targetFrameworkVersion)
-        {
-            switch (platformIdentifier)
-            {
-                case ".NETFramework":
-                    {
-                        if (targetFrameworkVersion <= 40601)
-                        {
-                            LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.DoNotScaleForDpiChangesSwitchName, true);
-                        }
-
-                        if (targetFrameworkVersion <= 40602)
-                        {
-                            LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.OverrideExceptionWithNullReferenceExceptionName, true);
-                        }
-
-                        if (targetFrameworkVersion <= 40702)
-                        {
-                            LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.DoNotUsePresentationDpiCapabilityTier2OrGreaterSwitchName, true);
-                        }
-
-                        break;
-                    }
-                case ".NETCoreApp":
-                    {
-                        InitializeNetFxSwitchDefaultsForNetCoreRuntime();
-                    }
-                    break;
-            }
-        }
-
-        private static void InitializeNetFxSwitchDefaultsForNetCoreRuntime()
         {
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.DoNotScaleForDpiChangesSwitchName, false);
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.OverrideExceptionWithNullReferenceExceptionName, false);
@@ -64,5 +31,4 @@ namespace System
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.DisableSpecialCharacterLigatureSwitchName, false);
         }
     }
-#pragma warning restore 436
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
@@ -2,22 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-using MS.Internal.PresentationFramework.Interop;
-using System;
 using System.Runtime.CompilerServices;
-using System.Windows;
+using System;
+
+// When building PresentationFramework, 'LocalAppContext' from WindowsBase.dll conflicts
+// with 'LocalAppContext' from PresentationCore.dll since there is InternalsVisibleTo set
+#pragma warning disable CS0436 // Type conflicts with imported type
 
 namespace MS.Internal
 {
-    // There are cases where we have multiple assemblies that are going to import this file and
-    // if they are going to also have InternalsVisibleTo between them, there will be a compiler warning
-    // that the type is found both in the source and in a referenced assembly. The compiler will prefer
-    // the version of the type defined in the source
-    //
-    // In order to disable the warning for this type we are disabling this warning for this entire file.
-    #pragma warning disable 436
-
     internal static class FrameworkAppContextSwitches
     {
         internal const string DoNotApplyLayoutRoundingToMarginsAndBorderThicknessSwitchName = "Switch.MS.Internal.DoNotApplyLayoutRoundingToMarginsAndBorderThickness";
@@ -156,6 +149,6 @@ namespace MS.Internal
             }
         }
     }
-
-#pragma warning restore 436
 }
+
+#pragma warning restore CS0436 // Type conflicts with imported type

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
@@ -2,68 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Since multiple assemblies (WindowsBase, PresentationFramework, PresentationCore, PresentationBuildTasks)
+// share this file/class and have InternalsVisibleTo set between them, there will be a compiler warning
+// that the type is found both in the source and in a referenced assembly. The compiler will prefer 
+// the version of the type defined in the source once the warning is supressed and won't compile the rest.
+
+// In order to disable the warning for this type we are disabling the warning for this entire file.
+#pragma warning disable CS0436 // Type conflicts with imported type
+
 using MS.Internal;
 
 namespace System
 {
-    // There are cases where we have multiple assemblies that are going to import this file and
-    // if they are going to also have InternalsVisibleTo between them, there will be a compiler warning
-    // that the type is found both in the source and in a referenced assembly. The compiler will prefer
-    // the version of the type defined in the source
-    //
-    // In order to disable the warning for this type we are disabling this warning for this entire file.
-    #pragma warning disable 436
-
     internal static partial class AppContextDefaultValues
     {
+        /// <summary>
+        /// This is a partial method. This method is responsible for populating the default values based on a TFM.
+        /// It is partial because each library should define this method in their code to contain their defaults.
+        /// </summary> 
         static partial void PopulateDefaultValuesPartial(string platformIdentifier, string profile, int targetFrameworkVersion)
         {
-            // The AppContext  analyzer expects an if statement here, we should have named the switch 'DoNotUseAdorner' and not included this line at all - by default, switches get set to 'false'
-            // Because this was realized after we shipped, we are going to disable the warning for this switch.
-#pragma warning disable BCL0012
-
             // The standard behavior is to draw Text/PasswordBox selections via the Adorner.
             // We want this to always be the case unless it is explicitly changed, regardless of .NET target version.
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRenderingSwitchName, true);
-#pragma warning restore BCL0012
 
-            switch (platformIdentifier)
-            {
-                case ".NETFramework":
-                    {
-                        if (targetFrameworkVersion <= 40502)
-                        {
-                            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DoNotApplyLayoutRoundingToMarginsAndBorderThicknessSwitchName, true);
-                        }
-                        if (targetFrameworkVersion <= 40602)
-                        {
-                            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.GridStarDefinitionsCanExceedAvailableSpaceSwitchName, true);
-                        }
-                        if (targetFrameworkVersion <= 40700)
-                        {
-                            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.SelectionPropertiesCanLagBehindSelectionChangedEventSwitchName, true);
-                        }
-                        if (targetFrameworkVersion <= 40701)
-                        {
-                            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DoNotUseFollowParentWhenBindingToADODataRelationSwitchName, true);
-                        }
-                        if (40000 <= targetFrameworkVersion && targetFrameworkVersion <= 40702)
-                        {
-                            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.IListIndexerHidesCustomIndexerSwitchName, true);
-                        }
-                    }
-                    break;
-
-                case ".NETCoreApp":
-                    {
-                        InitializeNetFxSwitchDefaultsForNetCoreRuntime();
-                    }
-                    break;
-            }
-        }
-
-        private static void InitializeNetFxSwitchDefaultsForNetCoreRuntime()
-        {
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DoNotApplyLayoutRoundingToMarginsAndBorderThicknessSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.GridStarDefinitionsCanExceedAvailableSpaceSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.SelectionPropertiesCanLagBehindSelectionChangedEventSwitchName, false);
@@ -74,12 +36,8 @@ namespace System
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.KeyboardNavigationFromHyperlinkInItemsControlIsNotRelativeToFocusedElementSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.ItemAutomationPeerKeepsItsItemAliveSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableFluentThemeWindowBackdropSwitchName, false);
-
-            // UseAdornerForTextboxSelectionRenderingSwitchName is always true, i.e., disabled by default. 
-            // Do not initialized this again - this was initialized earlier in PopulateDefaultValuesPartial unconditionally.
-            // LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRenderingSwitchName, true);
         }
     }
-
-    #pragma warning restore 436
 }
+
+#pragma warning restore CS0436 // Type conflicts with imported type

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
@@ -2,14 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Since multiple assemblies (WindowsBase, PresentationFramework, PresentationCore, PresentationBuildTasks)
-// share this file/class and have InternalsVisibleTo set between them, there will be a compiler warning
-// that the type is found both in the source and in a referenced assembly. The compiler will prefer 
-// the version of the type defined in the source once the warning is supressed and won't compile the rest.
-
-// In order to disable the warning for this type we are disabling the warning for this entire file.
-#pragma warning disable CS0436 // Type conflicts with imported type
-
 using MS.Internal;
 
 namespace System
@@ -22,6 +14,10 @@ namespace System
         /// </summary> 
         static partial void PopulateDefaultValuesPartial(string platformIdentifier, string profile, int targetFrameworkVersion)
         {
+            // When building PresentationFramework, 'LocalAppContext' from WindowsBase.dll conflicts
+            // with 'LocalAppContext' from PresentationCore.dll since there is InternalsVisibleTo set
+#pragma warning disable CS0436 // Type conflicts with imported type
+
             // The standard behavior is to draw Text/PasswordBox selections via the Adorner.
             // We want this to always be the case unless it is explicitly changed, regardless of .NET target version.
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRenderingSwitchName, true);
@@ -36,8 +32,8 @@ namespace System
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.KeyboardNavigationFromHyperlinkInItemsControlIsNotRelativeToFocusedElementSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.ItemAutomationPeerKeepsItsItemAliveSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableFluentThemeWindowBackdropSwitchName, false);
+
+#pragma warning restore CS0436 // Type conflicts with imported type
         }
     }
 }
-
-#pragma warning restore CS0436 // Type conflicts with imported type

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/BaseAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/BaseAppContextSwitches.cs
@@ -2,22 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-//
-
 using System;
 using System.Runtime.CompilerServices;
 
 namespace MS.Internal
 {
-    // There are cases where we have multiple assemblies that are going to import this file and
-    // if they are going to also have InternalsVisibleTo between them, there will be a compiler warning
-    // that the type is found both in the source and in a referenced assembly. The compiler will prefer
-    // the version of the type defined in the source
-    //
-    // In order to disable the warning for this type we are disabling this warning for this entire file.
-    #pragma warning disable 436
-
     /// <summary>
     /// Appcompat switches used by WindowsBase. See comments at the start of each switch.
     /// Also see AppContextDefaultValues which initializes default values for each of
@@ -132,6 +121,4 @@ namespace MS.Internal
 
         #endregion
     }
-
-#pragma warning restore 436
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/AppContextDefaultValues.cs
@@ -7,54 +7,21 @@ using System.Windows;
 
 namespace System
 {
-    // There are cases where we have multiple assemblies that are going to import this file and 
-    // if they are going to also have InternalsVisibleTo between them, there will be a compiler warning
-    // that the type is found both in the source and in a referenced assembly. The compiler will prefer 
-    // the version of the type defined in the source
-    //
-    // In order to disable the warning for this type we are disabling this warning for this entire file.
-    #pragma warning disable 436 
-
     /// <summary>
     /// Default values for app-compat quirks used within WindowsBase.
     /// Also see BaseAppContextSwitches
     /// </summary>
     internal static partial class AppContextDefaultValues
     {
-        static partial void PopulateDefaultValuesPartial(string platformIdentifier, string profile, int targetFrameworkVersion)
-        {
-            switch (platformIdentifier)
-            {
-                case ".NETFramework":
-                    {
-                        if (targetFrameworkVersion <= 40502)
-                        {
-                            LocalAppContext.DefineSwitchDefault(BaseAppContextSwitches.SwitchDoNotUseCulturePreservingDispatcherOperations, true);
-                        }
-
-                        if (targetFrameworkVersion <= 40700)
-                        {
-                            LocalAppContext.DefineSwitchDefault(BaseAppContextSwitches.SwitchUseSha1AsDefaultHashAlgorithmForDigitalSignatures, true);
-                        }
-                    }
-                    break;
-
-                case ".NETCoreApp":
-                    {
-                        InitializeNetFxSwitchDefaultsForNetCoreRuntime();
-                    }
-                    break;
-            }
-
-            // Ensure we set all the accessibility switch defaults
-            AccessibilitySwitches.SetSwitchDefaults(platformIdentifier, targetFrameworkVersion);
-        }
-
         /// <summary>
-        /// This is the full set of .NET Framework <see cref="AppContext"/> in <see cref="BaseAppContextSwitches"/>. These are being initialized
-        /// to <code>false</code> to ensure that the corresponding functionality will be treated as if it is enabled by default on .NET Core.
+        /// This is a partial method. This method is responsible for populating the default values based on a TFM.
+        /// It is partial because each library should define this method in their code to contain their defaults.
         /// </summary>
-        private static void InitializeNetFxSwitchDefaultsForNetCoreRuntime()
+        /// <remarks>
+        /// This is the full set of .NET Framework <see cref="AppContext"/> in <see cref="BaseAppContextSwitches"/>. These are being initialized
+        /// to <see langword="false"/> to ensure that the corresponding functionality will be treated as if it is enabled by default on .NET Core.
+        /// </remarks>
+        static partial void PopulateDefaultValuesPartial(string platformIdentifier, string profile, int targetFrameworkVersion)
         {
             LocalAppContext.DefineSwitchDefault(BaseAppContextSwitches.SwitchDoNotUseCulturePreservingDispatcherOperations, false);
             LocalAppContext.DefineSwitchDefault(BaseAppContextSwitches.SwitchUseSha1AsDefaultHashAlgorithmForDigitalSignatures, false);
@@ -62,8 +29,9 @@ namespace System
             LocalAppContext.DefineSwitchDefault(BaseAppContextSwitches.SwitchDoNotInvokeInWeakEventTableShutdownListener, false);
             LocalAppContext.DefineSwitchDefault(BaseAppContextSwitches.SwitchEnableCleanupSchedulingImprovements, false);
             LocalAppContext.DefineSwitchDefault(BaseAppContextSwitches.SwitchEnableWeakEventMemoryImprovements, false);
+
+            // Ensure we set all the accessibility switch defaults
+            AccessibilitySwitches.SetSwitchDefaults(platformIdentifier, targetFrameworkVersion);
         }
     }
-
-    #pragma warning restore 436
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AccessibilitySwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AccessibilitySwitches.cs
@@ -28,21 +28,16 @@ namespace System.Windows
         /// <summary>
         /// This id is used by .NET to report a fatal error.
         /// </summary>
-        const int EventId = 1023;
+        private const int EventId = 1023;
 
         /// <summary>
         /// This source is used by .NET to report events.
         /// </summary>
-        const string EventSource = ".NET Runtime";
+        private const string EventSource = ".NET Runtime";
 
         #endregion
 
         #region Fields
-
-        /// <summary>
-        /// Guards against multiple definitions of default switch values.
-        /// </summary>
-        static int s_DefaultsSet = 0;
 
         /// <summary>
         /// Guards against multiple verifications of the switch values.
@@ -172,41 +167,11 @@ namespace System.Windows
         /// <param name="targetFrameworkVersion"></param>
         internal static void SetSwitchDefaults(string platformIdentifier, int targetFrameworkVersion)
         {
-            switch (platformIdentifier)
-            {
-
-                case ".NETFramework":
-                    if (Interlocked.CompareExchange(ref s_DefaultsSet, 1, 0) == 0)
-                    {
-                        if (targetFrameworkVersion <= 40700)
-                        {
-                            LocalAppContext.DefineSwitchDefault(UseLegacyAccessibilityFeaturesSwitchName, true);
-                        }
-
-                        if (targetFrameworkVersion <= 40701)
-                        {
-                            LocalAppContext.DefineSwitchDefault(UseLegacyAccessibilityFeatures2SwitchName, true);
-                        }
-
-                        if (targetFrameworkVersion <= 40702)
-                        {
-                            LocalAppContext.DefineSwitchDefault(UseLegacyAccessibilityFeatures3SwitchName, true);
-                            LocalAppContext.DefineSwitchDefault(UseLegacyToolTipDisplaySwitchName, true);
-                            LocalAppContext.DefineSwitchDefault(ItemsControlDoesNotSupportAutomationSwitchName, true);
-                        }
-                    }
-                    break;
-
-                case ".NETCoreApp":
-                    {
-                        LocalAppContext.DefineSwitchDefault(UseLegacyAccessibilityFeaturesSwitchName, false);
-                        LocalAppContext.DefineSwitchDefault(UseLegacyAccessibilityFeatures2SwitchName, false);
-                        LocalAppContext.DefineSwitchDefault(UseLegacyAccessibilityFeatures3SwitchName, false);
-                        LocalAppContext.DefineSwitchDefault(UseLegacyToolTipDisplaySwitchName, false);
-                        LocalAppContext.DefineSwitchDefault(ItemsControlDoesNotSupportAutomationSwitchName, false);
-                    }
-                    break;
-            }
+            LocalAppContext.DefineSwitchDefault(UseLegacyAccessibilityFeaturesSwitchName, false);
+            LocalAppContext.DefineSwitchDefault(UseLegacyAccessibilityFeatures2SwitchName, false);
+            LocalAppContext.DefineSwitchDefault(UseLegacyAccessibilityFeatures3SwitchName, false);
+            LocalAppContext.DefineSwitchDefault(UseLegacyToolTipDisplaySwitchName, false);
+            LocalAppContext.DefineSwitchDefault(ItemsControlDoesNotSupportAutomationSwitchName, false);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

This is a follow-up to #9711, cleaning up the dead code from assemblies that are compiled for .NET Core only.
The PBT one has been kept for obvious reasons.

The effective process is removing the switch statement, values for `NetFX` and copying over contents of `InitializeNetFxSwitchDefaultsForNetCoreRuntime` directly into the partial method.

I have also removed the warning supressions where they were not necessary.

## Customer Impact

Smaller size of assemblies, 0.0001 ns faster start up time, cleaner codebase for developers.

## Regression

No.

## Testing

Local build, app startup.

## Risk

Low, this is just a cleanup after previous PR.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9866)