### PR TITLE
Add test coverage for public API surface of TextDecorationCollectionConverter

### DIFF
--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/TextDecorationCollectionConverter.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/TextDecorationCollectionConverter.Tests.cs
@@ -1,0 +1,137 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.Design.Serialization;
+
+namespace System.Windows
+{
+    public class TextDecorationCollectionConverterTests
+    {
+        [Theory]
+        [MemberData(nameof(ConvertFromString_TestData))]
+        public void ConvertFromString_ReturnsExpected(TextDecorationCollection expected, string text)
+        {
+            TextDecorationCollection converted = TextDecorationCollectionConverter.ConvertFromString(text);
+
+            // Check count
+            Assert.Equal(expected.Count, converted.Count);
+
+            // We require the order to be exact as well
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], converted[i]);
+            }
+        }
+
+        [Fact]
+        public void ConvertFromString_NullValue_ReturnsNull()
+        {
+            // null is simply null (NOTE: This differs from instance method ConvertFrom, that will throw on null value)
+            TextDecorationCollection? converted = TextDecorationCollectionConverter.ConvertFromString(null);
+
+            Assert.Null(converted);
+        }
+
+        public static IEnumerable<object?[]> ConvertFromString_TestData
+        {
+            get
+            {
+                // "None" returns no items
+                yield return new object[] { new TextDecorationCollection(), string.Empty };
+                yield return new object[] { new TextDecorationCollection(), "          " };
+                yield return new object[] { new TextDecorationCollection(), "None" };
+                yield return new object[] { new TextDecorationCollection(), "      None     " };
+
+                // Order matters here
+                yield return new object[] { new TextDecorationCollection([TextDecorations.Strikethrough[0]]), "Strikethrough" };
+                yield return new object[] { new TextDecorationCollection([TextDecorations.Strikethrough[0]]), "Strikethrough           " };
+
+                yield return new object[] { new TextDecorationCollection([TextDecorations.Underline[0], TextDecorations.Baseline[0]]), "Underline, Baseline" };
+                yield return new object[] { new TextDecorationCollection([TextDecorations.Strikethrough[0], TextDecorations.Underline[0], TextDecorations.Baseline[0]]),
+                                                                         "  Strikethrough   ,Underline, Baseline " };
+
+                yield return new object[] { new TextDecorationCollection([TextDecorations.Strikethrough[0], TextDecorations.Underline[0],
+                                                                          TextDecorations.Baseline[0], TextDecorations.OverLine[0]]),
+                                                                         "  Strikethrough   ,Underline, Baseline        , Overline             " };
+
+            }
+        }
+
+        [Theory]
+        // Starts with a separator
+        [InlineData(",  Strikethrough   ,Underline, Baseline ")]
+        // Ends with a separator
+        [InlineData(" Strikethrough   ,Underline, Baseline, Overline, ")]
+        // Duplicate item (must be unique)
+        [InlineData("  Strikethrough  , Strikethrough, ,Underline, Baseline ")]
+        [InlineData(" Underline, Underline ")]
+        // None must be specified alone
+        [InlineData("None,  Strikethrough   ,Underline, Baseline ")]
+        [InlineData("None,  Strikethrough   ,Underline, Baseline, Overline ")]
+        // Invalid decoration at the end
+        [InlineData(" Strikethrough   ,Underline, Baseline, Overline, x ")]
+        // Invalid decoration
+        [InlineData(" Noneee ")]
+        public void ConvertFromString_ThrowsArgumentException(string text)
+        {
+            Assert.Throws<ArgumentException>(() => TextDecorationCollectionConverter.ConvertFromString(text));
+        }
+
+        [Theory]
+        // Only valid type
+        [InlineData(true, typeof(InstanceDescriptor))]
+        // Invalid types
+        [InlineData(false, typeof(TextDecorationCollection))]
+        [InlineData(false, typeof(IEnumerable<TextDecoration>))]
+        [InlineData(false, typeof(string))]
+        public void CanConvertTo_ReturnsExpected(bool expected, Type destinationType)
+        {
+            TextDecorationCollectionConverter converter = new();
+
+            Assert.Equal(expected, converter.CanConvertTo(destinationType));
+        }
+
+        [Theory]
+        // Only valid type
+        [InlineData(true, typeof(string))]
+        // Invalid types
+        [InlineData(false, typeof(TextDecorationCollection))]
+        [InlineData(false, typeof(IEnumerable<TextDecoration>))]
+        [InlineData(false, typeof(InstanceDescriptor))]
+        public void CanConvertFrom_ReturnsExpected(bool expected, Type sourceType)
+        {
+            TextDecorationCollectionConverter converter = new();
+
+            Assert.Equal(expected, converter.CanConvertFrom(sourceType));
+        }
+
+        [Theory]
+        [MemberData(nameof(ConvertTo_ThrowsArgumentNullException_TestData))]
+        public void ConvertTo_ThrowsArgumentNullException(object value, Type destinationType)
+        {
+            TextDecorationCollectionConverter converter = new();
+
+            Assert.Throws<ArgumentNullException>(() => converter.ConvertTo(null, null, value, destinationType));
+        }
+
+        public static IEnumerable<object?[]> ConvertTo_ThrowsArgumentNullException_TestData
+        {
+            get
+            {
+                // null value and destinationType
+                yield return new object?[] { null, null };
+                // supported value, null destinationType
+                yield return new object?[] { new TextDecorationCollection(), null };
+            }
+        }
+
+        [Fact]
+        public void ConvertTo_ThrowsNotSupportedException()
+        {
+            TextDecorationCollectionConverter converter = new();
+
+            // supported value, bad destinationType
+            Assert.Throws<NotSupportedException>(() => converter.ConvertTo(null, null, new TextDecorationCollection(), typeof(TextDecorationCollection)));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/TextDecorationCollectionConverter.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/TextDecorationCollectionConverter.Tests.cs
@@ -8,7 +8,35 @@ namespace System.Windows;
 public class TextDecorationCollectionConverterTests
 {
     [Theory]
-    [MemberData(nameof(ConvertFromString_TestData))]
+    // Only valid type
+    [InlineData(true, typeof(string))]
+    // Invalid types
+    [InlineData(false, typeof(TextDecorationCollection))]
+    [InlineData(false, typeof(IEnumerable<TextDecoration>))]
+    [InlineData(false, typeof(InstanceDescriptor))]
+    public void CanConvertFrom_ReturnsExpected(bool expected, Type sourceType)
+    {
+        TextDecorationCollectionConverter converter = new();
+
+        Assert.Equal(expected, converter.CanConvertFrom(sourceType));
+    }
+
+    [Theory]
+    // Only valid type
+    [InlineData(true, typeof(InstanceDescriptor))]
+    // Invalid types
+    [InlineData(false, typeof(TextDecorationCollection))]
+    [InlineData(false, typeof(IEnumerable<TextDecoration>))]
+    [InlineData(false, typeof(string))]
+    public void CanConvertTo_ReturnsExpected(bool expected, Type destinationType)
+    {
+        TextDecorationCollectionConverter converter = new();
+
+        Assert.Equal(expected, converter.CanConvertTo(destinationType));
+    }
+
+    [Theory]
+    [MemberData(nameof(ConvertFromString_ReturnsExpected_Data))]
     public void ConvertFromString_ReturnsExpected(TextDecorationCollection expected, string text)
     {
         TextDecorationCollection converted = TextDecorationCollectionConverter.ConvertFromString(text);
@@ -23,16 +51,7 @@ public class TextDecorationCollectionConverterTests
         }
     }
 
-    [Fact]
-    public void ConvertFromString_NullValue_ReturnsNull()
-    {
-        // null is simply null (NOTE: This differs from instance method ConvertFrom, that will throw on null value)
-        TextDecorationCollection? converted = TextDecorationCollectionConverter.ConvertFromString(null);
-
-        Assert.Null(converted);
-    }
-
-    public static IEnumerable<object?[]> ConvertFromString_TestData
+    public static IEnumerable<object?[]> ConvertFromString_ReturnsExpected_Data
     {
         get
         {
@@ -57,6 +76,15 @@ public class TextDecorationCollectionConverterTests
         }
     }
 
+    [Fact]
+    public void ConvertFromString_NullValue_ReturnsNull()
+    {
+        // null is simply null (NOTE: This differs from instance method ConvertFrom, that will throw on null value)
+        TextDecorationCollection? converted = TextDecorationCollectionConverter.ConvertFromString(null);
+
+        Assert.Null(converted);
+    }
+
     [Theory]
     // Starts with a separator
     [InlineData(",  Strikethrough   ,Underline, Baseline ")]
@@ -75,34 +103,6 @@ public class TextDecorationCollectionConverterTests
     public void ConvertFromString_ThrowsArgumentException(string text)
     {
         Assert.Throws<ArgumentException>(() => TextDecorationCollectionConverter.ConvertFromString(text));
-    }
-
-    [Theory]
-    // Only valid type
-    [InlineData(true, typeof(InstanceDescriptor))]
-    // Invalid types
-    [InlineData(false, typeof(TextDecorationCollection))]
-    [InlineData(false, typeof(IEnumerable<TextDecoration>))]
-    [InlineData(false, typeof(string))]
-    public void CanConvertTo_ReturnsExpected(bool expected, Type destinationType)
-    {
-        TextDecorationCollectionConverter converter = new();
-
-        Assert.Equal(expected, converter.CanConvertTo(destinationType));
-    }
-
-    [Theory]
-    // Only valid type
-    [InlineData(true, typeof(string))]
-    // Invalid types
-    [InlineData(false, typeof(TextDecorationCollection))]
-    [InlineData(false, typeof(IEnumerable<TextDecoration>))]
-    [InlineData(false, typeof(InstanceDescriptor))]
-    public void CanConvertFrom_ReturnsExpected(bool expected, Type sourceType)
-    {
-        TextDecorationCollectionConverter converter = new();
-
-        Assert.Equal(expected, converter.CanConvertFrom(sourceType));
     }
 
     [Theory]

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/TextDecorationCollectionConverter.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/TextDecorationCollectionConverter.Tests.cs
@@ -215,13 +215,22 @@ public class TextDecorationCollectionConverterTests
             // Single decoration
             yield return new object[] { new TextDecorationCollection(new TextDecoration[1] { TextDecorations.Underline[0] }),
                                         new TextDecorationCollection(new TextDecoration[1] { TextDecorations.Underline[0] }),
-
                                         typeof(InstanceDescriptor) };
 
             // Multiple decorations
             yield return new object[] { new TextDecorationCollection(new TextDecoration[3] { TextDecorations.Underline[0], TextDecorations.OverLine[0], TextDecorations.Baseline[0] }),
                                         new TextDecorationCollection(new TextDecoration[3] { TextDecorations.Underline[0], TextDecorations.OverLine[0], TextDecorations.Baseline[0] }),
                                         typeof(InstanceDescriptor) };
+
+            // Source value just needs to be IEnumerable<TextDecoration>
+
+            // T[]
+            yield return new object[] { new TextDecorationCollection(new TextDecoration[3] { TextDecorations.Underline[0], TextDecorations.OverLine[0], TextDecorations.Baseline[0] }),
+                                        new TextDecoration[3] { TextDecorations.Underline[0], TextDecorations.OverLine[0], TextDecorations.Baseline[0] }, typeof(InstanceDescriptor) };
+
+            // List<T>
+            yield return new object[] { new TextDecorationCollection(new TextDecoration[3] { TextDecorations.Underline[0], TextDecorations.OverLine[0], TextDecorations.Baseline[0] }),
+                                        new List<TextDecoration> { TextDecorations.Underline[0], TextDecorations.OverLine[0], TextDecorations.Baseline[0] }, typeof(InstanceDescriptor) };
         }
     }
 

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/TextDecorationCollectionConverter.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/TextDecorationCollectionConverter.Tests.cs
@@ -3,135 +3,134 @@
 
 using System.ComponentModel.Design.Serialization;
 
-namespace System.Windows
+namespace System.Windows;
+
+public class TextDecorationCollectionConverterTests
 {
-    public class TextDecorationCollectionConverterTests
+    [Theory]
+    [MemberData(nameof(ConvertFromString_TestData))]
+    public void ConvertFromString_ReturnsExpected(TextDecorationCollection expected, string text)
     {
-        [Theory]
-        [MemberData(nameof(ConvertFromString_TestData))]
-        public void ConvertFromString_ReturnsExpected(TextDecorationCollection expected, string text)
+        TextDecorationCollection converted = TextDecorationCollectionConverter.ConvertFromString(text);
+
+        // Check count
+        Assert.Equal(expected.Count, converted.Count);
+
+        // We require the order to be exact as well
+        for (int i = 0; i < expected.Count; i++)
         {
-            TextDecorationCollection converted = TextDecorationCollectionConverter.ConvertFromString(text);
-
-            // Check count
-            Assert.Equal(expected.Count, converted.Count);
-
-            // We require the order to be exact as well
-            for (int i = 0; i < expected.Count; i++)
-            {
-                Assert.Equal(expected[i], converted[i]);
-            }
+            Assert.Equal(expected[i], converted[i]);
         }
+    }
 
-        [Fact]
-        public void ConvertFromString_NullValue_ReturnsNull()
+    [Fact]
+    public void ConvertFromString_NullValue_ReturnsNull()
+    {
+        // null is simply null (NOTE: This differs from instance method ConvertFrom, that will throw on null value)
+        TextDecorationCollection? converted = TextDecorationCollectionConverter.ConvertFromString(null);
+
+        Assert.Null(converted);
+    }
+
+    public static IEnumerable<object?[]> ConvertFromString_TestData
+    {
+        get
         {
-            // null is simply null (NOTE: This differs from instance method ConvertFrom, that will throw on null value)
-            TextDecorationCollection? converted = TextDecorationCollectionConverter.ConvertFromString(null);
+            // "None" returns no items
+            yield return new object[] { new TextDecorationCollection(), string.Empty };
+            yield return new object[] { new TextDecorationCollection(), "          " };
+            yield return new object[] { new TextDecorationCollection(), "None" };
+            yield return new object[] { new TextDecorationCollection(), "      None     " };
 
-            Assert.Null(converted);
+            // Order matters here
+            yield return new object[] { new TextDecorationCollection([TextDecorations.Strikethrough[0]]), "Strikethrough" };
+            yield return new object[] { new TextDecorationCollection([TextDecorations.Strikethrough[0]]), "Strikethrough           " };
+
+            yield return new object[] { new TextDecorationCollection([TextDecorations.Underline[0], TextDecorations.Baseline[0]]), "Underline, Baseline" };
+            yield return new object[] { new TextDecorationCollection([TextDecorations.Strikethrough[0], TextDecorations.Underline[0], TextDecorations.Baseline[0]]),
+                                                                     "  Strikethrough   ,Underline, Baseline " };
+
+            yield return new object[] { new TextDecorationCollection([TextDecorations.Strikethrough[0], TextDecorations.Underline[0],
+                                                                      TextDecorations.Baseline[0], TextDecorations.OverLine[0]]),
+                                                                     "  Strikethrough   ,Underline, Baseline        , Overline             " };
+
         }
+    }
 
-        public static IEnumerable<object?[]> ConvertFromString_TestData
+    [Theory]
+    // Starts with a separator
+    [InlineData(",  Strikethrough   ,Underline, Baseline ")]
+    // Ends with a separator
+    [InlineData(" Strikethrough   ,Underline, Baseline, Overline, ")]
+    // Duplicate item (must be unique)
+    [InlineData("  Strikethrough  , Strikethrough, ,Underline, Baseline ")]
+    [InlineData(" Underline, Underline ")]
+    // None must be specified alone
+    [InlineData("None,  Strikethrough   ,Underline, Baseline ")]
+    [InlineData("None,  Strikethrough   ,Underline, Baseline, Overline ")]
+    // Invalid decoration at the end
+    [InlineData(" Strikethrough   ,Underline, Baseline, Overline, x ")]
+    // Invalid decoration
+    [InlineData(" Noneee ")]
+    public void ConvertFromString_ThrowsArgumentException(string text)
+    {
+        Assert.Throws<ArgumentException>(() => TextDecorationCollectionConverter.ConvertFromString(text));
+    }
+
+    [Theory]
+    // Only valid type
+    [InlineData(true, typeof(InstanceDescriptor))]
+    // Invalid types
+    [InlineData(false, typeof(TextDecorationCollection))]
+    [InlineData(false, typeof(IEnumerable<TextDecoration>))]
+    [InlineData(false, typeof(string))]
+    public void CanConvertTo_ReturnsExpected(bool expected, Type destinationType)
+    {
+        TextDecorationCollectionConverter converter = new();
+
+        Assert.Equal(expected, converter.CanConvertTo(destinationType));
+    }
+
+    [Theory]
+    // Only valid type
+    [InlineData(true, typeof(string))]
+    // Invalid types
+    [InlineData(false, typeof(TextDecorationCollection))]
+    [InlineData(false, typeof(IEnumerable<TextDecoration>))]
+    [InlineData(false, typeof(InstanceDescriptor))]
+    public void CanConvertFrom_ReturnsExpected(bool expected, Type sourceType)
+    {
+        TextDecorationCollectionConverter converter = new();
+
+        Assert.Equal(expected, converter.CanConvertFrom(sourceType));
+    }
+
+    [Theory]
+    [MemberData(nameof(ConvertTo_ThrowsArgumentNullException_TestData))]
+    public void ConvertTo_ThrowsArgumentNullException(object value, Type destinationType)
+    {
+        TextDecorationCollectionConverter converter = new();
+
+        Assert.Throws<ArgumentNullException>(() => converter.ConvertTo(null, null, value, destinationType));
+    }
+
+    public static IEnumerable<object?[]> ConvertTo_ThrowsArgumentNullException_TestData
+    {
+        get
         {
-            get
-            {
-                // "None" returns no items
-                yield return new object[] { new TextDecorationCollection(), string.Empty };
-                yield return new object[] { new TextDecorationCollection(), "          " };
-                yield return new object[] { new TextDecorationCollection(), "None" };
-                yield return new object[] { new TextDecorationCollection(), "      None     " };
-
-                // Order matters here
-                yield return new object[] { new TextDecorationCollection([TextDecorations.Strikethrough[0]]), "Strikethrough" };
-                yield return new object[] { new TextDecorationCollection([TextDecorations.Strikethrough[0]]), "Strikethrough           " };
-
-                yield return new object[] { new TextDecorationCollection([TextDecorations.Underline[0], TextDecorations.Baseline[0]]), "Underline, Baseline" };
-                yield return new object[] { new TextDecorationCollection([TextDecorations.Strikethrough[0], TextDecorations.Underline[0], TextDecorations.Baseline[0]]),
-                                                                         "  Strikethrough   ,Underline, Baseline " };
-
-                yield return new object[] { new TextDecorationCollection([TextDecorations.Strikethrough[0], TextDecorations.Underline[0],
-                                                                          TextDecorations.Baseline[0], TextDecorations.OverLine[0]]),
-                                                                         "  Strikethrough   ,Underline, Baseline        , Overline             " };
-
-            }
+            // null value and destinationType
+            yield return new object?[] { null, null };
+            // supported value, null destinationType
+            yield return new object?[] { new TextDecorationCollection(), null };
         }
+    }
 
-        [Theory]
-        // Starts with a separator
-        [InlineData(",  Strikethrough   ,Underline, Baseline ")]
-        // Ends with a separator
-        [InlineData(" Strikethrough   ,Underline, Baseline, Overline, ")]
-        // Duplicate item (must be unique)
-        [InlineData("  Strikethrough  , Strikethrough, ,Underline, Baseline ")]
-        [InlineData(" Underline, Underline ")]
-        // None must be specified alone
-        [InlineData("None,  Strikethrough   ,Underline, Baseline ")]
-        [InlineData("None,  Strikethrough   ,Underline, Baseline, Overline ")]
-        // Invalid decoration at the end
-        [InlineData(" Strikethrough   ,Underline, Baseline, Overline, x ")]
-        // Invalid decoration
-        [InlineData(" Noneee ")]
-        public void ConvertFromString_ThrowsArgumentException(string text)
-        {
-            Assert.Throws<ArgumentException>(() => TextDecorationCollectionConverter.ConvertFromString(text));
-        }
+    [Fact]
+    public void ConvertTo_ThrowsNotSupportedException()
+    {
+        TextDecorationCollectionConverter converter = new();
 
-        [Theory]
-        // Only valid type
-        [InlineData(true, typeof(InstanceDescriptor))]
-        // Invalid types
-        [InlineData(false, typeof(TextDecorationCollection))]
-        [InlineData(false, typeof(IEnumerable<TextDecoration>))]
-        [InlineData(false, typeof(string))]
-        public void CanConvertTo_ReturnsExpected(bool expected, Type destinationType)
-        {
-            TextDecorationCollectionConverter converter = new();
-
-            Assert.Equal(expected, converter.CanConvertTo(destinationType));
-        }
-
-        [Theory]
-        // Only valid type
-        [InlineData(true, typeof(string))]
-        // Invalid types
-        [InlineData(false, typeof(TextDecorationCollection))]
-        [InlineData(false, typeof(IEnumerable<TextDecoration>))]
-        [InlineData(false, typeof(InstanceDescriptor))]
-        public void CanConvertFrom_ReturnsExpected(bool expected, Type sourceType)
-        {
-            TextDecorationCollectionConverter converter = new();
-
-            Assert.Equal(expected, converter.CanConvertFrom(sourceType));
-        }
-
-        [Theory]
-        [MemberData(nameof(ConvertTo_ThrowsArgumentNullException_TestData))]
-        public void ConvertTo_ThrowsArgumentNullException(object value, Type destinationType)
-        {
-            TextDecorationCollectionConverter converter = new();
-
-            Assert.Throws<ArgumentNullException>(() => converter.ConvertTo(null, null, value, destinationType));
-        }
-
-        public static IEnumerable<object?[]> ConvertTo_ThrowsArgumentNullException_TestData
-        {
-            get
-            {
-                // null value and destinationType
-                yield return new object?[] { null, null };
-                // supported value, null destinationType
-                yield return new object?[] { new TextDecorationCollection(), null };
-            }
-        }
-
-        [Fact]
-        public void ConvertTo_ThrowsNotSupportedException()
-        {
-            TextDecorationCollectionConverter converter = new();
-
-            // supported value, bad destinationType
-            Assert.Throws<NotSupportedException>(() => converter.ConvertTo(null, null, new TextDecorationCollection(), typeof(TextDecorationCollection)));
-        }
+        // supported value, bad destinationType
+        Assert.Throws<NotSupportedException>(() => converter.ConvertTo(null, null, new TextDecorationCollection(), typeof(TextDecorationCollection)));
     }
 }


### PR DESCRIPTION
## Description

Adds test coverage for `TextDecorationCollectionConverter`. Both the original and my PR #9778 have been tested against this.

- Again, this class is rather inconsistent with others.
    - Static `ConvertFromString` will return `null` on `null` but instance method will throw with `NotSupportedException`
    - While `ConvertTo` claims it only supports `InstanceDescriptor` as `destinationType`, it calls into base which will gladly accept `string` and based on the value type it will either return `string.Empty` (if value was null), or it returns the type name using `ToString`.
- I did not even include those edge cases because they should be rather fixed imho for more consistent behavior.

## Customer Impact

Improved test coverage on public surface.

## Regression

No.

## Testing

Local build.

## Risk

Low.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9895)