### PR TITLE
[release/9.0] Removing invalid Fluent DataGridColumn styles

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DataGrid.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DataGrid.xaml
@@ -59,8 +59,6 @@
 
     <!--  END REMOVE COLORS  -->
 
-    <Style x:Key="DefaultDataGridCheckBoxColumnCellStyle" TargetType="{x:Type DataGridColumn}" />
-
     <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="Template">
@@ -502,9 +500,6 @@
             </Trigger>
         </Style.Triggers>
     </Style>
-    <Style TargetType="{x:Type DataGridTextColumn}">
-        <Setter Property="EditingElementStyle" Value="{StaticResource TextBoxStyle}" />
-    </Style>
 
     <!--  Style and template for the DataGrid.  -->
     <Style x:Key="DefaultDataGridStyle" TargetType="{x:Type DataGrid}">
@@ -785,11 +780,6 @@
         BasedOn="{StaticResource DataGridCheckBoxElementDefaultStyle}"
         TargetType="{x:Type CheckBox}">
         <Setter Property="SnapsToDevicePixels" Value="True" />
-    </Style>
-
-    <Style TargetType="{x:Type DataGridCheckBoxColumn}">
-        <Setter Property="ElementStyle" Value="{StaticResource DataGridCheckBoxElementDefaultStyle}" />
-        <Setter Property="EditingElementStyle" Value="{StaticResource DataGridCheckBoxEditingElementDefaultStyle}" />
     </Style>
 
     <Style BasedOn="{StaticResource DefaultDataGridColumnHeadersPresenterStyle}" TargetType="{x:Type DataGridColumnHeadersPresenter}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -1572,7 +1572,6 @@
     </LinearGradientBrush.GradientStops>
   </LinearGradientBrush>
   <!--  END REMOVE COLORS  -->
-  <Style x:Key="DefaultDataGridCheckBoxColumnCellStyle" TargetType="{x:Type DataGridColumn}" />
   <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
@@ -1901,9 +1900,6 @@
       </Trigger>
     </Style.Triggers>
   </Style>
-  <Style TargetType="{x:Type DataGridTextColumn}">
-    <Setter Property="EditingElementStyle" Value="{StaticResource TextBoxStyle}" />
-  </Style>
   <!--  Style and template for the DataGrid.  -->
   <Style x:Key="DefaultDataGridStyle" TargetType="{x:Type DataGrid}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -2106,10 +2102,6 @@
   </Style>
   <Style x:Key="DataGridCheckBoxEditingElementDefaultStyle" BasedOn="{StaticResource DataGridCheckBoxElementDefaultStyle}" TargetType="{x:Type CheckBox}">
     <Setter Property="SnapsToDevicePixels" Value="True" />
-  </Style>
-  <Style TargetType="{x:Type DataGridCheckBoxColumn}">
-    <Setter Property="ElementStyle" Value="{StaticResource DataGridCheckBoxElementDefaultStyle}" />
-    <Setter Property="EditingElementStyle" Value="{StaticResource DataGridCheckBoxEditingElementDefaultStyle}" />
   </Style>
   <Style BasedOn="{StaticResource DefaultDataGridColumnHeadersPresenterStyle}" TargetType="{x:Type DataGridColumnHeadersPresenter}" />
   <Style BasedOn="{StaticResource DefaultDataGridStyle}" TargetType="{x:Type DataGrid}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -1550,7 +1550,6 @@
     </LinearGradientBrush.GradientStops>
   </LinearGradientBrush>
   <!--  END REMOVE COLORS  -->
-  <Style x:Key="DefaultDataGridCheckBoxColumnCellStyle" TargetType="{x:Type DataGridColumn}" />
   <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
@@ -1879,9 +1878,6 @@
       </Trigger>
     </Style.Triggers>
   </Style>
-  <Style TargetType="{x:Type DataGridTextColumn}">
-    <Setter Property="EditingElementStyle" Value="{StaticResource TextBoxStyle}" />
-  </Style>
   <!--  Style and template for the DataGrid.  -->
   <Style x:Key="DefaultDataGridStyle" TargetType="{x:Type DataGrid}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -2084,10 +2080,6 @@
   </Style>
   <Style x:Key="DataGridCheckBoxEditingElementDefaultStyle" BasedOn="{StaticResource DataGridCheckBoxElementDefaultStyle}" TargetType="{x:Type CheckBox}">
     <Setter Property="SnapsToDevicePixels" Value="True" />
-  </Style>
-  <Style TargetType="{x:Type DataGridCheckBoxColumn}">
-    <Setter Property="ElementStyle" Value="{StaticResource DataGridCheckBoxElementDefaultStyle}" />
-    <Setter Property="EditingElementStyle" Value="{StaticResource DataGridCheckBoxEditingElementDefaultStyle}" />
   </Style>
   <Style BasedOn="{StaticResource DefaultDataGridColumnHeadersPresenterStyle}" TargetType="{x:Type DataGridColumnHeadersPresenter}" />
   <Style BasedOn="{StaticResource DefaultDataGridStyle}" TargetType="{x:Type DataGrid}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -1570,7 +1570,6 @@
     </LinearGradientBrush.GradientStops>
   </LinearGradientBrush>
   <!--  END REMOVE COLORS  -->
-  <Style x:Key="DefaultDataGridCheckBoxColumnCellStyle" TargetType="{x:Type DataGridColumn}" />
   <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
@@ -1899,9 +1898,6 @@
       </Trigger>
     </Style.Triggers>
   </Style>
-  <Style TargetType="{x:Type DataGridTextColumn}">
-    <Setter Property="EditingElementStyle" Value="{StaticResource TextBoxStyle}" />
-  </Style>
   <!--  Style and template for the DataGrid.  -->
   <Style x:Key="DefaultDataGridStyle" TargetType="{x:Type DataGrid}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -2104,10 +2100,6 @@
   </Style>
   <Style x:Key="DataGridCheckBoxEditingElementDefaultStyle" BasedOn="{StaticResource DataGridCheckBoxElementDefaultStyle}" TargetType="{x:Type CheckBox}">
     <Setter Property="SnapsToDevicePixels" Value="True" />
-  </Style>
-  <Style TargetType="{x:Type DataGridCheckBoxColumn}">
-    <Setter Property="ElementStyle" Value="{StaticResource DataGridCheckBoxElementDefaultStyle}" />
-    <Setter Property="EditingElementStyle" Value="{StaticResource DataGridCheckBoxEditingElementDefaultStyle}" />
   </Style>
   <Style BasedOn="{StaticResource DefaultDataGridColumnHeadersPresenterStyle}" TargetType="{x:Type DataGridColumnHeadersPresenter}" />
   <Style BasedOn="{StaticResource DefaultDataGridStyle}" TargetType="{x:Type DataGrid}" />


### PR DESCRIPTION
Fixes # <!-- Issue Number --> #9755 

Main PR <!-- Link to PR if any that fixed this in the main branch. --> #9757 

## Description
Removes the invalid Fluent DataGridColumn styles, which can cause the application to crash when they are accessed explicitly.

## Customer Impact
Developers trying to iterate through the Fluent theme ResourceDictionary will not face crash in their applications. Will allow easier migration to use the Fluent styles.

## Regression
Not really, as this is part of the new Fluent styles being introduced in .NET 9. However, anyone who tries to use the new styles may face the following issues.

## Testing
Local build, reproduction app and WPF Gallery application.
<!-- What kind of testing has been done with the fix. -->

## Risk
Minimal, no one is using the above styles currently ( except for .NET 9 preview and rc releases )
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9896)