### PR TITLE
Remove double lookups on SizeLimitedCache<K, V>, improve performance

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSource.cs
@@ -166,9 +166,9 @@ namespace MS.Internal.FontCache
             byte[] bits;
 
             // Try our cache first.
-            lock (_resourceCache)
+            lock (s_resourceCache)
             {
-                bits = _resourceCache.Get(_fontUri);
+                bits = s_resourceCache.Get(_fontUri);
             }
 
             if (bits == null)
@@ -202,9 +202,9 @@ namespace MS.Internal.FontCache
                 fontStream?.Close();
             }
 
-            lock (_resourceCache)
+            lock (s_resourceCache)
             {
-                _resourceCache.Add(_fontUri, bits, false);
+                s_resourceCache.Add(_fontUri, bits, false);
             }
 
             return ByteArrayToUnmanagedStream(bits);
@@ -239,9 +239,9 @@ namespace MS.Internal.FontCache
             byte[] bits;
 
             // Try our cache first.
-            lock (_resourceCache)
+            lock (s_resourceCache)
             {
-                bits = _resourceCache.Get(_fontUri);
+                bits = s_resourceCache.Get(_fontUri);
             }
 
             if (bits != null)
@@ -423,7 +423,7 @@ namespace MS.Internal.FontCache
 
         private Uri     _fontUri;
 
-        private static SizeLimitedCache<Uri, byte[]> _resourceCache = new SizeLimitedCache<Uri, byte[]>(MaximumCacheItems);
+        private static readonly SizeLimitedCache<Uri, byte[]> s_resourceCache = new(MaximumCacheItems);
 
         /// <summary>
         /// The maximum number of fonts downloaded from pack:// Uris.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Shaping/GlyphingCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Shaping/GlyphingCache.cs
@@ -30,7 +30,7 @@ namespace MS.Internal.Shaping
     /// </summary>
     internal class GlyphingCache
     {
-        private SizeLimitedCache<Typeface, TypefaceMap>  _sizeLimitedCache;
+        private readonly SizeLimitedCache<Typeface, TypefaceMap> _sizeLimitedCache;
     
         internal GlyphingCache(int capacity)
         {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
@@ -20,7 +20,7 @@ namespace MS.Internal
     ///     changed, it gets moved to the end of the list. Also, permanent items,
     ///     though in the hash table, are NOT in the linked list.
     /// </remarks>
-    internal class SizeLimitedCache<K, V>
+    internal sealed class SizeLimitedCache<K, V>
     {
         //*****************************************************
         // Constructors
@@ -88,7 +88,7 @@ namespace MS.Internal
             ArgumentNullException.ThrowIfNull(key, nameof(key));
             ArgumentNullException.ThrowIfNull(resource, nameof(resource));
 
-            // note: [] throws, thus we should check if its in the dictionary first.
+            // Lookup first
             if (!_nodeLookup.TryGetValue(key, out Node node))
             {
                 node = new Node(key, resource, isPermanent);

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
@@ -235,7 +235,7 @@ namespace MS.Internal
         /// <param name="node">
         ///     The node to remove
         /// </param>
-        private void RemoveFromList(Node node)
+        private static void RemoveFromList(Node node)
         {
             node.Previous.Next = node.Next;
             node.Next.Previous = node.Previous;
@@ -250,7 +250,7 @@ namespace MS.Internal
         /// </returns>
         private bool IsFull()
         {
-            return (_nodeLookup.Count - _permanentCount >= _maximumItems);
+            return (_nodeLookup.Count - _permanentCount) >= _maximumItems;
         }
 
         /// <summary>
@@ -307,17 +307,17 @@ namespace MS.Internal
         // ****************************************************
 
         // the maximum nonpermanent items allowed
-        private int _maximumItems;
+        private readonly int _maximumItems;
 
         // need to keep a separate counter for permanent items
         private int _permanentCount;
 
         // the _begin and _end nodes are empty nodes marking the begin and
         // end of the list.
-        private Node _begin;
-        private Node _end;
+        private readonly Node _begin;
+        private readonly Node _end;
 
         // the hashtable mapping keys to nodes
-        private Dictionary<K, Node> _nodeLookup;
+        private readonly Dictionary<K, Node> _nodeLookup;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
@@ -239,7 +239,7 @@ namespace MS.Internal
         /// <summary>
         ///     Doubly linked list node class. Has 3 values: key, resource, permanence flag
         /// </summary>
-        private class Node
+        private sealed class Node
         {
             public Node(K key, V resource, bool isPermanent)
             {
@@ -248,41 +248,16 @@ namespace MS.Internal
                 IsPermanent = isPermanent;
             }
 
-            public K Key
-            {
-                get { return _key; }
-                set { _key = value; }
-            }
+            public K Key { get; }
 
-            public V Resource
-            {
-                get { return _resource; }
-                set { _resource = value; }
-            }
+            public V Resource { get; set; }
 
-            public bool IsPermanent
-            {
-                get { return _isPermanent; }
-                set { _isPermanent = value; }
-            }
+            public bool IsPermanent { get; set; }
 
-            public Node Next
-            {
-                get { return _next; }
-                set { _next = value; }
-            }
+            public Node Next { get; set; }
 
-            public Node Previous
-            {
-                get { return _previous; }
-                set { _previous = value; }
-            }
+            public Node Previous { get; set; }
 
-            private V _resource;
-            private K _key;
-            private bool _isPermanent;
-            private Node _next;
-            private Node _previous;
         }
 
         //*****************************************************

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
@@ -289,11 +289,11 @@ namespace MS.Internal
         // Private Fields
         // ****************************************************
 
-        // the maximum nonpermanent items allowed
-        private readonly int _maximumItems;
-
         // need to keep a separate counter for permanent items
         private int _permanentCount;
+
+        // the maximum nonpermanent items allowed
+        private readonly int _maximumItems;
 
         // the _begin and _end nodes are empty nodes marking the begin and
         // end of the list.

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
@@ -146,10 +146,8 @@ namespace MS.Internal
         {
             ArgumentNullException.ThrowIfNull(key, nameof(key));
 
-            if (!_nodeLookup.TryGetValue(key, out Node node))
+            if (!_nodeLookup.Remove(key, out Node node))
                 return;
-
-            _nodeLookup.Remove(key);
 
             if (!node.IsPermanent)
                 RemoveFromList(node);

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
@@ -40,12 +40,13 @@ namespace MS.Internal
             _permanentCount = 0;
 
             // set up an empty list.
-            // the _begin and _end nodes are empty nodes marking the begin and
-            // end of the list.
+            // the _begin and _end nodes are empty nodes marking the begin and end of the list.
             _begin = new Node(default(K), default(V), false);
             _end = new Node(default(K), default(V), false);
-           _begin.Next = _end;
+
+            _begin.Next = _end;
             _end.Previous = _begin;
+
             _nodeLookup = new Dictionary<K, Node>();
         }
 
@@ -192,7 +193,9 @@ namespace MS.Internal
         private void RemoveOldest()
         {
             Node node = _begin.Next;
+
             _nodeLookup.Remove(node.Key);
+
             RemoveFromList(node);
         }
 
@@ -206,6 +209,7 @@ namespace MS.Internal
         {
             node.Next = _end;
             node.Previous = _end.Previous;
+
             node.Previous.Next = node;
             _end.Previous = node;
         }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
@@ -187,17 +187,10 @@ namespace MS.Internal
         /// </returns>
         public V Get(K key)
         {
-            if ( (object)key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+            ArgumentNullException.ThrowIfNull(key, nameof(key));
 
-            // note: [] throws, thus we should check if its in the dictionary first.
-            if (!_nodeLookup.ContainsKey(key))
-            {
-                return default(V);
-            }
-            Node node = _nodeLookup[key];
+            if (!_nodeLookup.TryGetValue(key, out Node node))
+                return default;
 
             if (!node.IsPermanent)
             {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
@@ -85,20 +85,13 @@ namespace MS.Internal
         /// </param>
         public void Add(K key, V resource, bool isPermanent)
         {
-
-            if ( (object)key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if ( (object)resource == null)
-            {
-                throw new ArgumentNullException(nameof(resource));
-            }
+            ArgumentNullException.ThrowIfNull(key, nameof(key));
+            ArgumentNullException.ThrowIfNull(resource, nameof(resource));
 
             // note: [] throws, thus we should check if its in the dictionary first.
-            if (!_nodeLookup.ContainsKey(key))
+            if (!_nodeLookup.TryGetValue(key, out Node node))
             {
-                Node node = new Node(key, resource, isPermanent);
+                node = new Node(key, resource, isPermanent);
                 if (!isPermanent)
                 {
                     if (IsFull())
@@ -111,11 +104,11 @@ namespace MS.Internal
                 {
                     _permanentCount++;
                 }
+
                 _nodeLookup[key] = node;
             }
             else
             {
-                Node node = _nodeLookup[key];
                 if (!node.IsPermanent)
                 {
                     RemoveFromList(node);
@@ -151,27 +144,17 @@ namespace MS.Internal
         /// </param>
         public void Remove(K key)
         {
-            if ( (object)key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+            ArgumentNullException.ThrowIfNull(key, nameof(key));
 
-            // note: [] throws, thus we should check if its in the dictionary first.
-            if (!_nodeLookup.ContainsKey(key))
-            {
+            if (!_nodeLookup.TryGetValue(key, out Node node))
                 return;
-            }
-            Node node = _nodeLookup[key];
 
             _nodeLookup.Remove(key);
+
             if (!node.IsPermanent)
-            {
                 RemoveFromList(node);
-            }
             else
-            {
                 _permanentCount--;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #4828 

## Description

While checking out `SizeLimitedCache<K, V>` yesterday, I've noticed the double lookups on the dictionary and today I've found there's already a corresponding issue for it, hence we should fix it for optimal performance as this is used with glyphs/fonts.

- Use throw helpers over creating new instance of `ArgumentNullException` directly.
- `Remove` had even three lookups, so now it just has one.
- Fields that could be `readonly` have been adjusted.
- Sealed the class, proper naming conventions.
- `Node` uses auto properties now.

### 10 capacity, 15 unique additions first, 20 lookups

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  988.4 ns |    9.39 ns |     7.84 ns | 0.1183 |       2,045 B |        1992 B |
| PR_EDIT  |  809.3 ns |    9.18 ns |     8.14 ns | 0.1183 |       1,820 B |        1992 B |

## Customer Impact

Improved perfomance.

## Regression

No.

## Testing

Local build, tests with the class.

## Risk

Low, just basically compiler warnings.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9949)