### PR TITLE
Redefine FigureLength as readonly struct to prevent defensive copies

### DIFF
--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
@@ -405,9 +405,8 @@ namespace System.Windows
         PageRight = 2,
     }
     [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.FigureLengthConverter))]
-    public partial struct FigureLength : System.IEquatable<System.Windows.FigureLength>
+    public readonly partial struct FigureLength : System.IEquatable<System.Windows.FigureLength>
     {
-        private int _dummyPrimitive;
         public FigureLength(double pixels) { throw null; }
         public FigureLength(double value, System.Windows.FigureUnitType type) { throw null; }
         public System.Windows.FigureUnitType FigureUnitType { get { throw null; } }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
@@ -48,53 +48,43 @@ namespace System.Windows
     }
 
     /// <summary>
-    /// FigureLength is the type used for height and width on figure element
+    /// FigureLength is the type used for height and width on figure element.
     /// </summary>
     [TypeConverter(typeof(FigureLengthConverter))]
     public readonly struct FigureLength : IEquatable<FigureLength>
     {
-
+        /// <summary>
+        /// Represents the <see cref="Value"/> of this instance; 1.0 if <see cref="FigureUnitType"/> is <see cref="FigureUnitType.Auto"/>.
+        /// </summary>
         private readonly double _unitValue;
+        /// <summary>
+        /// Represents the <see cref="FigureUnitType"/> of this instance.
+        /// </summary>
         private readonly FigureUnitType _unitType;
 
-        //------------------------------------------------------
-        //
-        //  Constructors
-        //
-        //------------------------------------------------------
-
-        #region Constructors
-
         /// <summary>
-        /// Constructor, initializes the FigureLength as absolute value in pixels.
+        /// Constructor, initializes the <see cref="FigureLength"/> as absolute value in pixels.
         /// </summary>
         /// <param name="pixels">Specifies the number of 'device-independent pixels' 
         /// (96 pixels-per-inch).</param>
         /// <exception cref="ArgumentException">
-        /// If <c>pixels</c> parameter is <c>double.NaN</c>
-        /// or <c>pixels</c> parameter is <c>double.NegativeInfinity</c>
-        /// or <c>pixels</c> parameter is <c>double.PositiveInfinity</c>.
-        /// or <c>value</c> parameter is <c>negative</c>.
+        /// If <c>pixels</c> parameter is <c>double.NaN</c> or <c>pixels</c> parameter is <c>double.NegativeInfinity</c>
+        /// or <c>pixels</c> parameter is <c>double.PositiveInfinity</c> or <c>value</c> parameter is <c>negative</c>.
         /// </exception>
         public FigureLength(double pixels) : this(pixels, FigureUnitType.Pixel) { }
 
         /// <summary>
-        /// Constructor, initializes the FigureLength and specifies what kind of value 
-        /// it will hold.
+        /// Constructor, initializes the <see cref="FigureLength"/> and specifies what kind of value it will hold.
         /// </summary>
-        /// <param name="value">Value to be stored by this FigureLength 
-        /// instance.</param>
-        /// <param name="type">Type of the value to be stored by this FigureLength 
-        /// instance.</param>
+        /// <param name="value">Value to be stored by this <see cref="FigureLength"/> instance.</param>
+        /// <param name="type">Type of the value to be stored by this <see cref="FigureLength"/> instance.</param>
         /// <remarks> 
-        /// If the <c>type</c> parameter is <c>FigureUnitType.Auto</c>, 
-        /// then passed in value is ignored and replaced with <c>1</c>.
+        /// If the <paramref name="type"/> parameter is <see cref="FigureUnitType.Auto"/>, 
+        /// then the value passed in <paramref name="value"/> is ignored and replaced with 1.0.
         /// </remarks>
         /// <exception cref="ArgumentException">
-        /// If <c>value</c> parameter is <c>double.NaN</c>
-        /// or <c>value</c> parameter is <c>double.NegativeInfinity</c>
-        /// or <c>value</c> parameter is <c>double.PositiveInfinity</c>.
-        /// or <c>value</c> parameter is <c>negative</c>.
+        /// If <c>pixels</c> parameter is <c>double.NaN</c> or <c>pixels</c> parameter is <c>double.NegativeInfinity</c>
+        /// or <c>pixels</c> parameter is <c>double.PositiveInfinity</c> or <c>value</c> parameter is <c>negative</c>.
         /// </exception>
         public FigureLength(double value, FigureUnitType type)
         {
@@ -122,116 +112,103 @@ namespace System.Windows
             _unitType = type;
         }
 
-        #endregion Constructors
-
-        //------------------------------------------------------
-        //
-        //  Public Methods
-        //
-        //------------------------------------------------------
-
-        #region Public Methods 
-
         /// <summary>
-        /// Overloaded operator, compares 2 FigureLengths.
+        /// Compares two <see cref="FigureLength"/> structures for equality.
         /// </summary>
-        /// <param name="fl1">first FigureLength to compare.</param>
-        /// <param name="fl2">second FigureLength to compare.</param>
-        /// <returns>true if specified FigureLengths have same value 
-        /// and unit type.</returns>
+        /// <param name="fl1">The first <see cref="FigureLength"/> to compare.</param>
+        /// <param name="fl2">The second <see cref="FigureLength"/> to compare.</param>
+        /// <returns><see langword="true"/> if specified <see cref="FigureLength"/>s have same
+        /// <see cref="Value"/> and <see cref="FigureUnitType"/>.</returns>
         public static bool operator ==(FigureLength fl1, FigureLength fl2)
         {
             return fl1.FigureUnitType == fl2.FigureUnitType && fl1.Value == fl2.Value;
         }
 
         /// <summary>
-        /// Overloaded operator, compares 2 FigureLengths.
+        /// Compares two <see cref="FigureLength"/> structures for inequality.
         /// </summary>
-        /// <param name="fl1">first FigureLength to compare.</param>
-        /// <param name="fl2">second FigureLength to compare.</param>
-        /// <returns>true if specified FigureLengths have either different value or 
-        /// unit type.</returns>
+        /// <param name="fl1">The first <see cref="FigureLength"/> to compare.</param>
+        /// <param name="fl2">The second <see cref="FigureLength"/> to compare.</param>
+        /// <returns><see langword="true"/> if specified <see cref="FigureLength"/>s differ
+        /// in <see cref="Value"/> or <see cref="FigureUnitType"/>.</returns>
         public static bool operator !=(FigureLength fl1, FigureLength fl2)
         {
             return !(fl1 == fl2);
         }
 
         /// <summary>
-        /// Compares this instance of FigureLength with another object.
+        /// Compares this instance of <see cref="FigureLength"/> with another object.
         /// </summary>
         /// <param name="oCompare">Reference to an object for comparison.</param>
-        /// <returns><c>true</c>if this FigureLength instance has the same value 
-        /// and unit type as oCompare.</returns>
+        /// <returns><see langword="true"/> if this <see cref="FigureLength"/> instance has the same value
+        /// and unit type as <paramref name="oCompare"/>.</returns>
         public override bool Equals(object oCompare)
         {
             return oCompare is FigureLength figureLength && Equals(figureLength);
         }
 
         /// <summary>
-        /// Compares this instance of FigureLength with another object.
+        /// Compares this instance of <see cref="FigureLength"/> with another <see cref="FigureLength"/>.
         /// </summary>
         /// <param name="figureLength">FigureLength to compare.</param>
-        /// <returns><c>true</c>if this FigureLength instance has the same value 
-        /// and unit type as figureLength.</returns>
+        /// <returns><see langword="true"/> if this <see cref="FigureLength"/> instance has the same value 
+        /// and unit type as <paramref name="figureLength"/>.</returns>
         public bool Equals(FigureLength figureLength)
         {
             return this == figureLength;
         }
 
         /// <summary>
-        /// <see cref="Object.GetHashCode"/>
+        /// Returns the hash code for this <see cref="FigureLength"/>.
         /// </summary>
-        /// <returns><see cref="Object.GetHashCode"/></returns>
+        /// <returns>The hash code for this <see cref="FigureLength"/> structure.</returns>
         public override int GetHashCode()
         {
             return (int)_unitValue + (int)_unitType;
         }
 
         /// <summary>
-        /// Returns <c>true</c> if this FigureLength instance holds 
-        /// an absolute (pixel) value.
+        /// Returns <see langword="true"/> if this <see cref="FigureLength"/> instance holds an absolute (pixel) value.
         /// </summary>
         public bool IsAbsolute { get { return _unitType == FigureUnitType.Pixel; } }
 
         /// <summary>
-        /// Returns <c>true</c> if this FigureLength instance is 
-        /// automatic (not specified).
+        /// Returns <see langword="true"/> if this <see cref="FigureLength"/> instance is automatic (not specified).
         /// </summary>
         public bool IsAuto { get { return _unitType == FigureUnitType.Auto; } }
 
         /// <summary>
-        /// Returns <c>true</c> if this FigureLength instance is column relative.
+        /// Returns <see langword="true"/> if this <see cref="FigureLength"/> instance is column relative.
         /// </summary>
         public bool IsColumn { get { return _unitType == FigureUnitType.Column; } }
 
         /// <summary>
-        /// Returns <c>true</c> if this FigureLength instance is content relative.
+        /// Returns <see langword="true"/> if this <see cref="FigureLength"/> instance is content relative.
         /// </summary>
         public bool IsContent { get { return _unitType == FigureUnitType.Content; } }
 
         /// <summary>
-        /// Returns <c>true</c> if this FigureLength instance is page relative.
+        /// Returns <see langword="true"/> if this <see cref="FigureLength"/> instance is page relative.
         /// </summary>
         public bool IsPage { get { return _unitType == FigureUnitType.Page; } }
 
         /// <summary>
-        /// Returns value part of this FigureLength instance.
+        /// Returns value part of this <see cref="FigureLength"/> instance.
         /// </summary>
         public double Value { get { return _unitValue; } }
 
         /// <summary>
-        /// Returns unit type of this FigureLength instance.
+        /// Returns unit type of this <see cref="FigureLength"/> instance.
         /// </summary>
         public FigureUnitType FigureUnitType { get { return _unitType; } }
 
         /// <summary>
-        /// Returns the string representation of this object.
+        /// Returns the <see langword="string"/> representation of this <see cref="FigureLength"/>.
         /// </summary>
+        /// <returns>A <see langword="string"/> representation of this <see cref="FigureLength"/>.</returns>
         public override string ToString()
         {
             return FigureLengthConverter.ToString(this, CultureInfo.InvariantCulture);
         }
-        
-        #endregion Public Methods 
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
@@ -88,7 +88,7 @@ namespace System.Windows
         /// instance.</param>
         /// <remarks> 
         /// If the <c>type</c> parameter is <c>FigureUnitType.Auto</c>, 
-        /// then passed in value is ignored and replaced with <c>0</c>.
+        /// then passed in value is ignored and replaced with <c>1</c>.
         /// </remarks>
         /// <exception cref="ArgumentException">
         /// If <c>value</c> parameter is <c>double.NaN</c>
@@ -98,38 +98,27 @@ namespace System.Windows
         /// </exception>
         public FigureLength(double value, FigureUnitType type)
         {
-            double maxColumns = PTS.Restrictions.tscColumnRestriction;
-            double maxPixel = Math.Min(1000000, PTS.MaxPageSize);
-
+            // Check value
             if (double.IsNaN(value))
-            {
                 throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, "value"));
-            }
-            if (double.IsInfinity(value))
-            {
+            else if (double.IsInfinity(value))
                 throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoInfinity, "value"));
-            }
-            if (value < 0.0)
-            {
+            else if (value < 0.0)
                 throw new ArgumentOutOfRangeException(SR.Format(SR.InvalidCtorParameterNoNegative, "value"));
-            }
-            if (    type != FigureUnitType.Auto
-                &&  type != FigureUnitType.Pixel
-                &&  type != FigureUnitType.Column
-                &&  type != FigureUnitType.Content
-                &&  type != FigureUnitType.Page   )
-            {
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterUnknownFigureUnitType, "type"));
-            }
 
+            // Check unitType
             if (type is FigureUnitType.Content or FigureUnitType.Page)
                 ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 1.0);
-            else if (type == FigureUnitType.Column)
-                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, maxColumns);
-            else if (type == FigureUnitType.Pixel)
-                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, maxPixel);
+            else if (type is FigureUnitType.Column)
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, PTS.Restrictions.tscColumnRestriction);
+            else if (type is FigureUnitType.Pixel)
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, Math.Min(1000000, PTS.MaxPageSize));
+            else if (type is FigureUnitType.Auto)
+                value = 1.0; // Value is ignored in case of "Auto" and defaulted to "1.0"
+            else
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterUnknownFigureUnitType, "type"));
 
-            _unitValue = (type == FigureUnitType.Auto) ? 0.0 : value;
+            _unitValue = value;
             _unitType = type;
         }
 
@@ -228,7 +217,7 @@ namespace System.Windows
         /// <summary>
         /// Returns value part of this FigureLength instance.
         /// </summary>
-        public double Value { get { return (_unitType == FigureUnitType.Auto) ? 1.0 : _unitValue; } }
+        public double Value { get { return _unitValue; } }
 
         /// <summary>
         /// Returns unit type of this FigureLength instance.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
@@ -185,15 +185,9 @@ namespace System.Windows
         /// <param name="oCompare">Reference to an object for comparison.</param>
         /// <returns><c>true</c>if this FigureLength instance has the same value 
         /// and unit type as oCompare.</returns>
-        override public bool Equals(object oCompare)
+        public override bool Equals(object oCompare)
         {
-            if(oCompare is FigureLength)
-            {
-                FigureLength l = (FigureLength)oCompare;
-                return (this == l);
-            }
-            else
-                return false;
+            return oCompare is FigureLength figureLength && Equals(figureLength);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
@@ -100,11 +100,11 @@ namespace System.Windows
         {
             // Check value
             if (double.IsNaN(value))
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, "value"));
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, nameof(value)));
             else if (double.IsInfinity(value))
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoInfinity, "value"));
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoInfinity, nameof(value)));
             else if (value < 0.0)
-                throw new ArgumentOutOfRangeException(SR.Format(SR.InvalidCtorParameterNoNegative, "value"));
+                throw new ArgumentOutOfRangeException(SR.Format(SR.InvalidCtorParameterNoNegative, nameof(value)));
 
             // Check unitType
             if (type is FigureUnitType.Content or FigureUnitType.Page)
@@ -116,7 +116,7 @@ namespace System.Windows
             else if (type is FigureUnitType.Auto)
                 value = 1.0; // Value is ignored in case of "Auto" and defaulted to "1.0"
             else
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterUnknownFigureUnitType, "type"));
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterUnknownFigureUnitType, nameof(type)));
 
             _unitValue = value;
             _unitType = type;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
@@ -51,8 +51,12 @@ namespace System.Windows
     /// FigureLength is the type used for height and width on figure element
     /// </summary>
     [TypeConverter(typeof(FigureLengthConverter))]
-    public struct FigureLength : IEquatable<FigureLength>
+    public readonly struct FigureLength : IEquatable<FigureLength>
     {
+
+        private readonly double _unitValue;
+        private readonly FigureUnitType _unitType;
+
         //------------------------------------------------------
         //
         //  Constructors
@@ -258,16 +262,5 @@ namespace System.Windows
         }
         
         #endregion Public Methods 
-
-        //------------------------------------------------------
-        //
-        //  Private Fields
-        //
-        //------------------------------------------------------
-
-        #region Private Fields 
-        private double _unitValue;      //  unit value storage
-        private FigureUnitType _unitType; //  unit type storage
-        #endregion Private Fields 
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
@@ -76,10 +76,7 @@ namespace System.Windows
         /// or <c>pixels</c> parameter is <c>double.PositiveInfinity</c>.
         /// or <c>value</c> parameter is <c>negative</c>.
         /// </exception>
-        public FigureLength(double pixels)
-            : this(pixels, FigureUnitType.Pixel)
-        {
-        }
+        public FigureLength(double pixels) : this(pixels, FigureUnitType.Pixel) { }
 
         /// <summary>
         /// Constructor, initializes the FigureLength and specifies what kind of value 
@@ -124,20 +121,13 @@ namespace System.Windows
             {
                 throw new ArgumentException(SR.Format(SR.InvalidCtorParameterUnknownFigureUnitType, "type"));
             }
+
             if (type is FigureUnitType.Content or FigureUnitType.Page)
-            {
                 ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 1.0);
-            }
-
-            if (type == FigureUnitType.Column)
-            {
+            else if (type == FigureUnitType.Column)
                 ArgumentOutOfRangeException.ThrowIfGreaterThan(value, maxColumns);
-            }
-
-            if (type == FigureUnitType.Pixel)
-            {
+            else if (type == FigureUnitType.Pixel)
                 ArgumentOutOfRangeException.ThrowIfGreaterThan(value, maxPixel);
-            }
 
             _unitValue = (type == FigureUnitType.Auto) ? 0.0 : value;
             _unitType = type;
@@ -160,10 +150,9 @@ namespace System.Windows
         /// <param name="fl2">second FigureLength to compare.</param>
         /// <returns>true if specified FigureLengths have same value 
         /// and unit type.</returns>
-        public static bool operator == (FigureLength fl1, FigureLength fl2)
+        public static bool operator ==(FigureLength fl1, FigureLength fl2)
         {
-            return (    fl1.FigureUnitType == fl2.FigureUnitType 
-                    &&  fl1.Value == fl2.Value  );
+            return fl1.FigureUnitType == fl2.FigureUnitType && fl1.Value == fl2.Value;
         }
 
         /// <summary>
@@ -173,10 +162,9 @@ namespace System.Windows
         /// <param name="fl2">second FigureLength to compare.</param>
         /// <returns>true if specified FigureLengths have either different value or 
         /// unit type.</returns>
-        public static bool operator != (FigureLength fl1, FigureLength fl2)
+        public static bool operator !=(FigureLength fl1, FigureLength fl2)
         {
-            return (    fl1.FigureUnitType != fl2.FigureUnitType 
-                    ||  fl1.Value != fl2.Value  );
+            return !(fl1 == fl2);
         }
 
         /// <summary>
@@ -198,7 +186,7 @@ namespace System.Windows
         /// and unit type as figureLength.</returns>
         public bool Equals(FigureLength figureLength)
         {
-            return (this == figureLength);
+            return this == figureLength;
         }
 
         /// <summary>
@@ -207,45 +195,45 @@ namespace System.Windows
         /// <returns><see cref="Object.GetHashCode"/></returns>
         public override int GetHashCode()
         {
-            return ((int)_unitValue + (int)_unitType);
+            return (int)_unitValue + (int)_unitType;
         }
 
         /// <summary>
         /// Returns <c>true</c> if this FigureLength instance holds 
         /// an absolute (pixel) value.
         /// </summary>
-        public bool IsAbsolute { get { return (_unitType == FigureUnitType.Pixel); } }
+        public bool IsAbsolute { get { return _unitType == FigureUnitType.Pixel; } }
 
         /// <summary>
         /// Returns <c>true</c> if this FigureLength instance is 
         /// automatic (not specified).
         /// </summary>
-        public bool IsAuto { get { return (_unitType == FigureUnitType.Auto); } }
+        public bool IsAuto { get { return _unitType == FigureUnitType.Auto; } }
 
         /// <summary>
         /// Returns <c>true</c> if this FigureLength instance is column relative.
         /// </summary>
-        public bool IsColumn { get { return (_unitType == FigureUnitType.Column); } }
+        public bool IsColumn { get { return _unitType == FigureUnitType.Column; } }
 
         /// <summary>
         /// Returns <c>true</c> if this FigureLength instance is content relative.
         /// </summary>
-        public bool IsContent { get { return (_unitType == FigureUnitType.Content); } }
+        public bool IsContent { get { return _unitType == FigureUnitType.Content; } }
 
         /// <summary>
         /// Returns <c>true</c> if this FigureLength instance is page relative.
         /// </summary>
-        public bool IsPage { get { return (_unitType == FigureUnitType.Page); } }
+        public bool IsPage { get { return _unitType == FigureUnitType.Page; } }
 
         /// <summary>
         /// Returns value part of this FigureLength instance.
         /// </summary>
-        public double Value { get { return ((_unitType == FigureUnitType.Auto) ? 1.0 : _unitValue); } }
+        public double Value { get { return (_unitType == FigureUnitType.Auto) ? 1.0 : _unitValue; } }
 
         /// <summary>
         /// Returns unit type of this FigureLength instance.
         /// </summary>
-        public FigureUnitType FigureUnitType { get { return (_unitType); } }
+        public FigureUnitType FigureUnitType { get { return _unitType; } }
 
         /// <summary>
         /// Returns the string representation of this object.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -407,7 +407,7 @@ namespace System.Windows
         ColumnRight = 8,
     }
     [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.FigureLengthConverter))]
-    public partial struct FigureLength : System.IEquatable<System.Windows.FigureLength>
+    public readonly partial struct FigureLength : System.IEquatable<System.Windows.FigureLength>
     {
         public FigureLength(double pixels) { throw null; }
         public FigureLength(double value, System.Windows.FigureUnitType type) { throw null; }


### PR DESCRIPTION
## Description

Since `FigureLength` is immutable by design, we should adjust it to `readonly struct`. This will also prevent defensive copies. It will also improve code quality. **This is not a breaking change**.

- I've also simplified the ctor a bit, which will also offer a very minor performance benefit (it does not matter).
- Minor cleanup of the usual `IEquatable` functions to save precious code lines and simplify it.
- The value was being set to `0.0` in case of `Auto` but when queried, it is set to `1.0`.
     - I couldn't see a reason for it, the only thing that made sense was the hash code creation but the hash code is not unique even for basic values. It is too easy to get duplicates. This should be fixed later, I'll create a tracking issue.

## Customer Impact

Possibly a bit of perf and a clear directive that `FigureLength` and all its methods are not adjusting the state of the `struct`.

## Regression

No.

## Testing

Local build, base testing, type creation, etc.

## Risk

I do not asses any, since the struct is immutable and this is not a breaking change. It is a change to a public type but such changes have been done previously in runtime, see for example [#97421](https://github.com/dotnet/runtime/pull/97421).
