### PR TITLE
Replace ArrayList in InputProcessorProfiles with fixed-size array, reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputProcessorProfiles.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputProcessorProfiles.cs
@@ -2,43 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
-// 
-//
 // Description: Creates ITfInputProcessorProfiles instances.
-//
 //
 
 using System.Runtime.InteropServices;
+using System.Globalization;
+using System.Diagnostics;
 using System.Threading;
 using MS.Win32;
-using System.Globalization;
-using System.Collections;
 
 namespace System.Windows.Input
 {
-    //------------------------------------------------------
-    //
-    //  InputProcessorProfiles class
-    //
-    //------------------------------------------------------
-
     /// <summary>
-    /// The InputProcessorProfiles class is always associated with 
-    /// hwndInputLanguage class.
+    /// The <see cref="InputProcessorProfiles"/> class is always associated with hwndInputLanguage class.
     /// </summary>
     internal class InputProcessorProfiles
     {
-        //------------------------------------------------------
-        //
-        //  Constructors
-        //
-        //------------------------------------------------------
-
         /// <summary>
         /// InputProcessorProfiles Constructor;
         /// </summary>
-        /// Critical - as this sets the value for _ipp.
-        /// Safe - as this just initializes it to null.
         internal InputProcessorProfiles()
         {
             // _ipp is a ValueType, hence no need for new.
@@ -46,14 +28,6 @@ namespace System.Windows.Input
             _cookie = UnsafeNativeMethods.TF_INVALID_COOKIE;
         }
 
-        //------------------------------------------------------
-        //
-        //  Internal Methods
-        //
-        //------------------------------------------------------
- 
-        #region Internal Methods
- 
         /// <summary>
         /// Initialize an interface and notify sink.
         /// </summary>
@@ -81,18 +55,10 @@ namespace System.Windows.Input
         {
             Debug.Assert(_ipp != null, "Uninitialize called without initializing");
 
-            UnadviseNotifySink();            
+            UnadviseNotifySink();
             Marshal.ReleaseComObject(_ipp);
             _ipp = null;
         }
-
-        #endregion Internal Methods
-
-        //------------------------------------------------------
-        //
-        //  Internal Properties
-        //
-        //------------------------------------------------------
 
         /// <summary>
         /// Get the current input language of the current thread.
@@ -112,7 +78,7 @@ namespace System.Windows.Input
                         IntPtr[] hklList = null;
 
                         int count = (int)SafeNativeMethods.GetKeyboardLayoutList(0, null);
-                        if (count > 1) 
+                        if (count > 1)
                         {
                             hklList = new IntPtr[count];
 
@@ -123,7 +89,7 @@ namespace System.Windows.Input
                             {
                                 if (value == (short)hklList[i])
                                 {
-                                    SafeNativeMethods.ActivateKeyboardLayout(new HandleRef(this,hklList[i]), 0);
+                                    SafeNativeMethods.ActivateKeyboardLayout(new HandleRef(this, hklList[i]), 0);
                                     break;
                                 }
                             }
@@ -157,13 +123,6 @@ namespace System.Windows.Input
             }
         }
 
-
-        //------------------------------------------------------
-        //
-        //  Private Methods
-        //
-        //------------------------------------------------------
-        
         /// <summary>
         /// This advices the input language notify sink to
         /// ITfInputProcessorProfile.
@@ -194,16 +153,14 @@ namespace System.Windows.Input
             _cookie = UnsafeNativeMethods.TF_INVALID_COOKIE;
         }
 
-        //------------------------------------------------------
-        //
-        //  Private Fields
-        //
-        //------------------------------------------------------
-                
-        // The reference to ITfInputProcessorProfile.
+        /// <summary>
+        /// The reference to <see cref="UnsafeNativeMethods.ITfInputProcessorProfiles"/>.
+        /// </summary>
         private UnsafeNativeMethods.ITfInputProcessorProfiles _ipp;
 
-        // The cookie for the advised sink.
+        /// <summary>
+        /// The cookie for the advised sink.
+        /// </summary>
         private int _cookie;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputProcessorProfiles.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputProcessorProfiles.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Input
     /// <summary>
     /// The <see cref="InputProcessorProfiles"/> class is always associated with hwndInputLanguage class.
     /// </summary>
-    internal class InputProcessorProfiles
+    internal sealed class InputProcessorProfiles
     {
         /// <summary>
         /// InputProcessorProfiles Constructor;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputProcessorProfiles.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputProcessorProfiles.cs
@@ -7,7 +7,6 @@
 
 using System.Runtime.InteropServices;
 using System.Globalization;
-using System.Diagnostics;
 using System.Threading;
 using MS.Win32;
 


### PR DESCRIPTION
## Description

Loosely follows #9221, replacing the other part of the `InputLanguageSource.InputLanguageList` with more modern code.
- Instead of marshalling the array members, we just wrap the array in a `ReadOnlySpan<short>`.
- Instead of using `ArrayList`, we preallocate the array as we know the final count.
- The class can be sealed, no reason not to as it has no children.
- I've formatted the file and cleared unused usings for clarity.

### Single invocation of the property (without `_ipp` init); 5 profiles

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |   556.4 ns |    5.70 ns |     5.33 ns | 0.0696 |       1,245 B |        1176 B |
| PR_EDIT  |  443.8 ns |    4.42 ns |     3.69 ns | 0.0563 |         394 B |         944 B |

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, testing new output matches the old one.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9946)