### PR TITLE
Optimize SpecialBracketCharacters parsing and initialization of master caches

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Parser/SpecialBracketCharacters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Parser/SpecialBracketCharacters.cs
@@ -18,7 +18,7 @@ namespace MS.Internal.Xaml.Parser
     /// Class that provides helper functions for the parser/Xaml Reader
     /// to process Bracket Characters specified on a Markup Extension Property
     /// </summary>
-    internal class SpecialBracketCharacters : ISupportInitialize
+    internal sealed class SpecialBracketCharacters : ISupportInitialize
     {
         private string _startChars;
         private string _endChars;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Parser/SpecialBracketCharacters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Parser/SpecialBracketCharacters.cs
@@ -145,7 +145,7 @@ namespace MS.Internal.Xaml.Parser
         /// <summary>
         /// Stores characters that cannot be specified in <see cref="MarkupExtensionBracketCharactersAttribute"/>.
         /// </summary>
-        private static readonly ISet<char> s_restrictedCharSet = new SortedSet<char>(new char[] { '=', ',', '\'', '"', '{', '}', '\\' });
+        private static readonly SortedSet<char> s_restrictedCharSet = new(new char[] { '=', ',', '\'', '"', '{', '}', '\\' });
 
         private bool _initializing;
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Parser/SpecialBracketCharacters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Parser/SpecialBracketCharacters.cs
@@ -7,10 +7,11 @@
 //  Description: Data model for the Bracket characters specified on a Markup Extension property.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Text;
+using System.Buffers;
+using System.Windows.Markup;
+using System.ComponentModel;
+using System.Collections.Generic;
 
 namespace MS.Internal.Xaml.Parser
 {
@@ -20,6 +21,118 @@ namespace MS.Internal.Xaml.Parser
     /// </summary>
     internal sealed class SpecialBracketCharacters : ISupportInitialize
     {
+#if !NETFX
+        /// <summary>
+        /// Stores characters that cannot be specified in <see cref="MarkupExtensionBracketCharactersAttribute"/>.
+        /// </summary>
+        private static readonly SearchValues<char> s_restrictedCharSet = SearchValues.Create('=', ',', '\'', '"', '{', '}', '\\');
+
+        private string _startChars;
+        private string _endChars;
+        private bool _initializing;
+        private StringBuilder _startCharactersStringBuilder;
+        private StringBuilder _endCharactersStringBuilder;
+
+        internal SpecialBracketCharacters()
+        {
+            BeginInit();
+        }
+
+        internal SpecialBracketCharacters(IReadOnlyDictionary<char, char> attributeList)
+        {
+            BeginInit();
+            if (attributeList != null && attributeList.Count > 0)
+            {
+                Tokenize(attributeList);
+            }
+        }
+
+        internal void AddBracketCharacters(char openingBracket, char closingBracket)
+        {
+            if (_initializing)
+            {
+                _startCharactersStringBuilder.Append(openingBracket);
+                _endCharactersStringBuilder.Append(closingBracket);
+            }
+            else
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        private void Tokenize(IReadOnlyDictionary<char, char> attributeList)
+        {
+            if (_initializing)
+            {
+                foreach (char openingBracket in attributeList.Keys)
+                {
+                    char closingBracket = attributeList[openingBracket];
+
+                    if (IsValidBracketCharacter(openingBracket, closingBracket))
+                    {
+                        _startCharactersStringBuilder.Append(openingBracket);
+                        _endCharactersStringBuilder.Append(closingBracket);
+                    }
+                }
+            }
+        }
+
+        private static bool IsValidBracketCharacter(char openingBracket, char closingBracket)
+        {
+            if (openingBracket == closingBracket)
+                throw new InvalidOperationException("Opening bracket character cannot be the same as closing bracket character.");
+            else if (char.IsLetterOrDigit(openingBracket) || char.IsLetterOrDigit(closingBracket) || char.IsWhiteSpace(openingBracket) || char.IsWhiteSpace(closingBracket))
+                throw new InvalidOperationException("Bracket characters cannot be alpha-numeric or whitespace.");
+            else if (s_restrictedCharSet.Contains(openingBracket) || s_restrictedCharSet.Contains(closingBracket))
+                throw new InvalidOperationException("Bracket characters cannot be one of the following: '=' , ',', '\'', '\"', '{ ', ' }', '\\'");
+
+            return true;
+        }
+
+        internal bool IsSpecialCharacter(char ch)
+        {
+            return _startChars.Contains(ch) || _endChars.Contains(ch);
+        }
+
+        internal bool StartsEscapeSequence(char ch)
+        {
+            return _startChars.Contains(ch);
+        }
+
+        internal bool EndsEscapeSequence(char ch)
+        {
+            return _endChars.Contains(ch);
+        }
+
+        internal bool Match(char start, char end)
+        {
+            return _endChars.IndexOf(end, StringComparison.Ordinal) == _startChars.IndexOf(start, StringComparison.Ordinal);
+        }
+
+        internal string StartBracketCharacters
+        {
+            get { return _startChars; }
+        }
+
+        internal string EndBracketCharacters
+        {
+            get { return _endChars; }
+        }
+
+        public void BeginInit()
+        {
+            _initializing = true;
+            _startCharactersStringBuilder = new StringBuilder();
+            _endCharactersStringBuilder = new StringBuilder();
+        }
+
+        public void EndInit()
+        {
+            _startChars = _startCharactersStringBuilder.ToString();
+            _endChars = _endCharactersStringBuilder.ToString();
+            _initializing = false;
+        }
+#else
         private string _startChars;
         private string _endChars;
         private readonly static ISet<char> _restrictedCharSet = new SortedSet<char>((new char[] { '=', ',', '\'', '"', '{', '}', '\\' }));
@@ -134,5 +247,6 @@ namespace MS.Internal.Xaml.Parser
             _endChars = _endCharactersStringBuilder.ToString();
             _initializing = false;
         }
+#endif
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -564,25 +564,22 @@ namespace System.Xaml
         /// Looks up all properties via reflection on the given type, and scans through the attributes on all of them
         /// to build a cache of properties which have MarkupExtensionBracketCharactersAttribute set on them.
         /// </summary>
-        private Dictionary<string, SpecialBracketCharacters> BuildBracketCharacterCacheForType(XamlType type)
+        private static Dictionary<string, SpecialBracketCharacters> BuildBracketCharacterCacheForType(XamlType type)
         {
-            Dictionary<string, SpecialBracketCharacters> map = new Dictionary<string, SpecialBracketCharacters>(StringComparer.OrdinalIgnoreCase);
-            ICollection<XamlMember> members = type.GetAllMembers();
-            foreach (XamlMember member in members)
+            Dictionary<string, SpecialBracketCharacters> map = new(StringComparer.OrdinalIgnoreCase);
+
+            foreach (XamlMember member in type.GetAllMembers())
             {
-                string constructorArgumentName = member.ConstructorArgument;
-                string propertyName = member.Name;
-                IReadOnlyDictionary<char,char> markupExtensionBracketCharactersList = member.MarkupExtensionBracketCharacters;
-                SpecialBracketCharacters splBracketCharacters = markupExtensionBracketCharactersList != null && markupExtensionBracketCharactersList.Count > 0
-                    ? new SpecialBracketCharacters(markupExtensionBracketCharactersList)
-                    : null;
-                if (splBracketCharacters != null)
+                if (member.MarkupExtensionBracketCharacters?.Count > 0)
                 {
-                    splBracketCharacters.EndInit();
-                    map.Add(propertyName, splBracketCharacters);
-                    if (!string.IsNullOrEmpty(constructorArgumentName))
+                    SpecialBracketCharacters specialBracketChars = new(member.MarkupExtensionBracketCharacters);
+                    specialBracketChars.EndInit();
+
+                    map.Add(member.Name, specialBracketChars);
+
+                    if (!string.IsNullOrEmpty(member.ConstructorArgument))
                     {
-                        map.Add(constructorArgumentName, splBracketCharacters);
+                        map.Add(member.ConstructorArgument, specialBracketChars);
                     }
                 }
             }


### PR DESCRIPTION
## Description

Optimizes the very much unused `SpecialBracketCharacters` (which is used with `MarkupExtensionBracketCharactersAttribute`), bringing less static memory and more modern code.

- Yes, there's now `NetFX` and `NET` version, there's just no way around bringing markup/baml improvements without special-casing most of the stuff. We will remove the NetFX, once.
- Uses `SearchValues<char>` over `SortedSet<char>`, decreasing static memory 4 times and increasing perf 4 times.
- Fixes pretty much what you might classify as a blatant memory leak by keeping the `StringBuilder` instances around.
- This also leads to me doing, what in my opinion, is more proper implementation of `ISupportInitialize` (there are no new exceptions thrown, the code is written properly in all places I've checked, so it's just a safety work)
- Mark `BuildBracketCharacterCacheForType` method as static in both PBT and System.Xaml.
- Removes up to **TRIPLE** dictionary lookup in `InitBracketCharacterCacheForType` for `PBT`/`PresentationFramework`.
    - `ContainsKey` -> `Add` -> `indexer` lookup
- Since I consider half of `System.Xaml` a spaghetti code I've adjusted `BuildBracketCharacterCacheForType` to be more readable (that's my personal opinion).

### `SortedSet<char>` vs `SearchValues<char>` (2x contains)

| Method   | char1 | char2 | Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Allocated [B] |
|--------- |-------- |-------- |----------:|-----------:|------------:|--------------:|--------------:|
| Original | \u3039 | \u005c | 4.5088 ns |  0.0866 ns |   0.0810 ns |         101 B |             - |
| PR_EDIT  | \u3039 | \u005c| 0.3253 ns |  0.0075 ns |   0.0070 ns |          70 B |             - |

### Construction of those two (SortedSet has a heap array)
| Method       | Mean [ns]  | Error [ns] | StdDev [ns] | Code Size [B] | Gen0   | Allocated [B] |
|------------  |----------:|-----------:|------------:|--------------:|-------:|--------------:|
| SearchValues | 48.855 ns  |  0.9252 ns |   0.8654 ns |       1,377 B | 0.0048 |          80 B |
| SortedSet    | 71.338 ns  |  1.5273 ns |   3.6001 ns |       1,079 B | 0.0243 |         408 B |


## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build; I've tested the changes in `SpecialBracketCharacters` and it works as expected.

## Risk

Low, there are no functional changes, just optimizations.
