### PR TITLE
Remove Marshal Exception/HRESULT proxies from SecurityHelper, simplify code

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -88,9 +88,6 @@
     <Compile Include="$(WpfSharedDir)\MS\Internal\ReflectionUtils.cs">
       <Link>Shared\MS\Internal\ReflectionUtils.cs</Link>
     </Compile>
-    <Compile Include="$(WpfSharedDir)\MS\Internal\SecurityHelper.cs">
-      <Link>Shared\MS\Internal\SecurityHelper.cs</Link>
-    </Compile>
     <Compile Include="$(WpfSharedDir)\MS\Internal\TokenizerHelper.cs">
       <Link>Shared\MS\Internal\TokenizerHelper.cs</Link>
     </Compile>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamAsIStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamAsIStream.cs
@@ -207,9 +207,8 @@ namespace System.Windows.Media
                         toRead  = (uint) (cb - cbWritten);
                     }
 
-                    uint read = 0;
 
-                    hr = Read(buffer.AsSpan(0, (int) toRead), out read);
+                    hr = Read(buffer.AsSpan(0, (int)toRead), out uint read);
 
                     if (read == 0)
                     {
@@ -218,9 +217,8 @@ namespace System.Windows.Media
 
                     cbRead += read;
 
-                    uint written = 0;
 
-                    hr = MILIStreamWrite(pstm, buffer, read, out written);
+                    hr = MILIStreamWrite(pstm, buffer, read, out uint written);
 
                     if (written != read)
                     {
@@ -481,8 +479,8 @@ namespace System.Windows.Media
         internal static StreamAsIStream FromSD(ref StreamDescriptor sd)
         {
             Debug.Assert(((IntPtr)sd.m_handle) != IntPtr.Zero, "Stream is disposed.");
-            System.Runtime.InteropServices.GCHandle handle = (System.Runtime.InteropServices.GCHandle)(sd.m_handle);
-            return (StreamAsIStream)(handle.Target);
+
+            return (StreamAsIStream)sd.m_handle.Target;
         }
 
         internal static int Clone(ref StreamDescriptor pSD, out IntPtr stream)
@@ -507,8 +505,7 @@ namespace System.Windows.Media
 
         internal static unsafe int Read(ref StreamDescriptor pSD, IntPtr buffer, uint cb, out uint cbRead)
         {
-            var span = new Span<byte>(buffer.ToPointer(), (int) cb);
-            return (StreamAsIStream.FromSD(ref pSD)).Read(span, out cbRead);
+            return (StreamAsIStream.FromSD(ref pSD)).Read(new Span<byte>((void*)buffer, (int)cb), out cbRead);
         }
 
         internal static int Revert(ref StreamDescriptor pSD)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamAsIStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamAsIStream.cs
@@ -1,9 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using MS.Internal;
-using MS.Win32;
 using System.Runtime.InteropServices;
+using MS.Internal;
+using System.IO;
+using MS.Win32;
 
 using UnsafeNativeMethods = MS.Win32.PresentationCore.UnsafeNativeMethods;
 
@@ -162,7 +163,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return NativeMethods.E_NOTIMPL;
@@ -181,7 +182,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return NativeMethods.S_OK;
@@ -238,7 +239,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return hr;
@@ -254,7 +255,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return NativeMethods.E_NOTIMPL;
@@ -275,7 +276,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return NativeMethods.S_OK;
@@ -291,7 +292,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return NativeMethods.E_NOTIMPL;
@@ -363,7 +364,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return NativeMethods.S_OK;
@@ -381,7 +382,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return NativeMethods.S_OK;
@@ -406,7 +407,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return NativeMethods.S_OK;
@@ -422,7 +423,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return NativeMethods.E_NOTIMPL;
@@ -446,7 +447,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return NativeMethods.S_OK;
@@ -466,7 +467,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return NativeMethods.S_OK;
@@ -486,7 +487,7 @@ namespace System.Windows.Media
             {
                 // store the last exception
                 _lastException = e;
-                return SecurityHelper.GetHRForException(e);
+                return Marshal.GetHRForException(e);
             }
 
             return NativeMethods.S_OK;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamAsIStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamAsIStream.cs
@@ -117,8 +117,7 @@ namespace System.Windows.Media
         private const int STREAM_SEEK_CUR = 0x1;
         private const int STREAM_SEEK_END = 0x2;
 
-        protected System.IO.Stream dataStream;
-        private Exception _lastException;
+        protected Stream dataStream;
 
         // to support seeking ahead of the stream length...
         private long virtualPosition = -1;
@@ -161,8 +160,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 
@@ -180,8 +177,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 
@@ -237,8 +232,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 
@@ -253,8 +246,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 
@@ -274,8 +265,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 
@@ -290,8 +279,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 
@@ -362,8 +349,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 
@@ -380,8 +365,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 
@@ -405,8 +388,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 
@@ -421,8 +402,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 
@@ -445,8 +424,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 
@@ -465,8 +442,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 
@@ -485,8 +460,6 @@ namespace System.Windows.Media
             }
             catch (Exception e)
             {
-                // store the last exception
-                _lastException = e;
                 return Marshal.GetHRForException(e);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/XamlFilter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/XamlFilter.cs
@@ -16,7 +16,7 @@ using System.Globalization;             // For CultureInfo
 using System.Collections;               // For Stack and Hashtable
 using System.Runtime.InteropServices;   // For COMException
 using System.Windows;                   // for ExceptionStringTable
-using MS.Internal.Interop;  // for CHUNK_BREAKTYPE (and other IFilter-related definitions)
+using MS.Internal.Interop;              // for CHUNK_BREAKTYPE (and other IFilter-related definitions)
 
 namespace MS.Internal.IO.Packaging
 {
@@ -266,19 +266,19 @@ namespace MS.Internal.IO.Packaging
         /// <summary>
         /// Return a maximum of bufferCharacterCount characters (*not* bytes) from the current content unit.
         /// </summary>
-        public String GetText(int bufferCharacterCount)
+        public string GetText(int bufferCharacterCount)
         {
             //BufferCharacterCount should be non-negative
             Debug.Assert(bufferCharacterCount >= 0);
 
             if (_currentContent == null)
             {
-                SecurityHelper.ThrowExceptionForHR((int)FilterErrorCode.FILTER_E_NO_TEXT);
+                Marshal.ThrowExceptionForHR((int)FilterErrorCode.FILTER_E_NO_TEXT, errorInfo: -1);
             }
             int numCharactersToReturn = _currentContent.Length - _countOfCharactersReturned;
             if (numCharactersToReturn <= 0)
             {
-                SecurityHelper.ThrowExceptionForHR((int)FilterErrorCode.FILTER_E_NO_MORE_TEXT);
+                Marshal.ThrowExceptionForHR((int)FilterErrorCode.FILTER_E_NO_MORE_TEXT, errorInfo: -1);
             }
 
             // Return at most bufferCharacterCount characters. The marshaler makes sure it can add a terminating
@@ -296,10 +296,11 @@ namespace MS.Internal.IO.Packaging
         /// <summary>
         /// The XAML indexing filter never returns property values.
         /// </summary>
-        public Object GetValue()
+        public object GetValue()
         {
-            SecurityHelper.ThrowExceptionForHR((int)FilterErrorCode.FILTER_E_NO_VALUES);
-            return null;
+            Marshal.ThrowExceptionForHR((int)FilterErrorCode.FILTER_E_NO_VALUES, errorInfo: -1);
+
+            return null; // Unreachable
         }
 
     #endregion Managed IFilter API

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsCache.cs
@@ -14,9 +14,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Reflection;
 using MS.Utility;
-#if PBTCOMPILER
-using MS.Internal.PresentationBuildTasks;
-#else
+#if !PBTCOMPILER
 using MS.Internal.PresentationFramework;
 using MS.Internal.Utility;  // AssemblyCacheEnum
 #endif

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/ErrorCodes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/ErrorCodes.cs
@@ -412,7 +412,7 @@ namespace Standard
                 // the process of implementing an IErrorInfo and then use that.  There's no stock
                 // implementations of IErrorInfo available and I don't think it's worth the maintenance
                 // overhead of doing it, nor would it have significant value over this approach.
-                Exception e = MS.Internal.PresentationFramework.SecurityHelper.GetExceptionForHR((int)_value);
+                Exception e = Marshal.GetExceptionForHR((int)_value, errorInfo: -1);
                 Assert.IsNotNull(e);
                 // ArgumentNullException doesn't have the right constructor parameters,
                 // (nor does Win32Exception...)

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/ReachFramework.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/ReachFramework.csproj
@@ -51,7 +51,6 @@
     </Compile>
     <Compile Include="$(WpfSharedDir)\RefAssemblyAttrs.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\SafeSecurityHelper.cs" />
-    <Compile Include="$(WpfSharedDir)\MS\Internal\SecurityHelper.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\UriComparer.cs " />
     <Compile Include="$(WpfSharedDir)\MS\Utility\BindUriHelper.cs" />
     <Compile Include="GlobalUsings.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
@@ -7,29 +7,18 @@
 *
 \***************************************************************************/
 
-using System.Security;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using Microsoft.Win32;
 
-#if !PBTCOMPILER
-using MS.Win32;
-using System.IO.Packaging;
-#endif
-
 #if PRESENTATION_CORE
 using MS.Internal.AppModel;
+using System.Security;
+using MS.Win32;
 #endif
 
 #if PRESENTATIONFRAMEWORK_ONLY
-using System.Diagnostics;
 using System.Windows;
-using MS.Internal.Utility;      // BindUriHelper
-using MS.Internal.AppModel;
-#endif
-
-#if REACHFRAMEWORK
-using MS.Internal.Utility;
 #endif
 
 // The SecurityHelper class differs between assemblies and could not actually be
@@ -43,10 +32,6 @@ using MS.Internal.PresentationCore;
 namespace MS.Internal // Promote the one from PresentationCore as the default to use.
 #elif PRESENTATIONFRAMEWORK
 namespace MS.Internal.PresentationFramework
-#elif PBTCOMPILER
-namespace MS.Internal.PresentationBuildTasks
-#elif REACHFRAMEWORK
-namespace MS.Internal.ReachFramework
 #elif DRT
 namespace MS.Internal.Drt
 #else

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
@@ -32,7 +32,28 @@ using MS.Internal.AppModel;
 using MS.Internal.Utility;
 #endif
 
-internal static class SecurityHelper
+// The SecurityHelper class differs between assemblies and could not actually be
+//  shared, so it is duplicated across namespaces to prevent name collision.
+// This duplication seems hardly necessary now. We should continue
+// trying to reduce it by pushing things from Framework to Core (whenever it makes sense).
+#if WINDOWS_BASE
+namespace MS.Internal.WindowsBase
+#elif PRESENTATION_CORE
+using MS.Internal.PresentationCore;
+namespace MS.Internal // Promote the one from PresentationCore as the default to use.
+#elif PRESENTATIONFRAMEWORK
+namespace MS.Internal.PresentationFramework
+#elif PBTCOMPILER
+namespace MS.Internal.PresentationBuildTasks
+#elif REACHFRAMEWORK
+namespace MS.Internal.ReachFramework
+#elif DRT
+namespace MS.Internal.Drt
+#else
+#error Class is being used from an unknown assembly.
+#endif
+{
+    internal static class SecurityHelper
     {
 
 #if PRESENTATION_CORE
@@ -149,14 +170,14 @@ internal static class SecurityHelper
 #if WINDOWS_BASE
         ///
         /// Read and return a registry value.
-       internal static object ReadRegistryValue( RegistryKey baseRegistryKey, string keyName, string valueName )
-       {
+        internal static object ReadRegistryValue(RegistryKey baseRegistryKey, string keyName, string valueName)
+        {
             object value = null;
 
             RegistryKey key = baseRegistryKey.OpenSubKey(keyName);
             if (key != null)
             {
-                using( key )
+                using (key)
                 {
                     value = key.GetValue(valueName);
                 }
@@ -165,6 +186,5 @@ internal static class SecurityHelper
             return value;
         }
 #endif // WINDOWS_BASE
+    }
 }
-}
-

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
@@ -104,22 +104,6 @@ internal static class SecurityHelper
         {
             Marshal.ThrowExceptionForHR(hr, new IntPtr(-1));
         }
-        
-        internal static int GetHRForException(Exception exception)
-        {
-            ArgumentNullException.ThrowIfNull(exception);
-
-            // GetHRForException fills a per thread IErrorInfo object with data from the exception
-            // The exception may contain security sensitive data like full file paths that we do not
-            // want to leak into an IErrorInfo
-            int hr = Marshal.GetHRForException(exception);
-
-            // Call GetHRForException a second time with a security safe exception object
-            // to make sure the per thread IErrorInfo is cleared of security sensitive data
-            Marshal.GetHRForException(new Exception());
-
-            return hr;
-        }
 
 #endif
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
@@ -31,36 +31,8 @@ using MS.Internal.AppModel;
 #if REACHFRAMEWORK
 using MS.Internal.Utility;
 #endif
-#if WINDOWS_BASE
-// This existed originally to allow FontCache service to 
-// see the WindowsBase variant of this class. We no longer have
-// a FontCache service, but over time other parts of WPF might
-// have started to depend on this, so we leave it as-is for 
-// compat. 
-#endif
 
-// The SecurityHelper class differs between assemblies and could not actually be
-//  shared, so it is duplicated across namespaces to prevent name collision.
-// This duplication seems hardly necessary now. We should continue
-// trying to reduce it by pushing things from Framework to Core (whenever it makes sense).
-#if WINDOWS_BASE
-namespace MS.Internal.WindowsBase
-#elif PRESENTATION_CORE
-using MS.Internal.PresentationCore;
-namespace MS.Internal // Promote the one from PresentationCore as the default to use.
-#elif PRESENTATIONFRAMEWORK
-namespace MS.Internal.PresentationFramework
-#elif PBTCOMPILER
-namespace MS.Internal.PresentationBuildTasks
-#elif REACHFRAMEWORK
-namespace MS.Internal.ReachFramework
-#elif DRT
-namespace MS.Internal.Drt
-#else
-#error Class is being used from an unknown assembly.
-#endif
-{
-    internal static class SecurityHelper
+internal static class SecurityHelper
     {
 
 #if PRESENTATION_CORE
@@ -124,13 +96,6 @@ namespace MS.Internal.Drt
         internal static int SizeOf(Object o)
         {
             return Marshal.SizeOf(o);
-        }
-#endif
-
-#if WINDOWS_BASE || PRESENTATION_CORE || PRESENTATIONFRAMEWORK
-        internal static Exception GetExceptionForHR(int hr)
-        {
-            return Marshal.GetExceptionForHR(hr, new IntPtr(-1));
         }
 #endif
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
@@ -99,14 +99,6 @@ internal static class SecurityHelper
         }
 #endif
 
-#if WINDOWS_BASE || PRESENTATION_CORE
-        internal static void ThrowExceptionForHR(int hr)
-        {
-            Marshal.ThrowExceptionForHR(hr, new IntPtr(-1));
-        }
-
-#endif
-
 #if PRESENTATIONFRAMEWORK
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/ContainerUtilities.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/ContainerUtilities.cs
@@ -11,11 +11,7 @@ using System.IO;
 using System.Text;          // for StringBuilder
 using System.Diagnostics;   // for Debug.Assert
 
-
-#if PBTCOMPILER
-using MS.Utility;     // For SR.cs
-using MS.Internal.PresentationBuildTasks;
-#else
+#if !PBTCOMPILER
 using System.Windows;
 using MS.Internal.WindowsBase;
 #endif

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/StorageBasedPackageProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/StorageBasedPackageProperties.cs
@@ -592,7 +592,7 @@ namespace MS.Internal.IO.Packaging
             }
             else
             {
-                SecurityHelper.ThrowExceptionForHR(hresult);
+                Marshal.ThrowExceptionForHR(hresult, errorInfo: -1);
             }
 
             return obj;
@@ -792,7 +792,7 @@ namespace MS.Internal.IO.Packaging
             else
             {
                 // Throw if we failed.
-                SecurityHelper.ThrowExceptionForHR(hr);
+                Marshal.ThrowExceptionForHR(hr, errorInfo: -1);
             }
         }
 


### PR DESCRIPTION
## Description

Continues the work on removing CAS remnants, this time again method proxies and "helpers" from `SecurityHelper`.

In this PR we remove `GetHRForException` from `StreamAsIStream` along with obsolete warning suppresions and also `GetExceptionForHR` plus `ThrowExceptionForHR` proxies.

- `_lastException ` was just storing the latest exception in a private field that was never read.
- Technically we could just return `COR_E_OBJECTDISPOSED` in some cases instead of setting up a frame, conditionally throwing `ObjectDisposedException`, catching it just to retrieve the `HResult` and then returning it but I think it is out of scope for this PR.

## Customer Impact

Decreased size of assemblies, cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9977)