### PR TITLE
Remove RunClassConstructor proxy from SecurityHelper for code quality

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006Reader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006Reader.cs
@@ -16,6 +16,7 @@ using System.Windows.Media;
 using MS.Internal;
 using System.Globalization;
 using XamlReaderHelper = System.Windows.Markup.XamlReaderHelper;
+using System.Runtime.CompilerServices;
 
 namespace System.Windows.Baml2006
 {
@@ -1377,7 +1378,7 @@ namespace System.Windows.Baml2006
                 // Force load the Statics by walking up the hierarchy and running class constructors
                 while (null != currentType)
                 {
-                    MS.Internal.WindowsBase.SecurityHelper.RunClassConstructor(currentType);
+                    RuntimeHelpers.RunClassConstructor(currentType.TypeHandle);
                     currentType = currentType.BaseType;
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/RoutedEventConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/RoutedEventConverter.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
+using System.Xaml;
 using System.ComponentModel;
 using System.Globalization;
-
-using System.Windows;
 using System.Collections.Generic;
-using System.Xaml;
+using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup
 {
@@ -114,7 +112,7 @@ namespace System.Windows.Markup
                         // Force load the Statics by walking up the hierarchy and running class constructors
                         while (null != currentType)
                         {
-                            MS.Internal.WindowsBase.SecurityHelper.RunClassConstructor(currentType);
+                            RuntimeHelpers.RunClassConstructor(currentType.TypeHandle);
                             currentType = currentType.BaseType;
                         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/RoutedEventValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/RoutedEventValueSerializer.cs
@@ -6,9 +6,8 @@
 //  Contents:  Value serializer for the RoutedEvent class
 //
 
-using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup
 {
@@ -45,7 +44,7 @@ namespace System.Windows.Markup
             // Force load the Statics by walking up the hierarchy and running class constructors
             while (currentType != null && !initializedTypes.ContainsKey(currentType))
             {
-                MS.Internal.WindowsBase.SecurityHelper.RunClassConstructor(currentType);
+                RuntimeHelpers.RunClassConstructor(currentType.TypeHandle);
                 initializedTypes[currentType] = currentType;
                 currentType = currentType.BaseType;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
@@ -19,7 +19,6 @@ using System.Diagnostics;
 using System.Reflection;
 
 using MS.Utility;
-using System.Security;
 using System.Text;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;
@@ -34,6 +33,7 @@ using System.Xaml;
 using System.Xaml.Permissions;
 using System.Windows.Navigation;
 using MS.Internal.Xaml.Context;
+using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup
 {
@@ -943,7 +943,7 @@ namespace System.Windows.Markup
 
             // In some cases, the application constructor is not run prior to loading,
             // causing the loader not to recognize URIs beginning with "pack:" or "application:".
-            MS.Internal.WindowsBase.SecurityHelper.RunClassConstructor(typeof(System.Windows.Application));
+            RuntimeHelpers.RunClassConstructor(typeof(Application).TypeHandle);
 
             EventTrace.EasyTraceEvent(EventTrace.Keyword.KeywordXamlBaml | EventTrace.Keyword.KeywordPerf, EventTrace.Event.WClientParseXamlBegin, parserContext.BaseUri);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
@@ -10,28 +10,20 @@
 using System;
 using System.Xml;
 using System.IO;
+using MS.Utility;
 using System.Text;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.ComponentModel;
 using System.Collections.Specialized;
+using System.Runtime.CompilerServices;
 using System.Diagnostics;
 using System.Reflection;
-using MS.Utility;
 
 #if !PBTCOMPILER
 
-using System.Windows;
-using System.Windows.Markup;
-using System.Windows.Resources;
-using System.Windows.Threading;
-using SecurityHelper=MS.Internal.PresentationFramework.SecurityHelper;
 using MS.Internal;  // CriticalExceptions
-
-#else
-
-using System.Runtime.CompilerServices;
 
 #endif
 
@@ -2010,7 +2002,7 @@ namespace System.Windows.Markup
             // Force load the Statics by walking up the hierarchy and running class constructors
             while (null != currentType)
             {
-                MS.Internal.WindowsBase.SecurityHelper.RunClassConstructor(currentType);
+                RuntimeHelpers.RunClassConstructor(currentType.TypeHandle);
                 currentType = GetCachedBaseType(currentType);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -36,6 +36,7 @@ using MS.Internal.Interop;
 using MS.Internal.PresentationFramework;                   // SafeSecurityHelper
 using System.Windows.Baml2006;
 using System.Xaml.Permissions;
+using System.Runtime.CompilerServices;
 
 // Disable pragma warnings to enable PREsharp pragmas
 #pragma warning disable 1634, 1691
@@ -819,7 +820,7 @@ namespace System.Windows
                     Type knownTypeHelper = assembly.GetType("Microsoft.Windows.Themes.KnownTypeHelper");
                     if (knownTypeHelper != null)
                     {
-                        MS.Internal.WindowsBase.SecurityHelper.RunClassConstructor(knownTypeHelper);
+                        RuntimeHelpers.RunClassConstructor(knownTypeHelper.TypeHandle);
                     }
                 }
 #pragma warning restore 6502

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
@@ -119,15 +119,6 @@ internal static class SecurityHelper
         }
 #endif
 
-
-#if WINDOWS_BASE
-        internal static void RunClassConstructor(Type t)
-        {
-            System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(t.TypeHandle);
-        }
-
-#endif //  WINDOWS_BASE
-
 #if DRT
         /// <remarks> The LinkDemand on Marshal.SizeOf() was removed in v4. </remarks>
         internal static int SizeOf(Type t)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
@@ -2,19 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Threading;
-using System.Globalization;
-using System.ComponentModel;
-using System.Windows.Markup;// For ValueSerializerAttribute
-using System.Windows.Threading; // For DispatcherObject
 using MS.Utility;
-using MS.Internal.WindowsBase;
-using System.Reflection;   // for IsInstanceOfType
 using MS.Internal;
+using System.Threading;
+using System.Collections;
+using System.Diagnostics;
+using System.ComponentModel;
+using System.Windows.Markup;    // For ValueSerializerAttribute
+using MS.Internal.WindowsBase;
+using System.Windows.Threading; // For DispatcherObject
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 #pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
@@ -980,7 +978,7 @@ namespace System.Windows
             while (ownerType != null)
             {
                 // Ensure static constructor of type has run
-                SecurityHelper.RunClassConstructor(ownerType);
+                RuntimeHelpers.RunClassConstructor(ownerType.TypeHandle);
 
                 // Locate property
                 FromNameKey key = new(name, ownerType);


### PR DESCRIPTION
## Description

One of the few leftover remnants from CAS times is the `SecurityHelper.RunClassConstructor` the RunClassConstructor method from `RuntimeHelpers`. There is no reason for this, only makes people wonder what is "security" doing here.

Follows PRs like #9521, #9733 etc.

## Customer Impact

Better code quality of the code base.

## Regression

No.

## Testing

Local build.

## Risk

Pretty much none.
