### PR TITLE
Optimize FigureLength struct conversion to string, reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
@@ -254,7 +254,7 @@ namespace System.Windows
         /// </summary>
         public override string ToString()
         {
-            return FigureLengthConverter.ToString(this, CultureInfo.InvariantCulture);
+            return FigureLengthConverter.ToString(in this, CultureInfo.InvariantCulture);
         }
         
         #endregion Public Methods 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLengthConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLengthConverter.cs
@@ -105,23 +105,16 @@ namespace System.Windows
         /// An ArgumentException is thrown if the example object is not null 
         /// and is not a valid type which can be converted to a FigureLength.
         /// </exception>
-        public override object ConvertFrom(
-            ITypeDescriptorContext typeDescriptorContext, 
-            CultureInfo cultureInfo, 
-            object source)
+        public override object ConvertFrom(ITypeDescriptorContext typeDescriptorContext, CultureInfo cultureInfo, object source)
         {
-            if (source != null)
-            {
-                if (source is string)
-                {
-                    return (FromString((string)source, cultureInfo));
-                }
-                else
-                {
-                    return new FigureLength(Convert.ToDouble(source, cultureInfo)); //conversion from numeric type
-                }
-            }
-            throw GetConvertFromException(source);
+            if (source is null)
+                throw GetConvertFromException(source);
+
+            if (source is string stringValue)
+                return FromString(stringValue, cultureInfo);
+
+            // Attempt conversion from a numeric type (FigureLength.Pixel)
+            return new FigureLength(Convert.ToDouble(source, cultureInfo));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLengthConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLengthConverter.cs
@@ -141,30 +141,22 @@ namespace System.Windows
         /// An ArgumentException is thrown if the object is not null and is not a FigureLength,
         /// or if the destinationType isn't one of the valid destination types.
         /// </exception>
-        public override object ConvertTo(
-            ITypeDescriptorContext typeDescriptorContext, 
-            CultureInfo cultureInfo,
-            object value,
-            Type destinationType)
+        public override object ConvertTo(ITypeDescriptorContext typeDescriptorContext, CultureInfo cultureInfo, object value, Type destinationType)
         {
             ArgumentNullException.ThrowIfNull(destinationType);
 
-            if (    value != null
-                &&  value is FigureLength )
+            if (value is not FigureLength figureLength)
+                throw GetConvertToException(value, destinationType);
+
+            if (destinationType == typeof(string))
+                return ToString(in figureLength, cultureInfo);
+
+            if (destinationType == typeof(InstanceDescriptor))
             {
-                FigureLength fl = (FigureLength)value;
-
-                if (destinationType == typeof(string)) 
-                { 
-                    return (ToString(fl, cultureInfo)); 
-                }
-
-                if (destinationType == typeof(InstanceDescriptor))
-                {
-                    ConstructorInfo ci = typeof(FigureLength).GetConstructor(new Type[] { typeof(double), typeof(FigureUnitType) });
-                    return (new InstanceDescriptor(ci, new object[] { fl.Value, fl.FigureUnitType }));
-                }
+                ConstructorInfo ci = typeof(FigureLength).GetConstructor(new Type[] { typeof(double), typeof(FigureUnitType) });
+                return new InstanceDescriptor(ci, new object[] { figureLength.Value, figureLength.FigureUnitType });
             }
+
             throw GetConvertToException(value, destinationType);
         }
 
@@ -179,21 +171,29 @@ namespace System.Windows
         #region Internal Methods
 
         /// <summary>
-        /// Converts a FigureLength instance to a String given the CultureInfo.
+        /// Converts a <see cref="FigureLength"/> instance to a <see langword="string"/> given the <see cref="CultureInfo"/>.
         /// </summary>
-        /// <param name="fl">FigureLength instance to convert.</param>
-        /// <param name="cultureInfo">Culture Info.</param>
-        /// <returns>String representation of the object.</returns>
-        static internal string ToString(FigureLength fl, CultureInfo cultureInfo)
+        /// <param name="length">Reference to a <see cref="FigureLength"/> instance to convert from.</param>
+        /// <param name="cultureInfo">The <see cref="CultureInfo"/> which is respected during conversion.</param>
+        /// <returns><see langword="string"/> representation of the <see cref="FigureLength"/>.</returns>
+        internal static string ToString(ref readonly FigureLength length, CultureInfo cultureInfo) => length.FigureUnitType switch
         {
-            switch (fl.FigureUnitType)
-            {
-                //  for Auto print out "Auto". value is always "1.0"
-                case FigureUnitType.Auto:
-                    return ("Auto");
+            FigureUnitType.Auto => "Auto", // Print out "Auto", value is always "1.0"
+            FigureUnitType.Pixel => Convert.ToString(length.Value, cultureInfo),
+            _ => ToStringWithUnitType(in length, cultureInfo)
+        };
 
-                case FigureUnitType.Pixel:
-                    return Convert.ToString(fl.Value, cultureInfo);
+        /// <summary>
+        /// Converts a <see cref="FigureLength"/> instance to a <see langword="string"/> given the <see cref="CultureInfo"/>.
+        /// </summary>
+        /// <param name="length">Reference to a <see cref="FigureLength"/> instance to convert from.</param>
+        /// <param name="cultureInfo">The <see cref="CultureInfo"/> which is respected during conversion.</param>
+        /// <returns><see langword="string"/> representation of the <see cref="FigureLength"/>.</returns>
+        private static string ToStringWithUnitType(ref readonly FigureLength length, CultureInfo cultureInfo)
+        {
+            // 17 for digits; 3 for separator; 4 for negative sign; 5 for exponent; 3 scratch space
+            Span<char> doubleSpan = stackalloc char[32];
+            length.Value.TryFormat(doubleSpan, out int charsWritten, provider: cultureInfo);
 
             return string.Create(cultureInfo, stackalloc char[48], $"{doubleSpan.Slice(0, charsWritten)} {length.FigureUnitType}");
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLengthConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLengthConverter.cs
@@ -195,17 +195,15 @@ namespace System.Windows
                 case FigureUnitType.Pixel:
                     return Convert.ToString(fl.Value, cultureInfo);
 
-                default:
-                    return $"{Convert.ToString(fl.Value, cultureInfo)} {fl.FigureUnitType}";
-            }
+            return string.Create(cultureInfo, stackalloc char[48], $"{doubleSpan.Slice(0, charsWritten)} {length.FigureUnitType}");
         }
 
         /// <summary>
-        /// Parses a FigureLength from a string given the CultureInfo.
+        /// Parses a <see cref="FigureLength"/> from a <see langword="string"/> given the <see cref="CultureInfo"/>.
         /// </summary>
-        /// <param name="s">String to parse from.</param>
-        /// <param name="cultureInfo">Culture Info.</param>
-        /// <returns>Newly created FigureLength instance.</returns>
+        /// <param name="input"><see langword="string"/> to parse from.</param>
+        /// <param name="cultureInfo">The <see cref="CultureInfo"/> which is respected during conversion.</param>
+        /// <returns>Newly created <see cref="FigureLength"/> instance.</returns>
         /// <remarks>
         /// Formats: 
         /// "[value][unit]"
@@ -217,14 +215,11 @@ namespace System.Windows
         ///     As above, but the value is assumed to be 1.0
         ///     This is only acceptable for a subset of FigureUnitType: Auto
         /// </remarks>
-        static internal FigureLength FromString(string s, CultureInfo cultureInfo)
+        internal static FigureLength FromString(string input, CultureInfo cultureInfo)
         {
-            double value;
-            FigureUnitType unit;
-            XamlFigureLengthSerializer.FromString(s, cultureInfo,
-                out value, out unit);
+            XamlFigureLengthSerializer.FromString(input, cultureInfo, out double value, out FigureUnitType unit);
 
-            return (new FigureLength(value, unit));
+            return new FigureLength(value, unit);
         }
 
         #endregion Internal Methods

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLengthConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLengthConverter.cs
@@ -2,32 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-// 
-//
-// Description: Figure length converter implementation
-//
-//
-
-using MS.Internal;
-using MS.Utility;
-using System.ComponentModel;
-using System.Windows;
-using System;
-using System.Security;
 using System.ComponentModel.Design.Serialization;
-using System.Diagnostics;
+using System.ComponentModel;
+using System.Windows.Markup;
 using System.Globalization;
 using System.Reflection;
-using System.Windows.Markup;
 
 namespace System.Windows
 {
     /// <summary>
-    /// FigureLengthConverter - Converter class for converting 
-    /// instances of other types to and from FigureLength instances.
+    /// Converter class for converting instances of other types to and from <see cref="FigureLength"/> instances.
     /// </summary> 
-    public class FigureLengthConverter: TypeConverter
+    public class FigureLengthConverter : TypeConverter
     {
         //-------------------------------------------------------------------
         //
@@ -40,16 +26,10 @@ namespace System.Windows
         /// <summary>
         /// Checks whether or not this class can convert from a given type.
         /// </summary>
-        /// <param name="typeDescriptorContext">The ITypeDescriptorContext 
-        /// for this call.</param>
-        /// <param name="sourceType">The Type being queried for support.</param>
-        /// <returns>
-        /// <c>true</c> if thie converter can convert from the provided type, 
-        /// <c>false</c> otherwise.
-        /// </returns>
-        public override bool CanConvertFrom(
-            ITypeDescriptorContext typeDescriptorContext, 
-            Type sourceType)
+        /// <param name="typeDescriptorContext">Context information used for conversion.</param>
+        /// <param name="sourceType">Type being evaluated for conversion.</param>
+        /// <returns><see langword="true"/> if the given <paramref name="t"/> can be converted from, <see langword="false"/> otherwise.</returns>
+        public override bool CanConvertFrom(ITypeDescriptorContext typeDescriptorContext, Type sourceType)
         {
             // We can only handle strings, integral and floating types
             TypeCode tc = Type.GetTypeCode(sourceType);
@@ -66,7 +46,7 @@ namespace System.Windows
                 case TypeCode.UInt32:
                 case TypeCode.UInt64:
                     return true;
-                default: 
+                default:
                     return false;
             }
         }
@@ -84,20 +64,20 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Attempts to convert to a FigureLength from the given object.
+        /// Attempts to initialize an instance of <see cref="FigureLength"/> from the given <paramref name="source"/>.
         /// </summary>
         /// <param name="typeDescriptorContext">The ITypeDescriptorContext for this call.</param>
-        /// <param name="cultureInfo">The CultureInfo which is respected when converting.</param>
-        /// <param name="source">The object to convert to a FigureLength.</param>
+        /// <param name="cultureInfo">The <see cref="CultureInfo"/> which is respected during conversion.</param>
+        /// <param name="source">The object to convert to a <see cref="FigureLength"/>.</param>
         /// <returns>
-        /// The FigureLength instance which was constructed.
+        /// The <see cref="FigureLength"/> instance which was constructed.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// An ArgumentNullException is thrown if the example object is null.
+        /// An ArgumentNullException is thrown if the example object is <see langword="null"/>.
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// An ArgumentException is thrown if the example object is not null 
-        /// and is not a valid type which can be converted to a FigureLength.
+        /// An ArgumentException is thrown if the example object is not <see langword="null"/> 
+        /// and is not a valid type which can be converted to a <see cref="FigureLength"/>.
         /// </exception>
         public override object ConvertFrom(ITypeDescriptorContext typeDescriptorContext, CultureInfo cultureInfo, object source)
         {
@@ -112,21 +92,21 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Attempts to convert a FigureLength instance to the given type.
+        /// Attempts to convert a <see cref="FigureLength"/> instance to the given type.
         /// </summary>
         /// <param name="typeDescriptorContext">The ITypeDescriptorContext for this call.</param>
-        /// <param name="cultureInfo">The CultureInfo which is respected when converting.</param>
-        /// <param name="value">The FigureLength to convert.</param>
-        /// <param name="destinationType">The type to which to convert the FigureLength instance.</param>
+        /// <param name="cultureInfo">The <see cref="CultureInfo"/> which is respected during conversion.</param>
+        /// <param name="value">The <see cref="FigureLength"/> to convert.</param>
+        /// <param name="destinationType">The type to which to convert the <see cref="FigureLength"/> instance.</param>
         /// <returns>
         /// The object which was constructed.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// An ArgumentNullException is thrown if the example object is null.
+        /// An ArgumentNullException is thrown if the <paramref name="destinationType"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// An ArgumentException is thrown if the object is not null and is not a FigureLength,
-        /// or if the destinationType isn't one of the valid destination types.
+        /// An ArgumentException is thrown if the <paramref name="value"/> is <see langword="null"/> or not a <see cref="FigureLength"/>,
+        /// or if the <paramref name="destinationType"/> isn't one of the valid destination types.
         /// </exception>
         public override object ConvertTo(ITypeDescriptorContext typeDescriptorContext, CultureInfo cultureInfo, object value, Type destinationType)
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLengthConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLengthConverter.cs
@@ -72,21 +72,15 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Checks whether or not this class can convert to a given type.
+        /// Returns whether this class can convert specified value to <see langword="string"/> or <see cref="InstanceDescriptor"/>.
         /// </summary>
-        /// <param name="typeDescriptorContext">The ITypeDescriptorContext 
-        /// for this call.</param>
-        /// <param name="destinationType">The Type being queried for support.</param>
-        /// <returns>
-        /// <c>true</c> if this converter can convert to the provided type, 
-        /// <c>false</c> otherwise.
-        /// </returns>
-        public override bool CanConvertTo(
-            ITypeDescriptorContext typeDescriptorContext, 
-            Type destinationType) 
+        /// <param name="typeDescriptorContext">Context information used for conversion.</param>
+        /// <param name="destinationType">Type being evaluated for conversion.</param>
+        /// <returns><see langword="true"/> when <paramref name="destinationType"/> specified is
+        /// <see langword="string"/> or <see cref="InstanceDescriptor"/>, <see langword="false"/> otherwise.</returns>
+        public override bool CanConvertTo(ITypeDescriptorContext typeDescriptorContext, Type destinationType)
         {
-            return (    destinationType == typeof(InstanceDescriptor) 
-                    ||  destinationType == typeof(string)   );
+            return destinationType == typeof(InstanceDescriptor) || destinationType == typeof(string);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Optimizes conversion of `FigureLength` to `string`. Simplifies Can* methods, adds some documentation.
- The benchmark is done with #9887 which allows for better perf navigating through the methods.

### Simple ToString conversion

| Method    | figureLength | Mean [ns]   | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|---------- |------------- |------------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original  | 999          | 102.3501 ns |  2.0471 ns |   3.0640 ns | 0.0048 |       4,171 B |          80 B |
| PR__EDIT  | 999          |  76.9590 ns |  1.3950 ns |   1.2367 ns | 0.0029 |         957 B |          48 B |

```csharp
yield return new FigureLength(999.0, FigureUnitType.Column);
```

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, conversion tests.

## Risk

Low; do note that #9887 should be taken first imho.
