### PR TITLE
Redefine GridLength as readonly struct to prevent defensive copies

### DIFF
--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
@@ -834,9 +834,8 @@ namespace System.Windows
         protected virtual void ValidateTemplatedParent(System.Windows.FrameworkElement templatedParent) { }
     }
     [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.GridLengthConverter))]
-    public partial struct GridLength : System.IEquatable<System.Windows.GridLength>
+    public readonly partial struct GridLength : System.IEquatable<System.Windows.GridLength>
     {
-        private int _dummyPrimitive;
         public GridLength(double pixels) { throw null; }
         public GridLength(double value, System.Windows.GridUnitType type) { throw null; }
         public static System.Windows.GridLength Auto { get { throw null; } }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/GridLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/GridLength.cs
@@ -45,15 +45,16 @@ namespace System.Windows
     /// properties of ColumnDefinition and RowDefinition used by Grid.
     /// </summary>
     [TypeConverter(typeof(GridLengthConverter))]
-    public struct GridLength : IEquatable<GridLength>
+    public readonly struct GridLength : IEquatable<GridLength>
     {
-        //------------------------------------------------------
-        //
-        //  Constructors
-        //
-        //------------------------------------------------------
-
-        #region Constructors
+        /// <summary>
+        /// Represents the <see cref="Value"/> of this instance; 1.0 if <see cref="Windows.GridUnitType"/> is <see cref="GridUnitType.Auto"/>.
+        /// </summary>
+        private readonly double _unitValue;
+        /// <summary>
+        /// Represents the <see cref="GridUnitType"/> of this instance.
+        /// </summary>
+        private readonly GridUnitType _unitType;
 
         /// <summary>
         /// Constructor, initializes the GridLength as absolute value in pixels.
@@ -107,8 +108,6 @@ namespace System.Windows
             _unitValue = (type == GridUnitType.Auto) ? 0.0 : value;
             _unitType = type;
         }
-
-        #endregion Constructors
 
         //------------------------------------------------------
         //
@@ -238,8 +237,6 @@ namespace System.Windows
         //------------------------------------------------------
 
         #region Private Fields 
-        private double _unitValue;      //  unit value storage
-        private GridUnitType _unitType; //  unit type storage
         
         //  static instance of Auto GridLength
         private static readonly GridLength s_auto = new GridLength(1.0, GridUnitType.Auto);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/GridLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/GridLength.cs
@@ -11,7 +11,7 @@
 //
 //
 
-using MS.Internal;
+using System.Windows.Controls;
 using System.ComponentModel;
 using System.Globalization;
 
@@ -40,9 +40,9 @@ namespace System.Windows
     }
 
     /// <summary>
-    /// GridLength is the type used for various length-like properties in the system, 
-    /// that explicitely support Star unit type. For example, "Width", "Height" 
-    /// properties of ColumnDefinition and RowDefinition used by Grid.
+    /// <see cref="GridLength"/> is the type used for various length-like properties in the system, 
+    /// that explicitly support <see cref="GridUnitType.Star"/> unit type. For example, "Width", "Height" 
+    /// properties of <see cref="ColumnDefinition"/> and <see cref="RowDefinition"/> used by <see cref="Grid"/>.
     /// </summary>
     [TypeConverter(typeof(GridLengthConverter))]
     public readonly struct GridLength : IEquatable<GridLength>
@@ -57,7 +57,7 @@ namespace System.Windows
         private readonly GridUnitType _unitType;
 
         /// <summary>
-        /// Constructor, initializes the GridLength as absolute value in pixels.
+        /// Constructor, initializes the <see cref="GridLength"/> as absolute value in pixels.
         /// </summary>
         /// <param name="pixels">Specifies the number of 'device-independent pixels' 
         /// (96 pixels-per-inch).</param>
@@ -69,16 +69,13 @@ namespace System.Windows
         public GridLength(double pixels) : this(pixels, GridUnitType.Pixel) { }
 
         /// <summary>
-        /// Constructor, initializes the GridLength and specifies what kind of value 
-        /// it will hold.
+        /// Constructor, initializes the <see cref="GridLength"/> and specifies what kind of value it will hold.
         /// </summary>
-        /// <param name="value">Value to be stored by this GridLength 
-        /// instance.</param>
-        /// <param name="type">Type of the value to be stored by this GridLength 
-        /// instance.</param>
+        /// <param name="value">Value to be stored by this <see cref="GridLength"/> instance.</param>
+        /// <param name="type">Type of the value to be stored by this <see cref="GridLength"/> instance.</param>
         /// <remarks> 
-        /// If the <c>type</c> parameter is <c>GridUnitType.Auto</c>, 
-        /// then passed in value is ignored and replaced with <c>0</c>.
+        /// If the <paramref name="type"/> parameter is <see cref="GridUnitType.Auto"/>, 
+        /// then passed in <paramref name="value"/> is ignored and replaced with 1.0.
         /// </remarks>
         /// <exception cref="ArgumentException">
         /// If <c>value</c> parameter is <c>double.NaN</c>
@@ -104,137 +101,107 @@ namespace System.Windows
             _unitType = type;
         }
 
-        //------------------------------------------------------
-        //
-        //  Public Methods
-        //
-        //------------------------------------------------------
-
-        #region Public Methods 
-
         /// <summary>
-        /// Overloaded operator, compares 2 GridLength's.
+        /// Compares two <see cref="GridLength"/> structures for equality.
         /// </summary>
-        /// <param name="gl1">first GridLength to compare.</param>
-        /// <param name="gl2">second GridLength to compare.</param>
-        /// <returns>true if specified GridLengths have same value 
-        /// and unit type.</returns>
-        public static bool operator == (GridLength gl1, GridLength gl2)
+        /// <param name="gl1">The first <see cref="GridLength"/> to compare.</param>
+        /// <param name="gl2">The second <see cref="GridLength"/> to compare.</param>
+        /// <returns><see langword="true"/> if specified <see cref="GridLength"/>s have the same
+        /// <see cref="Value"/> and <see cref="GridUnitType"/> values.</returns>
+        public static bool operator ==(GridLength gl1, GridLength gl2)
         {
-            return (    gl1.GridUnitType == gl2.GridUnitType 
-                    &&  gl1.Value == gl2.Value  );
+            return gl1.GridUnitType == gl2.GridUnitType && gl1.Value == gl2.Value;
         }
 
         /// <summary>
-        /// Overloaded operator, compares 2 GridLength's.
+        /// Compares two<see cref="GridLength"/> structures for inequality.
         /// </summary>
-        /// <param name="gl1">first GridLength to compare.</param>
-        /// <param name="gl2">second GridLength to compare.</param>
-        /// <returns>true if specified GridLengths have either different value or 
-        /// unit type.</returns>
-        public static bool operator != (GridLength gl1, GridLength gl2)
+        /// <param name="gl1">The first <see cref="GridLength"/> to compare.</param>
+        /// <param name="gl2">The second <see cref="GridLength"/> to compare.</param>
+        /// <returns><see langword="true"/> if specified <see cref="GridLength"/>s differ
+        /// in either <see cref="Value"/> or <see cref="GridUnitType"/>.</returns>
+        public static bool operator !=(GridLength gl1, GridLength gl2)
         {
-            return (    gl1.GridUnitType != gl2.GridUnitType 
-                    ||  gl1.Value != gl2.Value  );
+            return !(gl1 == gl2);
         }
 
         /// <summary>
-        /// Compares this instance of GridLength with another object.
+        /// Compares this instance of <see cref="GridLength"/> with another object.
         /// </summary>
         /// <param name="oCompare">Reference to an object for comparison.</param>
-        /// <returns><c>true</c>if this GridLength instance has the same value 
-        /// and unit type as oCompare.</returns>
+        /// <returns><see langword="true"/> if this <see cref="GridLength"/> instance has the same value
+        /// and unit type as <paramref name="oCompare"/>, <see langword="false"/> otherwise.</returns>
         public override bool Equals(object oCompare)
         {
             return oCompare is GridLength gridLength && Equals(gridLength);
         }
 
         /// <summary>
-        /// Compares this instance of GridLength with another instance.
+        /// Compares this instance of <see cref="GridLength"/> with another <see cref="GridLength"/> instance.
         /// </summary>
-        /// <param name="gridLength">Grid length instance to compare.</param>
-        /// <returns><c>true</c>if this GridLength instance has the same value 
-        /// and unit type as gridLength.</returns>
+        /// <param name="gridLength">The <see cref="GridLength"/> instance to compare.</param>
+        /// <returns><see langword="true"/> if this <see cref="GridLength"/> instance has the same value 
+        /// and unit type as <paramref name="gridLength"/>, <see langword="false"/> otherwise.</returns>
         public bool Equals(GridLength gridLength)
         {
-            return (this == gridLength);
+            return this == gridLength;
         }
 
         /// <summary>
-        /// <see cref="Object.GetHashCode"/>
+        /// Returns the hash code for this <see cref="GridLength"/>.
         /// </summary>
-        /// <returns><see cref="Object.GetHashCode"/></returns>
+        /// <returns>The hash code for this <see cref="GridLength"/> structure.</returns>
         public override int GetHashCode()
         {
-            return ((int)_unitValue + (int)_unitType);
+            return (int)_unitValue + (int)_unitType;
         }
 
         /// <summary>
-        /// Returns <c>true</c> if this GridLength instance holds 
-        /// an absolute (pixel) value.
+        /// Returns <see langword="true"/> if this <see cref="GridLength"/> instance holds an absolute (pixel) value.
         /// </summary>
-        public bool IsAbsolute { get { return (_unitType == GridUnitType.Pixel); } }
+        public bool IsAbsolute { get { return _unitType == GridUnitType.Pixel; } }
 
         /// <summary>
-        /// Returns <c>true</c> if this GridLength instance is 
-        /// automatic (not specified).
+        /// Returns <see langword="true"/> if this <see cref="GridLength"/> instance is automatic (not specified).
         /// </summary>
-        public bool IsAuto { get { return (_unitType == GridUnitType.Auto); } }
+        public bool IsAuto { get { return _unitType == GridUnitType.Auto; } }
 
         /// <summary>
-        /// Returns <c>true</c> if this GridLength instance holds weighted propertion 
-        /// of available space.
+        /// Returns <see langword="true"/> if this <see cref="GridLength"/> instance holds weighted propertion of available space.
         /// </summary>
-        public bool IsStar { get { return (_unitType == GridUnitType.Star); } }
+        public bool IsStar { get { return _unitType == GridUnitType.Star; } }
 
         /// <summary>
-        /// Returns value part of this GridLength instance.
+        /// Returns value part of this <see cref="GridLength"/> instance.
         /// </summary>
-        public double Value { get { return (_unitValue); } }
+        public double Value { get { return _unitValue; } }
 
         /// <summary>
-        /// Returns unit type of this GridLength instance.
+        /// Returns unit type of this <see cref="GridLength"/> instance.
         /// </summary>
-        public GridUnitType GridUnitType { get { return (_unitType); } }
+        public GridUnitType GridUnitType { get { return _unitType; } }
 
         /// <summary>
-        /// Returns the string representation of this object.
+        /// Returns the <see cref="string"/> representation of this <see cref="GridLength"/>.
         /// </summary>
+        /// <returns>A <see cref="string"/> representation of this <see cref="GridLength"/>.</returns>
         public override string ToString()
         {
             return GridLengthConverter.ToString(this, CultureInfo.InvariantCulture);
         }
-        
-        #endregion Public Methods 
-
-        //------------------------------------------------------
-        //
-        //  Public Properties
-        //
-        //------------------------------------------------------
-
-        #region Public Properties
 
         /// <summary>
-        /// Returns initialized Auto GridLength value.
+        /// Returns initialized instace of <see cref="GridLength"/> with <see cref="GridUnitType.Auto"/> value.
         /// </summary>
         public static GridLength Auto
         {
-            get { return (s_auto); }
+            get { return s_auto; }
         }
 
-        #endregion Public Properties
+        /// <summary>
+        /// Pre-initialized instance, used by <see cref="Auto"/> property.
+        /// </summary>
+        private static readonly GridLength s_auto = new(1.0, GridUnitType.Auto);
 
-        //------------------------------------------------------
-        //
-        //  Private Fields
-        //
-        //------------------------------------------------------
-
-        #region Private Fields 
-        
-        //  static instance of Auto GridLength
-        private static readonly GridLength s_auto = new GridLength(1.0, GridUnitType.Auto);
-        #endregion Private Fields 
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/GridLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/GridLength.cs
@@ -66,10 +66,7 @@ namespace System.Windows
         /// or <c>pixels</c> parameter is <c>double.NegativeInfinity</c>
         /// or <c>pixels</c> parameter is <c>double.PositiveInfinity</c>.
         /// </exception>
-        public GridLength(double pixels)
-            : this(pixels, GridUnitType.Pixel)
-        {
-        }
+        public GridLength(double pixels) : this(pixels, GridUnitType.Pixel) { }
 
         /// <summary>
         /// Constructor, initializes the GridLength and specifies what kind of value 
@@ -90,22 +87,20 @@ namespace System.Windows
         /// </exception>
         public GridLength(double value, GridUnitType type)
         {
+            // Check value
             if (double.IsNaN(value))
-            {
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, "value"));
-            }
-            if (double.IsInfinity(value))
-            {
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoInfinity, "value"));
-            }
-            if (    type != GridUnitType.Auto
-                &&  type != GridUnitType.Pixel
-                &&  type != GridUnitType.Star   )
-            {
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterUnknownGridUnitType, "type"));
-            }
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, nameof(value)));
+            else if (double.IsInfinity(value))
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoInfinity, nameof(value)));
 
-            _unitValue = (type == GridUnitType.Auto) ? 0.0 : value;
+            // Check unitType
+            if (type is GridUnitType.Pixel or GridUnitType.Star)
+                _unitValue = value;
+            else if (type is GridUnitType.Auto)
+                _unitValue = 1.0; // Value is ignored in case of "Auto" and defaulted to "1.0"
+            else
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterUnknownGridUnitType, nameof(type)));
+
             _unitType = type;
         }
 
@@ -195,7 +190,7 @@ namespace System.Windows
         /// <summary>
         /// Returns value part of this GridLength instance.
         /// </summary>
-        public double Value { get { return ((_unitType == GridUnitType.Auto) ? 1.0 : _unitValue); } }
+        public double Value { get { return (_unitValue); } }
 
         /// <summary>
         /// Returns unit type of this GridLength instance.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/GridLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/GridLength.cs
@@ -150,15 +150,9 @@ namespace System.Windows
         /// <param name="oCompare">Reference to an object for comparison.</param>
         /// <returns><c>true</c>if this GridLength instance has the same value 
         /// and unit type as oCompare.</returns>
-        override public bool Equals(object oCompare)
+        public override bool Equals(object oCompare)
         {
-            if(oCompare is GridLength)
-            {
-                GridLength l = (GridLength)oCompare;
-                return (this == l);
-            }
-            else
-                return false;
+            return oCompare is GridLength gridLength && Equals(gridLength);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -835,7 +835,7 @@ namespace System.Windows
         protected virtual void ValidateTemplatedParent(System.Windows.FrameworkElement templatedParent) { }
     }
     [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.GridLengthConverter))]
-    public partial struct GridLength : System.IEquatable<System.Windows.GridLength>
+    public readonly partial struct GridLength : System.IEquatable<System.Windows.GridLength>
     {
         public GridLength(double pixels) { throw null; }
         public GridLength(double value, System.Windows.GridUnitType type) { throw null; }


### PR DESCRIPTION
## Description

Since `GridLength` is immutable by design, we should adjust it to `readonly struct`. This will also prevent defensive copies. It will also improve code quality. **This is not a breaking change**.

- I've also simplified the ctor a bit, which will also offer a very minor performance benefit (it does not matter).
- Minor cleanup of the usual `IEquatable` functions to save precious code lines and simplify it.
- The value was being set to `0.0` in case of `Auto` but when queried, it is set to `1.0`.
     - I couldn't see a reason for it, the only thing that made sense was the hash code creation but the hash code is not unique even for basic values. It is too easy to get duplicates. This should be fixed later, I'll create a tracking issue.
     - See #9887 for a small conversation regarding this with miloush.

## Customer Impact

Possibly a bit of perf and a clear directive that `GridLength` and all its methods are not adjusting the state of the `struct`.

## Regression

No.

## Testing

Local build, base testing, type creation, etc.

## Risk

I do not asses any, since the struct is immutable and this is not a breaking change. It is a change to a public type but such changes have been done previously in runtime, see for example [#97421](https://github.com/dotnet/runtime/pull/97421).