### PR TITLE
Remove WLDP/UseLegacyDangerousClipboardDeserializationMode leftovers

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ExternDll.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ExternDll.cs
@@ -45,7 +45,6 @@ namespace MS.Win32
         public const string Wininet = "wininet.dll";
         public const string Winmm = "winmm.dll";
         public const string Winspool = "winspool.drv";
-        public const string Wldp = "wldp.dll";
         public const string WpfGfx = "WpfGfx_cor3.dll";
         public const string WtsApi32 = "wtsapi32.dll";
     }


### PR DESCRIPTION
## Description

Cleans up rest of the dead code after #1286, as this code is uncalled since the switch doesn't exist.

## Customer Impact

Smaller size of assemblies, cleaner code base for developers.

## Regression

No.

## Testing

Local build.

## Risk

Next to none, just dead code removal.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9975)