### PR TITLE
Remove NetCoreReference

### DIFF
--- a/Documentation/LocalMarkupCompilation.md
+++ b/Documentation/LocalMarkupCompilation.md
@@ -37,8 +37,4 @@ It can be enabled for a project by setting this:
 In addition to these, care must be taken for the following: 
 
 - Use `<EmbeddedResource>` instead of `<Resource>`
-  - `PresentationBuildTask` will strip out `<Resource>` items during `_CompileTemporaryAssembly` phase. Using `EmbeddedResource` is equivalent (esp. in for `Xlf` based string resource generation with `Arcade.Sdk`) and will not be adversely affected by `PresentationBuildTasks` transformations. 
-- Always use `<NetCoreReference>` instead of implicitly acquiring the full set of `Microsoft.NetCore.App` references. 
-  - `Microsoft.NetCore.App` contains a version `WindowsBase` that clashes with WPF's `WindowsBase` during markup compilation.
-  - To avoid this clash, we must always specify the references we need explicitly. 
-  - Also, our code-base requires that all references be specified explicitly anyway to avoid inadvertent reference-creep to bug-fixes. 
+  - `PresentationBuildTask` will strip out `<Resource>` items during `_CompileTemporaryAssembly` phase. Using `EmbeddedResource` is equivalent (esp. in for `Xlf` based string resource generation with `Arcade.Sdk`) and will not be adversely affected by `PresentationBuildTasks` transformations.

--- a/Microsoft.Dotnet.Wpf.sln
+++ b/Microsoft.Dotnet.Wpf.sln
@@ -239,21 +239,37 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "OSVersionHelper", "src\Micr
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PresentationNative", "src\Microsoft.DotNet.Wpf\redist\PresentationNative\PresentationNative.vcxproj", "{AF9084C3-BF37-4A56-A851-89F3BAE731B3}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{F3F4DFE8-A29C-4BA1-964D-954AB6732744}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.DotNet.Wpf", "Microsoft.DotNet.Wpf", "{C9ECC1A1-917F-43D3-B340-2035B4938507}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{34B64A4A-7C83-4F92-8C47-80E9FA10D660}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnitTests", "UnitTests", "{A48B585E-6AB0-4F8D-8484-77F37CB44437}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Xaml.Tests", "src\Microsoft.DotNet.Wpf\tests\UnitTests\System.Xaml.Tests\System.Xaml.Tests.csproj", "{B2F2A89C-55C9-41B1-A645-0948609BD8BE}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PresentationFramework.Fluent", "src\Microsoft.DotNet.Wpf\src\Themes\PresentationFramework.Fluent\PresentationFramework.Fluent.csproj", "{3F2C0E0E-BB13-46D9-8D9A-08256A49ECA9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PresentationFramework.Fluent-ref", "src\Microsoft.DotNet.Wpf\src\Themes\PresentationFramework.Fluent\ref\PresentationFramework.Fluent-ref.csproj", "{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PresentationCore.Tests", "src\Microsoft.DotNet.Wpf\tests\UnitTests\PresentationCore.Tests\PresentationCore.Tests.csproj", "{A4377D3F-6BA1-4994-945C-88667993E4F3}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "eng", "eng", "{92968783-2008-4A16-A823-6737224FEB9E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{B90B3D18-1B80-4FAF-A8DF-146C4F930AF9}"
+	ProjectSection(SolutionItems) = preProject
+		Documentation\acceptance_criteria.md = Documentation\acceptance_criteria.md
+		Documentation\api-compat.md = Documentation\api-compat.md
+		Documentation\C++-notes.md = Documentation\C++-notes.md
+		Documentation\c++-private-tools.md = Documentation\c++-private-tools.md
+		Documentation\codegen.md = Documentation\codegen.md
+		Documentation\contributing.md = Documentation\contributing.md
+		Documentation\cycle-breakers.md = Documentation\cycle-breakers.md
+		Documentation\developer-guide.md = Documentation\developer-guide.md
+		Documentation\gen-api.md = Documentation\gen-api.md
+		Documentation\getting-started.md = Documentation\getting-started.md
+		Documentation\issue-guide.md = Documentation\issue-guide.md
+		Documentation\localization_untranslated_strings.md = Documentation\localization_untranslated_strings.md
+		Documentation\LocalMarkupCompilation.md = Documentation\LocalMarkupCompilation.md
+		Documentation\packaging.md = Documentation\packaging.md
+		Documentation\projects-and-assemblies.md = Documentation\projects-and-assemblies.md
+		Documentation\redistributables.md = Documentation\redistributables.md
+		Documentation\report-on-adding-new-property.md = Documentation\report-on-adding-new-property.md
+		Documentation\solution-and-project-configurations.md = Documentation\solution-and-project-configurations.md
+		Documentation\testing-in-helix.md = Documentation\testing-in-helix.md
+		Documentation\wpf.vsconfig = Documentation\wpf.vsconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1926,22 +1942,6 @@ Global
 		{AF9084C3-BF37-4A56-A851-89F3BAE731B3}.Release|x86.ActiveCfg = Release|Win32
 		{AF9084C3-BF37-4A56-A851-89F3BAE731B3}.Release|x86.Build.0 = Release|Win32
 		{AF9084C3-BF37-4A56-A851-89F3BAE731B3}.Release|x86.Deploy.0 = Release|Win32
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|ARM64.Build.0 = Debug|ARM64
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|x64.ActiveCfg = Debug|x64
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|x64.Build.0 = Debug|x64
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|x86.ActiveCfg = Debug|x86
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|x86.Build.0 = Debug|x86
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|ARM64.ActiveCfg = Release|ARM64
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|ARM64.Build.0 = Release|ARM64
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|x64.ActiveCfg = Release|x64
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|x64.Build.0 = Release|x64
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|x86.ActiveCfg = Release|x86
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|x86.Build.0 = Release|x86
 		{3F2C0E0E-BB13-46D9-8D9A-08256A49ECA9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3F2C0E0E-BB13-46D9-8D9A-08256A49ECA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3F2C0E0E-BB13-46D9-8D9A-08256A49ECA9}.Debug|ARM64.ActiveCfg = Debug|arm64
@@ -1974,22 +1974,6 @@ Global
 		{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD}.Release|x64.Build.0 = Release|x64
 		{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD}.Release|x86.ActiveCfg = Release|Any CPU
 		{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD}.Release|x86.Build.0 = Release|Any CPU
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|ARM64.Build.0 = Debug|ARM64
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|x64.ActiveCfg = Debug|x64
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|x64.Build.0 = Debug|x64
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|x86.ActiveCfg = Debug|x86
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|x86.Build.0 = Debug|x86
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|ARM64.ActiveCfg = Release|ARM64
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|ARM64.Build.0 = Release|ARM64
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|x64.ActiveCfg = Release|x64
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|x64.Build.0 = Release|x64
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|x86.ActiveCfg = Release|x86
-		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2106,13 +2090,9 @@ Global
 		{7EE0E965-7DA4-4A94-9441-801E8D2CC1CD} = {4557C5C6-10B1-475C-8279-5511955D1C29}
 		{3801B5AE-6871-4A72-B400-1F6ABCBF9045} = {7EE0E965-7DA4-4A94-9441-801E8D2CC1CD}
 		{AF9084C3-BF37-4A56-A851-89F3BAE731B3} = {DDED00A7-24FD-4AEF-B264-2150F0E59B4D}
-		{C9ECC1A1-917F-43D3-B340-2035B4938507} = {F3F4DFE8-A29C-4BA1-964D-954AB6732744}
-		{34B64A4A-7C83-4F92-8C47-80E9FA10D660} = {C9ECC1A1-917F-43D3-B340-2035B4938507}
-		{A48B585E-6AB0-4F8D-8484-77F37CB44437} = {34B64A4A-7C83-4F92-8C47-80E9FA10D660}
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE} = {A48B585E-6AB0-4F8D-8484-77F37CB44437}
+		{A48B585E-6AB0-4F8D-8484-77F37CB44437} = {B0EFDB12-C931-4E7F-A6C2-D4AC111D7EDF}
 		{3F2C0E0E-BB13-46D9-8D9A-08256A49ECA9} = {5ACFB055-649D-4A01-98C2-B0BFE7E543D6}
 		{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD} = {60F4058B-D35B-42D2-B276-D44B3AC579BD}
-		{A4377D3F-6BA1-4994-945C-88667993E4F3} = {A48B585E-6AB0-4F8D-8484-77F37CB44437}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B4340004-DAC0-497D-B69D-CFA7CD93F567}

--- a/Microsoft.Dotnet.Wpf.sln
+++ b/Microsoft.Dotnet.Wpf.sln
@@ -246,6 +246,13 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PresentationFramework.Fluent-ref", "src\Microsoft.DotNet.Wpf\src\Themes\PresentationFramework.Fluent\ref\PresentationFramework.Fluent-ref.csproj", "{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "eng", "eng", "{92968783-2008-4A16-A823-6737224FEB9E}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		eng\WpfArcadeSdk\Sdk\Sdk.props = eng\WpfArcadeSdk\Sdk\Sdk.props
+		eng\WpfArcadeSdk\Sdk\Sdk.targets = eng\WpfArcadeSdk\Sdk\Sdk.targets
+		eng\WpfArcadeSdk\tools\SdkReferences.targets = eng\WpfArcadeSdk\tools\SdkReferences.targets
+		eng\Versions.props = eng\Versions.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{B90B3D18-1B80-4FAF-A8DF-146C4F930AF9}"
 	ProjectSection(SolutionItems) = preProject
@@ -270,6 +277,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\testing-in-helix.md = Documentation\testing-in-helix.md
 		Documentation\wpf.vsconfig = Documentation\wpf.vsconfig
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PresentationCore.Tests", "src\Microsoft.DotNet.Wpf\tests\UnitTests\PresentationCore.Tests\PresentationCore.Tests.csproj", "{398CD1C6-A92E-4B63-97CD-4CABD96FA868}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Xaml.Tests", "src\Microsoft.DotNet.Wpf\tests\UnitTests\System.Xaml.Tests\System.Xaml.Tests.csproj", "{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1974,6 +1985,38 @@ Global
 		{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD}.Release|x64.Build.0 = Release|x64
 		{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD}.Release|x86.ActiveCfg = Release|Any CPU
 		{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD}.Release|x86.Build.0 = Release|Any CPU
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Debug|ARM64.Build.0 = Debug|ARM64
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Debug|x64.ActiveCfg = Debug|x64
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Debug|x64.Build.0 = Debug|x64
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Debug|x86.ActiveCfg = Debug|x86
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Debug|x86.Build.0 = Debug|x86
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Release|Any CPU.Build.0 = Release|Any CPU
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Release|ARM64.ActiveCfg = Release|ARM64
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Release|ARM64.Build.0 = Release|ARM64
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Release|x64.ActiveCfg = Release|x64
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Release|x64.Build.0 = Release|x64
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Release|x86.ActiveCfg = Release|x86
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868}.Release|x86.Build.0 = Release|x86
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Debug|ARM64.Build.0 = Debug|ARM64
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Debug|x64.ActiveCfg = Debug|x64
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Debug|x64.Build.0 = Debug|x64
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Debug|x86.ActiveCfg = Debug|x86
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Debug|x86.Build.0 = Debug|x86
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Release|ARM64.ActiveCfg = Release|ARM64
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Release|ARM64.Build.0 = Release|ARM64
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Release|x64.ActiveCfg = Release|x64
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Release|x64.Build.0 = Release|x64
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Release|x86.ActiveCfg = Release|x86
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2093,6 +2136,8 @@ Global
 		{A48B585E-6AB0-4F8D-8484-77F37CB44437} = {B0EFDB12-C931-4E7F-A6C2-D4AC111D7EDF}
 		{3F2C0E0E-BB13-46D9-8D9A-08256A49ECA9} = {5ACFB055-649D-4A01-98C2-B0BFE7E543D6}
 		{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD} = {60F4058B-D35B-42D2-B276-D44B3AC579BD}
+		{398CD1C6-A92E-4B63-97CD-4CABD96FA868} = {A48B585E-6AB0-4F8D-8484-77F37CB44437}
+		{93C6A5C8-4545-49DD-8D48-DDD6665ADFC0} = {A48B585E-6AB0-4F8D-8484-77F37CB44437}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B4340004-DAC0-497D-B69D-CFA7CD93F567}

--- a/eng/WpfArcadeSdk/tools/Pbt.targets
+++ b/eng/WpfArcadeSdk/tools/Pbt.targets
@@ -26,21 +26,6 @@
     -->
     <EmbedUntrackedSources Condition="'$(InternalMarkupCompilation)'=='true'">false</EmbedUntrackedSources>
   </PropertyGroup>
-  <!--
-    Internal PBT compilation requires that we use <NetCoreReference>
-    This is so that the copy of ref\WindowsBase.dll inherited from Microsoft.NetCore.App
-    does not make its way through to markup-compilation.
-
-    In addition to this, our codebase requires that all references to Microsoft.NetCore.App
-    be explicitly enumerated through the use of <NetCoreReference> to avoid inadvertent additions
-    to assembly references during code-changes.
-  -->
-  <ItemGroup Condition="'$(InternalMarkupCompilation)'=='true'">
-    <NetCoreReference Include="mscorlib" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Runtime" />
-  </ItemGroup>
 
   <PropertyGroup Condition="'$(InternalMarkupCompilation)'=='true' And Exists('$(LocalMicrosoftWinFXTargets)')">
     <PrepareResourceNamesDependsOn>

--- a/eng/WpfArcadeSdk/tools/SdkReferences.targets
+++ b/eng/WpfArcadeSdk/tools/SdkReferences.targets
@@ -135,9 +135,9 @@
     Allows excluding specific .NET runtime libraries from being implicitly referenced.
     For example, to exclude WindowsBase from being implicitly referenced, add the following to your project file:
 
-      <DefaultReferenceExclusion>
-        <MicrosoftPrivateWinFormsReference Include="WindowsBase" />
-      </DefaultReferenceExclusion>
+      <ItemGroup>
+        <DefaultReferenceExclusion Include="WindowsBase" />
+      </ItemGroup>
   -->
   <Target Name="FilterImplicitAssemblyReferences"
           Condition="'@(DefaultReferenceExclusion)' != ''"

--- a/eng/WpfArcadeSdk/tools/SdkReferences.targets
+++ b/eng/WpfArcadeSdk/tools/SdkReferences.targets
@@ -4,23 +4,14 @@
                       Version="$(MicrosoftPrivateWinformsVersion)"
                       ExcludeAssets="All"
                       GeneratePathProperty="True"
-                      Condition="'$(MSBuildProjectExtension)'!='.vcxproj'
+                      Condition="'$(MSBuildProjectExtension)' != '.vcxproj'
                               And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                               And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0'))
-                              And '$(NoAutoMicrosoftPrivateWinformsReference)'!='true'"/>
-
-    <!--
-      When @(NetCoreReference) is non-empty, exclude all assets (ExcludeAssets = All) and re-add them in
-      ResolveMicrosoftNetCoreAppReferences target
-    -->
-    <PackageReference Update="Microsoft.NETCore.App"
-                      GeneratePathProperty="true"
-                      ExcludeAssets="All"
-                      Condition="'@(NetCoreReference)'!='' And '$(DoNotLimitMicrosoftNetCoreReferences)'!='true' And '$(MSBuildProjectExtension)'!='.vcxproj' And '$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+                              And '$(NoAutoMicrosoftPrivateWinformsReference)' != 'true'"/>
 
     <PackageReference Update="Microsoft.NETCore.App"
                     GeneratePathProperty="true"
-                    Condition="('@(NetCoreReference)'=='' Or '$(DoNotLimitMicrosoftNetCoreReferences)' == 'true') And '$(MSBuildProjectExtension)'!='.vcxproj' And '$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+                    Condition="'$(MSBuildProjectExtension)'!='.vcxproj' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>
 
   <Target Name="GeneratePathPropertyforMicrosoftWindowsDesktopApp"
@@ -39,82 +30,6 @@
       $(ResolveAssemblyReferencesDependsOn)
     </ResolveAssemblyReferencesDependsOn>
   </PropertyGroup>
-
-
-  <Target
-    Name="LimitNetCoreAppReferences"
-    AfterTargets="ResolveTargetingPackAssets;ResolveTargetingPacks"
-    Returns="@(Reference)"
-    Condition="'@(NetCoreReference)' != '' And '@(Reference)' != ''">
-    <!--
-      Example
-      <NetCoreReference Include="Microsoft.CSharp" />
-    -->
-
-    <!--
-       Save Microsoft.NETCore.App.Ref assemblies, and remove those from @(Reference)
-     -->
-    <ItemGroup>
-      <_netCoreAppSdkReference Remove="@(_netCoreAppSdkReference)" />
-      <_netCoreAppSdkReference Include="@(Reference)"
-                               Condition="'%(Reference.NuGetPackageId)'=='Microsoft.NETCore.App.Ref'">
-        <OriginalPath>%(Reference.Identity)</OriginalPath>
-      </_netCoreAppSdkReference>
-
-      <Reference Remove="@(_netCoreAppSdkReference)" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <_netCoreAppReferences Remove="@(_netCoreAppReferences)" />
-    </ItemGroup>
-    <FilterItem1ByItem2 Item1="@(_netCoreAppSdkReference->'%(FileName)')"
-                        Item2="@(NetCoreReference)"
-                        Metadata2="Identity"
-                        PreserveItem1Metadata="true">
-      <Output ItemName="_netCoreAppReferences" TaskParameter="Result" />
-    </FilterItem1ByItem2>
-
-    <ItemGroup>
-      <Reference Include="@(_netCoreAppReferences->'%(OriginalPath)')" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="LimitWindowsDesktopAppReferences"
-        AfterTargets="ResolveTargetingPacks;ResolveTargetingPackAsssets"
-        Returns="@(Reference)"
-        Condition="'@(WindowsDesktopReference)'!='' and '@(Reference)' != ''">
-    <!--
-      Example
-      <WindowsDesktopReference Include="PresentationCore" />
-    -->
-
-    <!--
-       Save Microsoft.WindowsDesktop.App.Ref assemblies, and remove those from @(Reference)
-     -->
-    <ItemGroup>
-      <_windowsDesktopAppSdkReference Remove="@(_windowsDesktopAppSdkReference)" />
-      <_windowsDesktopAppSdkReference Include="@(Reference)"
-                                      Condition="'%(Reference.NuGetPackageId)'=='Microsoft.WindowsDesktop.App.Ref'">
-        <OriginalPath>%(Reference.Identity)</OriginalPath>
-      </_windowsDesktopAppSdkReference>
-
-      <Reference Remove="@(_windowsDesktopAppSdkReference)" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <_windowsDesktopAppReferences Remove="@(_windowsDesktopAppReferences)" />
-    </ItemGroup>
-    <FilterItem1ByItem2 Item1="@(_windowsDesktopAppSdkReference->'%(FileName)')"
-                        Item2="@(WindowsDesktopReference)"
-                        Metadata2="Identity"
-                        PreserveItem1Metadata="true">
-      <Output ItemName="_windowsDesktopAppReferences" TaskParameter="Result" />
-    </FilterItem1ByItem2>
-
-    <ItemGroup>
-      <Reference Include="@(_windowsDesktopAppReferences->'%(OriginalPath)')" />
-    </ItemGroup>
-  </Target>
 
   <Target
     Name="ResolveMicrosoftDotNetWpfGitHubReferences"
@@ -208,6 +123,35 @@
                  And Exists('$(PkgMicrosoft_Private_Winforms)\ref\net8.0\%(MicrosoftPrivateWinFormsReference.Identity).dll')">
         <NuGetPackageId>Microsoft.Private.Winforms</NuGetPackageId>
       </Reference>
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <!-- We always want to use the local WindowsBase, not the one coming from the .NET runtime. -->
+    <DefaultReferenceExclusion Include="WindowsBase"/>
+  </ItemGroup>
+
+  <!--
+    Allows excluding specific .NET runtime libraries from being implicitly referenced.
+    For example, to exclude WindowsBase from being implicitly referenced, add the following to your project file:
+
+      <DefaultReferenceExclusion>
+        <MicrosoftPrivateWinFormsReference Include="WindowsBase" />
+      </DefaultReferenceExclusion>
+  -->
+  <Target Name="FilterImplicitAssemblyReferences"
+          Condition="'@(DefaultReferenceExclusion)' != ''"
+          DependsOnTargets="ResolveProjectReferences"
+          AfterTargets="ResolveTargetingPackAssets">
+    <ItemGroup>
+      <_referenceExclusion Include="@(DefaultReferenceExclusion)">
+        <AssemblyName>%(DefaultReferenceExclusion.Identity)</AssemblyName>
+        <FrameworkReferenceName>Microsoft.NETCore.App</FrameworkReferenceName>
+        <ExternallyResolved>true</ExternallyResolved>
+      </_referenceExclusion>
+
+      <Reference Remove="@(_referenceExclusion)"
+                 MatchOnMetadata="AssemblyName;FrameworkReferenceName;ExternallyResolved"/>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework-PresentationUI-api-cycle.csproj
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework-PresentationUI-api-cycle.csproj
@@ -10,18 +10,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="System.Windows.Controls.DocumentViewer.cs" />
     <Compile Include="System.Windows.Controls.ToolBar.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework-ReachFramework-impl-cycle.csproj
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework-ReachFramework-impl-cycle.csproj
@@ -13,35 +13,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="PresentationFramework.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Dynamic.Runtime" />
-    <NetCoreReference Include="System.Linq.Expressions" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Net.Requests" />
-    <NetCoreReference Include="System.Net.WebHeaderCollection" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Xml" />
-    <NetCoreReference Include="System.Xml.Document" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework-System.Printing-api-cycle.csproj
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework-System.Printing-api-cycle.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -24,29 +23,6 @@
     <Compile Include="System.Windows.Documents.Serialization.Delegates.cs" />
     <Compile Include="System.Windows.Documents.Serialization.SerializerWriter.cs" />
     <Compile Include="System.Windows.Documents.Serialization.SerializerWriterCollator.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Dynamic.Runtime" />
-    <NetCoreReference Include="System.Linq.Expressions" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Net.Requests" />
-    <NetCoreReference Include="System.Net.WebHeaderCollection" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Xml" />
-    <NetCoreReference Include="System.Xml.Document" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework-System.Printing-impl-cycle.csproj
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework-System.Printing-impl-cycle.csproj
@@ -13,35 +13,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="PresentationFramework.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Dynamic.Runtime" />
-    <NetCoreReference Include="System.Linq.Expressions" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Net.Requests" />
-    <NetCoreReference Include="System.Net.WebHeaderCollection" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Xml" />
-    <NetCoreReference Include="System.Xml.Document" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationUI/PresentationUI-PresentationFramework-impl-cycle.csproj
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationUI/PresentationUI-PresentationFramework-impl-cycle.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -20,12 +19,6 @@
     <Compile Include="PresentationUI.cs" />
     <Compile Include="PresentationUI.internals.cs" />
     <Compile Include="$(WpfSharedDir)RefAssemblyAttrs.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/ReachFramework/ReachFramework-PresentationFramework-api-cycle.csproj
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/ReachFramework/ReachFramework-PresentationFramework-api-cycle.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -18,10 +17,5 @@
     <Compile Include="System.Printing.PrintTicket.cs" />
     <Compile Include="System.Windows.Xps.Serialization.PrintTicketLevel.cs" />
     <Compile Include="$(WpfSharedDir)RefAssemblyAttrs.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/ReachFramework/ReachFramework-System.Printing-api-cycle.csproj
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/ReachFramework/ReachFramework-System.Printing-api-cycle.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -23,10 +22,5 @@
     <Compile Include="System.Windows.Xps.Serialization.RCW.IXpsOMPackageWriter.cs" />
     <Compile Include="System.Windows.Xps.Packaging.XpsDocument.cs" />
     <Compile Include="$(WpfSharedDir)RefAssemblyAttrs.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/System.Printing/System.Printing-PresentationFramework-api-cycle.csproj
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/System.Printing/System.Printing-PresentationFramework-api-cycle.csproj
@@ -10,17 +10,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="System.Printing.PrintQueue.cs" />
     <Compile Include="$(WpfSharedDir)RefAssemblyAttrs.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemCore/PresentationFramework-SystemCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemCore/PresentationFramework-SystemCore.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -12,15 +11,5 @@
   <ItemGroup>
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Linq.Expressions" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Threading" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemData/PresentationFramework-SystemData.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemData/PresentationFramework-SystemData.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -11,19 +10,5 @@
   <ItemGroup>
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Data.Common" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemDrawing/PresentationFramework-SystemDrawing.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemDrawing/PresentationFramework-SystemDrawing.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -12,19 +11,6 @@
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="$(SystemDrawingCommonPackage)" Version="$(SystemDrawingCommonVersion)" />

--- a/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemXml/PresentationFramework-SystemXml.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemXml/PresentationFramework-SystemXml.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -13,17 +12,5 @@
     <ProjectReference Include="$(WpfSourceDir)System.Xaml\System.Xaml.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Xaml" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemXmlLinq/PresentationFramework-SystemXmlLinq.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemXmlLinq/PresentationFramework-SystemXmlLinq.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -11,16 +10,5 @@
   <ItemGroup>
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Xml.XDocument" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -1417,54 +1416,6 @@
     <Compile Include="System\Windows\Media3D\Generated\Visual3D.cs" />
     <Compile Include="System\Windows\Navigation\BaseUriHelper.cs" />
     <Compile Include="System\Windows\Resources\AssemblyAssociatedContentFileAttribute.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="Microsoft.Win32.Registry" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Immutable" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Console" />
-    <NetCoreReference Include="System.Diagnostics.Contracts" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.StackTrace" />
-    <NetCoreReference Include="System.Diagnostics.TextWriterTraceListener" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Diagnostics.Tracing" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Net.Requests" />
-    <NetCoreReference Include="System.Net.WebHeaderCollection" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Reflection.Metadata" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.CompilerServices.VisualC" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
-    <NetCoreReference Include="System.Text.Encoding.Extensions" />
-    <NetCoreReference Include="System.Text.RegularExpressions" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Linq" />
-    <NetCoreReference Include="System.Threading.Tasks" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-    <NetCoreReference Include="System.Threading.Timer" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
-    <NetCoreReference Include="netstandard" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore-ref.csproj
@@ -11,7 +11,6 @@
     <GenerateResourcesSRNamespace>MS.Internal.PresentationCore</GenerateResourcesSRNamespace>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
-    
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,47 +19,6 @@
     <Compile Include="$(WpfSourceDir)PresentationCore\OtherAssemblyAttrs.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="Microsoft.Win32.Registry" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Console" />
-    <NetCoreReference Include="System.Diagnostics.Contracts" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.StackTrace" />
-    <NetCoreReference Include="System.Diagnostics.TextWriterTraceListener" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Diagnostics.Tracing" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Net.Requests" />
-    <NetCoreReference Include="System.Net.WebHeaderCollection" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.CompilerServices.VisualC" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
-    <NetCoreReference Include="System.Text.Encoding.Extensions" />
-    <NetCoreReference Include="System.Text.RegularExpressions" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Tasks" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-    <NetCoreReference Include="System.Threading.Timer" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
-    <NetCoreReference Include="netstandard" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
@@ -1373,64 +1373,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="Microsoft.Win32.Registry" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Console" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Diagnostics.Contracts" />
-    <NetCoreReference Include="System.Diagnostics.FileVersionInfo" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.StackTrace" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TextWriterTraceListener" />
-    <NetCoreReference Include="System.Diagnostics.Tracing" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.IO.Compression" />
-    <NetCoreReference Include="System.IO.IsolatedStorage" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Net.Requests" />
-    <NetCoreReference Include="System.Linq" />
-    <NetCoreReference Include="System.Linq.Expressions" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.CompilerServices.DynamicAttribute" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
-    <NetCoreReference Include="System.Text.RegularExpressions" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Tasks" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-    <NetCoreReference Include="System.Threading.Timer" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Security.Claims" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Csp" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Text.Encoding.Extensions" />
-    <NetCoreReference Include="System.Text.Encoding.CodePages" />
-    <NetCoreReference Include="System.Xml" />
-    <NetCoreReference Include="System.Xml.XPath" />
-    <NetCoreReference Include="System.Xml.Document" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="$(WpfCycleBreakersDir)PresentationUI\PresentationUI-PresentationFramework-impl-cycle.csproj" />
     <ProjectReference Include="$(WpfSourceDir)ReachFramework\ReachFramework.csproj" />
     <ProjectReference Include="$(WpfSourceDir)System.Printing\ref\System.Printing-ref.csproj" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework-ref.csproj
@@ -11,7 +11,6 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
-    
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,60 +21,6 @@
 
   <ItemGroup>
     <MicrosoftPrivateWinFormsReference Include="Accessibility" />
-  </ItemGroup>
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="Microsoft.Win32.Registry" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Console" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Diagnostics.Contracts" />
-    <NetCoreReference Include="System.Diagnostics.FileVersionInfo" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.StackTrace" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TextWriterTraceListener" />
-    <NetCoreReference Include="System.Diagnostics.Tracing" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.IO.Compression" />
-    <NetCoreReference Include="System.IO.IsolatedStorage" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Net.Requests" />
-    <NetCoreReference Include="System.Linq" />
-    <NetCoreReference Include="System.Linq.Expressions" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.CompilerServices.DynamicAttribute" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
-    <NetCoreReference Include="System.Text.RegularExpressions" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Tasks" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-    <NetCoreReference Include="System.Threading.Timer" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Security.Claims" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Text.Encoding.Extensions" />
-    <NetCoreReference Include="System.Xml" />
-    <NetCoreReference Include="System.Xml.XPath" />
-    <NetCoreReference Include="System.Xml.Document" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(WpfSourceDir)ReachFramework\ref\ReachFramework-ref.csproj" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
@@ -1,8 +1,6 @@
 ﻿<Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
 
     <EnableDefaultItems>false</EnableDefaultItems>
@@ -15,6 +13,7 @@
     <InternalMarkupCompilation>true</InternalMarkupCompilation>
     <NoInternalTypeHelper>true</NoInternalTypeHelper>
     <GenerateDependencyFile>false</GenerateDependencyFile>
+    <DoNotLimitMicrosoftNetCoreReferences>true</DoNotLimitMicrosoftNetCoreReferences>
   </PropertyGroup>
 
   <!-- Theme files -->
@@ -221,40 +220,7 @@
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsVersion)" />
   </ItemGroup>
 
-  <!--
-    Minimal set of references needed to build PresentationUI
-  -->
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="Microsoft.Win32.Registry" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.IO.FileSystem.AccessControl" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Runtime.Loader" />
-    <NetCoreReference Include="System.Security.AccessControl" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
     <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms" />
     <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms.Primitives" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
@@ -13,7 +13,6 @@
     <InternalMarkupCompilation>true</InternalMarkupCompilation>
     <NoInternalTypeHelper>true</NoInternalTypeHelper>
     <GenerateDependencyFile>false</GenerateDependencyFile>
-    <DoNotLimitMicrosoftNetCoreReferences>true</DoNotLimitMicrosoftNetCoreReferences>
   </PropertyGroup>
 
   <!-- Theme files -->

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/ref/PresentationUI-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/ref/PresentationUI-ref.csproj
@@ -3,7 +3,6 @@
     <AssemblyName>PresentationUI</AssemblyName>
     <PackageId>PresentationUI-ref</PackageId>
     <TargetOutputRelPath>$(TargetGroup)-$(PackageId)/</TargetOutputRelPath>
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
@@ -13,14 +12,6 @@
     <Compile Include="$(WpfSourceDir)PresentationUI\OtherAssemblyAttrs.cs" />
   </ItemGroup>
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\ref\WindowsBase-ref.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\ref\PresentationFramework-ref.csproj" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/ReachFramework.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/ReachFramework.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -333,39 +332,6 @@
     <Compile Include="MS\Internal\Printing\Configuration\SafeModuleHandle.cs" />
     <Compile Include="MS\Internal\Printing\Configuration\WinSpoolPrinterCapabilities.cs" />
     <Compile Include="MS\Internal\Printing\TestHook.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Console" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Net.Requests" />
-    <NetCoreReference Include="System.Net.WebHeaderCollection" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Text.RegularExpressions" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Xml" />
-    <NetCoreReference Include="System.Xml.Document" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/ref/ReachFramework-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/ref/ReachFramework-ref.csproj
@@ -10,43 +10,10 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
-    
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(WpfSharedDir)ref\AttributesForReferenceAssemblies.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Console" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Net.Requests" />
-    <NetCoreReference Include="System.Net.WebHeaderCollection" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Text.RegularExpressions" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Xml" />
-    <NetCoreReference Include="System.Xml.Document" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\ref\PresentationCore-ref.csproj" />

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/ref/System.Printing-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/ref/System.Printing-ref.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -18,28 +17,6 @@
     <Compile Include="System.Printing.cs" />
     <Compile Include="System.Printing.internals.cs" />
     <Compile Include="$(WpfSharedDir)RefAssemblyAttrs.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Net.Requests" />
-    <NetCoreReference Include="System.Net.WebHeaderCollection" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Xml" />
-    <NetCoreReference Include="System.Xml.Document" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/System.Windows.Controls.Ribbon.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/System.Windows.Controls.Ribbon.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.Net.Sdk">
 
   <PropertyGroup>
-
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <EnableDefaultItems>false</EnableDefaultItems>
     <DefineConstants>$(DefineConstants);RIBBON_IN_FRAMEWORK</DefineConstants>
@@ -13,7 +11,6 @@
     <InternalMarkupCompilation>true</InternalMarkupCompilation>
     <NoInternalTypeHelper>true</NoInternalTypeHelper>
     <GenerateDependencyFile>false</GenerateDependencyFile>
-
   </PropertyGroup>
 
   <ItemGroup>
@@ -183,47 +180,5 @@
     <ProjectReference Include="$(WpfSourceDir)System.Windows.Controls.Ribbon\ref\System.Windows.Controls.Ribbon-ref.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-
   </ItemGroup>
-
-  <!--
-    Minimal set of references needed to build System.Windows.Controls.Ribbon
-  -->
-  <ItemGroup>
-
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/ref/System.Windows.Controls.Ribbon-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/ref/System.Windows.Controls.Ribbon-ref.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>System.Windows.Controls.Ribbon</AssemblyName>
     <PackageId>System.Windows.Controls.Ribbon-ref</PackageId>
     <TargetOutputRelPath>$(TargetGroup)-$(PackageId)/</TargetOutputRelPath>
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <DefineConstants>$(DefineConstants);RIBBON_IN_FRAMEWORK</DefineConstants>
     <NoWarn>$(NoWarn);0618</NoWarn>
@@ -32,45 +31,4 @@
 
     <ProjectReference Include="$(WpfSourceDir)Themes\PresentationFramework.Classic\ref\PresentationFramework.Classic-ref.csproj" />
   </ItemGroup>
-
-  <!--
-    Minimal set of references needed to build System.Windows.Controls.Ribbon
-  -->
-  <ItemGroup>
-
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System.Windows.Input.Manipulations.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System.Windows.Input.Manipulations.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    
     <EnableDefaultItems>false</EnableDefaultItems>
     <Platforms>AnyCPU;x64;arm64</Platforms>
   </PropertyGroup>
@@ -37,20 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="$(WpfSourceDir)System.Windows.Input.Manipulations\ref\System.Windows.Input.Manipulations-ref.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/ref/System.Windows.Input.Manipulations-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/ref/System.Windows.Input.Manipulations-ref.csproj
@@ -3,21 +3,10 @@
     <AssemblyName>System.Windows.Input.Manipulations</AssemblyName>
     <PackageId>System.Windows.Input.Manipulations-ref</PackageId>
     <TargetOutputRelPath>$(TargetGroup)-$(PackageId)/</TargetOutputRelPath>
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(WpfSharedDir)ref\AttributesForReferenceAssemblies.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Presentation/System.Windows.Presentation.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Presentation/System.Windows.Presentation.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -10,14 +9,6 @@
     <Compile Include="System\Windows\Threading\TaskExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
     <ProjectReference Include="$(WpfSourceDir)System.Windows.Presentation\ref\System.Windows.Presentation-ref.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Presentation/ref/System.Windows.Presentation-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Presentation/ref/System.Windows.Presentation-ref.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>System.Windows.Presentation</AssemblyName>
     <PackageId>System.Windows.Presentation-ref</PackageId>
     <TargetOutputRelPath>$(TargetGroup)-$(PackageId)/</TargetOutputRelPath>
-    
+
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
@@ -12,14 +12,6 @@
     <Compile Include="$(WpfSharedDir)ref\AttributesForReferenceAssemblies.cs" />
   </ItemGroup>
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
@@ -80,41 +80,6 @@
     <!-- Do not include reference assembly files. -->
     <Compile Remove="ref\System.Xaml.cs" />
   </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Globalization" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Reflection.Emit.ILGeneration" />
-    <NetCoreReference Include="System.Reflection.Emit.Lightweight" />
-    <NetCoreReference Include="System.Reflection.Primitives" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Reflection" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
-    <NetCoreReference Include="System.Text.Encoding" />
-    <NetCoreReference Include="System.Text.Encoding.Extensions" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Tasks" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-    <NetCoreReference Include="System.Xml" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/ref/System.Xaml-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/ref/System.Xaml-ref.csproj
@@ -16,39 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Globalization" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Reflection.Emit.ILGeneration" />
-    <NetCoreReference Include="System.Reflection.Emit.Lightweight" />
-    <NetCoreReference Include="System.Reflection.Primitives" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Reflection" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
-    <NetCoreReference Include="System.Text.Encoding" />
-    <NetCoreReference Include="System.Text.Encoding.Extensions" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Tasks" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-    <NetCoreReference Include="System.Xml" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/PresentationFramework.Aero.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/PresentationFramework.Aero.csproj
@@ -2,8 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-
-    
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -51,38 +49,4 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for PresentationFramework.Aero -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/ref/PresentationFramework.Aero-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/ref/PresentationFramework.Aero-ref.csproj
@@ -28,39 +28,4 @@
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for PresentationFramework.Aero -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/PresentationFramework.Aero2.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/PresentationFramework.Aero2.csproj
@@ -2,8 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-
-    
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -51,38 +49,4 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for PresentationFramework.Aero2 -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/ref/PresentationFramework.Aero2-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/ref/PresentationFramework.Aero2-ref.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>PresentationFramework.Aero2</AssemblyName>
     <PackageId>PresentationFramework.Aero2-ref</PackageId>
     <TargetOutputRelPath>$(TargetGroup)-$(PackageId)/</TargetOutputRelPath>
-    
+
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -28,39 +28,4 @@
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for PresentationFramework.Aero2 -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.AeroLite/PresentationFramework.AeroLite.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.AeroLite/PresentationFramework.AeroLite.csproj
@@ -2,8 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-
-    
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -48,38 +46,4 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for PresentationFramework.AeroLite -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.AeroLite/ref/PresentationFramework.AeroLite-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.AeroLite/ref/PresentationFramework.AeroLite-ref.csproj
@@ -27,39 +27,4 @@
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for PresentationFramework.AeroLite -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Classic/PresentationFramework.Classic.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Classic/PresentationFramework.Classic.csproj
@@ -2,8 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-
-    
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -18,7 +16,6 @@
     <InternalMarkupCompilation>true</InternalMarkupCompilation>
     <NoInternalTypeHelper>true</NoInternalTypeHelper>
     <GenerateDependencyFile>false</GenerateDependencyFile>
-
   </PropertyGroup>
 
   <!-- Compile Targets -->
@@ -48,38 +45,4 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for PresentationFramework.Classic -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Classic/ref/PresentationFramework.Classic-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Classic/ref/PresentationFramework.Classic-ref.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>PresentationFramework.Classic</AssemblyName>
     <PackageId>PresentationFramework.Classic-ref</PackageId>
     <TargetOutputRelPath>$(TargetGroup)-$(PackageId)/</TargetOutputRelPath>
-    
+
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -27,39 +27,4 @@
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for PresentationFramework.Classic -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/PresentationFramework.Fluent.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/PresentationFramework.Fluent.csproj
@@ -1,6 +1,5 @@
-<!-- Fluent -->
+﻿<!-- Fluent -->
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
@@ -41,43 +40,9 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for Fluent -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
   <ItemGroup>
     <Page Update="Styles\Menu.xaml">
       <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/ref/PresentationFramework.Fluent-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/ref/PresentationFramework.Fluent-ref.csproj
@@ -28,39 +28,4 @@
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for Fluent -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/PresentationFramework.Luna.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/PresentationFramework.Luna.csproj
@@ -1,9 +1,6 @@
 ﻿<!-- PresentationFramework.Luna -->
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-
-    
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -56,38 +53,4 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for PresentationFramework.Luna -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/ref/PresentationFramework.Luna-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/ref/PresentationFramework.Luna-ref.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>PresentationFramework.Luna</AssemblyName>
     <PackageId>PresentationFramework.Luna-ref</PackageId>
     <TargetOutputRelPath>$(TargetGroup)-$(PackageId)/</TargetOutputRelPath>
-    
+
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -27,39 +27,4 @@
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for PresentationFramework.Luna -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Royale/PresentationFramework.Royale.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Royale/PresentationFramework.Royale.csproj
@@ -1,9 +1,6 @@
 ﻿<!-- PresentationFramework.Royale -->
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-
-    
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -50,38 +47,4 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for PresentationFramework.Royale -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Royale/ref/PresentationFramework.Royale-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Royale/ref/PresentationFramework.Royale-ref.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>PresentationFramework.Royale</AssemblyName>
     <PackageId>PresentationFramework.Royale-ref</PackageId>
     <TargetOutputRelPath>$(TargetGroup)-$(PackageId)/</TargetOutputRelPath>
-    
+
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -27,39 +27,4 @@
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
   </ItemGroup>
-
-  <!-- Minimal set of .NET core references -->
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing.Common" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-
-    <!-- Additional references beyond the minimal set for PresentationFramework.Royale -->
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/UIAutomationClient.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/UIAutomationClient.csproj
@@ -7,7 +7,6 @@
     <NoWarn>$(NoWarn);0618;CA1821</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
@@ -103,24 +102,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.StackTrace" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
     <MicrosoftPrivateWinFormsReference Include="Accessibility" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/ref/UIAutomationClient-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/ref/UIAutomationClient-ref.csproj
@@ -21,23 +21,6 @@
     <ProjectReference Include="$(WpfSourceDir)UIAutomation\UIAutomationProvider\ref\UIAutomationProvider-ref.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.StackTrace" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
     <MicrosoftPrivateWinFormsReference Include="Accessibility" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/UIAutomationClientSideProviders.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/UIAutomationClientSideProviders.csproj
@@ -7,7 +7,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
-    
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
@@ -112,24 +111,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.StackTrace" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
     <MicrosoftPrivateWinFormsReference Include="Accessibility" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/ref/UIAutomationClientSideProviders-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/ref/UIAutomationClientSideProviders-ref.csproj
@@ -7,7 +7,7 @@
     <DefineConstants>$(DefineConstants);UIAUTOMATIONCLIENTSIDEPROVIDERS</DefineConstants>
     <NoWarn>$(NoWarn);0618</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    
+
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
 
@@ -22,23 +22,6 @@
     <ProjectReference Include="$(WpfSourceDir)UIAutomation\UIAutomationClient\ref\UIAutomationClient-ref.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.StackTrace" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
     <MicrosoftPrivateWinFormsReference Include="Accessibility" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/UIAutomationProvider.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/UIAutomationProvider.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -45,22 +44,6 @@
     <Compile Include="System\Windows\Automation\Provider\IValueProvider.cs" />
     <Compile Include="System\Windows\Automation\Provider\IVirtualizedItemProvider.cs" />
     <Compile Include="System\Windows\Automation\Provider\IWindowProvider.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/ref/UIAutomationProvider-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/ref/UIAutomationProvider-ref.csproj
@@ -7,27 +7,10 @@
     <DefineConstants>$(DefineConstants);AUTOMATION</DefineConstants>
     <EnablePInvokeAnalyzer>false</EnablePInvokeAnalyzer>
     <Platforms>AnyCPU;x64;arm64</Platforms>
-    
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="$(WpfSharedDir)ref\AttributesForReferenceAssemblies.cs" />
     <Compile Include="$(WpfSourceDir)UIAutomation\UIAutomationProvider\Forwards.cs"/>
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(WpfSourceDir)System.Xaml\ref\System.Xaml-ref.csproj" />

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/UIAutomationTypes.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/UIAutomationTypes.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -89,22 +88,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
     <MicrosoftPrivateWinFormsReference Include="Accessibility" />
   </ItemGroup>
-
-  <ItemGroup>
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/ref/UIAutomationTypes-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/ref/UIAutomationTypes-ref.csproj
@@ -7,7 +7,6 @@
     <DefineConstants>$(DefineConstants);UIAUTOMATIONTYPES</DefineConstants>
     <NoWarn>$(NoWarn);0618</NoWarn>
     <EnablePInvokeAnalyzer>false</EnablePInvokeAnalyzer>
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
   </PropertyGroup>
 
@@ -20,17 +19,6 @@
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\ref\WindowsBase-ref.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
     <MicrosoftPrivateWinFormsReference Include="Accessibility" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/WindowsBase.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/WindowsBase.csproj
@@ -7,7 +7,6 @@
     <NoWarn>$(NoWarn);0618</NoWarn>
     <EnablePInvokeAnalyzer>false</EnablePInvokeAnalyzer>
     <ProjectGuid>{FA69991B-9696-42D0-A5C7-F5E73F0DEE9E}</ProjectGuid>
-    
     <Platforms>AnyCPU;x64;arm64</Platforms>
   </PropertyGroup>
 
@@ -371,46 +370,6 @@
   </Target>
 
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="Microsoft.Win32.Registry" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.IO.Compression" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.IO.IsolatedStorage" />
-    <NetCoreReference Include="System.Linq" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.AccessControl" />
-    <NetCoreReference Include="System.Security.Claims" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Security.Principal.Windows" />
-    <NetCoreReference Include="System.Text.Encoding.Extensions" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Tasks" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-    <NetCoreReference Include="System.Threading.Timer" />
-    <NetCoreReference Include="System.Xml" />
-    <NetCoreReference Include="System.Xml.Document" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
     <MicrosoftPrivateWinFormsReference Include="Accessibility" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/ref/WindowsBase-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/ref/WindowsBase-ref.csproj
@@ -18,45 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="Microsoft.Win32.Registry" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Specialized" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.IO.Compression" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.IO.IsolatedStorage" />
-    <NetCoreReference Include="System.Linq" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Security.AccessControl" />
-    <NetCoreReference Include="System.Security.Claims" />
-    <NetCoreReference Include="System.Security.Cryptography" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Security.Principal.Windows" />
-    <NetCoreReference Include="System.Text.Encoding.Extensions" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Tasks" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-    <NetCoreReference Include="System.Threading.Timer" />
-    <NetCoreReference Include="System.Xml" />
-    <NetCoreReference Include="System.Xml.Document" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
     <MicrosoftPrivateWinFormsReference Include="Accessibility" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/WindowsFormsIntegration.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/WindowsFormsIntegration.csproj
@@ -6,7 +6,6 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
   <PropertyGroup>
-    
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
@@ -54,24 +53,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.Memory" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Threading" />
-
     <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms" />
     <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms.Primitives" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/ref/WindowsFormsIntegration-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/ref/WindowsFormsIntegration-ref.csproj
@@ -7,7 +7,6 @@
     <DefineConstants>$(DefineConstants);WINDOWSFORMSINTEGRATION</DefineConstants>
     <NoWarn>$(NoWarn);0618</NoWarn>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-    
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
   <ItemGroup>
@@ -20,27 +19,9 @@
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
-
     <ProjectReference Include="$(WpfSourceDir)UIAutomation\UIAutomationProvider\UIAutomationProvider.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Drawing" />
-    <NetCoreReference Include="System.Drawing.Primitives" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Threading" />
-
     <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms" />
     <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms.Primitives" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/tests/IntegrationTests/DRT/DrtXaml/BamlTestClasses40/BamlTestClasses40.csproj
+++ b/src/Microsoft.DotNet.Wpf/tests/IntegrationTests/DRT/DrtXaml/BamlTestClasses40/BamlTestClasses40.csproj
@@ -9,7 +9,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>TRACE</DefineConstants>
 
-    <!-- 
+    <!--
       Properties needed for local markup-compilation
     -->
     <InternalMarkupCompilation>true</InternalMarkupCompilation>
@@ -70,70 +70,5 @@
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NetCoreReference Include="mscorlib" />
-    <NetCoreReference Include="netstandard" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Runtime.Extensions" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Linq" />
-    <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.ComponentModel" />
-    <NetCoreReference Include="System.ComponentModel.Primitives" />
-    <NetCoreReference Include="System.Collections" />
-    <NetCoreReference Include="System.Collections.Generic" />
-    <NetCoreReference Include="System.Collections.NonGeneric" />
-    <NetCoreReference Include="System.Collections.Concurrent" />
-    <NetCoreReference Include="System.Reflection.Primitives" />
-    <NetCoreReference Include="System.Text.Encoding.Extensions" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.Tasks" />
-    <NetCoreReference Include="System.Xml.ReaderWriter" />
-    <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="System.AppContext" />
-    <NetCoreReference Include="System.Collections.Immutable" />
-    <NetCoreReference Include="System.ComponentModel.EventBasedAsync" />
-    <NetCoreReference Include="System.Console" />
-    <NetCoreReference Include="System.Diagnostics.Process" />
-    <NetCoreReference Include="System.Diagnostics.TextWriterTraceListener" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Diagnostics.Tracing" />
-    <NetCoreReference Include="System.Dynamic.Runtime" />
-    <NetCoreReference Include="System.Globalization" />
-    <NetCoreReference Include="System.Globalization.Calendars" />
-    <NetCoreReference Include="System.IO" />
-    <NetCoreReference Include="System.IO.Compression" />
-    <NetCoreReference Include="System.IO.Compression.ZipFile" />
-    <NetCoreReference Include="System.IO.FileSystem" />
-    <NetCoreReference Include="System.IO.FileSystem.Primitives" />
-    <NetCoreReference Include="System.Linq.Expressions" />
-    <NetCoreReference Include="System.Net.Http" />
-    <NetCoreReference Include="System.Net.Primitives" />
-    <NetCoreReference Include="System.Net.Sockets" />
-    <NetCoreReference Include="System.Reflection" />
-    <NetCoreReference Include="System.Reflection.Extensions" />
-    <NetCoreReference Include="System.Reflection.Metadata" />
-    <NetCoreReference Include="System.Reflection.TypeExtensions" />
-    <NetCoreReference Include="System.Runtime.Handles" />
-    <NetCoreReference Include="System.Runtime.InteropServices.RuntimeInformation" />
-    <NetCoreReference Include="System.Runtime.Loader" />
-    <NetCoreReference Include="System.Runtime.Numerics" />
-    <NetCoreReference Include="System.Runtime.Serialization.Json" />
-    <NetCoreReference Include="System.Runtime.Serialization.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
-    <NetCoreReference Include="System.Security.Cryptography.Encoding" />
-    <NetCoreReference Include="System.Security.Cryptography.Primitives" />
-    <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
-    <NetCoreReference Include="System.Text.Encoding" />
-    <NetCoreReference Include="System.Text.RegularExpressions" />
-    <NetCoreReference Include="System.Threading.Timer" />
-    <NetCoreReference Include="System.Xml.XDocument" />
-    <NetCoreReference Include="System.Xml.XmlDocument" />
-    <NetCoreReference Include="System.Xml.XPath" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This removes the `NetCoreReference` infrastructure and replaces it with `DefaultReferenceExclusion` to remove the one problematic implicit reference to WindowsBase.

Manually picking references was blocking using System.Private.Windows.Core from the WinForms repo. Not having this also greatly simplifies the projects.

This also tweaks the solution to add folders docs and eng items.

Fixes #9168
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9914)