### PR TITLE
Add test coverage for public API surface of MouseActionConverter

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseActionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseActionConverter.cs
@@ -87,7 +87,8 @@ namespace System.Windows.Input
             if (value is null || destinationType != typeof(string))
                 throw GetConvertToException(value, destinationType);
 
-            return (MouseAction)value switch
+            MouseAction mouseAction = (MouseAction)value;
+            return mouseAction switch
             {
                 MouseAction.None => string.Empty,
                 MouseAction.LeftClick => "LeftClick",
@@ -97,7 +98,7 @@ namespace System.Windows.Input
                 MouseAction.LeftDoubleClick => "LeftDoubleClick",
                 MouseAction.RightDoubleClick => "RightDoubleClick",
                 MouseAction.MiddleDoubleClick => "MiddleDoubleClick",
-                _ => throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(MouseAction))
+                _ => throw new InvalidEnumArgumentException(nameof(value), (int)mouseAction, typeof(MouseAction))
             };
         }
 

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Input/MouseActionConverter.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Input/MouseActionConverter.Tests.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections;
-using System.Windows.Input;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 
-namespace PresentationCore.Tests.System.Windows.Input
+namespace System.Windows.Input
 {
     public class MouseActionConverterTests
     {

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Input/MouseActionConverter.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Input/MouseActionConverter.Tests.cs
@@ -1,0 +1,165 @@
+﻿using System.Collections;
+using System.Windows.Input;
+using System.ComponentModel;
+using System.ComponentModel.Design.Serialization;
+
+namespace PresentationCore.Tests.System.Windows.Input
+{
+    public class MouseActionConverterTests
+    {
+        [Fact]
+        public void ConvertTo_ConvertFrom_ReturnsExpected()
+        {
+            MouseActionConverter converter = new();
+
+            // Test MouseAction.None (Special case)
+            string emptyToNone = string.Empty;
+            MouseAction constantName = MouseAction.None;
+
+            MouseAction lowerCase = (MouseAction)converter.ConvertFrom(null, null, emptyToNone.ToLowerInvariant());
+            MouseAction upperCase = (MouseAction)converter.ConvertFrom(null, null, emptyToNone.ToUpperInvariant());
+            MouseAction normalColor = (MouseAction)converter.ConvertFrom(null, null, emptyToNone);
+
+            Assert.Equal<MouseAction>(constantName, lowerCase);
+            Assert.Equal<MouseAction>(constantName, upperCase);
+            Assert.Equal<MouseAction>(constantName, normalColor);
+
+            // Test the rest of the enum
+            foreach (string action in Enum.GetNames<MouseAction>())
+            {
+                constantName = Enum.Parse<MouseAction>(action);
+
+                lowerCase = (MouseAction)converter.ConvertFrom(null, null, action.ToLowerInvariant());
+                upperCase = (MouseAction)converter.ConvertFrom(null, null, action.ToUpperInvariant());
+                normalColor = (MouseAction)converter.ConvertFrom(null, null, action);
+
+                Assert.Equal<MouseAction>(constantName, lowerCase);
+                Assert.Equal<MouseAction>(constantName, upperCase);
+                Assert.Equal<MouseAction>(constantName, normalColor);
+
+                // Back to the original values
+                string result = (string)converter.ConvertTo(null, null, constantName, typeof(string));
+                result = result == string.Empty ? "None" : result; // Test for MouseAction.None (Special case)
+                Assert.Equal(action, result);
+            }
+        }
+
+        [Fact]
+        public void ConvertTo_ThrowsArgumentNullException()
+        {
+            MouseActionConverter converter = new();
+
+            Assert.Throws<ArgumentNullException>(() => converter.ConvertTo(MouseAction.None, destinationType: null!));
+        }
+
+        [Theory]
+        [InlineData(null, typeof(string))] // Unsupported value
+        [InlineData(MouseAction.None, typeof(int))] // Unsupported destinationType
+        public void ConvertTo_ThrowsNotSupportedException(object? value, Type destinationType)
+        {
+            MouseActionConverter converter = new();
+
+            Assert.Throws<NotSupportedException>(() => converter.ConvertTo(value, destinationType));
+        }
+
+        [Fact]
+        public void ConvertTo_ThrowsInvalidCastException()
+        {
+            MouseActionConverter converter = new();
+
+            Assert.Throws<InvalidCastException>(() => converter.ConvertTo(null, null, (int)(MouseAction.MiddleDoubleClick), typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_ThrowsInvalidEnumArgumentException()
+        {
+            MouseActionConverter converter = new();
+
+            Assert.Throws<InvalidEnumArgumentException>(() => converter.ConvertTo(null, null, (MouseAction)(MouseAction.MiddleDoubleClick + 1), typeof(string)));
+        }
+
+        [Theory]
+        // Unsupported values (data type)
+        [InlineData(null)]
+        [InlineData(MouseAction.None)]
+        // Unsupported value (bad string)
+        [InlineData("BadString")]
+        public void ConvertFrom_ThrowsNotSupportedException(object? value)
+        {
+            MouseActionConverter converter = new();
+
+            Assert.Throws<NotSupportedException>(() => converter.ConvertFrom(null, null, value));
+        }
+
+        [Theory]
+        // Supported type
+        [InlineData(true, typeof(string))]
+        // Unsupported types
+        [InlineData(false, typeof(InstanceDescriptor))]
+        [InlineData(false, typeof(MouseAction))]
+        public void CanConvertFrom_ReturnsExpected(bool expected, Type sourceType)
+        {
+            MouseActionConverter converter = new();
+
+            Assert.Equal(expected, converter.CanConvertFrom(null, sourceType));
+        }
+
+        [Fact]
+        public void CanConvertTo_ThrowsInvalidCastException()
+        {
+            MouseActionConverter converter = new();
+            StandardContextImpl context = new();
+            context.Instance = 10;
+
+            // NOTE: CanConvert* methods should not throw but the implementation is faulty
+            Assert.Throws<InvalidCastException>(() => converter.CanConvertTo(context, typeof(string)));
+        }
+
+        [Theory]
+        [MemberData(nameof(CanConvertTo_TestData))]
+        public void CanConvertTo_ReturnsExpected(bool expected, bool passContext, object? value, Type? destinationType)
+        {
+            MouseActionConverter converter = new();
+            StandardContextImpl context = new();
+            context.Instance = value;
+
+            Assert.Equal(expected, converter.CanConvertTo(passContext ? context : null, destinationType));
+        }
+
+        public static IEnumerable<object?[]> CanConvertTo_TestData
+        {
+            get
+            {
+                // Supported cases
+                yield return new object[] { true, true, MouseAction.None, typeof(string) };
+                yield return new object[] { true, true, MouseAction.MiddleDoubleClick, typeof(string) };
+
+                // Unsupported case (Value is above MouseAction range)
+                yield return new object[] { false, true, MouseAction.MiddleDoubleClick + 1, typeof(string) };
+
+                // Unsupported cases
+                yield return new object[] { false, false, MouseAction.None, typeof(string) };
+                yield return new object[] { false, false, MouseAction.MiddleDoubleClick, typeof(string) };
+                yield return new object?[] { false, true, null, typeof(MouseAction) };
+                yield return new object?[] { false, true, null, typeof(string) };
+                yield return new object?[] { false, false, MouseAction.MiddleDoubleClick, typeof(string) };
+                yield return new object?[] { false, false, null, typeof(string) };
+                yield return new object?[] { false, false, null, null };
+
+                yield return new object[] { false, true, MouseAction.MiddleDoubleClick + 1, typeof(string) };
+            }
+        }
+
+        public sealed class StandardContextImpl : ITypeDescriptorContext
+        {
+            public IContainer? Container => throw new NotImplementedException();
+
+            public object? Instance { get; set; }
+
+            public PropertyDescriptor? PropertyDescriptor => throw new NotImplementedException();
+            public object? GetService(Type serviceType) => throw new NotImplementedException();
+            public void OnComponentChanged() => throw new NotImplementedException();
+            public bool OnComponentChanging() => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Input/MouseActionConverter.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Input/MouseActionConverter.Tests.cs
@@ -4,163 +4,164 @@
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 
-namespace System.Windows.Input
+namespace System.Windows.Input;
+
+public class MouseActionConverterTests
 {
-    public class MouseActionConverterTests
+    [Fact]
+    public void ConvertTo_ConvertFrom_ReturnsExpected()
     {
-        [Fact]
-        public void ConvertTo_ConvertFrom_ReturnsExpected()
+        MouseActionConverter converter = new();
+
+        // Test MouseAction.None (Special case)
+        string emptyToNone = string.Empty;
+        MouseAction constantName = MouseAction.None;
+
+        MouseAction lowerCase = (MouseAction)converter.ConvertFrom(null, null, emptyToNone.ToLowerInvariant());
+        MouseAction upperCase = (MouseAction)converter.ConvertFrom(null, null, emptyToNone.ToUpperInvariant());
+        MouseAction normalColor = (MouseAction)converter.ConvertFrom(null, null, emptyToNone);
+
+        Assert.Equal<MouseAction>(constantName, lowerCase);
+        Assert.Equal<MouseAction>(constantName, upperCase);
+        Assert.Equal<MouseAction>(constantName, normalColor);
+
+        // Test the rest of the enum
+        foreach (string action in Enum.GetNames<MouseAction>())
         {
-            MouseActionConverter converter = new();
+            constantName = Enum.Parse<MouseAction>(action);
 
-            // Test MouseAction.None (Special case)
-            string emptyToNone = string.Empty;
-            MouseAction constantName = MouseAction.None;
-
-            MouseAction lowerCase = (MouseAction)converter.ConvertFrom(null, null, emptyToNone.ToLowerInvariant());
-            MouseAction upperCase = (MouseAction)converter.ConvertFrom(null, null, emptyToNone.ToUpperInvariant());
-            MouseAction normalColor = (MouseAction)converter.ConvertFrom(null, null, emptyToNone);
+            lowerCase = (MouseAction)converter.ConvertFrom(null, null, action.ToLowerInvariant());
+            upperCase = (MouseAction)converter.ConvertFrom(null, null, action.ToUpperInvariant());
+            normalColor = (MouseAction)converter.ConvertFrom(null, null, action);
 
             Assert.Equal<MouseAction>(constantName, lowerCase);
             Assert.Equal<MouseAction>(constantName, upperCase);
             Assert.Equal<MouseAction>(constantName, normalColor);
 
-            // Test the rest of the enum
-            foreach (string action in Enum.GetNames<MouseAction>())
-            {
-                constantName = Enum.Parse<MouseAction>(action);
-
-                lowerCase = (MouseAction)converter.ConvertFrom(null, null, action.ToLowerInvariant());
-                upperCase = (MouseAction)converter.ConvertFrom(null, null, action.ToUpperInvariant());
-                normalColor = (MouseAction)converter.ConvertFrom(null, null, action);
-
-                Assert.Equal<MouseAction>(constantName, lowerCase);
-                Assert.Equal<MouseAction>(constantName, upperCase);
-                Assert.Equal<MouseAction>(constantName, normalColor);
-
-                // Back to the original values
-                string result = (string)converter.ConvertTo(null, null, constantName, typeof(string));
-                result = result == string.Empty ? "None" : result; // Test for MouseAction.None (Special case)
-                Assert.Equal(action, result);
-            }
+            // Back to the original values
+            string result = (string)converter.ConvertTo(null, null, constantName, typeof(string));
+            result = result == string.Empty ? "None" : result; // Test for MouseAction.None (Special case)
+            Assert.Equal(action, result);
         }
+    }
 
-        [Fact]
-        public void ConvertTo_ThrowsArgumentNullException()
+    [Fact]
+    public void ConvertTo_ThrowsArgumentNullException()
+    {
+        MouseActionConverter converter = new();
+
+        Assert.Throws<ArgumentNullException>(() => converter.ConvertTo(MouseAction.None, destinationType: null!));
+    }
+
+    [Theory]
+    [InlineData(null, typeof(string))] // Unsupported value
+    [InlineData(MouseAction.None, typeof(int))] // Unsupported destinationType
+    public void ConvertTo_ThrowsNotSupportedException(object? value, Type destinationType)
+    {
+        MouseActionConverter converter = new();
+
+        Assert.Throws<NotSupportedException>(() => converter.ConvertTo(value, destinationType));
+    }
+
+    [Fact]
+    public void ConvertTo_ThrowsInvalidCastException()
+    {
+        MouseActionConverter converter = new();
+
+        Assert.Throws<InvalidCastException>(() => converter.ConvertTo(null, null, (int)(MouseAction.MiddleDoubleClick), typeof(string)));
+    }
+
+    [Fact]
+    public void ConvertTo_ThrowsInvalidEnumArgumentException()
+    {
+        MouseActionConverter converter = new();
+
+        Assert.Throws<InvalidEnumArgumentException>(() => converter.ConvertTo(null, null, (MouseAction)(MouseAction.MiddleDoubleClick + 1), typeof(string)));
+    }
+
+    [Theory]
+    // Unsupported values (data type)
+    [InlineData(null)]
+    [InlineData(MouseAction.None)]
+    // Unsupported value (bad string)
+    [InlineData("BadString")]
+    public void ConvertFrom_ThrowsNotSupportedException(object? value)
+    {
+        MouseActionConverter converter = new();
+
+        Assert.Throws<NotSupportedException>(() => converter.ConvertFrom(null, null, value));
+    }
+
+    [Theory]
+    // Supported type
+    [InlineData(true, typeof(string))]
+    // Unsupported types
+    [InlineData(false, typeof(InstanceDescriptor))]
+    [InlineData(false, typeof(MouseAction))]
+    public void CanConvertFrom_ReturnsExpected(bool expected, Type sourceType)
+    {
+        MouseActionConverter converter = new();
+
+        Assert.Equal(expected, converter.CanConvertFrom(null, sourceType));
+    }
+
+    [Fact]
+    public void CanConvertTo_ThrowsInvalidCastException()
+    {
+        MouseActionConverter converter = new();
+        StandardContextImpl context = new();
+        context.Instance = 10;
+
+        // NOTE: CanConvert* methods should not throw but the implementation is faulty
+        Assert.Throws<InvalidCastException>(() => converter.CanConvertTo(context, typeof(string)));
+    }
+
+    [Theory]
+    [MemberData(nameof(CanConvertTo_Data))]
+    public void CanConvertTo_ReturnsExpected(bool expected, bool passContext, object? value, Type? destinationType)
+    {
+        MouseActionConverter converter = new();
+        StandardContextImpl context = new()
         {
-            MouseActionConverter converter = new();
+            Instance = value
+        };
 
-            Assert.Throws<ArgumentNullException>(() => converter.ConvertTo(MouseAction.None, destinationType: null!));
-        }
+        Assert.Equal(expected, converter.CanConvertTo(passContext ? context : null, destinationType));
+    }
 
-        [Theory]
-        [InlineData(null, typeof(string))] // Unsupported value
-        [InlineData(MouseAction.None, typeof(int))] // Unsupported destinationType
-        public void ConvertTo_ThrowsNotSupportedException(object? value, Type destinationType)
+    public static IEnumerable<object?[]> CanConvertTo_Data
+    {
+        get
         {
-            MouseActionConverter converter = new();
+            // Supported cases
+            yield return new object[] { true, true, MouseAction.None, typeof(string) };
+            yield return new object[] { true, true, MouseAction.MiddleDoubleClick, typeof(string) };
 
-            Assert.Throws<NotSupportedException>(() => converter.ConvertTo(value, destinationType));
+            // Unsupported case (Value is above MouseAction range)
+            yield return new object[] { false, true, MouseAction.MiddleDoubleClick + 1, typeof(string) };
+
+            // Unsupported cases
+            yield return new object[] { false, false, MouseAction.None, typeof(string) };
+            yield return new object[] { false, false, MouseAction.MiddleDoubleClick, typeof(string) };
+            yield return new object?[] { false, true, null, typeof(MouseAction) };
+            yield return new object?[] { false, true, null, typeof(string) };
+            yield return new object?[] { false, false, MouseAction.MiddleDoubleClick, typeof(string) };
+            yield return new object?[] { false, false, null, typeof(string) };
+            yield return new object?[] { false, false, null, null };
+
+            yield return new object[] { false, true, MouseAction.MiddleDoubleClick + 1, typeof(string) };
         }
+    }
 
-        [Fact]
-        public void ConvertTo_ThrowsInvalidCastException()
-        {
-            MouseActionConverter converter = new();
+    public sealed class StandardContextImpl : ITypeDescriptorContext
+    {
+        public IContainer? Container => throw new NotImplementedException();
 
-            Assert.Throws<InvalidCastException>(() => converter.ConvertTo(null, null, (int)(MouseAction.MiddleDoubleClick), typeof(string)));
-        }
+        public object? Instance { get; set; }
 
-        [Fact]
-        public void ConvertTo_ThrowsInvalidEnumArgumentException()
-        {
-            MouseActionConverter converter = new();
-
-            Assert.Throws<InvalidEnumArgumentException>(() => converter.ConvertTo(null, null, (MouseAction)(MouseAction.MiddleDoubleClick + 1), typeof(string)));
-        }
-
-        [Theory]
-        // Unsupported values (data type)
-        [InlineData(null)]
-        [InlineData(MouseAction.None)]
-        // Unsupported value (bad string)
-        [InlineData("BadString")]
-        public void ConvertFrom_ThrowsNotSupportedException(object? value)
-        {
-            MouseActionConverter converter = new();
-
-            Assert.Throws<NotSupportedException>(() => converter.ConvertFrom(null, null, value));
-        }
-
-        [Theory]
-        // Supported type
-        [InlineData(true, typeof(string))]
-        // Unsupported types
-        [InlineData(false, typeof(InstanceDescriptor))]
-        [InlineData(false, typeof(MouseAction))]
-        public void CanConvertFrom_ReturnsExpected(bool expected, Type sourceType)
-        {
-            MouseActionConverter converter = new();
-
-            Assert.Equal(expected, converter.CanConvertFrom(null, sourceType));
-        }
-
-        [Fact]
-        public void CanConvertTo_ThrowsInvalidCastException()
-        {
-            MouseActionConverter converter = new();
-            StandardContextImpl context = new();
-            context.Instance = 10;
-
-            // NOTE: CanConvert* methods should not throw but the implementation is faulty
-            Assert.Throws<InvalidCastException>(() => converter.CanConvertTo(context, typeof(string)));
-        }
-
-        [Theory]
-        [MemberData(nameof(CanConvertTo_TestData))]
-        public void CanConvertTo_ReturnsExpected(bool expected, bool passContext, object? value, Type? destinationType)
-        {
-            MouseActionConverter converter = new();
-            StandardContextImpl context = new();
-            context.Instance = value;
-
-            Assert.Equal(expected, converter.CanConvertTo(passContext ? context : null, destinationType));
-        }
-
-        public static IEnumerable<object?[]> CanConvertTo_TestData
-        {
-            get
-            {
-                // Supported cases
-                yield return new object[] { true, true, MouseAction.None, typeof(string) };
-                yield return new object[] { true, true, MouseAction.MiddleDoubleClick, typeof(string) };
-
-                // Unsupported case (Value is above MouseAction range)
-                yield return new object[] { false, true, MouseAction.MiddleDoubleClick + 1, typeof(string) };
-
-                // Unsupported cases
-                yield return new object[] { false, false, MouseAction.None, typeof(string) };
-                yield return new object[] { false, false, MouseAction.MiddleDoubleClick, typeof(string) };
-                yield return new object?[] { false, true, null, typeof(MouseAction) };
-                yield return new object?[] { false, true, null, typeof(string) };
-                yield return new object?[] { false, false, MouseAction.MiddleDoubleClick, typeof(string) };
-                yield return new object?[] { false, false, null, typeof(string) };
-                yield return new object?[] { false, false, null, null };
-
-                yield return new object[] { false, true, MouseAction.MiddleDoubleClick + 1, typeof(string) };
-            }
-        }
-
-        public sealed class StandardContextImpl : ITypeDescriptorContext
-        {
-            public IContainer? Container => throw new NotImplementedException();
-
-            public object? Instance { get; set; }
-
-            public PropertyDescriptor? PropertyDescriptor => throw new NotImplementedException();
-            public object? GetService(Type serviceType) => throw new NotImplementedException();
-            public void OnComponentChanged() => throw new NotImplementedException();
-            public bool OnComponentChanging() => throw new NotImplementedException();
-        }
+        public PropertyDescriptor? PropertyDescriptor => throw new NotImplementedException();
+        public object? GetService(Type serviceType) => throw new NotImplementedException();
+        public void OnComponentChanged() => throw new NotImplementedException();
+        public bool OnComponentChanging() => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
## Description

Adds test coverage for `MouseActionConverter`. I've also fixed an unintentional behavioral change I've introduced with #9676, which would mean it wouldn't throw `InvalidEnumArgumentException` due to passing wrong value type to the exception.

- As I've outlined previously, there are basically two (in my opinion) bugs in the class
    - `CanConvertTo` throws `InvalidCastException` due to an unboxing cast when you pass an `int`
    - The same thing happens in `ConvertTo` when you pass an `int` within range

## Customer Impact

Improved test coverage on public surface.

## Regression

Fixing my own oversight at the same time.

## Testing

Local build.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9891)