### PR TITLE
Adjust MouseWheelEventArgs.Delta from static to an instance readonly field

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseWheelEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseWheelEventArgs.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-using System;
-
 namespace System.Windows.Input
 {
     /// <summary>
@@ -34,7 +31,7 @@ namespace System.Windows.Input
         /// </summary>
         public int Delta
         {
-            get {return _delta;}
+            get => _delta;
         }
 
         /// <summary>
@@ -49,10 +46,10 @@ namespace System.Windows.Input
         /// </param>
         protected override void InvokeEventHandler(Delegate genericHandler, object genericTarget)
         {
-            MouseWheelEventHandler handler = (MouseWheelEventHandler) genericHandler;
+            MouseWheelEventHandler handler = (MouseWheelEventHandler)genericHandler;
             handler(genericTarget, this);
         }
 
-        private static int _delta;
+        private readonly int _delta;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseWheelEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseWheelEventArgs.cs
@@ -5,7 +5,7 @@
 namespace System.Windows.Input
 {
     /// <summary>
-    ///     The MouseWheelEventArgs describes the state of a Mouse wheel.
+    ///     The <see cref="MouseWheelEventArgs"/> describes the state of a <see cref="Mouse"/> wheel.
     /// </summary>
     public class MouseWheelEventArgs : MouseEventArgs
     {
@@ -50,6 +50,10 @@ namespace System.Windows.Input
             handler(genericTarget, this);
         }
 
+        /// <summary>
+        ///     Specifies the delta the mouse wheel has turned.
+        /// </summary>
         private readonly int _delta;
+
     }
 }


### PR DESCRIPTION
## Description

Similarly as in #7910, the `MouseWheelEventArgs.Delta` is a static field, meaning a creation of a new event changes the `Delta` value for all previously created events. This is clearly a bug, the field shall not be `static` but an instanced `readonly` as the event should describe the state at the exact point of time it was generated.

## Customer Impact

Creation of a new `MouseWheelEventArgs` will not influence the value of `Delta` for previous instances.

## Regression

No.

## Testing

Local build.

## Risk

Low.
