### PR TITLE
Replace ArrayList with List<GlyphRun> in PtsHost for performance/code quality

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
@@ -668,7 +668,7 @@ namespace MS.Internal.PtsHost
         /// <param name="dcpEnd">
         /// End dcp of range.
         /// </param>
-        internal void GetGlyphRuns(System.Collections.Generic.List<GlyphRun> glyphRuns, int dcpStart, int dcpEnd)
+        internal void GetGlyphRuns(List<GlyphRun> glyphRuns, int dcpStart, int dcpEnd)
         {
             // NOTE: Following logic is only temporary workaround for lack
             //       of appropriate API that should be exposed by TextLine.
@@ -691,7 +691,7 @@ namespace MS.Internal.PtsHost
             // Copy glyph runs into separate array (for backward navigation).
             // And count number of chracters in the glyph runs collection.
             int cchGlyphRuns = 0;
-            ArrayList glyphRunsCollection = new ArrayList(4);
+            List<GlyphRun> glyphRunsCollection = new(4);
 
             AddGlyphRunRecursive(drawing, glyphRunsCollection, ref cchGlyphRuns);
 
@@ -712,7 +712,7 @@ namespace MS.Internal.PtsHost
             // Remove those glyph runs from our colleciton.
             while (cchGlyphRuns > cchTextSpans)
             {
-                GlyphRun glyphRun = (GlyphRun)glyphRunsCollection[0];
+                GlyphRun glyphRun = glyphRunsCollection[0];
                 cchGlyphRuns -= (glyphRun.Characters == null ? 0 : glyphRun.Characters.Count);
                 glyphRunsCollection.RemoveAt(0);
             }
@@ -727,7 +727,7 @@ namespace MS.Internal.PtsHost
                     while (cchRunsInSpan < span.Length)
                     {
                         Invariant.Assert(runIndex < glyphRunsCollection.Count);
-                        GlyphRun run = (GlyphRun)glyphRunsCollection[runIndex];
+                        GlyphRun run = glyphRunsCollection[runIndex];
                         int characterCount = (run.Characters == null ? 0 : run.Characters.Count);
                         if ((dcp < curDcp + characterCount) && (dcp + cch > curDcp))
                         {
@@ -1072,10 +1072,7 @@ namespace MS.Internal.PtsHost
         /// <param name="cchGlyphRuns">
         /// Character length of glyph run collection
         /// </param>
-        private void AddGlyphRunRecursive(
-            Drawing drawing,
-            IList   glyphRunsCollection,
-            ref int cchGlyphRuns)
+        private static void AddGlyphRunRecursive(Drawing drawing, List<GlyphRun> glyphRunsCollection, ref int cchGlyphRuns)
         {
             DrawingGroup group = drawing as DrawingGroup;
             if (group != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
@@ -1074,8 +1074,7 @@ namespace MS.Internal.PtsHost
         /// </param>
         private static void AddGlyphRunRecursive(Drawing drawing, List<GlyphRun> glyphRunsCollection, ref int cchGlyphRuns)
         {
-            DrawingGroup group = drawing as DrawingGroup;
-            if (group != null)
+            if (drawing is DrawingGroup group)
             {
                 foreach (Drawing child in group.Children)
                 {
@@ -1084,8 +1083,7 @@ namespace MS.Internal.PtsHost
             }
             else
             {
-                GlyphRunDrawing glyphRunDrawing = drawing as GlyphRunDrawing;
-                if (glyphRunDrawing != null)
+                if (drawing is GlyphRunDrawing glyphRunDrawing)
                 {
                     // Add a glyph run
                     GlyphRun glyphRun = glyphRunDrawing.GlyphRun;


### PR DESCRIPTION
## Description

Replaces `ArrayList` with `List<GlyphRun>` to function as a temporary array. Improves code quality by swapping to generic collection. Also makes `AddGlyphRunRecursive` function static as it does not use any instance members.

Sample benchmark showing difference between `ArrayList` and `List<T>` with reference type can be found f.e. in #9432.

## Customer Impact

Improved performance, getting rid of `ArrayList`.

## Regression

No.

## Testing

Local build.

## Risk

None, changes are minimal.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9870)