### PR TITLE
Optimize parsing and serialization of generic type names in Xaml, decrease allocs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameScanner.cs
@@ -100,7 +100,7 @@ namespace MS.Internal.Xaml.Parser
 
         // Parse a single subscript (e.g. [] or [,]) at the given position, returning its rank
         // Returns 0 if the parse failed
-        internal static int ParseSubscriptSegment(string subscript, ref int pos)
+        internal static int ParseSubscriptSegment(ReadOnlySpan<char> subscript, ref int pos)
         {
             bool openBracketFound = false;
             int rank = 1;
@@ -150,17 +150,17 @@ namespace MS.Internal.Xaml.Parser
         }
 
         // strips the subscript off the end of typeName, and returns it
-        internal static string StripSubscript(string typeName, out string subscript)
+        internal static ReadOnlySpan<char> StripSubscript(ReadOnlySpan<char> typeName, out ReadOnlySpan<char> subscript)
         {
             int openBracketNdx = typeName.IndexOf(OpenBracket);
             if (openBracketNdx < 0)
             {
-                subscript = null;
+                subscript = ReadOnlySpan<char>.Empty;
                 return typeName;
             }
 
-            subscript = typeName.Substring(openBracketNdx);
-            return typeName.Substring(0, openBracketNdx);
+            subscript = typeName.Slice(openBracketNdx);
+            return typeName.Slice(0, openBracketNdx);
         }
 
         private void State_Start()

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
@@ -5,6 +5,9 @@
 #nullable disable
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Reflection;
 using System.Xaml.MS.Impl;
 using MS.Internal.Xaml.Parser;
@@ -70,8 +73,7 @@ namespace System.Xaml.Schema
         private XamlType TryGetXamlType(string typeName)
         {
             // Look up the type in our cache. If it's there, we're done.
-            XamlType xamlType;
-            if (_typeCache.TryGetValue(typeName, out xamlType))
+            if (_typeCache.TryGetValue(typeName, out XamlType xamlType))
             {
                 return xamlType;
             }
@@ -99,11 +101,11 @@ namespace System.Xaml.Schema
 
             // It is not possible to get an array of open generic and then call
             // MakeGenericType on it so we need to process array subscripts.
-            typeName = GenericTypeNameScanner.StripSubscript(typeName, out string subscript);
-            typeName = MangleGenericTypeName(typeName, typeArgs.Length);
+            ReadOnlySpan<char> typeNameSpan = GenericTypeNameScanner.StripSubscript(typeName, out ReadOnlySpan<char> subscript);
+            string mangledTypeName = MangleGenericTypeName(typeNameSpan, typeArgs.Length);
 
             // Get the open generic type.
-            XamlType openXamlType = TryGetXamlType(typeName);
+            XamlType openXamlType = TryGetXamlType(mangledTypeName);
             Type openType = openXamlType?.UnderlyingType;
             if (openType is null)
             {
@@ -112,7 +114,7 @@ namespace System.Xaml.Schema
 
             // Close the open generic type.
             Type closedType = openType.MakeGenericType(typeArgs);
-            if (!string.IsNullOrEmpty(subscript))
+            if (!subscript.IsEmpty)
             {
                 closedType = MakeArrayType(closedType, subscript);
                 if (closedType is null)
@@ -125,7 +127,7 @@ namespace System.Xaml.Schema
             return SchemaContext.GetXamlType(closedType);
         }
 
-        private static Type MakeArrayType(Type elementType, string subscript)
+        private static Type MakeArrayType(Type elementType, ReadOnlySpan<char> subscript)
         {
             Type type = elementType;
             int pos = 0;
@@ -144,9 +146,9 @@ namespace System.Xaml.Schema
             return type;
         }
 
-        private static string MangleGenericTypeName(string typeName, int paramNum)
+        private static string MangleGenericTypeName(ReadOnlySpan<char> typeName, int paramNum)
         {
-            return typeName + KnownStrings.GraveQuote + paramNum;
+            return $"{typeName}{KnownStrings.GraveQuote}{paramNum}";
         }
 
         private Type[] ConvertArrayOfXamlTypesToTypes(XamlType[] typeArgs)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
@@ -99,8 +99,7 @@ namespace System.Xaml.Schema
 
             // It is not possible to get an array of open generic and then call
             // MakeGenericType on it so we need to process array subscripts.
-            string subscript;
-            typeName = GenericTypeNameScanner.StripSubscript(typeName, out subscript);
+            typeName = GenericTypeNameScanner.StripSubscript(typeName, out string subscript);
             typeName = MangleGenericTypeName(typeName, typeArgs.Length);
 
             // Get the open generic type.

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
@@ -1623,8 +1623,8 @@ namespace System.Xaml
             if (index >= 0)
             {
                 // save the subscript
-                typeName = GenericTypeNameScanner.StripSubscript(typeName, out string subscript);
-                typeName = string.Concat(typeName.AsSpan(0, index), subscript);
+                ReadOnlySpan<char> typeNameSpan = GenericTypeNameScanner.StripSubscript(typeName, out ReadOnlySpan<char> subscript);
+                typeName = string.Concat(typeNameSpan.Slice(0, index), subscript);
             }
 
             // if nested, add the containing name

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
@@ -1623,8 +1623,7 @@ namespace System.Xaml
             if (index >= 0)
             {
                 // save the subscript
-                string subscript;
-                typeName = GenericTypeNameScanner.StripSubscript(typeName, out subscript);
+                typeName = GenericTypeNameScanner.StripSubscript(typeName, out string subscript);
                 typeName = string.Concat(typeName.AsSpan(0, index), subscript);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
@@ -239,8 +239,7 @@ namespace System.Xaml.Schema
             if (HasTypeArgs)
             {
                 // The subscript goes after the type args
-                string subscript;
-                string name = GenericTypeNameScanner.StripSubscript(Name, out subscript);
+                string name = GenericTypeNameScanner.StripSubscript(Name, out string subscript);
                 result.Append(name);
 
                 result.Append('(');

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
@@ -148,16 +148,14 @@ namespace System.Xaml.Schema
             }
         }
 
-        internal static string ConvertListToStringInternal(IList<XamlTypeName> typeNameList,
-            Func<string, string> prefixGenerator)
+        internal static string ConvertListToStringInternal(IList<XamlTypeName> typeNameList, Func<string, string> prefixGenerator)
         {
             StringBuilder result = new StringBuilder();
             ConvertListToStringInternal(result, typeNameList, prefixGenerator);
             return result.ToString();
         }
 
-        internal static void ConvertListToStringInternal(StringBuilder result, IList<XamlTypeName> typeNameList,
-            Func<string, string> prefixGenerator)
+        internal static void ConvertListToStringInternal(StringBuilder result, IList<XamlTypeName> typeNameList, Func<string, string> prefixGenerator)
         {
             bool first = true;
             foreach (XamlTypeName typeName in typeNameList)
@@ -188,8 +186,7 @@ namespace System.Xaml.Schema
             return xamlTypeName;
         }
 
-        internal static IList<XamlTypeName> ParseListInternal(string typeNameList,
-            Func<string, string> prefixResolver, out string error)
+        internal static IList<XamlTypeName> ParseListInternal(string typeNameList, Func<string, string> prefixResolver, out string error)
         {
             GenericTypeNameParser nameParser = new GenericTypeNameParser(prefixResolver);
             IList<XamlTypeName> xamlTypeName = nameParser.ParseList(typeNameList, out error);
@@ -239,7 +236,7 @@ namespace System.Xaml.Schema
             if (HasTypeArgs)
             {
                 // The subscript goes after the type args
-                string name = GenericTypeNameScanner.StripSubscript(Name, out string subscript);
+                ReadOnlySpan<char> name = GenericTypeNameScanner.StripSubscript(Name, out ReadOnlySpan<char> subscript);
                 result.Append(name);
 
                 result.Append('(');

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
@@ -632,10 +632,10 @@ namespace System.Xaml
         {
             string prefix = LookupPrefix(type.GetXamlNamespaces(), out _);
             string typeName = GetTypeName(type);
-            string typeNamePrefixed = string.IsNullOrEmpty(prefix) ? typeName : $"{prefix}:{typeName}";
+            ReadOnlySpan<char> typeNamePrefixed = string.IsNullOrEmpty(prefix) ? typeName : $"{prefix}:{typeName}";
 
             // save the subscript
-            typeNamePrefixed = GenericTypeNameScanner.StripSubscript(typeNamePrefixed, out string subscript);
+            typeNamePrefixed = GenericTypeNameScanner.StripSubscript(typeNamePrefixed, out ReadOnlySpan<char> subscript);
 
             builder.Append(typeNamePrefixed);
             if (type.TypeArguments is not null)
@@ -657,7 +657,7 @@ namespace System.Xaml
             }
 
             // re-attach the subscript
-            if (subscript is not null)
+            if (!subscript.IsEmpty)
             {
                 builder.Append(subscript);
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
@@ -635,8 +635,7 @@ namespace System.Xaml
             string typeNamePrefixed = string.IsNullOrEmpty(prefix) ? typeName : $"{prefix}:{typeName}";
 
             // save the subscript
-            string subscript;
-            typeNamePrefixed = GenericTypeNameScanner.StripSubscript(typeNamePrefixed, out subscript);
+            typeNamePrefixed = GenericTypeNameScanner.StripSubscript(typeNamePrefixed, out string subscript);
 
             builder.Append(typeNamePrefixed);
             if (type.TypeArguments is not null)


### PR DESCRIPTION
## Description

Optimizes retrievals of subscripts/type names from generic types and also its serialization back to string.

This is meant to be very straightforward (as the main modification is done to `GenericTypeNameScanner.StripSubscript` and other modifications are just to comfort the change), so a lot of strings were kept, that's not an oversight. I believe those changes should be done in small batches.

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, unit tests.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9940)