### PR TITLE
Fix FontSource/FontFileStream embedded resource memory leak

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSource.cs
@@ -184,7 +184,7 @@ namespace MS.Internal.FontCache
                 {
                     WebResponse response = WpfWebRequestHelper.CreateRequestAndGetResponse(_fontUri);
                     fontStream = response.GetResponseStream();
-                    if (String.Equals(response.ContentType, ObfuscatedContentType, StringComparison.Ordinal))
+                    if (string.Equals(response.ContentType, ObfuscatedContentType, StringComparison.Ordinal))
                     {
                         // The third parameter makes sure the original stream is closed
                         // when the deobfuscating stream is disposed.
@@ -192,19 +192,19 @@ namespace MS.Internal.FontCache
                     }
                 }
 
-                UnmanagedMemoryStream unmanagedStream = fontStream as UnmanagedMemoryStream;
+                // We don't want any memory leaks
+                // TODO: Remove FinalizableUnmanagedStream once FontFileStream is migrated from C++/CLI.
+                if (fontStream is UnmanagedMemoryStream unmanagedMemoryStream)
+                    return new FinalizableUnmanagedStream(unmanagedMemoryStream);
 
-                if (unmanagedStream != null)
-                    return unmanagedStream;
-
+                // Convert the DeobfuscatingStream to byte[]; add it to our cache, dispose it
                 bits = StreamToByteArray(fontStream);
+                lock (s_resourceCache)
+                {
+                    s_resourceCache.Add(_fontUri, bits, false);
+                }
 
-                fontStream?.Close();
-            }
-
-            lock (s_resourceCache)
-            {
-                s_resourceCache.Add(_fontUri, bits, false);
+                fontStream.Close();
             }
 
             return ByteArrayToUnmanagedStream(bits);
@@ -358,7 +358,7 @@ namespace MS.Internal.FontCache
             Assembly fontResourceAssembly = Assembly.GetExecutingAssembly();
             ResourceManager rm = new($"{ReflectionUtils.GetAssemblyPartialName(fontResourceAssembly)}.g", fontResourceAssembly);
 
-            return rm?.GetStream($"fonts/{fontFilename}");
+            return rm.GetStream($"fonts/{fontFilename}");
         }
 
         #endregion Private Methods
@@ -370,6 +370,26 @@ namespace MS.Internal.FontCache
         //------------------------------------------------------
 
         #region Private Classes
+
+        /// <summary>
+        /// Calls <see cref="UnmanagedMemoryStream.Dispose"/> from the destructor.
+        /// </summary>
+        // TODO: Remove this once FontFileStream is migrated from C++/CLI.
+        private sealed class FinalizableUnmanagedStream : UnmanagedMemoryStream
+        {
+            private readonly UnmanagedMemoryStream _unmanaged;
+
+            internal unsafe FinalizableUnmanagedStream(UnmanagedMemoryStream unmanagedStream)
+            {
+                _unmanaged = unmanagedStream;
+                Initialize(_unmanaged.PositionPointer, _unmanaged.Length, _unmanaged.Length, FileAccess.Read);
+            }
+
+            ~FinalizableUnmanagedStream()
+            {
+                _unmanaged.Dispose();
+            }
+        }
 
         private class PinnedByteArrayStream : UnmanagedMemoryStream
         {


### PR DESCRIPTION
Fixes #7289

## Description

Fixes memory leak when using fonts from embedded resources that are materialized onto `FontSource` -> `FontFamily`, etc.

The issue is basically in `FontSource.GetUnmanagedStream()`:
- We're passing around pure `UnmanagedMemoryStream` instance, but life without destructor is kind of hard.
    - This can be removed once `FontFileStream` from `DirectWriteForwarder` would be migrated to C#.

More context: The fix could be done by disposing the `UnmanagedMemoryStream` instantly and wrapping it in a new instance so it's cleared from the `List<Stream>` of `PackagePart` but I think it's nice to tie the lifetime together.

## Customer Impact

Customers will finally get their fix after 10 years.

https://stackoverflow.com/questions/31452443/wpf-textblock-memory-leak-when-using-font
https://stackoverflow.com/questions/49550759/wpf-load-font-from-resources
https://stackoverflow.com/questions/45297837/what-causes-unmanagedmemorystream-in-wpf-memory-leak
https://stackoverflow.com/questions/39157846/wpf-glyphs-control-font-uriits-slow-and-remains-in-memory

## Regression

Has been around since at least .NET 4.5.

## Testing

Using the repro in #7289; sample apps use.

## Risk

Low though we're passing around stuff onto C++/CLI, that's always awful.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9948)