### PR TITLE
Avoid calling soon-to-be-removed string.Trim(ReadOnlySpan<char>) methods

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
@@ -35,7 +35,7 @@ namespace System.Xaml.MS.Impl
         public const string DefaultPrefix = "p";
 
         public const string ReferenceName = "__ReferenceID";
-        public static ReadOnlySpan<char> WhitespaceChars => [' ', '\t', '\n', '\r', '\f'];
+        public static readonly char[] WhitespaceChars = [' ', '\t', '\n', '\r', '\f'];
         public const char SpaceChar = ' ';
         public const char TabChar = '\t';
         public const char NewlineChar = '\n';

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
@@ -287,9 +287,9 @@ namespace MS.Internal
                 {   
                     foreach (string paramterKey in _parameterDictionary.Keys)
                     {
-                        stringBuilder.Append(LinearWhiteSpaceChars[0]);
+                        stringBuilder.Append(_linearWhiteSpaceChars[0]);
                         stringBuilder.Append(_semicolonSeparator);
-                        stringBuilder.Append(LinearWhiteSpaceChars[0]);
+                        stringBuilder.Append(_linearWhiteSpaceChars[0]);
                         stringBuilder.Append(paramterKey);
                         stringBuilder.Append(_equalSeparator);
                         stringBuilder.Append(_parameterDictionary[paramterKey]);
@@ -399,13 +399,13 @@ namespace MS.Internal
             //character of the content type are not Linear White Spaces. So its safe to
             //assume that the index will be greater than 0 and less that length-2.
 
-            int index = contentType.IndexOf(LinearWhiteSpaceChars[2]);
+            int index = contentType.IndexOf(_linearWhiteSpaceChars[2]);
             
             while (index != -1)
             {
-                if (contentType[index - 1] == LinearWhiteSpaceChars[1] || contentType[index + 1] == LinearWhiteSpaceChars[1])
+                if (contentType[index - 1] == _linearWhiteSpaceChars[1] || contentType[index + 1] == _linearWhiteSpaceChars[1])
                 {
-                    index = contentType.IndexOf(LinearWhiteSpaceChars[2], ++index);
+                    index = contentType.IndexOf(_linearWhiteSpaceChars[2], ++index);
                 }
                 else
                     throw new ArgumentException(SR.InvalidLinearWhiteSpaceCharacter);
@@ -421,7 +421,7 @@ namespace MS.Internal
         private void ParseTypeAndSubType(ReadOnlySpan<char> typeAndSubType)
         {
             //okay to trim at this point the end of the string as Linear White Spaces(LWS) chars are allowed here.
-            typeAndSubType = typeAndSubType.TrimEnd(LinearWhiteSpaceChars);
+            typeAndSubType = typeAndSubType.TrimEnd(_linearWhiteSpaceChars);
 
             int forwardSlashPos = typeAndSubType.IndexOf('/');
             if (forwardSlashPos < 0 || // no slashes
@@ -460,7 +460,7 @@ namespace MS.Internal
 
                 //okay to trim start as there can be spaces before the begining
                 //of the parameter name.
-                parameterAndValue = parameterAndValue.TrimStart(LinearWhiteSpaceChars);
+                parameterAndValue = parameterAndValue.TrimStart(_linearWhiteSpaceChars);
 
                 int equalSignIndex = parameterAndValue.IndexOf(_equalSeparator);
 
@@ -478,7 +478,7 @@ namespace MS.Internal
                     ValidateToken(parameterAndValue.Slice(0, equalSignIndex).ToString()),
                     ValidateQuotedStringOrToken(parameterAndValue.Slice(parameterStartIndex, parameterValueLength).ToString()));
 
-                parameterAndValue = parameterAndValue.Slice(parameterStartIndex + parameterValueLength).TrimStart(LinearWhiteSpaceChars);
+                parameterAndValue = parameterAndValue.Slice(parameterStartIndex + parameterValueLength).TrimStart(_linearWhiteSpaceChars);
             }
         }
 
@@ -501,7 +501,7 @@ namespace MS.Internal
 
                 if (semicolonIndex != -1)
                 {
-                    int lwsIndex = s.Slice(startIndex).IndexOfAny(LinearWhiteSpaceChars);
+                    int lwsIndex = s.Slice(startIndex).IndexOfAny(_linearWhiteSpaceChars);
                     length = lwsIndex != -1 && lwsIndex < semicolonIndex ? lwsIndex : semicolonIndex;
                     length += startIndex; // the indexes from IndexOf{Any} are based on slicing from startIndex
                 }
@@ -635,7 +635,7 @@ namespace MS.Internal
         /// </summary>
         /// <param name="ch">input character</param>
         /// <returns></returns>
-        private static bool IsLinearWhiteSpaceChar(char ch) => LinearWhiteSpaceChars.Contains(ch);
+        private static bool IsLinearWhiteSpaceChar(char ch) => new ReadOnlySpan<char>(_linearWhiteSpaceChars).Contains(ch);
 
         /// <summary>
         /// Lazy initialization for the ParameterDictionary
@@ -678,7 +678,7 @@ namespace MS.Internal
          ];
         
         //Linear White Space characters
-        private static ReadOnlySpan<char> LinearWhiteSpaceChars => [ 
+        private static readonly char[] _linearWhiteSpaceChars = [
            ' ',  // space           - \x20
            '\n', // new line        - \x0A
            '\r', // carriage return - \x0D


### PR DESCRIPTION
## Description

.NET 9 previews added new string.Trim/TrimStart/TrimEnd methods accepting (params) `ReadOnlySpan<char>`.  Those methods are being removed from .NET 9 GA (and .NET 10/main), so they should no longer be called by WPF.

## Customer Impact

WPF won't build.

## Regression

No

## Testing

It compiles.

## Risk

Extremely low, mechanical change.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9907)