### PR TITLE
Optimize assembly/namespace pair creation and updating in XamlSchema

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
@@ -1,17 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
+using System.Diagnostics;
 using System.Reflection;
 
 namespace System.Xaml.MS.Impl
 {
     [DebuggerDisplay("{ClrNamespace} {Assembly.FullName}")]
-    internal class AssemblyNamespacePair
+    internal readonly struct AssemblyNamespacePair
     {
-        private WeakReference _assembly;
-        private string _clrNamespace;
+        private readonly WeakReference _assembly;
+        private readonly string _clrNamespace;
 
         public AssemblyNamespacePair(Assembly asm, string clrNamespace)
         {
@@ -19,9 +18,9 @@ namespace System.Xaml.MS.Impl
             _clrNamespace = clrNamespace;
         }
 
-        public Assembly Assembly
+        public Assembly? Assembly
         {
-            get { return (Assembly)_assembly.Target; }
+            get { return (Assembly?)_assembly.Target; }
         }
 
         public string ClrNamespace

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Reflection;
 
 namespace System.Xaml.MS.Impl

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
@@ -6,6 +6,9 @@ using System.Reflection;
 
 namespace System.Xaml.MS.Impl
 {
+    /// <summary>
+    /// Holds a <see cref="WeakReference"/> to an <see cref="Reflection.Assembly"/> associated with the current <see cref="ClrNamespace"/>.
+    /// </summary>
     [DebuggerDisplay("{ClrNamespace} {Assembly.FullName}")]
     internal readonly struct AssemblyNamespacePair
     {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
@@ -12,23 +12,23 @@ namespace System.Xaml.MS.Impl
     [DebuggerDisplay("{ClrNamespace} {Assembly.FullName}")]
     internal readonly struct AssemblyNamespacePair
     {
-        private readonly WeakReference _assembly;
+        private readonly WeakReference<Assembly> _assembly;
         private readonly string _clrNamespace;
 
         public AssemblyNamespacePair(Assembly asm, string clrNamespace)
         {
-            _assembly = new WeakReference(asm);
+            _assembly = new WeakReference<Assembly>(asm);
             _clrNamespace = clrNamespace;
         }
 
         public Assembly? Assembly
         {
-            get { return (Assembly?)_assembly.Target; }
+            get => _assembly.TryGetTarget(out Assembly? assembly) ? assembly : null;
         }
 
         public string ClrNamespace
         {
-            get { return _clrNamespace; }
+            get => _clrNamespace;
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
@@ -17,7 +17,7 @@ namespace System.Xaml.Schema
     {
         public readonly XamlSchemaContext SchemaContext;
 
-        private List<AssemblyNamespacePair> _assemblyNamespaces;
+        private AssemblyNamespacePair[] _assemblyNamespaces;
         private ConcurrentDictionary<string, XamlType> _typeCache;
         private ICollection<XamlType> _allPublicTypes;
 
@@ -169,7 +169,7 @@ namespace System.Xaml.Schema
         {
             // The only external mutation we allow is adding new namespaces. So the count of
             // namespaces also serves as a revision number.
-            get => (_assemblyNamespaces is not null) ? _assemblyNamespaces.Count : 0;
+            get => (_assemblyNamespaces != null) ? _assemblyNamespaces.Length : 0;
         }
 
         private Type TryGetType(string typeName)
@@ -177,7 +177,7 @@ namespace System.Xaml.Schema
             Type type = SearchAssembliesForShortName(typeName);
             if (type is null && IsClrNamespace)
             {
-                Debug.Assert(_assemblyNamespaces.Count == 1);
+                Debug.Assert(_assemblyNamespaces.Length == 1);
                 type = XamlLanguage.LookupClrNamespaceType(_assemblyNamespaces[0], typeName);
             }
 
@@ -233,13 +233,13 @@ namespace System.Xaml.Schema
             return xamlTypeList.AsReadOnly();
         }
 
-        private List<AssemblyNamespacePair> GetClrNamespacePair(string clrNs, string assemblyName)
+        private AssemblyNamespacePair[] GetClrNamespacePair(string clrNs, string assemblyName)
         {
             Assembly asm = SchemaContext.OnAssemblyResolve(assemblyName);
             if (asm is null)
                 return null;
 
-            return new List<AssemblyNamespacePair>(1) { new AssemblyNamespacePair(asm, clrNs) };
+            return new AssemblyNamespacePair[1] { new AssemblyNamespacePair(asm, clrNs) };
         }
 
         private Type SearchAssembliesForShortName(string shortName)
@@ -268,22 +268,23 @@ namespace System.Xaml.Schema
         // This method should only be called inside SchemaContext._syncExaminingAssemblies lock
         internal void AddAssemblyNamespacePair(AssemblyNamespacePair pair)
         {
-            // To allow the list to be read by multiple threads, we create a new list, add the pair,
-            // then assign it back to the original variable. Assignments are assured to be atomic.
+            // To allow the array to be read concurrently by multiple threads, we create a new array, add the pair,
+            // then assign it back to the original variable. Assignments are guaranteed to be atomic for word size.
 
-            List<AssemblyNamespacePair> assemblyNamespacesCopy;
+            AssemblyNamespacePair[] assemblyNamespacesCopy;
             if (_assemblyNamespaces is null)
             {
-                assemblyNamespacesCopy = new List<AssemblyNamespacePair>(1);
+                assemblyNamespacesCopy = new AssemblyNamespacePair[1];
                 Initialize();
             }
             else
             {
-                assemblyNamespacesCopy = new List<AssemblyNamespacePair>(_assemblyNamespaces.Count + 1);
+                assemblyNamespacesCopy = new AssemblyNamespacePair[_assemblyNamespaces.Length + 1];
             }
 
-            assemblyNamespacesCopy.AddRange(_assemblyNamespaces);
-            assemblyNamespacesCopy.Add(pair);
+            // Copy over and add new item
+            _assemblyNamespaces.CopyTo(assemblyNamespacesCopy, 0);
+            assemblyNamespacesCopy[assemblyNamespacesCopy.Length - 1] = pair;
 
             _assemblyNamespaces = assemblyNamespacesCopy;
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
@@ -169,7 +169,7 @@ namespace System.Xaml.Schema
         {
             // The only external mutation we allow is adding new namespaces. So the count of
             // namespaces also serves as a revision number.
-            get => (_assemblyNamespaces != null) ? _assemblyNamespaces.Length : 0;
+            get => _assemblyNamespaces?.Length ?? 0;
         }
 
         private Type TryGetType(string typeName)
@@ -279,12 +279,13 @@ namespace System.Xaml.Schema
             }
             else
             {
+                // Copy items over to the new collection
                 assemblyNamespacesCopy = new AssemblyNamespacePair[_assemblyNamespaces.Length + 1];
+                _assemblyNamespaces.CopyTo(assemblyNamespacesCopy, 0);
             }
 
-            // Copy over and add new item
-            _assemblyNamespaces.CopyTo(assemblyNamespacesCopy, 0);
-            assemblyNamespacesCopy[assemblyNamespacesCopy.Length - 1] = pair;
+            // Add new pair as the last one
+            assemblyNamespacesCopy[^1] = pair;
 
             _assemblyNamespaces = assemblyNamespacesCopy;
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
@@ -237,13 +237,9 @@ namespace System.Xaml.Schema
         {
             Assembly asm = SchemaContext.OnAssemblyResolve(assemblyName);
             if (asm is null)
-            {
                 return null;
-            }
 
-            List<AssemblyNamespacePair> onePair = new List<AssemblyNamespacePair>();
-            onePair.Add(new AssemblyNamespacePair(asm, clrNs));
-            return onePair;
+            return new List<AssemblyNamespacePair>(1) { new AssemblyNamespacePair(asm, clrNs) };
         }
 
         private Type SearchAssembliesForShortName(string shortName)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
@@ -269,20 +269,22 @@ namespace System.Xaml.Schema
         internal void AddAssemblyNamespacePair(AssemblyNamespacePair pair)
         {
             // To allow the list to be read by multiple threads, we create a new list, add the pair,
-            // then assign it back to the original variable.  Assignments are assured to be atomic.
+            // then assign it back to the original variable. Assignments are assured to be atomic.
 
             List<AssemblyNamespacePair> assemblyNamespacesCopy;
             if (_assemblyNamespaces is null)
             {
-                assemblyNamespacesCopy = new List<AssemblyNamespacePair>();
+                assemblyNamespacesCopy = new List<AssemblyNamespacePair>(1);
                 Initialize();
             }
             else
             {
-                assemblyNamespacesCopy = new List<AssemblyNamespacePair>(_assemblyNamespaces);
+                assemblyNamespacesCopy = new List<AssemblyNamespacePair>(_assemblyNamespaces.Count + 1);
             }
 
+            assemblyNamespacesCopy.AddRange(_assemblyNamespaces);
             assemblyNamespacesCopy.Add(pair);
+
             _assemblyNamespaces = assemblyNamespacesCopy;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -1182,15 +1182,15 @@ namespace System.Xaml
 
         private bool UpdateNamespaceByUriList(XmlNsInfo nsInfo)
         {
-            bool foundNew = false;
             IList<XmlNsInfo.XmlNsDefinition> xmlnsDefs = nsInfo.NsDefs;
-            int xmlnsDefsCount = xmlnsDefs.Count;
-            for (int i = 0; i < xmlnsDefsCount; i++)
+            bool foundNew = false;
+
+            for (int i = 0; i < xmlnsDefs.Count; i++)
             {
                 XmlNsInfo.XmlNsDefinition xmlnsDef = xmlnsDefs[i];
-                AssemblyNamespacePair pair = new AssemblyNamespacePair(nsInfo.Assembly, xmlnsDef.ClrNamespace);
                 XamlNamespace ns = GetXamlNamespace(xmlnsDef.XmlNamespace);
-                ns.AddAssemblyNamespacePair(pair);
+
+                ns.AddAssemblyNamespacePair(new AssemblyNamespacePair(nsInfo.Assembly, xmlnsDef.ClrNamespace));
                 foundNew = true;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -1180,6 +1180,7 @@ namespace System.Xaml
             return foundNew;
         }
 
+        // This method should be called inside _syncExaminingAssemblies lock
         private bool UpdateNamespaceByUriList(XmlNsInfo nsInfo)
         {
             IList<XmlNsInfo.XmlNsDefinition> xmlnsDefs = nsInfo.NsDefs;


### PR DESCRIPTION
## Description

Adjusts inefficient `List<AssemblyNamespacePair>` copies in `AddAssemblyNamespacePair` that result in up to double gen0 allocations needed for the job, offering perf benefit and decreased allocations.

- I have changed it to be a `readonly struct`, there's like zero benefit but I think it serves better purpose.
- The `WeakReference` is now generic to prevent unnecessary casting.
- Since `_assemblyNamespaces` is under a write-lock and copies are created each time to allow reading concurrently by multiple readers, we can just swap to an array for overall efficiency since only 1 item is added each time.

### Initial creation
| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 108.37 ns |   2.179 ns |    2.594 ns | 0.0086 |         317 B |         144 B |
| PR_EDIT |  89.78 ns |   1.833 ns |    2.687 ns | 0.0038 |         223 B |          64 B |

### Initial creation plus 9x AddAssemblyNamespacePair

| Method   | Mean [ns]  | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |-----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  1,419.8 ns |   28.21 ns |    37.66 ns | 0.1678 |       2,668 B |        2824 B |
| PR_EDIT |  1,100.8 ns |   18.28 ns |    16.20 ns | 0.0935 |       2,329 B |        1584 B |

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, basic method testing.

## Risk

Low, there's only a swap from class to readonly struct being stored in a private array (that was originally a list).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9926)