### PR TITLE
Fix IndexOutOfRangeException/Infinite loop in UpdateComponent (Track control)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Track.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Track.cs
@@ -360,11 +360,7 @@ namespace System.Windows.Controls.Primitives
         /// </summary>
         protected override Visual GetVisualChild(int index)
         {
-            if (_visualChildren == null || _visualChildren[index] == null)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, SR.Visual_ArgumentOutOfRange);
-            }
-            return _visualChildren[index];
+            return _visualChildren?[index] ?? throw new ArgumentOutOfRangeException(nameof(index), index, SR.Visual_ArgumentOutOfRange);
         }
         
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Track.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Track.cs
@@ -109,42 +109,38 @@ namespace System.Windows.Controls.Primitives
         {
             if (oldValue != newValue)
             {
-                if (_visualChildren == null)
-                {
-                    _visualChildren = new Visual[3];
-                }
+                const int VisualChildrenCount = 3;
+                const int VisualChildrenMaxIndex = 2;
+                _visualChildren ??= new Visual[VisualChildrenCount];
 
+                // Notify the visual layer that the old component has been removed
                 if (oldValue != null)
-                {
-                    // notify the visual layer that the old component has been removed.
                     RemoveVisualChild(oldValue);
-                }
 
-                // Remove the old value from our z index list and add new value to end
-                int i = 0;
-                while (i < 3) 
+                int itemIndex = 0;
+                int nullIndex = 0;
+
+                // Find the Count of the items
+                while (nullIndex < VisualChildrenCount && _visualChildren[nullIndex] != null)
+                    nullIndex++;
+
+                // Find the oldValue item index
+                while (itemIndex < VisualChildrenMaxIndex && _visualChildren[itemIndex] != oldValue)
+                    itemIndex++;
+
+                Debug.Assert(_visualChildren[itemIndex] == oldValue, "Attempt to add a 4th item into _visualChildren");
+
+                // In case we're replacing a value, we need to shift the items to the left first, and then append newValue as last
+                nullIndex--;
+                if (itemIndex < nullIndex)
                 {
-                    // Array isn't full, break
-                    if (_visualChildren[i] == null)
-                        break;
-
-                    // found the old value
-                    if (_visualChildren[i] == oldValue)
-                    {
-                        // Move values down until end of array or a null element
-                        while (i < 2 && _visualChildren[i + 1] != null)
-                        {
-                            _visualChildren[i] = _visualChildren[i + 1];
-                            i++;
-                        }
-                    }
-                    else
-                    {
-                        i++;
-                    }
+                    Array.Copy(_visualChildren, itemIndex + 1, _visualChildren, itemIndex, nullIndex - itemIndex);
+                    _visualChildren[nullIndex] = newValue;
                 }
-                // Add newValue at end of z-order
-                _visualChildren[i] = newValue;
+                else // In case there are still leftover NULL items (empty spots) or it is the last one, we just append
+                {
+                    _visualChildren[itemIndex] = newValue;
+                }
 
                 AddVisualChild(newValue);
 


### PR DESCRIPTION
Fixes #9904 

## Description

Fixes `IndexOutOfRangeException` and infinite loop issues when updating any of `Track`'s children after they've been already set from template or manually.

This issue is present when you attempt to update via any of the public properties (`DecreaseRepeatButton`, `IncreaseRepeatButton`, `Thumb`) after all the public members of Track has already been previously set (and therefore `_visualChildren` is initialized and has stored all three properties).

In standard Aero2 theme, using a `ScrollBar` (as `Track` has no template on its own), the order of the children is:
- _visualChildren[0] = RepeatButton1
- _visualChildren[1] = RepeatButton2
- _visualChildren[2] = Thumb

Setting item at position 2 (which would be `Thumb` property now) will result in an infinite loop.
Setting items at positions 0 and 1 will result in `IndexOutOfRangeException` during assigment.

The simplest reproduction code with pure `Track` goes like this:
```csharp
Track crashMe = new Track();
crashMe.DecreaseRepeatButton = new RepeatButton();
crashMe.IncreaseRepeatButton = new RepeatButton();
crashMe.Thumb = new Thumb();

// Uncomment this for IndexOutOfRangeException
// crashMe.IncreaseRepeatButton = new RepeatButton();

// Uncomment this for infinite loop
// crashMe.Thumb = new Thumb()
```

The original code was written with updates in mind but I think it got a bit lost in shifting array members. I have fixed it to behave exactly as described in [Track.GetVisualChild](https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.primitives.track.getvisualchild?view=windowsdesktop-8.0) and [Track.VisualChildrenCount](https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.primitives.track.visualchildrencount?view=windowsdesktop-8.0) describes (+ the original comments), that means whenever you update an item, the array is shifted to the left if needed, so the order is always from oldest to newest (left to right).
This is aligned with `VisualChildrenCount` behavior where `NULL` allows you to remove children basically as well.

## Customer Impact

Customers will be finally able to change the `Track` components as they please and won't experience undocumented behavior and exceptions that were not originally inteded.

## Regression

This seems to be present way back. PresentationFramework v3 from NetFX has a bit different code but also buggy.

## Testing

Testing the forementioned exceptions and the order of the items, visual refresh, everything seems in order.

## Risk

Low, a loop has been fixed to work properly without changing anything else (e.g. collection types, etc.)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9934)