### PR TITLE
Swap backing for ParserStack from ArrayList to List<T>, improve performance

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -4304,17 +4304,17 @@ namespace System.Windows.Markup
         {
             ReaderContextStackData d;
 
-            lock(_stackDataFactoryCache)
+            lock (s_stackDataFactoryCache)
             {
-                if (_stackDataFactoryCache.Count == 0)
+                if (s_stackDataFactoryCache.Count == 0)
                 {
                     d = new ReaderContextStackData();
                 }
                 else
                 {
                     // Get StackData from the factory cache
-                    d = _stackDataFactoryCache[_stackDataFactoryCache.Count-1];
-                    _stackDataFactoryCache.RemoveAt(_stackDataFactoryCache.Count-1);
+                    d = s_stackDataFactoryCache[s_stackDataFactoryCache.Count - 1];
+                    s_stackDataFactoryCache.RemoveAt(s_stackDataFactoryCache.Count - 1);
                 }
             }
 
@@ -4355,9 +4355,9 @@ namespace System.Windows.Markup
             // Clear the stack data and then add it to the factory cache for reuse
             stackData.ClearData();
 
-            lock(_stackDataFactoryCache)
+            lock (s_stackDataFactoryCache)
             {
-                _stackDataFactoryCache.Add(stackData);
+                s_stackDataFactoryCache.Add(stackData);
             }
         }
 
@@ -5574,13 +5574,6 @@ namespace System.Windows.Markup
             get { return _xamlReaderStream; }
         }
 
-        // The stack of context information accumulated during reading.
-        internal ParserStack<ReaderContextStackData> ContextStack
-        {
-            get { return _contextStack; }
-            set { _contextStack = value; }
-        }
-
         internal int LineNumber
         {
             get { return ParserContext.LineNumber; }
@@ -5623,11 +5616,13 @@ namespace System.Windows.Markup
             get { return _previousBamlRecordReader; }
         }
 
-#endregion Properties
+        #endregion Properties
 
-#region Data
+        #region Data
 
         // state vars
+        private readonly ParserStack<ReaderContextStackData> _contextStack = new();
+
         IComponentConnector                 _componentConnector;
         object                              _rootElement;
         bool                                _bamlAsForest;
@@ -5636,7 +5631,6 @@ namespace System.Windows.Markup
         ParserContext                       _parserContext;   // XamlTypeMapper, namespace state, lang/space values
         TypeConvertContext                  _typeConvertContext;
         int                                 _persistId;
-        ParserStack<ReaderContextStackData> _contextStack = new();
         XamlParseMode                       _parseMode = XamlParseMode.Synchronous;
         int                                 _maxAsyncRecords;
         // end of state vars
@@ -5653,7 +5647,7 @@ namespace System.Windows.Markup
         // The outer BRR, when this one is nested.
         BamlRecordReader             _previousBamlRecordReader;
 
-        static List<ReaderContextStackData> _stackDataFactoryCache = new List<ReaderContextStackData>();
+        private static readonly List<ReaderContextStackData> s_stackDataFactoryCache = new();
 
 #endregion Data
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -525,7 +525,7 @@ namespace System.Windows.Markup
             CurrentContext.ObjectData = null;
 
             #if DEBUG  // ifdef's around Debug.Assert are necessary because stackDepth is only DEBUG defined
-            Debug.Assert( stackDepth == ReaderContextStack.Count );
+            Debug.Assert(stackDepth == ReaderContextStack.Count);
             #endif
 
             PopContext();
@@ -4081,12 +4081,12 @@ namespace System.Windows.Markup
             // Check each one for the resource we are searching for until we reach a DependencyObject
             // which is actually in the element tree.  Stop at this one.
 
-            ParserStack contextStack = ReaderContextStack;
+            ParserStack<ReaderContextStackData> contextStack = ReaderContextStack;
             BamlRecordReader reader = this;
 
-            while( contextStack != null )
+            while (contextStack != null)
             {
-                for (int i = contextStack.Count-1; i >= 0; i--)
+                for (int i = contextStack.Count - 1; i >= 0; i--)
                 {
                     ReaderContextStackData stackData = (ReaderContextStackData) contextStack[i];
                     IDictionary dictionary = GetDictionaryFromContext(stackData, false /*toInsert*/);
@@ -4340,7 +4340,7 @@ namespace System.Windows.Markup
         // Pos the reader context stack.
         internal void PopContext()
         {
-            ReaderContextStackData stackData = (ReaderContextStackData) ReaderContextStack.Pop();
+            ReaderContextStackData stackData = ReaderContextStack.Pop();
 
             // If we're through with an Name scoping point, take it off the stack.
             INameScope nameScope = NameScope.NameScopeFromObject(stackData.ObjectData);
@@ -5493,12 +5493,12 @@ namespace System.Windows.Markup
 
         internal ReaderContextStackData CurrentContext
         {
-            get { return (ReaderContextStackData) ReaderContextStack.CurrentContext; }
+            get { return ReaderContextStack.CurrentContext; }
         }
 
         internal ReaderContextStackData ParentContext
         {
-            get { return (ReaderContextStackData) ReaderContextStack.ParentContext; }
+            get { return ReaderContextStack.ParentContext; }
         }
 
         internal object ParentObjectData
@@ -5506,13 +5506,13 @@ namespace System.Windows.Markup
             get
             {
                 ReaderContextStackData contextData = ParentContext;
-                return contextData == null ? null : contextData.ObjectData;
+                return contextData?.ObjectData;
             }
         }
 
         internal ReaderContextStackData GrandParentContext
         {
-            get { return (ReaderContextStackData) ReaderContextStack.GrandParentContext; }
+            get { return ReaderContextStack.GrandParentContext; }
         }
 
         internal object GrandParentObjectData
@@ -5520,16 +5520,16 @@ namespace System.Windows.Markup
             get
             {
                 ReaderContextStackData contextData = GrandParentContext;
-                return contextData == null ? null : contextData.ObjectData;
+                return contextData?.ObjectData;
             }
         }
 
         internal ReaderContextStackData GreatGrandParentContext
         {
-            get { return (ReaderContextStackData) ReaderContextStack.GreatGrandParentContext; }
+            get { return ReaderContextStack.GreatGrandParentContext; }
         }
 
-        internal ParserStack ReaderContextStack
+        internal ParserStack<ReaderContextStackData> ReaderContextStack
         {
             get { return _contextStack; }
         }
@@ -5575,7 +5575,7 @@ namespace System.Windows.Markup
         }
 
         // The stack of context information accumulated during reading.
-        internal ParserStack ContextStack
+        internal ParserStack<ReaderContextStackData> ContextStack
         {
             get { return _contextStack; }
             set { _contextStack = value; }
@@ -5628,27 +5628,27 @@ namespace System.Windows.Markup
 #region Data
 
         // state vars
-        IComponentConnector          _componentConnector;
-        object                       _rootElement;
-        bool                         _bamlAsForest;
-        bool                         _isRootAlreadyLoaded;
-        ArrayList                    _rootList;
-        ParserContext                _parserContext;   // XamlTypeMapper, namespace state, lang/space values
-        TypeConvertContext           _typeConvertContext;
-        int                          _persistId;
-        ParserStack                  _contextStack = new ParserStack();
-        XamlParseMode                _parseMode = XamlParseMode.Synchronous;
-        int                          _maxAsyncRecords;
+        IComponentConnector                 _componentConnector;
+        object                              _rootElement;
+        bool                                _bamlAsForest;
+        bool                                _isRootAlreadyLoaded;
+        ArrayList                           _rootList;
+        ParserContext                       _parserContext;   // XamlTypeMapper, namespace state, lang/space values
+        TypeConvertContext                  _typeConvertContext;
+        int                                 _persistId;
+        ParserStack<ReaderContextStackData> _contextStack = new();
+        XamlParseMode                       _parseMode = XamlParseMode.Synchronous;
+        int                                 _maxAsyncRecords;
         // end of state vars
 
-        Stream                       _bamlStream;
-        ReaderStream                 _xamlReaderStream;
-        BamlBinaryReader             _binaryReader;
-        BamlRecordManager            _bamlRecordManager;
-        BamlRecord                   _preParsedBamlRecordsStart = null;
-        BamlRecord                   _preParsedIndexRecord = null;
-        bool                         _endOfDocument = false;
-        bool                         _buildTopDown = true;
+        Stream                              _bamlStream;
+        ReaderStream                        _xamlReaderStream;
+        BamlBinaryReader                    _binaryReader;
+        BamlRecordManager                   _bamlRecordManager;
+        BamlRecord                          _preParsedBamlRecordsStart = null;
+        BamlRecord                          _preParsedIndexRecord = null;
+        bool                                _endOfDocument = false;
+        bool                                _buildTopDown = true;
 
         // The outer BRR, when this one is nested.
         BamlRecordReader             _previousBamlRecordReader;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlWriter.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Markup
             _startDocumentWritten = false;
             _depth = 0;
             _closed = false;
-            _nodeTypeStack = new ParserStack();
+            _nodeTypeStack = new ParserStack<WriteStackNode>();
             _assemblies = new Hashtable(7);
            _extensionParser = new MarkupExtensionParser((IParserHelper)this, _parserContext);
            _markupExtensionNodes = new ArrayList();
@@ -1282,7 +1282,7 @@ namespace System.Windows.Markup
     // Pop an item off the node stack and return its type.
     private BamlRecordType Pop()
     {
-        WriteStackNode stackNode = _nodeTypeStack.Pop() as WriteStackNode;
+        WriteStackNode stackNode = _nodeTypeStack.Pop();
         Debug.Assert(stackNode != null);
         return stackNode.RecordType;
     }
@@ -1290,7 +1290,7 @@ namespace System.Windows.Markup
     // Return the record type on the top of the stack
     private BamlRecordType PeekRecordType()
     {
-        WriteStackNode stackNode = _nodeTypeStack.Peek() as WriteStackNode;
+        WriteStackNode stackNode = _nodeTypeStack.Peek();
         Debug.Assert(stackNode != null);
         return stackNode.RecordType;
     }
@@ -1298,7 +1298,7 @@ namespace System.Windows.Markup
     // Return the element type on the top of the stack
     private Type PeekElementType()
     {
-        WriteStackNode stackNode = _nodeTypeStack.Peek() as WriteStackNode;
+        WriteStackNode stackNode = _nodeTypeStack.Peek();
         Debug.Assert(stackNode != null);
         return stackNode.ElementType;
     }
@@ -1309,16 +1309,10 @@ namespace System.Windows.Markup
     {
         if (_nodeTypeStack.Count > 0)
         {
-            WriteStackNode parentNode = _nodeTypeStack.Peek() as WriteStackNode;
-            if (!parentNode.EndAttributesReached &&
-                parentNode.RecordType == BamlRecordType.ElementStart)
+            WriteStackNode parentNode = _nodeTypeStack.Peek();
+            if (!parentNode.EndAttributesReached && parentNode.RecordType == BamlRecordType.ElementStart)
             {
-                XamlEndAttributesNode node = new XamlEndAttributesNode(
-                                                   0,
-                                                   0,
-                                                   _depth,
-                                                   false);
-                _bamlRecordWriter.WriteEndAttributes(node);
+                _bamlRecordWriter.WriteEndAttributes(new XamlEndAttributesNode(0, 0, _depth, false));
             }
             parentNode.EndAttributesReached = true;
         }
@@ -1389,7 +1383,7 @@ namespace System.Windows.Markup
         // Stack of the type of nodes written to the baml stream.  This is 
         // used for end-tag matching and basic structure checking.  This
         // contains WriteStackNode objects.
-        ParserStack           _nodeTypeStack;
+        private readonly ParserStack<WriteStackNode> _nodeTypeStack;
 
         // Cache of assemblies that are needed for type resolutions when
         // doingIBamlSerialize

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlWriter.cs
@@ -7,23 +7,11 @@
 * Purpose:  Public api for writing baml records to a stream
 *
 \***************************************************************************/
-using System;
-using System.Xml;
+
 using System.IO;
-using System.Windows;
-using System.Text;
-using System.Collections;
-using System.ComponentModel;
-using MS.Internal.Utility;
-using MS.Internal;
-
-using System.Diagnostics;
 using System.Reflection;
-using System.Windows.Controls;
-using System.Windows.Documents;
-using System.Windows.Threading;
-
-using MS.Utility;
+using System.Collections;
+using System.Diagnostics;
 
 namespace System.Windows.Markup
 {
@@ -37,8 +25,7 @@ namespace System.Windows.Markup
         /// <summary>
         /// Create a BamlWriter on the passed stream.  The stream must be writable.
         /// </summary>
-        public BamlWriter(
-            Stream stream)
+        public BamlWriter(Stream stream)
         {
             ArgumentNullException.ThrowIfNull(stream);
             if (!stream.CanWrite)
@@ -59,8 +46,8 @@ namespace System.Windows.Markup
             _closed = false;
             _nodeTypeStack = new ParserStack<WriteStackNode>();
             _assemblies = new Hashtable(7);
-           _extensionParser = new MarkupExtensionParser((IParserHelper)this, _parserContext);
-           _markupExtensionNodes = new ArrayList();
+            _extensionParser = new MarkupExtensionParser(this, _parserContext);
+            _markupExtensionNodes = new ArrayList();
         }
 
   

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/ParserStack.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/ParserStack.cs
@@ -27,9 +27,15 @@ namespace System.Windows.Markup
     internal sealed class ParserStack<T> : List<T> where T : class
     {
         /// <summary>
-        ///     Creates a default ParserStack
+        /// Creates an empty <see cref="ParserStack{T}"/> with default capacity.
         /// </summary>
         internal ParserStack() : base() { }
+
+        /// <summary>
+        /// Private constructor, supports <see cref="Clone"/> method execution.
+        /// </summary>
+        /// <param name="collection"></param>
+        private ParserStack(IEnumerable<T> collection) : base(collection) { }
 
         public void Push(T item)
         {
@@ -52,9 +58,13 @@ namespace System.Windows.Markup
         }
 #endif
 
-        public List<T> Clone()
+        /// <summary>
+        /// Creates a shallow copy of <see cref="ParserStack{T}"/>.
+        /// </summary>
+        /// <returns>A newly initialized instance.</returns>
+        public ParserStack<T> Clone()
         {
-            return new List<T>(this);
+            return new ParserStack<T>(this);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/ParserStack.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/ParserStack.cs
@@ -8,32 +8,7 @@
 *
 \***************************************************************************/
 
-using System;
-using System.Xml;
-using System.Xml.Serialization;
-using System.IO;
-using System.Text;
-using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Reflection;
-using System.Globalization;
-using MS.Utility;
-using System.Collections.Specialized;
-using Microsoft.Win32;
-using System.Runtime.InteropServices;
-using MS.Internal;
-
-
-#if !PBTCOMPILER
-
-using System.Windows;
-using System.Windows.Documents;
-using System.Windows.Media;
-using System.Windows.Shapes;
-
-#endif
 
 #if PBTCOMPILER
 namespace MS.Internal.Markup
@@ -49,88 +24,71 @@ namespace System.Windows.Markup
     /// Main goal is to track current/parent context with a minimum of overhead.
     /// This class is internal so it can be shared with the BamlRecordReader
     /// </summary>
-    internal class ParserStack : ArrayList
+    internal sealed class ParserStack<T> : List<T> where T : class
     {
         /// <summary>
         ///     Creates a default ParserStack
         /// </summary>
-        internal ParserStack() : base()
+        internal ParserStack() : base() { }
+
+        public void Push(T item)
         {
+            Add(item);
         }
 
-        /// <summary>
-        ///     Creates a clone.
-        /// </summary>
-        private ParserStack(ICollection collection) : base(collection)
+        public T Pop()
         {
-        }
-
-        #region StackOverrides
-
-        public void Push(object o)
-        {
-            Add(o);
-        }
-
-        public object Pop()
-        {
-            object o = this[Count - 1];
+            T item = this[Count - 1];
             RemoveAt(Count - 1);
-            return o;
+
+            return item;
         }
 
 #if !PBTCOMPILER
-        public object Peek()
+        public T Peek()
         {
             // Die if peeking on empty stack
             return this[Count - 1];
         }
 #endif
 
-        public override object Clone()
+        public List<T> Clone()
         {
-            return new ParserStack(this);
+            return new List<T>(this);
         }
-
-        #endregion // StackOverrides
-
-        #region Properties
 
         /// <summary>
         /// Returns the Current Context on the stack
         /// </summary>
-        internal object CurrentContext
+        internal T CurrentContext
         {
-            get { return Count > 0 ? this[Count - 1] : null; }
+            get => Count > 0 ? this[Count - 1] : null;
         }
 
         /// <summary>
         /// Returns the Parent of the Current Context
         /// </summary>
-        internal object ParentContext
+        internal T ParentContext
         {
-            get { return Count > 1 ? this[Count - 2] : null; }
+            get => Count > 1 ? this[Count - 2] : null;
         }
 
         /// <summary>
         /// Returns the GrandParent of the Current Context
         /// </summary>
-        internal object GrandParentContext
+        internal T GrandParentContext
         {
-            get { return Count > 2 ? this[Count - 3] : null; }
+            get => Count > 2 ? this[Count - 3] : null;
         }
 
 #if !PBTCOMPILER
         /// <summary>
         /// Returns the GreatGrandParent of the Current Context
         /// </summary>
-        internal object GreatGrandParentContext
+        internal T GreatGrandParentContext
         {
-            get { return Count > 3 ? this[Count - 4] : null; }
+            get => Count > 3 ? this[Count - 4] : null;
         }
 #endif
-
-        #endregion // Properties
-
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -1968,11 +1968,9 @@ namespace System.Windows.Markup
             }
             else
             {
-                if(ShouldImplyContentProperty())
+                if (ShouldImplyContentProperty())
                 {
-                    ElementContextStackData CpaStackData = new ElementContextStackData();
-                    CpaStackData.ContextType = ElementContextType.Default;
-                    ElementContextStack.Push(CpaStackData);
+                    ElementContextStack.Push(new ElementContextStackData() { ContextType = ElementContextType.Default });
                     ParserContext.PushScope();
 
                     CompileContentProperty(ParentContext);
@@ -3958,13 +3956,12 @@ namespace System.Windows.Markup
             // BamlRecordReader has secondary protection against nested property
             //  records, but the error message less friendly to users. ("'Property'
             //  record unexpected in BAML stream.")
-            ElementContextStackData parentTag = ElementContextStack.ParentContext as ElementContextStackData;
-            if( parentTag != null )
+            if (ElementContextStack.ParentContext is ElementContextStackData parentTag)
             {
-                if ( parentTag.ContextType == ElementContextType.PropertyComplex ||
-                     parentTag.ContextType == ElementContextType.PropertyArray ||
-                     parentTag.ContextType == ElementContextType.PropertyIList ||
-                     parentTag.ContextType == ElementContextType.PropertyIDictionary )
+                if (parentTag.ContextType == ElementContextType.PropertyComplex ||
+                    parentTag.ContextType == ElementContextType.PropertyArray ||
+                    parentTag.ContextType == ElementContextType.PropertyIList ||
+                    parentTag.ContextType == ElementContextType.PropertyIDictionary)
                 {
                     ThrowException(nameof(SR.ParserNestedComplexProp), complexPropName);
                 }
@@ -6682,7 +6679,7 @@ namespace System.Windows.Markup
         /// </summary>
         ElementContextStackData CurrentContext
         {
-            get { return (ElementContextStackData)ElementContextStack.CurrentContext; }
+            get { return ElementContextStack.CurrentContext; }
         }
 
         /// <summary>
@@ -6692,7 +6689,7 @@ namespace System.Windows.Markup
         {
             get
             {
-                ElementContextStackData stackData = (ElementContextStackData)ElementContextStack.CurrentContext;
+                ElementContextStackData stackData = ElementContextStack.CurrentContext;
                 return stackData.ComplexProperties;
             }
         }
@@ -6704,7 +6701,7 @@ namespace System.Windows.Markup
         {
             get
             {
-                ElementContextStackData stackData = (ElementContextStackData)ElementContextStack.ParentContext;
+                ElementContextStackData stackData = ElementContextStack.ParentContext;
                 return stackData.ComplexProperties;
             }
         }
@@ -6714,17 +6711,16 @@ namespace System.Windows.Markup
         /// </summary>
         ElementContextStackData ParentContext
         {
-            get { return (ElementContextStackData)ElementContextStack.ParentContext; }
+            get { return ElementContextStack.ParentContext; }
         }
 
         /// <summary>
         /// ElementContext stack
         /// </summary>
-        ParserStack ElementContextStack
+        ParserStack<ElementContextStackData> ElementContextStack
         {
             get { return _elementContextStack; }
         }
-
 
         /// <summary>
         /// Current Parsercontext for the node being processed
@@ -6739,7 +6735,7 @@ namespace System.Windows.Markup
         /// </summary>
         ElementContextStackData GrandParentContext
         {
-            get { return (ElementContextStackData)ElementContextStack.GrandParentContext; }
+            get { return ElementContextStack.GrandParentContext; }
         }
 
 
@@ -6821,7 +6817,7 @@ namespace System.Windows.Markup
         XamlParser _xamlParser;
 
         // Context stack for each Element
-        ParserStack _elementContextStack = new ParserStack();
+        private readonly ParserStack<ElementContextStackData> _elementContextStack = new();
 
         // State of the parser
         ParserState _parseLoopState;


### PR DESCRIPTION
## Description

Swaps `ParserStack`'s base class from `ArrayList` to `List<T>` to allow for generic interface. This increases type-safety and also improves performance slightly. For comparison between those two types, you may check #9432.

## Customer Impact

Improved performance, cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low, just type swaps.
