### PR TITLE
Improve font performance in FamilyCollection.GetFontFromFamily

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FamilyCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FamilyCollection.cs
@@ -503,11 +503,12 @@ namespace MS.Internal.FontCache
             // An exact match was not found and so we will start looking for the best match.
             Text.TextInterface.Font matchingFont = null;
             int indexOfSpace = faceName.LastIndexOf(' ');
+            Dictionary<string, Text.TextInterface.Font>.AlternateLookup<ReadOnlySpan<char>> alternateLookup = faces.GetAlternateLookup<ReadOnlySpan<char>>();
 
             while (indexOfSpace > 0)
             {
                 faceName = faceName.Slice(0, indexOfSpace);
-                if (faces.TryGetValue(faceName.ToString(), out matchingFont))
+                if (alternateLookup.TryGetValue(faceName, out matchingFont))
                 {
                     return matchingFont;
                 }


### PR DESCRIPTION
## Description
I improved performance and allocations by using the new GetAlternateLookup introduced in .Net 9.0. This is a followup to dotnet/wpf#7794 where GetAlternateLookup wasn't available at the time.

Here's the result of my benchmark:
```
|          Method |     Mean |   Error |  StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|---------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
| LookupFamilyOld | 344.6 ns | 4.59 ns | 4.29 ns |  1.00 |    0.00 | 0.0706 |   1.16 KB |        1.00 |
| LookupFamilyNew | 333.0 ns | 3.23 ns | 2.86 ns |  0.97 |    0.02 | 0.0687 |   1.13 KB |        0.97 |
```

## Customer Impact
Better perf.

## Regression
No.

## Testing
I ran FamilyCollection.GetFontFromFamily with different combinations to make sure that the result was the same.

## Risk
Low.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9883)