### PR TITLE
Fix datagrid memory leak - selection and clear

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -8631,7 +8631,7 @@ namespace System.Windows.Controls
             get { return _newItemPlaceholder; }
         }
 
-        //Clearing the properties which will hold references even after the datagrid is cleared. Fixes memory leaks.
+        // Clearing the properties which will hold references even after the datagrid is cleared. Fixes memory leaks.
         internal void ClearFocusAndSelection()
         {
             FocusedCell = null;
@@ -8639,7 +8639,7 @@ namespace System.Windows.Controls
             CurrentCell = default;
             CurrentItem = null;
             CurrentColumn = null;
-            //Clear the focused info as well in ItemsControl
+            // Clear the focused info as well in ItemsControl
             ClearFocusedInfo();
         }
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -8631,6 +8631,17 @@ namespace System.Windows.Controls
             get { return _newItemPlaceholder; }
         }
 
+        //Clearing the properties which will hold references even after the datagrid is cleared. Fixes memory leaks.
+        internal void ClearFocusAndSelection()
+        {
+            FocusedCell = null;
+            _selectionAnchor = null;
+            CurrentCell = default;
+            CurrentItem = null;
+            CurrentColumn = null;
+            //Clear the focused info as well in ItemsControl
+            ClearFocusedInfo();
+        }
         #endregion
 
         #region Data

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridRow.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridRow.cs
@@ -497,7 +497,7 @@ namespace System.Windows.Controls
             {
                 detailsPresenter.Content = BindingExpressionBase.DisconnectedItem;
             }
-            //Clear the properties to fix memory leaks case of selection and then clearing the items.
+            // Clear the properties to fix memory leaks case of selection and then clearing the items.
             _owner?.ClearFocusAndSelection();
             _owner = null;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridRow.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridRow.cs
@@ -497,7 +497,8 @@ namespace System.Windows.Controls
             {
                 detailsPresenter.Content = BindingExpressionBase.DisconnectedItem;
             }
-
+            //Clear the properties to fix memory leaks case of selection and then clearing the items.
+            _owner?.ClearFocusAndSelection();
             _owner = null;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
@@ -2263,6 +2263,12 @@ namespace System.Windows.Controls
                 true /*shouldFocus*/,
                 out container);
         }
+        
+        //Clear the _focusedInfo property when the row is cleared in datagrid.
+        internal void ClearFocusedInfo()
+        {
+            _focusedInfo = null;
+        }
 
         private bool NavigateByPageInternal(object startingItem,
             FocusNavigationDirection direction,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
@@ -2264,7 +2264,7 @@ namespace System.Windows.Controls
                 out container);
         }
         
-        //Clear the _focusedInfo property when the row is cleared in datagrid.
+        // Clear the _focusedInfo property when the row is cleared in datagrid.
         internal void ClearFocusedInfo()
         {
             _focusedInfo = null;


### PR DESCRIPTION
Fixes #6983 and partially fixes 6087 

## Description
Clear properties which were holding references related to selection and focused info, once the datagrid is cleared.

## Customer Impact
Huge memory consumption.

## Regression
No

## Testing
Local testing with sample app for memory leak fix.
WPF CTP testing.

## Risk
Low

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9924)