### PR TITLE
Replace use of ArrayList with List<T> in BamlMapTable for performance

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -1769,10 +1769,9 @@ namespace System.Windows.Markup
 
         internal XamlTypeMapper XamlTypeMapper
         {
-            get { return _xamlTypeMapper; }
-
+            get => _xamlTypeMapper;
 #if !PBTCOMPILER
-            set { _xamlTypeMapper = value;  }
+            set => _xamlTypeMapper = value;
 #endif
         }
 
@@ -1833,9 +1832,11 @@ namespace System.Windows.Markup
         /// <summary>
         /// List of <see cref="BamlStringInfoRecord"/> (strings).
         /// </summary>
-        private readonly List<BamlStringInfoRecord> _stringIdToInfo = new();     
+        private readonly List<BamlStringInfoRecord> _stringIdToInfo = new();
 
-        // XamlTypeMapper associated with this map table.  There is always a one-to-one correspondence.
+        /// <summary>
+        /// XamlTypeMapper associated with this map table. There is always a one-to-one correspondence.
+        /// </summary>
         private XamlTypeMapper _xamlTypeMapper;
 
         // The assembly record for the known types of controls

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -615,7 +615,7 @@ namespace System.Windows.Markup
             else
             {
                 Debug.Assert(id < StringIdMap.Count);
-                BamlStringInfoRecord infoRecord = (BamlStringInfoRecord)StringIdMap[id];
+                BamlStringInfoRecord infoRecord = StringIdMap[id];
                 return infoRecord.Value;
             }
         }
@@ -1472,8 +1472,9 @@ namespace System.Windows.Markup
             Debug.Assert(GetHashTableData(stringValue) == null,
                 "Already have this String in the BamlMapTable string table");
 
-            BamlStringInfoRecord stringInfo = new BamlStringInfoRecord();
-            stringInfo.StringId = (short)StringIdMap.Add(stringInfo);
+            BamlStringInfoRecord stringInfo = new();
+            StringIdMap.Add(stringInfo);
+            stringInfo.StringId = (short)(StringIdMap.Count - 1);
             stringInfo.Value = stringValue;
 
             // add to the hash
@@ -1659,9 +1660,7 @@ namespace System.Windows.Markup
         // an existing record something different.
         internal void LoadStringInfoRecord(BamlStringInfoRecord record)
         {
-            Debug.Assert(StringIdMap.Count == record.StringId ||
-                         record.Value ==
-                         ((BamlStringInfoRecord)StringIdMap[record.StringId]).Value);
+            Debug.Assert(StringIdMap.Count == record.StringId || record.Value == StringIdMap[record.StringId].Value);
 
             if (StringIdMap.Count == record.StringId)
             {
@@ -1699,7 +1698,7 @@ namespace System.Windows.Markup
                 _assemblyIdToInfo = new List<BamlAssemblyInfoRecord>(_assemblyIdToInfo),
                 _typeIdToInfo = new List<BamlTypeInfoRecord>(_typeIdToInfo),
                 _attributeIdToInfo = new List<BamlAttributeInfoRecord>(_attributeIdToInfo),
-                _stringIdToInfo = (ArrayList)_stringIdToInfo.Clone()
+                _stringIdToInfo = new List<BamlStringInfoRecord>(_stringIdToInfo)
             };
 
             return table;
@@ -1762,7 +1761,7 @@ namespace System.Windows.Markup
             get { return _attributeIdToInfo; }
         }
 
-        private ArrayList StringIdMap
+        private List<BamlStringInfoRecord> StringIdMap
         {
             get { return _stringIdToInfo; }
         }
@@ -1830,7 +1829,10 @@ namespace System.Windows.Markup
         /// List of Attribute Ids
         /// </summary>
         private List<BamlAttributeInfoRecord> _attributeIdToInfo = new(10);
-        private ArrayList _stringIdToInfo = new ArrayList(1);     // arrayList of String Info
+        /// <summary>
+        /// List of String Info
+        /// </summary>
+        private List<BamlStringInfoRecord> _stringIdToInfo = new();     
 
         // XamlTypeMapper associated with this map table.  There is always a one-to-one correspondence.
         private XamlTypeMapper _xamlTypeMapper;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -1681,19 +1681,14 @@ namespace System.Windows.Markup
 #endif
 
 #if !PBTCOMPILER
-        internal BamlMapTable Clone()
+        internal BamlMapTable Clone() => new BamlMapTable(_xamlTypeMapper)
         {
-            BamlMapTable table = new BamlMapTable(_xamlTypeMapper)
-            {
-                _objectHashTable = (Hashtable)_objectHashTable.Clone(),
-                _assemblyIdToInfo = new List<BamlAssemblyInfoRecord>(_assemblyIdToInfo),
-                _typeIdToInfo = new List<BamlTypeInfoRecord>(_typeIdToInfo),
-                _attributeIdToInfo = new List<BamlAttributeInfoRecord>(_attributeIdToInfo),
-                _stringIdToInfo = new List<BamlStringInfoRecord>(_stringIdToInfo)
-            };
-
-            return table;
-        }
+            ObjectHashTable = (Hashtable)_objectHashTable.Clone(),
+            AssemblyIdMap = new List<BamlAssemblyInfoRecord>(_assemblyIdToInfo),
+            TypeIdMap = new List<BamlTypeInfoRecord>(_typeIdToInfo),
+            AttributeIdMap = new List<BamlAttributeInfoRecord>(_attributeIdToInfo),
+            StringIdMap = new List<BamlStringInfoRecord>(_stringIdToInfo)
+        };
 
         private TypeConverter GetConverterFromCache(short typeId)
         {
@@ -1734,27 +1729,42 @@ namespace System.Windows.Markup
 
         private Hashtable ObjectHashTable
         {
-            get { return _objectHashTable; }
+            get => _objectHashTable;
+#if !PBTCOMPILER
+            init => _objectHashTable = value;
+#endif
         }
 
         private List<BamlAssemblyInfoRecord> AssemblyIdMap
         {
-            get { return _assemblyIdToInfo; }
+            get => _assemblyIdToInfo;
+#if !PBTCOMPILER
+            init => _assemblyIdToInfo = value;
+#endif
         }
 
         private List<BamlTypeInfoRecord> TypeIdMap
         {
-            get { return _typeIdToInfo; }
+            get => _typeIdToInfo;
+#if !PBTCOMPILER
+            init => _typeIdToInfo = value;
+#endif
         }
 
         private List<BamlAttributeInfoRecord> AttributeIdMap
         {
-            get { return _attributeIdToInfo; }
+            get => _attributeIdToInfo;
+#if !PBTCOMPILER
+            init => _attributeIdToInfo = value;
+#endif
         }
 
         private List<BamlStringInfoRecord> StringIdMap
         {
-            get { return _stringIdToInfo; }
+            get => _stringIdToInfo;
+#if !PBTCOMPILER
+            init => _stringIdToInfo = value;
+#endif
         }
 
         internal XamlTypeMapper XamlTypeMapper
@@ -1806,24 +1816,24 @@ namespace System.Windows.Markup
         // see if any advantage in breaking up or searching
         // by PropId, etc. instead of Hash. Hash is only used on compile
         // so leave null so Load doesn't take the hit.
-        private Hashtable _objectHashTable = new Hashtable();
+        private readonly Hashtable _objectHashTable = new();
 
         /// <summary>
-        /// List of Assemblies
+        /// List of <see cref="BamlAssemblyInfoRecord"/> (user assemblies).
         /// </summary>
-        private List<BamlAssemblyInfoRecord> _assemblyIdToInfo = new();
+        private readonly List<BamlAssemblyInfoRecord> _assemblyIdToInfo = new();
         /// <summary>
-        /// List of class types
+        /// List of <see cref="BamlTypeInfoRecord"/> (class types).
         /// </summary>
-        private List<BamlTypeInfoRecord> _typeIdToInfo = new();
+        private readonly List<BamlTypeInfoRecord> _typeIdToInfo = new();
         /// <summary>
-        /// List of Attribute Ids
+        /// List of <see cref="BamlAttributeInfoRecord"/> (attribute IDs).
         /// </summary>
-        private List<BamlAttributeInfoRecord> _attributeIdToInfo = new(10);
+        private readonly List<BamlAttributeInfoRecord> _attributeIdToInfo = new(10);
         /// <summary>
-        /// List of String Info
+        /// List of <see cref="BamlStringInfoRecord"/> (strings).
         /// </summary>
-        private List<BamlStringInfoRecord> _stringIdToInfo = new();     
+        private readonly List<BamlStringInfoRecord> _stringIdToInfo = new();     
 
         // XamlTypeMapper associated with this map table.  There is always a one-to-one correspondence.
         private XamlTypeMapper _xamlTypeMapper;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -14,6 +14,8 @@ using System.Collections;
 using System.Collections.Specialized;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -398,26 +400,19 @@ namespace System.Windows.Markup
         // and types that are a part of BamlTypeInfoRecords in the baml file.
         internal Type GetTypeFromId(short id)
         {
-            Type type = null;
-
             if (id < 0)
             {
                 return KnownTypes.Types[-id];
             }
-            else
+
+            BamlTypeInfoRecord typeInfo = TypeIdMap[id];
+            Type type = GetTypeFromTypeInfo(typeInfo);
+
+            if (type is null)
             {
-                BamlTypeInfoRecord typeInfo = TypeIdMap[id];
-
-                if (typeInfo is not null)
-                {
-                    type = GetTypeFromTypeInfo(typeInfo);
-
-                    if (type is null)
-                    {
-                        ThrowException(nameof(SR.ParserFailFindType), typeInfo.TypeFullName);
-                    }
-                }
+                ThrowException(nameof(SR.ParserFailFindType), typeInfo.TypeFullName);
             }
+
             return type;
         }
 
@@ -1624,10 +1619,11 @@ namespace System.Windows.Markup
 
 #if !PBTCOMPILER
         // Helper method to throw an Exception.
-        private void ThrowException(string id, string parameter)
+        [DoesNotReturn]
+        private static void ThrowException(string id, string parameter)
         {
-            ApplicationException bamlException = new ApplicationException(
-                                                     SR.Format(SR.GetResourceString(id), parameter));
+            ApplicationException bamlException = new(SR.Format(SR.GetResourceString(id), parameter));
+
             throw bamlException;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -679,12 +679,8 @@ namespace System.Windows.Markup
             else
             {
                 BamlAttributeInfoRecord record = AttributeIdMap[id];
-                if (record is not null)
-                {
-                    return record.Name;
-                }
+                return record.Name;
             }
-            return null;
         }
 
         internal bool DoesAttributeMatch(short id, short ownerTypeId, string name)
@@ -799,10 +795,7 @@ namespace System.Windows.Markup
                 else
                 {
                     BamlTypeInfoRecord typeInfo = TypeIdMap[bamlAttributeInfoRecord.OwnerTypeId];
-                    if (typeInfo is not null)
-                    {
-                        bamlAttributeInfoRecord.OwnerType = GetTypeFromTypeInfo(typeInfo);
-                    }
+                    bamlAttributeInfoRecord.OwnerType = GetTypeFromTypeInfo(typeInfo);
                 }
             }
 
@@ -1021,10 +1014,9 @@ namespace System.Windows.Markup
                 AssemblyFullName = assemblyFullName
             };
 
-            BamlAssemblyInfoRecord bamlAssemblyInfoRecord =
-                (BamlAssemblyInfoRecord)GetHashTableData(key);
+            BamlAssemblyInfoRecord bamlAssemblyInfoRecord = (BamlAssemblyInfoRecord)GetHashTableData(key);
 
-            if (null == bamlAssemblyInfoRecord)
+            if (bamlAssemblyInfoRecord is null)
             {
                 bamlAssemblyInfoRecord = new BamlAssemblyInfoRecord
                 {
@@ -1113,8 +1105,7 @@ namespace System.Windows.Markup
         // sure we are not overwriting existing data.
         internal void LoadAssemblyInfoRecord(BamlAssemblyInfoRecord record)
         {
-            Debug.Assert(AssemblyIdMap.Count == record.AssemblyId ||
-                         record.AssemblyFullName == AssemblyIdMap[record.AssemblyId].AssemblyFullName);
+            Debug.Assert(AssemblyIdMap.Count == record.AssemblyId || record.AssemblyFullName == AssemblyIdMap[record.AssemblyId].AssemblyFullName);
 
             if (AssemblyIdMap.Count == record.AssemblyId)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -365,9 +365,9 @@ namespace System.Windows.Markup
                 {
                     // Loop through attributes. We only care about having CLR properties in
                     // the hash table.  DependencyProperties are already cached by the framework.
-                    for (int i=0; i<AttributeIdMap.Count; i++)
+                    for (int i = 0; i < AttributeIdMap.Count; i++)
                     {
-                        BamlAttributeInfoRecord info = AttributeIdMap[i] as BamlAttributeInfoRecord;
+                        BamlAttributeInfoRecord info = AttributeIdMap[i];
                         if (info.PropInfo != null)
                         {
                             object key = GetAttributeInfoKey(info.OwnerType.FullName, info.Name);
@@ -647,7 +647,7 @@ namespace System.Windows.Markup
                 return record;
             }
 
-            return (BamlAttributeInfoRecord)AttributeIdMap[id];
+            return AttributeIdMap[id];
         }
 
         internal BamlAttributeInfoRecord GetAttributeInfoFromIdWithOwnerType(short attributeId)
@@ -678,8 +678,8 @@ namespace System.Windows.Markup
             }
             else
             {
-                BamlAttributeInfoRecord record = (BamlAttributeInfoRecord)AttributeIdMap[id];
-                if (record != null)
+                BamlAttributeInfoRecord record = AttributeIdMap[id];
+                if (record is not null)
                 {
                     return record.Name;
                 }
@@ -698,7 +698,7 @@ namespace System.Windows.Markup
             }
             else
             {
-                BamlAttributeInfoRecord record = (BamlAttributeInfoRecord)AttributeIdMap[id];
+                BamlAttributeInfoRecord record = AttributeIdMap[id];
                 return (record.OwnerTypeId == ownerTypeId) && (string.Equals(record.Name, name, StringComparison.Ordinal));
             }
         }
@@ -719,7 +719,7 @@ namespace System.Windows.Markup
             }
             else
             {
-                BamlAttributeInfoRecord record = (BamlAttributeInfoRecord)AttributeIdMap[id];
+                BamlAttributeInfoRecord record = AttributeIdMap[id];
                 return attributeUsage == record.AttributeUsage;
             }
         }
@@ -735,7 +735,7 @@ namespace System.Windows.Markup
             }
             else
             {
-                BamlAttributeInfoRecord record = (BamlAttributeInfoRecord)AttributeIdMap[id];
+                BamlAttributeInfoRecord record = AttributeIdMap[id];
                 name = record.Name;
                 ownerTypeId = record.OwnerTypeId;
                 attributeUsage = record.AttributeUsage;
@@ -907,7 +907,7 @@ namespace System.Windows.Markup
             }
             else
             {
-                BamlAttributeInfoRecord attribInfo = (BamlAttributeInfoRecord)AttributeIdMap[id];
+                BamlAttributeInfoRecord attribInfo = AttributeIdMap[id];
                 return GetDependencyProperty(attribInfo);
             }
         }
@@ -1348,7 +1348,7 @@ namespace System.Windows.Markup
             object key = GetAttributeInfoKey(typeFullName, fieldName);
 
             bamlAttributeInfoRecord = (BamlAttributeInfoRecord)GetHashTableData(key);
-            if (null == bamlAttributeInfoRecord)
+            if (bamlAttributeInfoRecord is null)
             {
                 // The property is new and needs a record created.
                 bamlAttributeInfoRecord = new BamlAttributeInfoRecord
@@ -1357,7 +1357,8 @@ namespace System.Windows.Markup
                     OwnerTypeId = typeId
                 };
 
-                bamlAttributeInfoRecord.AttributeId = (short)AttributeIdMap.Add(bamlAttributeInfoRecord);
+                AttributeIdMap.Add(bamlAttributeInfoRecord);
+                bamlAttributeInfoRecord.AttributeId = (short)(AttributeIdMap.Count - 1);
                 bamlAttributeInfoRecord.AttributeUsage = attributeUsage;
 
                 // add to the hash
@@ -1644,9 +1645,7 @@ namespace System.Windows.Markup
         // an existing record something different.
         internal void LoadAttributeInfoRecord(BamlAttributeInfoRecord record)
         {
-            Debug.Assert(AttributeIdMap.Count == record.AttributeId ||
-                         record.Name ==
-                         ((BamlAttributeInfoRecord)AttributeIdMap[record.AttributeId]).Name);
+            Debug.Assert(AttributeIdMap.Count == record.AttributeId || record.Name == AttributeIdMap[record.AttributeId].Name);
 
             if (AttributeIdMap.Count == record.AttributeId)
             {
@@ -1699,7 +1698,7 @@ namespace System.Windows.Markup
                 _objectHashTable = (Hashtable)_objectHashTable.Clone(),
                 _assemblyIdToInfo = new List<BamlAssemblyInfoRecord>(_assemblyIdToInfo),
                 _typeIdToInfo = new List<BamlTypeInfoRecord>(_typeIdToInfo),
-                _attributeIdToInfo = (ArrayList)_attributeIdToInfo.Clone(),
+                _attributeIdToInfo = new List<BamlAttributeInfoRecord>(_attributeIdToInfo),
                 _stringIdToInfo = (ArrayList)_stringIdToInfo.Clone()
             };
 
@@ -1758,7 +1757,7 @@ namespace System.Windows.Markup
             get { return _typeIdToInfo; }
         }
 
-        private ArrayList AttributeIdMap
+        private List<BamlAttributeInfoRecord> AttributeIdMap
         {
             get { return _attributeIdToInfo; }
         }
@@ -1826,8 +1825,11 @@ namespace System.Windows.Markup
         /// <summary>
         /// List of class types
         /// </summary>
-        private List<BamlTypeInfoRecord> _typeIdToInfo = new();    
-        private ArrayList _attributeIdToInfo = new ArrayList(10);   // arrayList of Attribute Ids
+        private List<BamlTypeInfoRecord> _typeIdToInfo = new();
+        /// <summary>
+        /// List of Attribute Ids
+        /// </summary>
+        private List<BamlAttributeInfoRecord> _attributeIdToInfo = new(10);
         private ArrayList _stringIdToInfo = new ArrayList(1);     // arrayList of String Info
 
         // XamlTypeMapper associated with this map table.  There is always a one-to-one correspondence.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -376,9 +376,9 @@ namespace System.Windows.Markup
                     }
 
                     // Loop through types and cache them.
-                    for (int j=0; j<TypeIdMap.Count; j++)
+                    for (int j = 0; j < TypeIdMap.Count; j++)
                     {
-                        BamlTypeInfoRecord info = TypeIdMap[j] as BamlTypeInfoRecord;
+                        BamlTypeInfoRecord info = TypeIdMap[j];
                         if (info.Type != null)
                         {
                             BamlAssemblyInfoRecord assyInfo = GetAssemblyInfoFromId(info.AssemblyId);
@@ -406,13 +406,13 @@ namespace System.Windows.Markup
             }
             else
             {
-                BamlTypeInfoRecord typeInfo  = (BamlTypeInfoRecord)TypeIdMap[id];
+                BamlTypeInfoRecord typeInfo = TypeIdMap[id];
 
-                if (null != typeInfo)
+                if (typeInfo is not null)
                 {
                     type = GetTypeFromTypeInfo(typeInfo);
 
-                    if (null == type)
+                    if (type is null)
                     {
                         ThrowException(nameof(SR.ParserFailFindType), typeInfo.TypeFullName);
                     }
@@ -500,7 +500,7 @@ namespace System.Windows.Markup
             }
             else
             {
-                return (BamlTypeInfoRecord) TypeIdMap[id];
+                return TypeIdMap[id];
             }
         }
 
@@ -794,15 +794,14 @@ namespace System.Windows.Markup
             {
                 if (bamlAttributeInfoRecord.OwnerTypeId < 0)
                 {
-                    bamlAttributeInfoRecord.OwnerType =
-                                         GetKnownTypeFromId(bamlAttributeInfoRecord.OwnerTypeId);
+                    bamlAttributeInfoRecord.OwnerType = GetKnownTypeFromId(bamlAttributeInfoRecord.OwnerTypeId);
                 }
                 else
                 {
-                    BamlTypeInfoRecord typeInfo = (BamlTypeInfoRecord)TypeIdMap[bamlAttributeInfoRecord.OwnerTypeId];
-                    if (null != typeInfo)
+                    BamlTypeInfoRecord typeInfo = TypeIdMap[bamlAttributeInfoRecord.OwnerTypeId];
+                    if (typeInfo is not null)
                     {
-                        bamlAttributeInfoRecord.OwnerType =  GetTypeFromTypeInfo(typeInfo);
+                        bamlAttributeInfoRecord.OwnerType = GetTypeFromTypeInfo(typeInfo);
                     }
                 }
             }
@@ -1251,7 +1250,8 @@ namespace System.Windows.Markup
             bamlTypeInfoRecord.IsInternalType = (elementType != null && ReflectionHelper.IsInternalType(elementType));
 
             // review, could be a race condition here.
-            bamlTypeInfoRecord.TypeId = (short)TypeIdMap.Add(bamlTypeInfoRecord);
+            TypeIdMap.Add(bamlTypeInfoRecord);
+            bamlTypeInfoRecord.TypeId = (short)(TypeIdMap.Count - 1);
 
             // add to the hash
             ObjectHashTable.Add(key, bamlTypeInfoRecord);
@@ -1268,9 +1268,7 @@ namespace System.Windows.Markup
         // as an existing record, ensure we're not trying to overwrite something.
         internal void LoadTypeInfoRecord(BamlTypeInfoRecord record)
         {
-            Debug.Assert(TypeIdMap.Count == record.TypeId ||
-                         record.TypeFullName ==
-                         ((BamlTypeInfoRecord)TypeIdMap[record.TypeId]).TypeFullName);
+            Debug.Assert(TypeIdMap.Count == record.TypeId || record.TypeFullName == TypeIdMap[record.TypeId].TypeFullName);
 
             if (TypeIdMap.Count == record.TypeId)
             {
@@ -1700,7 +1698,7 @@ namespace System.Windows.Markup
             {
                 _objectHashTable = (Hashtable)_objectHashTable.Clone(),
                 _assemblyIdToInfo = new List<BamlAssemblyInfoRecord>(_assemblyIdToInfo),
-                _typeIdToInfo = (ArrayList)_typeIdToInfo.Clone(),
+                _typeIdToInfo = new List<BamlTypeInfoRecord>(_typeIdToInfo),
                 _attributeIdToInfo = (ArrayList)_attributeIdToInfo.Clone(),
                 _stringIdToInfo = (ArrayList)_stringIdToInfo.Clone()
             };
@@ -1755,7 +1753,7 @@ namespace System.Windows.Markup
             get { return _assemblyIdToInfo; }
         }
 
-        private ArrayList TypeIdMap
+        private List<BamlTypeInfoRecord> TypeIdMap
         {
             get { return _typeIdToInfo; }
         }
@@ -1821,8 +1819,14 @@ namespace System.Windows.Markup
         // so leave null so Load doesn't take the hit.
         private Hashtable _objectHashTable = new Hashtable();
 
-        private List<BamlAssemblyInfoRecord> _assemblyIdToInfo = new();    // List of Assemblies
-        private ArrayList _typeIdToInfo = new ArrayList(0);    // arrayList of class Types
+        /// <summary>
+        /// List of Assemblies
+        /// </summary>
+        private List<BamlAssemblyInfoRecord> _assemblyIdToInfo = new();
+        /// <summary>
+        /// List of class types
+        /// </summary>
+        private List<BamlTypeInfoRecord> _typeIdToInfo = new();    
         private ArrayList _attributeIdToInfo = new ArrayList(10);   // arrayList of Attribute Ids
         private ArrayList _stringIdToInfo = new ArrayList(1);     // arrayList of String Info
 


### PR DESCRIPTION
## Description

Replaces 4x `ArrayList` collections with `List<T>` for improved performance and increased type safety.

I've also introduced `init` setters for the respective properties so they can be used as part of the `Clone` operation and the underlying fields can be converted to `readonly`. Rest are just NULL check removals coming from the `as` casting pattern or simply redundant as the values in the lists are always from freshly initialized types, no NULLs are inserted.

Sample benchmark showing difference between `ArrayList` and `List<T>` with reference type can be found f.e. in #9432.

## Customer Impact

Improved performance, cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low, just type swaps.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9967)