### PR TITLE
Use ThreadStatic fields over LocalDataStoreSlot for improved performance

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndKeyboardInputProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndKeyboardInputProvider.cs
@@ -510,8 +510,8 @@ namespace System.Windows.Interop
         internal void ProcessKeyAction(ref MSG msg, ref bool handled)
         {
             // Remember the last message
-            MSG previousMSG = ComponentDispatcher.UnsecureCurrentKeyboardMessage;
-            ComponentDispatcher.UnsecureCurrentKeyboardMessage = msg;
+            MSG previousMSG = ComponentDispatcher.CurrentKeyboardMessage;
+            ComponentDispatcher.CurrentKeyboardMessage = msg;
 
             try
             {
@@ -534,7 +534,7 @@ namespace System.Windows.Interop
             finally
             {
                 // Restore the last message
-                ComponentDispatcher.UnsecureCurrentKeyboardMessage = previousMSG;
+                ComponentDispatcher.CurrentKeyboardMessage = previousMSG;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
@@ -2795,6 +2795,9 @@ namespace System.Windows.Interop
 
         private RestoreFocusMode _restoreFocusMode;
 
+        /// <summary>
+        /// This is variable stores <see cref="ThreadDataBlob"/> class instance per thread.
+        /// </summary>
         [ThreadStatic]
         private static ThreadDataBlob s_threadDataBlobInstance;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
@@ -2796,7 +2796,7 @@ namespace System.Windows.Interop
         private RestoreFocusMode _restoreFocusMode;
 
         /// <summary>
-        /// This is variable stores <see cref="ThreadDataBlob"/> class instance per thread.
+        /// Holds a thread-specific instance of <see cref="ThreadDataBlob"/>.
         /// </summary>
         [ThreadStatic]
         private static ThreadDataBlob s_threadDataBlobInstance;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
@@ -2712,9 +2712,9 @@ namespace System.Windows.Interop
                 _addToFront = addToFront;
                 _handler = new ThreadMessageEventHandler(this.OnPreprocessMessage);
 
-                if(addToFront)
+                if (addToFront)
                 {
-                    ComponentDispatcher.CriticalAddThreadPreprocessMessageHandlerFirst(_handler);
+                    ComponentDispatcher.AddThreadPreprocessMessageHandlerFirst(_handler);
                 }
                 else
                 {
@@ -2738,9 +2738,9 @@ namespace System.Windows.Interop
 
             public void Dispose()
             {
-                if(_addToFront)
+                if (_addToFront)
                 {
-                    ComponentDispatcher.CriticalRemoveThreadPreprocessMessageHandlerFirst(_handler);
+                    ComponentDispatcher.RemoveThreadPreprocessMessageHandlerFirst(_handler);
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
@@ -19,11 +19,6 @@ namespace System.Windows.Interop
     /// </summary>
     public class HwndSource : PresentationSource, IDisposable, IWin32Window, IKeyboardInputSink
     {
-        static HwndSource()
-        {
-            _threadSlot = Thread.AllocateDataSlot();
-        }
-
         /// <summary>
         ///    Constructs an instance of the HwndSource class that will always resize to its content size.
         /// </summary>
@@ -2670,18 +2665,9 @@ namespace System.Windows.Interop
         {
             get
             {
-                ThreadDataBlob data;
-                object obj = Thread.GetData(_threadSlot);
-                if(null == obj)
-                {
-                    data = new ThreadDataBlob();
-                    Thread.SetData(_threadSlot, data);
-                }
-                else
-                {
-                    data = (ThreadDataBlob) obj;
-                }
-                return data;
+                s_threadDataBlobInstance ??= new ThreadDataBlob();
+
+                return s_threadDataBlobInstance;
             }
         }
 
@@ -2807,9 +2793,10 @@ namespace System.Windows.Interop
         private WeakEventPreprocessMessage _weakPreprocessMessageHandler;
         private WeakEventPreprocessMessage _weakMenuModeMessageHandler;
 
-        private static System.LocalDataStoreSlot _threadSlot;
-
         private RestoreFocusMode _restoreFocusMode;
+
+        [ThreadStatic]
+        private static ThreadDataBlob s_threadDataBlobInstance;
 
         [ThreadStatic]
         private static bool? _defaultAcquireHwndFocusInMenuMode;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/OleServicesContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/OleServicesContext.cs
@@ -27,8 +27,11 @@ namespace System.Windows;
 //    affinity -- it could happen on any thread, which breaks us.
 internal class OleServicesContext
 {
-    // This is a slot to store OleServicesContext class per thread.
-    private static readonly LocalDataStoreSlot s_threadDataSlot = Thread.AllocateDataSlot();
+    /// <summary>
+    /// This is variable stores <see cref="OleServicesContext"/> class instance per thread.
+    /// </summary>
+    [ThreadStatic]
+    private static OleServicesContext s_oleServicesContextInstance;
 
 #if DEBUG
     // Ref count of calls to OleInitialize/OleUnitialize.
@@ -45,28 +48,18 @@ internal class OleServicesContext
         SetDispatcherThread();
     }
 
-    /// <summary>
-    ///  Get the ole services context associated with the current Thread.
-    /// </summary>
-    internal static OleServicesContext CurrentOleServicesContext
-    {
-        get
+        /// <summary>
+        /// Get the ole services context associated with the current Thread.
+        /// </summary>
+        internal static OleServicesContext CurrentOleServicesContext
         {
-            // Get the ole services context from the Thread data slot.
-            OleServicesContext oleServicesContext = (OleServicesContext)Thread.GetData(s_threadDataSlot);
-
-            if (oleServicesContext is null)
+            get
             {
-                // Create OleSErvicesContext instance.
-                oleServicesContext = new OleServicesContext();
+                s_oleServicesContextInstance ??= new OleServicesContext();
 
-                // Save the ole services context into the UIContext data slot.
-                Thread.SetData(s_threadDataSlot, oleServicesContext);
+                return s_oleServicesContextInstance;
             }
-
-            return oleServicesContext;
         }
-    }
 
     /// <summary>
     ///  Ensure the current thread is STA and OLE is initialized.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/OleServicesContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/OleServicesContext.cs
@@ -28,7 +28,7 @@ namespace System.Windows;
 internal class OleServicesContext
 {
     /// <summary>
-    /// This is variable stores <see cref="OleServicesContext"/> class instance per thread.
+    /// Holds a thread-specific instance of <see cref="OleServicesContext"/>.
     /// </summary>
     [ThreadStatic]
     private static OleServicesContext s_oleServicesContextInstance;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonDialog.cs
@@ -93,13 +93,13 @@ namespace Microsoft.Win32
                 // Signal that this thread is going to go modal.
                 try
                 {
-                    ComponentDispatcher.CriticalPushModal();
+                    ComponentDispatcher.PushModal();
 
                     return RunDialog(hwndOwner);
                 }
                 finally
                 {
-                    ComponentDispatcher.CriticalPopModal();
+                    ComponentDispatcher.PopModal();
                 }
             }
             finally
@@ -146,13 +146,13 @@ namespace Microsoft.Win32
             // Signal that this thread is going to go modal.
             try
             {
-                ComponentDispatcher.CriticalPushModal();
+                ComponentDispatcher.PushModal();
 
                 return RunDialog(hwndOwner);
             }
             finally
             {
-                ComponentDispatcher.CriticalPopModal();
+                ComponentDispatcher.PopModal();
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
@@ -3277,7 +3277,7 @@ namespace System.Windows.Controls
         private const int c_layoutLoopMaxCount = 5;             // 5 is an arbitrary constant chosen to end the measure loop
 
         /// <summary>
-        /// This is variable stores <see cref="WeakReference{DefinitionBase[]}"/> class instance per thread.
+        /// Holds a thread-specific instance of <see cref="WeakReference{DefinitionBase[]}"/>.
         /// </summary>
         [ThreadStatic]
         private static WeakReference<DefinitionBase[]> s_tempDefinitionsWeakRef;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
@@ -3276,6 +3276,9 @@ namespace System.Windows.Controls
         private const double c_starClip = 1e298;                //  used as maximum for clipping star values during normalization
         private const int c_layoutLoopMaxCount = 5;             // 5 is an arbitrary constant chosen to end the measure loop
 
+        /// <summary>
+        /// This is variable stores <see cref="WeakReference{DefinitionBase[]}"/> class instance per thread.
+        /// </summary>
         [ThreadStatic]
         private static WeakReference<DefinitionBase[]> s_tempDefinitionsWeakRef;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
@@ -3065,27 +3065,24 @@ namespace System.Windows.Controls
                 ExtendedData extData = ExtData;
                 int requiredLength = Math.Max(DefinitionsU.Length, DefinitionsV.Length) * 2;
 
-                if (    extData.TempDefinitions == null
-                    ||  extData.TempDefinitions.Length < requiredLength   )
+                if (extData.TempDefinitions == null || extData.TempDefinitions.Length < requiredLength)
                 {
-                    WeakReference tempDefinitionsWeakRef = (WeakReference)Thread.GetData(s_tempDefinitionsDataSlot);
-                    if (tempDefinitionsWeakRef == null)
+                    if (s_tempDefinitionsWeakRef is null)
                     {
                         extData.TempDefinitions = new DefinitionBase[requiredLength];
-                        Thread.SetData(s_tempDefinitionsDataSlot, new WeakReference(extData.TempDefinitions));
+                        s_tempDefinitionsWeakRef = new WeakReference<DefinitionBase[]>(extData.TempDefinitions);
                     }
                     else
                     {
-                        extData.TempDefinitions = (DefinitionBase[])tempDefinitionsWeakRef.Target;
-                        if (    extData.TempDefinitions == null
-                            ||  extData.TempDefinitions.Length < requiredLength   )
+                        if (!s_tempDefinitionsWeakRef.TryGetTarget(out extData.TempDefinitions) || extData.TempDefinitions.Length < requiredLength)
                         {
                             extData.TempDefinitions = new DefinitionBase[requiredLength];
-                            tempDefinitionsWeakRef.Target = extData.TempDefinitions;
+                            s_tempDefinitionsWeakRef.SetTarget(extData.TempDefinitions);
                         }
                     }
                 }
-                return (extData.TempDefinitions);
+
+                return extData.TempDefinitions;
             }
         }
 
@@ -3274,10 +3271,14 @@ namespace System.Windows.Controls
         //------------------------------------------------------
 
         #region Static Fields
+
         private const double c_epsilon = 1e-5;                  //  used in fp calculations
         private const double c_starClip = 1e298;                //  used as maximum for clipping star values during normalization
         private const int c_layoutLoopMaxCount = 5;             // 5 is an arbitrary constant chosen to end the measure loop
-        private static readonly LocalDataStoreSlot s_tempDefinitionsDataSlot = Thread.AllocateDataSlot();
+
+        [ThreadStatic]
+        private static WeakReference<DefinitionBase[]> s_tempDefinitionsWeakRef;
+
         private static readonly Comparison<DefinitionBase> s_spanPreferredDistributionOrderComparer = SpanPreferredDistributionOrderComparer;
         private static readonly Comparison<DefinitionBase> s_spanMaxDistributionOrderComparer = SpanMaxDistributionOrderComparer;
         private static readonly Comparison<DefinitionBase> s_starDistributionOrderComparer = StarDistributionOrderComparer;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditor.cs
@@ -2017,7 +2017,9 @@ namespace System.Windows.Documents
         // Weak-ref to the most recent ImmComposition - used when detaching
         private WeakReference<ImmComposition> _immCompositionForDetach;
 
-        // Thread local storage for TextEditor and dependent classes.
+        /// <summary>
+        /// This is variable stores <see cref="TextEditorThreadLocalStore"/> class instance per thread.
+        /// </summary>
         [ThreadStatic]
         private static TextEditorThreadLocalStore s_textEditorTLSInstance;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditor.cs
@@ -2018,7 +2018,7 @@ namespace System.Windows.Documents
         private WeakReference<ImmComposition> _immCompositionForDetach;
 
         /// <summary>
-        /// This is variable stores <see cref="TextEditorThreadLocalStore"/> class instance per thread.
+        /// Holds a thread-specific instance of <see cref="TextEditorThreadLocalStore"/>.
         /// </summary>
         [ThreadStatic]
         private static TextEditorThreadLocalStore s_textEditorTLSInstance;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditor.cs
@@ -1345,17 +1345,9 @@ namespace System.Windows.Documents
         {
             get
             {
-                TextEditorThreadLocalStore store;
+                s_textEditorTLSInstance ??= new TextEditorThreadLocalStore();
 
-                store = (TextEditorThreadLocalStore)Thread.GetData(_threadLocalStoreSlot);
-
-                if (store == null)
-                {
-                    store = new TextEditorThreadLocalStore();
-                    Thread.SetData(_threadLocalStoreSlot, store);
-                }
-
-                return store;
+                return s_textEditorTLSInstance;
             }
         }
 
@@ -2026,7 +2018,8 @@ namespace System.Windows.Documents
         private WeakReference<ImmComposition> _immCompositionForDetach;
 
         // Thread local storage for TextEditor and dependent classes.
-        private static LocalDataStoreSlot _threadLocalStoreSlot = Thread.AllocateDataSlot();
+        [ThreadStatic]
+        private static TextEditorThreadLocalStore s_textEditorTLSInstance;
 
         // Flag indicating that MouseDown handler is in progress,
         // to ignore all MouseMoves caused by CaptureMouse call.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
@@ -128,16 +128,7 @@ namespace System.Windows.Interop
         /// <param name="e"></param>
         protected override void OnKeyUp(KeyEventArgs e)
         {
-            MSG msg;
-            if (_fTrusted)
-            {
-                msg = ComponentDispatcher.UnsecureCurrentKeyboardMessage;
-            }
-            else
-            {
-                msg = ComponentDispatcher.CurrentKeyboardMessage;
-            }
-
+            MSG msg = ComponentDispatcher.CurrentKeyboardMessage;
             ModifierKeys modifiers = HwndKeyboardInputProvider.GetSystemModifierKeys();
 
             bool handled = ((IKeyboardInputSink)this).TranslateAccelerator(ref msg, modifiers);
@@ -162,17 +153,7 @@ namespace System.Windows.Interop
         /// <param name="e"></param>
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            MSG msg;
-            if (_fTrusted)
-            {
-                msg = ComponentDispatcher.UnsecureCurrentKeyboardMessage;
-            }
-            else
-            {
-                msg = ComponentDispatcher.CurrentKeyboardMessage;
-            }
-
-
+            MSG msg = ComponentDispatcher.CurrentKeyboardMessage;
             ModifierKeys modifiers = HwndKeyboardInputProvider.GetSystemModifierKeys();
 
             bool handled = ((IKeyboardInputSink)this).TranslateAccelerator(ref msg, modifiers);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Windows.Interop
@@ -51,11 +50,7 @@ namespace System.Windows.Interop
         ///</summary>
         public static bool IsThreadModal
         {
-            get
-            {
-                ComponentDispatcherThread data = ComponentDispatcher.CurrentThreadData;
-                return data.IsThreadModal;
-            }
+            get => CurrentThreadData.IsThreadModal;
         }
 
         /// <summary>
@@ -88,22 +83,17 @@ namespace System.Windows.Interop
         /// <summary>
         /// The message loop pumper calls this when it is time to do idle processing.
         ///</summary>
-        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate")]
         public static void RaiseIdle()
         {
-            ComponentDispatcherThread data = ComponentDispatcher.CurrentThreadData;
-            data.RaiseIdle();
+            CurrentThreadData.RaiseIdle();
         }
 
         /// <summary>
         /// The message loop pumper calls this for every keyboard message.
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate")]
-        [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference")]
         public static bool RaiseThreadMessage(ref MSG msg)
         {
-            ComponentDispatcherThread data = ComponentDispatcher.CurrentThreadData;
-            return data.RaiseThreadMessage(ref msg);
+            return CurrentThreadData.RaiseThreadMessage(ref msg);
         }
 
         // Events
@@ -114,12 +104,8 @@ namespace System.Windows.Interop
         ///</summary>
         public static event EventHandler ThreadIdle
         {
-            add {
-                ComponentDispatcher.CurrentThreadData.ThreadIdle += value;
-            }
-            remove {
-                ComponentDispatcher.CurrentThreadData.ThreadIdle -= value;
-            }
+            add => CurrentThreadData.ThreadIdle += value;
+            remove => CurrentThreadData.ThreadIdle -= value;
         }
 
         /// <summary>
@@ -128,12 +114,8 @@ namespace System.Windows.Interop
         ///</summary>
         public static event ThreadMessageEventHandler ThreadFilterMessage
         {
-            add {
-                ComponentDispatcher.CurrentThreadData.ThreadFilterMessage += value;
-            }
-            remove {
-                ComponentDispatcher.CurrentThreadData.ThreadFilterMessage -= value;
-            }
+            add => CurrentThreadData.ThreadFilterMessage += value;
+            remove => CurrentThreadData.ThreadFilterMessage -= value;
         }
 
         /// <summary>
@@ -142,13 +124,8 @@ namespace System.Windows.Interop
         ///</summary>
         public static event ThreadMessageEventHandler ThreadPreprocessMessage
         {
-            add
-            {
-                ComponentDispatcher.CurrentThreadData.ThreadPreprocessMessage += value;
-            }
-            remove {
-                ComponentDispatcher.CurrentThreadData.ThreadPreprocessMessage -= value;
-            }
+            add => CurrentThreadData.ThreadPreprocessMessage += value;
+            remove => CurrentThreadData.ThreadPreprocessMessage -= value;
         }
 
         /// <summary>
@@ -175,12 +152,8 @@ namespace System.Windows.Interop
         ///</summary>
         public static event EventHandler EnterThreadModal
         {
-            add {
-                ComponentDispatcher.CurrentThreadData.EnterThreadModal += value;
-            }
-            remove {
-                ComponentDispatcher.CurrentThreadData.EnterThreadModal -= value;
-            }
+            add => CurrentThreadData.EnterThreadModal += value;
+            remove => CurrentThreadData.EnterThreadModal -= value;
         }
 
         /// <summary>
@@ -189,13 +162,8 @@ namespace System.Windows.Interop
         ///</summary>
         public static event EventHandler LeaveThreadModal
         {
-            add
-            {
-                ComponentDispatcher.CurrentThreadData.LeaveThreadModal += value;
-            }
-            remove {
-                ComponentDispatcher.CurrentThreadData.LeaveThreadModal -= value;
-            }
+            add => CurrentThreadData.LeaveThreadModal += value;
+            remove => CurrentThreadData.LeaveThreadModal -= value;
         }
     }
-};
+}

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
@@ -24,27 +24,22 @@ namespace System.Windows.Interop
     ///</summary>
     public static class ComponentDispatcher
     {
-        static ComponentDispatcher()
-        {
-            _threadSlot = Thread.AllocateDataSlot();
-        }
+        /// <summary>
+        /// Holds a thread-specific instance of <see cref="ComponentDispatcherThread"/>.
+        /// </summary>
+        [ThreadStatic]
+        private static ComponentDispatcherThread s_componentDispatcherThread;
 
+        /// <summary>
+        /// Retrieves or creates an instance of <see cref="ComponentDispatcherThread"/> for the current thread.
+        /// </summary>
         private static ComponentDispatcherThread CurrentThreadData
         {
             get
             {
-                ComponentDispatcherThread data;
-                object obj = Thread.GetData(_threadSlot);
-                if(null == obj)
-                {
-                    data = new ComponentDispatcherThread();
-                    Thread.SetData(_threadSlot, data);
-                }
-                else
-                {
-                    data = (ComponentDispatcherThread) obj;
-                }
-                return data;
+                s_componentDispatcherThread ??= new ComponentDispatcherThread();
+
+                return s_componentDispatcherThread;
             }
         }
 
@@ -238,8 +233,5 @@ namespace System.Windows.Interop
                 ComponentDispatcher.CurrentThreadData.LeaveThreadModal -= value;
             }
         }
-
-        // member data
-        private static System.LocalDataStoreSlot _threadSlot;
     }
 };

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
@@ -1,7 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Diagnostics.CodeAnalysis;
 
 namespace System.Windows.Interop
 {
@@ -9,7 +7,6 @@ namespace System.Windows.Interop
     ///     This is the delegate used for registering with the
     ///     ThreadFilterMessage and ThreadPreprocessMessage Events.
     ///</summary>
-    [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference")]
     public delegate void ThreadMessageEventHandler(ref MSG msg, ref bool handled);
 
     /// <summary>
@@ -129,8 +126,8 @@ namespace System.Windows.Interop
         }
 
         /// <summary>
-        ///     Adds the specified handler to the front of the invocation list
-        ///     of the PreprocessMessage event.
+        /// Adds the specified handler to the front of the invocation list
+        /// of the PreprocessMessage event.
         /// <summary>
         internal static void AddThreadPreprocessMessageHandlerFirst(ThreadMessageEventHandler handler)
         {
@@ -138,8 +135,8 @@ namespace System.Windows.Interop
         }
 
         /// <summary>
-        ///     Removes the first occurance of the specified handler from the
-        ///     invocation list of the PreprocessMessage event.
+        /// Removes the first occurrence of the specified handler from the
+        /// invocation list of the PreprocessMessage event.
         /// <summary>
         internal static void RemoveThreadPreprocessMessageHandlerFirst(ThreadMessageEventHandler handler)
         {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
@@ -59,30 +59,12 @@ namespace System.Windows.Interop
         }
 
         /// <summary>
-        /// Returns "current" message.   More exactly the last MSG Raised.
+        /// Returns "current" message. More exactly the last MSG Raised.
         ///</summary>
         public static MSG CurrentKeyboardMessage
         {
-            get
-            {
-                return ComponentDispatcher.CurrentThreadData.CurrentKeyboardMessage;
-            }
-        }
-
-        /// <summary>
-        /// Returns "current" message.   More exactly the last MSG Raised.
-        ///</summary>
-        internal static MSG UnsecureCurrentKeyboardMessage
-        {
-            get
-            {
-                return ComponentDispatcher.CurrentThreadData.CurrentKeyboardMessage;
-            }
-
-            set
-            {
-                ComponentDispatcher.CurrentThreadData.CurrentKeyboardMessage = value;
-            }
+            get => CurrentThreadData.CurrentKeyboardMessage;
+            internal set => CurrentThreadData.CurrentKeyboardMessage = value;
         }
 
         // Methods

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
@@ -70,20 +70,11 @@ namespace System.Windows.Interop
         // Methods
 
         /// <summary>
-        /// A component calls this to go modal.  Current thread wide only.
+        /// A component calls this to go modal. Current thread wide only.
         ///</summary>
         public static void PushModal()
         {
-            CriticalPushModal();
-        }
-
-        /// <summary>
-        /// A component calls this to go modal.  Current thread wide only.
-        ///</summary>
-        internal static void CriticalPushModal()
-        {
-            ComponentDispatcherThread data = ComponentDispatcher.CurrentThreadData;
-            data.PushModal();
+            CurrentThreadData.PushModal();
         }
 
         /// <summary>
@@ -91,16 +82,7 @@ namespace System.Windows.Interop
         ///</summary>
         public static void PopModal()
         {
-            CriticalPopModal();
-        }
-
-        /// <summary>
-        /// A component calls this to end being modal.
-        ///</summary>
-        internal static void CriticalPopModal()
-        {
-            ComponentDispatcherThread data = ComponentDispatcher.CurrentThreadData;
-            data.PopModal();
+            CurrentThreadData.PopModal();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
@@ -155,18 +155,18 @@ namespace System.Windows.Interop
         ///     Adds the specified handler to the front of the invocation list
         ///     of the PreprocessMessage event.
         /// <summary>
-        internal static void CriticalAddThreadPreprocessMessageHandlerFirst(ThreadMessageEventHandler handler)
+        internal static void AddThreadPreprocessMessageHandlerFirst(ThreadMessageEventHandler handler)
         {
-            ComponentDispatcher.CurrentThreadData.AddThreadPreprocessMessageHandlerFirst(handler);
+            CurrentThreadData.AddThreadPreprocessMessageHandlerFirst(handler);
         }
 
         /// <summary>
         ///     Removes the first occurance of the specified handler from the
         ///     invocation list of the PreprocessMessage event.
         /// <summary>
-        internal static void CriticalRemoveThreadPreprocessMessageHandlerFirst(ThreadMessageEventHandler handler)
+        internal static void RemoveThreadPreprocessMessageHandlerFirst(ThreadMessageEventHandler handler)
         {
-            ComponentDispatcher.CurrentThreadData.RemoveThreadPreprocessMessageHandlerFirst(handler);
+            CurrentThreadData.RemoveThreadPreprocessMessageHandlerFirst(handler);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
@@ -1,166 +1,165 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace System.Windows.Interop
+namespace System.Windows.Interop;
+
+/// <summary>
+/// This is the delegate used for registering with the
+/// ThreadFilterMessage and ThreadPreprocessMessage Events.
+/// </summary>
+public delegate void ThreadMessageEventHandler(ref MSG msg, ref bool handled);
+
+/// <summary>
+/// This is a static class used to share control of the message pump.
+/// Whomever is pumping (i.e. calling GetMessage()) will also send
+/// the messages to RaiseThreadKeyMessage() which will dispatch them to
+/// the ThreadFilterMessage and then (if not handled) to the ThreadPreprocessMessage
+/// delegates.  That way everyone can be included in the message loop.
+/// Currently only Keyboard messages are supported.
+/// There are also Events for Idle and facilities for Thread-Modal operation.
+///</summary>
+public static class ComponentDispatcher
 {
     /// <summary>
-    ///     This is the delegate used for registering with the
-    ///     ThreadFilterMessage and ThreadPreprocessMessage Events.
-    ///</summary>
-    public delegate void ThreadMessageEventHandler(ref MSG msg, ref bool handled);
+    /// Holds a thread-specific instance of <see cref="ComponentDispatcherThread"/>.
+    /// </summary>
+    [ThreadStatic]
+    private static ComponentDispatcherThread s_componentDispatcherThread;
 
     /// <summary>
-    /// This is a static class used to share control of the message pump.
-    /// Whomever is pumping (i.e. calling GetMessage()) will also send
-    /// the messages to RaiseThreadKeyMessage() which will dispatch them to
-    /// the ThreadFilterMessage and then (if not handled) to the ThreadPreprocessMessage
-    /// delegates.  That way everyone can be included in the message loop.
-    /// Currently only Keyboard messages are supported.
-    /// There are also Events for Idle and facilities for Thread-Modal operation.
-    ///</summary>
-    public static class ComponentDispatcher
+    /// Retrieves or creates an instance of <see cref="ComponentDispatcherThread"/> for the current thread.
+    /// </summary>
+    private static ComponentDispatcherThread CurrentThreadData
     {
-        /// <summary>
-        /// Holds a thread-specific instance of <see cref="ComponentDispatcherThread"/>.
-        /// </summary>
-        [ThreadStatic]
-        private static ComponentDispatcherThread s_componentDispatcherThread;
-
-        /// <summary>
-        /// Retrieves or creates an instance of <see cref="ComponentDispatcherThread"/> for the current thread.
-        /// </summary>
-        private static ComponentDispatcherThread CurrentThreadData
+        get
         {
-            get
-            {
-                s_componentDispatcherThread ??= new ComponentDispatcherThread();
+            s_componentDispatcherThread ??= new ComponentDispatcherThread();
 
-                return s_componentDispatcherThread;
-            }
+            return s_componentDispatcherThread;
         }
+    }
 
-        // Properties
+    // Properties
 
-        /// <summary>
-        /// Returns true if one or more components has gone modal.
-        /// Although once one component is modal a 2nd shouldn't.
-        ///</summary>
-        public static bool IsThreadModal
-        {
-            get => CurrentThreadData.IsThreadModal;
-        }
+    /// <summary>
+    /// Returns true if one or more components has gone modal.
+    /// Although once one component is modal a 2nd shouldn't.
+    ///</summary>
+    public static bool IsThreadModal
+    {
+        get => CurrentThreadData.IsThreadModal;
+    }
 
-        /// <summary>
-        /// Returns "current" message. More exactly the last MSG Raised.
-        ///</summary>
-        public static MSG CurrentKeyboardMessage
-        {
-            get => CurrentThreadData.CurrentKeyboardMessage;
-            internal set => CurrentThreadData.CurrentKeyboardMessage = value;
-        }
+    /// <summary>
+    /// Returns "current" message. More exactly the last MSG Raised.
+    ///</summary>
+    public static MSG CurrentKeyboardMessage
+    {
+        get => CurrentThreadData.CurrentKeyboardMessage;
+        internal set => CurrentThreadData.CurrentKeyboardMessage = value;
+    }
 
-        // Methods
+    // Methods
 
-        /// <summary>
-        /// A component calls this to go modal. Current thread wide only.
-        ///</summary>
-        public static void PushModal()
-        {
-            CurrentThreadData.PushModal();
-        }
+    /// <summary>
+    /// A component calls this to go modal. Current thread wide only.
+    ///</summary>
+    public static void PushModal()
+    {
+        CurrentThreadData.PushModal();
+    }
 
-        /// <summary>
-        /// A component calls this to end being modal.
-        ///</summary>
-        public static void PopModal()
-        {
-            CurrentThreadData.PopModal();
-        }
+    /// <summary>
+    /// A component calls this to end being modal.
+    ///</summary>
+    public static void PopModal()
+    {
+        CurrentThreadData.PopModal();
+    }
 
-        /// <summary>
-        /// The message loop pumper calls this when it is time to do idle processing.
-        ///</summary>
-        public static void RaiseIdle()
-        {
-            CurrentThreadData.RaiseIdle();
-        }
+    /// <summary>
+    /// The message loop pumper calls this when it is time to do idle processing.
+    ///</summary>
+    public static void RaiseIdle()
+    {
+        CurrentThreadData.RaiseIdle();
+    }
 
-        /// <summary>
-        /// The message loop pumper calls this for every keyboard message.
-        /// </summary>
-        public static bool RaiseThreadMessage(ref MSG msg)
-        {
-            return CurrentThreadData.RaiseThreadMessage(ref msg);
-        }
+    /// <summary>
+    /// The message loop pumper calls this for every keyboard message.
+    /// </summary>
+    public static bool RaiseThreadMessage(ref MSG msg)
+    {
+        return CurrentThreadData.RaiseThreadMessage(ref msg);
+    }
 
-        // Events
+    // Events
 
-        /// <summary>
-        /// Components register delegates with this event to handle
-        /// thread idle processing.
-        ///</summary>
-        public static event EventHandler ThreadIdle
-        {
-            add => CurrentThreadData.ThreadIdle += value;
-            remove => CurrentThreadData.ThreadIdle -= value;
-        }
+    /// <summary>
+    /// Components register delegates with this event to handle
+    /// thread idle processing.
+    ///</summary>
+    public static event EventHandler ThreadIdle
+    {
+        add => CurrentThreadData.ThreadIdle += value;
+        remove => CurrentThreadData.ThreadIdle -= value;
+    }
 
-        /// <summary>
-        /// Components register delegates with this event to handle
-        /// Keyboard Messages (first chance processing).
-        ///</summary>
-        public static event ThreadMessageEventHandler ThreadFilterMessage
-        {
-            add => CurrentThreadData.ThreadFilterMessage += value;
-            remove => CurrentThreadData.ThreadFilterMessage -= value;
-        }
+    /// <summary>
+    /// Components register delegates with this event to handle
+    /// Keyboard Messages (first chance processing).
+    ///</summary>
+    public static event ThreadMessageEventHandler ThreadFilterMessage
+    {
+        add => CurrentThreadData.ThreadFilterMessage += value;
+        remove => CurrentThreadData.ThreadFilterMessage -= value;
+    }
 
-        /// <summary>
-        /// Components register delegates with this event to handle
-        /// Keyboard Messages (second chance processing).
-        ///</summary>
-        public static event ThreadMessageEventHandler ThreadPreprocessMessage
-        {
-            add => CurrentThreadData.ThreadPreprocessMessage += value;
-            remove => CurrentThreadData.ThreadPreprocessMessage -= value;
-        }
+    /// <summary>
+    /// Components register delegates with this event to handle
+    /// Keyboard Messages (second chance processing).
+    ///</summary>
+    public static event ThreadMessageEventHandler ThreadPreprocessMessage
+    {
+        add => CurrentThreadData.ThreadPreprocessMessage += value;
+        remove => CurrentThreadData.ThreadPreprocessMessage -= value;
+    }
 
-        /// <summary>
-        /// Adds the specified handler to the front of the invocation list
-        /// of the PreprocessMessage event.
-        /// <summary>
-        internal static void AddThreadPreprocessMessageHandlerFirst(ThreadMessageEventHandler handler)
-        {
-            CurrentThreadData.AddThreadPreprocessMessageHandlerFirst(handler);
-        }
+    /// <summary>
+    /// Adds the specified handler to the front of the invocation list
+    /// of the PreprocessMessage event.
+    /// <summary>
+    internal static void AddThreadPreprocessMessageHandlerFirst(ThreadMessageEventHandler handler)
+    {
+        CurrentThreadData.AddThreadPreprocessMessageHandlerFirst(handler);
+    }
 
-        /// <summary>
-        /// Removes the first occurrence of the specified handler from the
-        /// invocation list of the PreprocessMessage event.
-        /// <summary>
-        internal static void RemoveThreadPreprocessMessageHandlerFirst(ThreadMessageEventHandler handler)
-        {
-            CurrentThreadData.RemoveThreadPreprocessMessageHandlerFirst(handler);
-        }
+    /// <summary>
+    /// Removes the first occurrence of the specified handler from the
+    /// invocation list of the PreprocessMessage event.
+    /// <summary>
+    internal static void RemoveThreadPreprocessMessageHandlerFirst(ThreadMessageEventHandler handler)
+    {
+        CurrentThreadData.RemoveThreadPreprocessMessageHandlerFirst(handler);
+    }
 
-        /// <summary>
-        /// Components register delegates with this event to handle
-        /// a component on this thread has "gone modal", when previously none were.
-        ///</summary>
-        public static event EventHandler EnterThreadModal
-        {
-            add => CurrentThreadData.EnterThreadModal += value;
-            remove => CurrentThreadData.EnterThreadModal -= value;
-        }
+    /// <summary>
+    /// Components register delegates with this event to handle
+    /// a component on this thread has "gone modal", when previously none were.
+    ///</summary>
+    public static event EventHandler EnterThreadModal
+    {
+        add => CurrentThreadData.EnterThreadModal += value;
+        remove => CurrentThreadData.EnterThreadModal -= value;
+    }
 
-        /// <summary>
-        /// Components register delegates with this event to handle
-        /// all components on this thread are done being modal.
-        ///</summary>
-        public static event EventHandler LeaveThreadModal
-        {
-            add => CurrentThreadData.LeaveThreadModal += value;
-            remove => CurrentThreadData.LeaveThreadModal -= value;
-        }
+    /// <summary>
+    /// Components register delegates with this event to handle
+    /// all components on this thread are done being modal.
+    ///</summary>
+    public static event EventHandler LeaveThreadModal
+    {
+        add => CurrentThreadData.LeaveThreadModal += value;
+        remove => CurrentThreadData.LeaveThreadModal -= value;
     }
 }


### PR DESCRIPTION
## Description

Replaces `LocalDataStoreSlot` with `[ThreadStatic]` fields for improved performance and increased type safety.
- Static cost of initializing a `LocalDataStoreSlot` is about `500 ns` and `184 B`, that will forever live.
- The retrieval process using `Thread.GetData` is about 40% more expensive.
- There is no reason to use `LocalDataStoreSlot` these days (though it uses `ThreadLocal<object?>` under the hood since .NET Core 3.0 afaik so the performance is not THAT bad, while `NetFX` still goes with the original impl).

In the other commits, I've just cleaned up some CAS remnants (`Critical`*/`Unsecure`* methods/properties) from `ComponentDispatcher`, that just unnecessarily complicate the code these days. Since the formatting was different style on each, I've unified that.

### 10 property retrievals before/after (already initialized)
| Method   |  Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|--------------:|--------------:|
| Original |  25.15 ns |   0.061 ns |    0.054 ns |         334 B |             - |
| PR_EDIT  |  14.07 ns |   0.157 ns |    0.139 ns |         130 B |             - |

## Customer Impact

Improved performance, increased code base quality and type safety for developers.

## Regression

No.

## Testing

Local build, sample app run and testing with all the modified types.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9959)