### PR TITLE
Remove array/object allocs during Alt+Numpad composition, improve performance

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextCompositionManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextCompositionManager.cs
@@ -482,24 +482,24 @@ namespace System.Windows.Input
         private void PostProcessInput(object sender, ProcessInputEventArgs e)
         {
             // KeyUp
-            if(e.StagingItem.Input.RoutedEvent == Keyboard.KeyUpEvent)
+            if (e.StagingItem.Input.RoutedEvent == Keyboard.KeyUpEvent)
             {
-                KeyEventArgs keyArgs = (KeyEventArgs) e.StagingItem.Input;
-                if(!keyArgs.Handled)
+                KeyEventArgs keyArgs = (KeyEventArgs)e.StagingItem.Input;
+                if (!keyArgs.Handled)
                 {
-                    if(keyArgs.RealKey == Key.LeftAlt || keyArgs.RealKey == Key.RightAlt)
+                    if (keyArgs.RealKey == Key.LeftAlt || keyArgs.RealKey == Key.RightAlt)
                     {
                         // Make sure both Alt keys are up.
                         ModifierKeys modifiers = keyArgs.KeyboardDevice.Modifiers;
-                        if((modifiers & ModifierKeys.Alt) == 0)
+                        if ((modifiers & ModifierKeys.Alt) == 0)
                         {
-                            if(_altNumpadEntryMode)
+                            if (_altNumpadEntryMode)
                             {
                                 _altNumpadEntryMode = false;
 
                                 // Generate the Unicode equivalent if we
                                 // actually entered a number via the numpad.
-                                if(_altNumpadEntry != 0)
+                                if (_altNumpadEntry != 0)
                                 {
                                     _altNumpadcomposition.ClearTexts();
                                     if (_altNumpadConversionMode == AltNumpadConversionMode.OEMCodePage)
@@ -513,9 +513,7 @@ namespace System.Windows.Input
                                     }
                                     else if (_altNumpadConversionMode == AltNumpadConversionMode.HexUnicode)
                                     {
-                                        Char[] chars = new Char[1];
-                                        chars[0] = (Char) _altNumpadEntry;
-                                        _altNumpadcomposition.SetText(new string(chars));
+                                        _altNumpadcomposition.SetText(((char)_altNumpadEntry).ToString());
                                     }
                                 }
                             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextCompositionManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextCompositionManager.cs
@@ -1,11 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
 using System.Windows.Threading;
-using System.Diagnostics;
+using System.ComponentModel;
 using Microsoft.Win32;
-using System.Text;
 using MS.Win32;
 
 namespace System.Windows.Input
@@ -490,7 +488,7 @@ namespace System.Windows.Input
                 KeyEventArgs keyArgs = (KeyEventArgs)e.StagingItem.Input;
                 if (!keyArgs.Handled)
                 {
-                    if (keyArgs.RealKey == Key.LeftAlt || keyArgs.RealKey == Key.RightAlt)
+                    if (keyArgs.RealKey is Key.LeftAlt or Key.RightAlt)
                     {
                         // Make sure both Alt keys are up.
                         ModifierKeys modifiers = keyArgs.KeyboardDevice.Modifiers;
@@ -505,16 +503,15 @@ namespace System.Windows.Input
                                 if (_altNumpadEntry != 0)
                                 {
                                     _altNumpadcomposition.ClearTexts();
-                                    if (_altNumpadConversionMode == AltNumpadConversionMode.OEMCodePage)
+                                    if (_altNumpadConversionMode is AltNumpadConversionMode.OEMCodePage)
                                     {
                                         _altNumpadcomposition.SetText(GetCurrentOEMCPEncoding(_altNumpadEntry));
                                     }
-                                    else if ((_altNumpadConversionMode == AltNumpadConversionMode.DefaultCodePage) ||
-                                             (_altNumpadConversionMode == AltNumpadConversionMode.HexDefaultCodePage))
+                                    else if (_altNumpadConversionMode is AltNumpadConversionMode.DefaultCodePage or AltNumpadConversionMode.HexDefaultCodePage)
                                     {
                                         _altNumpadcomposition.SetText(CharacterEncoding(InputLanguageManager.Current.CurrentInputLanguage.TextInfo.ANSICodePage, _altNumpadEntry));
                                     }
-                                    else if (_altNumpadConversionMode == AltNumpadConversionMode.HexUnicode)
+                                    else if (_altNumpadConversionMode is AltNumpadConversionMode.HexUnicode)
                                     {
                                         _altNumpadcomposition.SetText(((char)_altNumpadEntry).ToString());
                                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextCompositionManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextCompositionManager.cs
@@ -1,11 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text;
-using System.Windows.Threading;
 using System.Runtime.InteropServices;
-using MS.Win32;
+using System.Windows.Threading;
+using System.Diagnostics;
 using Microsoft.Win32;
+using System.Text;
+using MS.Win32;
 
 namespace System.Windows.Input
 {
@@ -890,13 +891,7 @@ namespace System.Windows.Input
         // Return true if we're in hex conversion mode.
         private bool HexConversionMode
         {
-            get 
-            {
-                if ((_altNumpadConversionMode == AltNumpadConversionMode.HexDefaultCodePage) ||
-                    (_altNumpadConversionMode == AltNumpadConversionMode.HexUnicode))
-                    return true;
-                return false;
-            }
+            get => _altNumpadConversionMode is AltNumpadConversionMode.HexDefaultCodePage or AltNumpadConversionMode.HexUnicode;
         }
 
         /// <summary>
@@ -908,15 +903,11 @@ namespace System.Windows.Input
             {
                 if (!_isHexNumpadRegistryChecked)
                 {
-                    object obj;
-                    RegistryKey key;
-
-                    key = Registry.CurrentUser.OpenSubKey("Control Panel\\Input Method");
+                    RegistryKey key = Registry.CurrentUser.OpenSubKey("Control Panel\\Input Method");
                     if (key != null)
                     {
-                        obj = key.GetValue("EnableHexNumpad");
-
-                        if ((obj is string) && ((string)obj != "0"))
+                        object obj = key.GetValue("EnableHexNumpad");
+                        if (obj is string value && value != "0")
                         {
                             _isHexNumpadEnabled = true;
                         }
@@ -924,6 +915,7 @@ namespace System.Windows.Input
 
                     _isHexNumpadRegistryChecked = true;
                 }
+
                 return _isHexNumpadEnabled;
             }
         }
@@ -966,23 +958,21 @@ namespace System.Windows.Input
         // ScanCode of Numpad keys.
         internal static class NumpadScanCode
         {
-            internal static int DigitFromScanCode(int scanCode)
+            internal static int DigitFromScanCode(int scanCode) => scanCode switch
             {
-                switch (scanCode)
-                {
-                    case Numpad0: return 0;
-                    case Numpad1: return 1;
-                    case Numpad2: return 2;
-                    case Numpad3: return 3;
-                    case Numpad4: return 4;
-                    case Numpad5: return 5;
-                    case Numpad6: return 6;
-                    case Numpad7: return 7;
-                    case Numpad8: return 8;
-                    case Numpad9: return 9;
-                }
-                return -1;
-            }
+                Numpad0 => 0,
+                Numpad1 => 1,
+                Numpad2 => 2,
+                Numpad3 => 3,
+                Numpad4 => 4,
+                Numpad5 => 5,
+                Numpad6 => 6,
+                Numpad7 => 7,
+                Numpad8 => 8,
+                Numpad9 => 9,
+                _ => -1,
+            };
+
             internal const int NumpadDot      =  0x53;
             internal const int NumpadPlus     =  0x4e;
             internal const int Numpad0        =  0x52;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextCompositionManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextCompositionManager.cs
@@ -9,15 +9,27 @@ using Microsoft.Win32;
 
 namespace System.Windows.Input
 {
-    //
-    // Modes of AltNumpad.
-    //
+    /// <summary>
+    /// Modes when entering characters via Alt+Numpad keys.
+    /// </summary>
     internal enum AltNumpadConversionMode
     {
-        DefaultCodePage,         // ACP code page encoding. Alt+Numpad0+NumpadX
-        OEMCodePage,             // OEM code page encoding. Alt+NumpadX
-        HexDefaultCodePage,      // HEX value in ACP.       Alt+NumpadDOT+NumpadX
-        HexUnicode,              // HEX value in Unicode.   Alt+NumpadPlus+NumpadX
+        /// <summary>
+        /// ACP code page encoding: Alt+Numpad0+NumpadX
+        /// </summary>
+        DefaultCodePage,
+        /// <summary>
+        /// OEM code page encoding: Alt+NumpadX
+        /// </summary>
+        OEMCodePage,
+        /// <summary>
+        /// HEX value in ACP: Alt+NumpadDOT+NumpadX
+        /// </summary>
+        HexDefaultCodePage,
+        /// <summary>
+        /// HEX value in Unicode: Alt+NumpadPlus+NumpadX
+        /// </summary>
+        HexUnicode,
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
@@ -213,7 +213,7 @@ namespace MS.Win32
         public const int MB_USEGLYPHCHARS          = 0x00000004;
         public const int MB_ERR_INVALID_CHARS      = 0x00000008;
         [DllImport(ExternDll.Kernel32, ExactSpelling=true, CharSet=CharSet.Unicode, SetLastError=true)]
-        public static extern int MultiByteToWideChar(int CodePage, int dwFlags, byte[] lpMultiByteStr, int cchMultiByte, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder lpWideCharStr, int cchWideChar);
+        public static unsafe extern int MultiByteToWideChar(int CodePage, int dwFlags, byte* lpMultiByteStr, int cchMultiByte, char* lpWideCharStr, int cchWideChar);
         [DllImport(ExternDll.Kernel32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
         public static extern int WideCharToMultiByte(int codePage, int flags, [MarshalAs(UnmanagedType.LPWStr)]string wideStr, int chars, [In,Out]byte[] pOutBytes, int bufferBytes, IntPtr defaultChar, IntPtr pDefaultUsed);
 


### PR DESCRIPTION
## Description

Removes unnecessary `byte[]` , `char[]` and `StringBuilder` alocations during post-input processing when the char is inputted via Alt+Numpad combination. This is not somewhat impactful allocation but it will allow for more optimizations in the future.

Time spent is cut by 2/5 which is more impactful in this case.

### GetCurrentOEMCPEncoding method chain call

| Method   |Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |-----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 48.77 ns |   0.674 ns |    0.630 ns | 0.0086 |         814 B |         144 B |
| PR_EDIT  |  31.83 ns |   0.292 ns |    0.273 ns | 0.0019 |         418 B |          32 B |

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, text input.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9954)