### PR TITLE
Optimize working with EllipseGeometry/RectangleGeometry, reduce allocs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EllipseGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EllipseGeometry.cs
@@ -2,25 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//                                             
-
-using System;
 using MS.Internal;
-using System.ComponentModel;
-using System.ComponentModel.Design.Serialization;
-using System.Reflection;
-using System.Collections;
-using System.Text;
-using System.Globalization;
-using System.Windows.Media;
 using System.Windows.Media.Composition;
-using System.Windows;
-using System.Text.RegularExpressions;
-using System.Windows.Media.Animation;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Security;
-using SR=MS.Internal.PresentationCore.SR;
+
+using SR = MS.Internal.PresentationCore.SR;
 
 namespace System.Windows.Media 
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EllipseGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EllipseGeometry.cs
@@ -120,7 +120,7 @@ namespace System.Windows.Media
         internal static unsafe Rect GetBoundsHelper(Pen pen, Matrix worldMatrix, Point center, double radiusX, double radiusY,
                                                     Matrix geometryMatrix, double tolerance, ToleranceType type)
         {
-            if ((pen == null || pen.DoesNotContainGaps) && worldMatrix.IsIdentity && geometryMatrix.IsIdentity)
+            if ((pen is null || pen.DoesNotContainGaps) && worldMatrix.IsIdentity && geometryMatrix.IsIdentity)
             {
                 double strokeThickness = Pen.ContributesToBounds(pen) ? Math.Abs(pen.Thickness) : 0.0;
 
@@ -129,14 +129,16 @@ namespace System.Windows.Media
                                 2.0 * Math.Abs(radiusX) + strokeThickness,
                                 2.0 * Math.Abs(radiusY) + strokeThickness);
             }
-
-            Point* ptrPoints = stackalloc Point[(int)PointCount];
-            EllipseGeometry.InitializePointList(ptrPoints, (int)PointCount, center, radiusX, radiusY);
-
-            fixed (byte* ptrTypes = RoundedPathTypes) // Merely retrieves the pointer to static PE data, no actual pinning occurs
+            else
             {
-                return Geometry.GetBoundsHelper(pen, &worldMatrix, ptrPoints, ptrTypes, PointCount, SegmentCount, &geometryMatrix,
-                                                tolerance, type, false); // skip hollows - meaningless here, this is never a hollow
+                Point* ptrPoints = stackalloc Point[(int)PointCount];
+                EllipseGeometry.InitializePointList(ptrPoints, (int)PointCount, center, radiusX, radiusY);
+
+                fixed (byte* ptrTypes = RoundedPathTypes) // Merely retrieves the pointer to static PE data, no actual pinning occurs
+                {
+                    return Geometry.GetBoundsHelper(pen, &worldMatrix, ptrPoints, ptrTypes, PointCount, SegmentCount, &geometryMatrix,
+                                                    tolerance, type, false); // skip hollows - meaningless here, this is never a hollow
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EllipseGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EllipseGeometry.cs
@@ -267,32 +267,23 @@ namespace System.Windows.Media
 
         internal override PathFigureCollection GetTransformedFigureCollection(Transform transform)
         {
-            Point [] points = GetPointList();
+            Point[] points = GetPointList();
 
             // Get the combined transform argument with the internal transform
             Matrix matrix = GetCombinedMatrix(transform);
             if (!matrix.IsIdentity)
             {
-                for (int i=0; i<points.Length; i++)
+                for (int i = 0; i < points.Length; i++)
                 {
                     points[i] *= matrix;
                 }
             }
 
-            PathFigureCollection figureCollection = new PathFigureCollection();
-            figureCollection.Add(
-                new PathFigure(
-                    points[0],
-                    new PathSegment[]{
-                    new BezierSegment(points[1], points[2], points[3], true, true),
-                    new BezierSegment(points[4], points[5], points[6], true, true),
-                    new BezierSegment(points[7], points[8], points[9], true, true),
-                    new BezierSegment(points[10], points[11], points[12], true, true)},
-                    true
-                    )
-                );
-
-            return figureCollection;
+            return new PathFigureCollection(1) { new PathFigure(points[0], [new BezierSegment(points[1], points[2], points[3], true, true),
+                                                                            new BezierSegment(points[4], points[5], points[6], true, true),
+                                                                            new BezierSegment(points[7], points[8], points[9], true, true),
+                                                                            new BezierSegment(points[10], points[11], points[12], true, true)],
+                                                                            closed: true) };
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/LineGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/LineGeometry.cs
@@ -114,19 +114,19 @@ namespace System.Windows.Media
             {
                 unsafe
                 {
-                    Point* pPoints = stackalloc Point[2];
+                    Point* pPoints = stackalloc Point[(int)PointCount];
                     pPoints[0] = pt1;
                     pPoints[1] = pt2;
 
-                    fixed (byte* pTypes = LineTypes) //Merely retrieves the pointer to static PE data, no actual pinning occurs
+                    fixed (byte* pTypes = LineTypes) // Merely retrieves the pointer to static PE data, no actual pinning occurs
                     {
                         return Geometry.GetBoundsHelper(
                             pen, 
                             &worldMatrix, 
                             pPoints, 
-                            pTypes, 
-                            c_pointCount,
-                            c_segmentCount,
+                            pTypes,
+                            PointCount,
+                            SegmentCount,
                             &geometryMatrix,
                             tolerance,
                             type,
@@ -140,11 +140,11 @@ namespace System.Windows.Media
         {
             unsafe
             {
-                Point* pPoints = stackalloc Point[2];
+                Point* pPoints = stackalloc Point[(int)PointCount];
                 pPoints[0] = StartPoint;
                 pPoints[1] = EndPoint;
                 
-                fixed (byte* pTypes = LineTypes) //Merely retrieves the pointer to static PE data, no actual pinning occurs
+                fixed (byte* pTypes = LineTypes) // Merely retrieves the pointer to static PE data, no actual pinning occurs
                 {
                     return ContainsInternal(
                         pen,
@@ -152,9 +152,9 @@ namespace System.Windows.Media
                         tolerance, 
                         type,
                         pPoints,
-                        GetPointCount(),
+                        PointCount,
                         pTypes,
-                        GetSegmentCount());
+                        SegmentCount);
                 }
             }
         }
@@ -184,12 +184,6 @@ namespace System.Windows.Media
         {
             return 0.0;
         }
-
-        private static ReadOnlySpan<byte> LineTypes => [(byte)MILCoreSegFlags.SegTypeLine];
-
-        private static uint GetPointCount() { return c_pointCount; }
-
-        private static uint GetSegmentCount() { return c_segmentCount; }
 
         /// <summary>
         /// GetAsPathGeometry - return a PathGeometry version of this Geometry
@@ -261,8 +255,10 @@ namespace System.Windows.Media
 
         #region Static Data
         
-        private const UInt32 c_segmentCount = 1;
-        private const UInt32 c_pointCount = 2;
+        private const uint SegmentCount = 1;
+        private const uint PointCount = 2;
+
+        private static ReadOnlySpan<byte> LineTypes => [(byte)MILCoreSegFlags.SegTypeLine];
 
         #endregion
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/LineGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/LineGeometry.cs
@@ -230,16 +230,7 @@ namespace System.Windows.Media
                 endPoint *= matrix;
             }
 
-            PathFigureCollection collection = new PathFigureCollection();
-            collection.Add(
-                new PathFigure(
-                startPoint,
-                new PathSegment[]{new LineSegment(endPoint, true)},
-                false // ==> not closed
-                )
-            );
-
-            return collection;
+            return new PathFigureCollection(1) { new PathFigure(startPoint, [new LineSegment(endPoint, true)], false) }; // ==> not closed;
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/LineGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/LineGeometry.cs
@@ -1,27 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// See the LICENSE file in the project root for more information.                                          
 
-//                                             
-
-using System;                   
-using MS.Internal;
-using System.ComponentModel;
-using System.ComponentModel.Design.Serialization;
-using System.Reflection;
-using System.Collections;
-using System.Text;
-using System.Globalization;
-using System.Windows.Media;
-using System.Windows;
-using System.Text.RegularExpressions;
-using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
-using System.Diagnostics;
-using System.Runtime.InteropServices; 
-using System.Security;
-
-using SR=MS.Internal.PresentationCore.SR;
 
 namespace System.Windows.Media 
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/PathFigure.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/PathFigure.cs
@@ -50,15 +50,24 @@ namespace System.Windows.Media
         /// <param name="closed">Indicates whether the figure is closed</param>
         public PathFigure(Point start, IEnumerable<PathSegment> segments, bool closed)
         {
+            ArgumentNullException.ThrowIfNull(segments);
+
             StartPoint = start;
             PathSegmentCollection mySegments = Segments;
 
-            ArgumentNullException.ThrowIfNull(segments);
+            foreach (PathSegment item in segments)
+                mySegments.Add(item);
+
+            IsClosed = closed;
+        }
+
+        internal PathFigure(Point start, ReadOnlySpan<PathSegment> segments, bool closed)
+        {
+            StartPoint = start;
+            PathSegmentCollection mySegments = Segments;
 
             foreach (PathSegment item in segments)
-            {
                 mySegments.Add(item);
-            }
 
             IsClosed = closed;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/PathGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/PathGeometry.cs
@@ -76,6 +76,14 @@ namespace System.Windows.Media
             SetDirty();
         }
 
+        internal PathGeometry(params ReadOnlySpan<PathFigure> figures)
+        {
+            foreach (PathFigure item in figures)
+                Figures.Add(item);
+
+            SetDirty();
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
@@ -449,7 +449,7 @@ namespace System.Windows.Media
             if (IsRounded(radiusX, radiusY))
             {
                 // It is a rounded rectangle
-                Invariant.Assert(pointsCount >= c_roundedPointCount);
+                Invariant.Assert(pointsCount >= RoundedPointCount);
 
                 radiusX = Math.Min(rect.Width * (1.0 / 2.0), Math.Abs(radiusX));
                 radiusY = Math.Min(rect.Height * (1.0 / 2.0), Math.Abs(radiusY));
@@ -476,7 +476,7 @@ namespace System.Windows.Media
             else
             {
                 // The rectangle is not rounded
-                Invariant.Assert(pointsCount >= c_squaredPointCount);
+                Invariant.Assert(pointsCount >= SquaredPointCount);
 
                 points[0].X = points[3].X = points[4].X = rect.X;
                 points[1].X = points[2].X = rect.Right;
@@ -510,11 +510,11 @@ namespace System.Windows.Media
             }
             else if (IsRounded(radiusX, radiusY))
             {
-                return c_roundedPointCount;
+                return RoundedPointCount;
             }
             else
             {
-                return c_squaredPointCount;
+                return SquaredPointCount;
             }
         }
 
@@ -526,11 +526,11 @@ namespace System.Windows.Media
             }
             else if (IsRounded(radiusX, radiusY))
             {
-                return c_roundedSegmentCount;
+                return RoundedSegmentCount;
             }
             else
             {
-                return c_squaredSegmentCount;
+                return SquaredSegmentCount;
             }
         }
 
@@ -544,13 +544,13 @@ namespace System.Windows.Media
             else if (IsRounded(radiusX, radiusY))
             {
                 // The rectangle is rounded
-                pointCount = c_roundedPointCount;
-                segmentCount = c_roundedSegmentCount;
+                pointCount = RoundedPointCount;
+                segmentCount = RoundedSegmentCount;
             }
             else
             {
-                pointCount = c_squaredPointCount;
-                segmentCount = c_squaredSegmentCount;
+                pointCount = SquaredPointCount;
+                segmentCount = SquaredSegmentCount;
             }
         }
 
@@ -577,8 +577,8 @@ namespace System.Windows.Media
         #region InstanceData
 
         // Rouneded
-        static private UInt32 c_roundedSegmentCount = 8;
-        static private UInt32 c_roundedPointCount = 17;
+        private const uint RoundedSegmentCount = 8;
+        private const uint RoundedPointCount = 17;
 
         private const byte SmoothBezier = (byte)MILCoreSegFlags.SegTypeBezier |
                                           (byte)MILCoreSegFlags.SegIsCurved   |
@@ -599,8 +599,8 @@ namespace System.Windows.Media
                                                                SmoothLine];
 
         // Squared
-        private const UInt32 c_squaredSegmentCount = 4;
-        private const UInt32 c_squaredPointCount = 5;
+        private const uint SquaredSegmentCount = 4;
+        private const uint SquaredPointCount = 5;
 
         private static ReadOnlySpan<byte> SquaredPathTypes => [(byte)MILCoreSegFlags.SegTypeLine | (byte)MILCoreSegFlags.SegClosed,
                                                                (byte)MILCoreSegFlags.SegTypeLine,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
@@ -502,7 +502,7 @@ namespace System.Windows.Media
             }
         }
 
-        private uint GetPointCount(Rect rect, double radiusX, double radiusY)
+        private static uint GetPointCount(Rect rect, double radiusX, double radiusY)
         {
             if (rect.IsEmpty)
             {
@@ -518,7 +518,7 @@ namespace System.Windows.Media
             }
         }
 
-        private uint GetSegmentCount(Rect rect, double radiusX, double radiusY)
+        private static uint GetSegmentCount(Rect rect, double radiusX, double radiusY)
         {
             if (rect.IsEmpty)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
@@ -2,25 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//                                             
-
-using System;
 using MS.Internal;
-using System.ComponentModel.Design.Serialization;
-using System.Reflection;
-using System.Collections;
-using System.Text;
-using System.Globalization;
-using System.Windows.Media;
 using System.Windows.Media.Composition;
-using System.Windows;
-using System.Text.RegularExpressions;
-using System.Windows.Media.Animation;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Security;
-
-using SR=MS.Internal.PresentationCore.SR;
 
 namespace System.Windows.Media 
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
@@ -580,25 +580,23 @@ namespace System.Windows.Media
         static private UInt32 c_roundedSegmentCount = 8;
         static private UInt32 c_roundedPointCount = 17;
 
-        static private byte smoothBezier = (byte)MILCoreSegFlags.SegTypeBezier |
-                                            (byte)MILCoreSegFlags.SegIsCurved   |
-                                            (byte)MILCoreSegFlags.SegSmoothJoin;
+        private const byte SmoothBezier = (byte)MILCoreSegFlags.SegTypeBezier |
+                                          (byte)MILCoreSegFlags.SegIsCurved   |
+                                          (byte)MILCoreSegFlags.SegSmoothJoin;
 
-        static private byte smoothLine = (byte)MILCoreSegFlags.SegTypeLine | (byte)MILCoreSegFlags.SegSmoothJoin;
+        private const byte SmoothLine = (byte)MILCoreSegFlags.SegTypeLine | (byte)MILCoreSegFlags.SegSmoothJoin;
 
-        private static ReadOnlySpan<byte> RoundedPathTypes => new byte[] {
-            (byte)MILCoreSegFlags.SegTypeBezier |
-            (byte)MILCoreSegFlags.SegIsCurved   |
-            (byte)MILCoreSegFlags.SegSmoothJoin |
-            (byte)MILCoreSegFlags.SegClosed,
-            smoothLine,
-            smoothBezier,
-            smoothLine,
-            smoothBezier,
-            smoothLine,
-            smoothBezier,
-            smoothLine
-        };
+        private static ReadOnlySpan<byte> RoundedPathTypes => [(byte)MILCoreSegFlags.SegTypeBezier |
+                                                               (byte)MILCoreSegFlags.SegIsCurved   |
+                                                               (byte)MILCoreSegFlags.SegSmoothJoin |
+                                                               (byte)MILCoreSegFlags.SegClosed,
+                                                               SmoothLine,
+                                                               SmoothBezier,
+                                                               SmoothLine,
+                                                               SmoothBezier,
+                                                               SmoothLine,
+                                                               SmoothBezier,
+                                                               SmoothLine];
 
         // Squared
         private const UInt32 c_squaredSegmentCount = 4;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
@@ -332,50 +332,26 @@ namespace System.Windows.Media
                 // Transform if applicable.
                 if (!matrix.IsIdentity)
                 {
-                    for (int i=0; i<points.Length; i++)
+                    for (int i = 0; i < points.Length; i++)
                     {
                         points[i] *= matrix;
                     }
                 }
 
-                PathFigureCollection collection = new PathFigureCollection();
-                collection.Add(
-                    new PathFigure(
-                    points[0],
-                    new PathSegment[]{
-                        new BezierSegment(points[1], points[2], points[3], true, true),
-                        new LineSegment(points[4], true, true),
-                        new BezierSegment(points[5], points[6], points[7], true, true),
-                        new LineSegment(points[8], true, true),
-                        new BezierSegment(points[9], points[10], points[11], true, true),
-                        new LineSegment(points[12], true, true),
-                        new BezierSegment(points[13], points[14], points[15], true, true)},
-                        true    // closed
-                    )
-                );
-
-                return collection;
+                return new PathFigureCollection(1) { new PathFigure(points[0], [new BezierSegment(points[1], points[2], points[3], true, true),
+                                                                                new LineSegment(points[4], true, true),
+                                                                                new BezierSegment(points[5], points[6], points[7], true, true),
+                                                                                new LineSegment(points[8], true, true),
+                                                                                new BezierSegment(points[9], points[10], points[11], true, true),
+                                                                                new LineSegment(points[12], true, true),
+                                                                                new BezierSegment(points[13], points[14], points[15], true, true)],
+                                                                                closed: true) };    // closed
             }
             else
-            {                
-                PathFigureCollection collection = new PathFigureCollection();
-                collection.Add(
-                    new PathFigure(
-                    rect.TopLeft * matrix,
-                    new PathSegment[]{
-                        new PolyLineSegment(
-                        new Point[]
-                        {
-                            rect.TopRight * matrix,
-                            rect.BottomRight * matrix,
-                            rect.BottomLeft * matrix
-                        },
-                        true)},
-                        true    // closed
-                    )
-                );
-
-                return collection;
+            {
+                Point[] points = [rect.TopRight * matrix, rect.BottomRight * matrix, rect.BottomLeft * matrix];
+                
+                return new PathFigureCollection(1) { new PathFigure(rect.TopLeft * matrix, [new PolyLineSegment(points, isStroked: true)], closed: true) };
             }            
         }
         

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
@@ -454,8 +454,8 @@ namespace System.Windows.Media
                 radiusX = Math.Min(rect.Width * (1.0 / 2.0), Math.Abs(radiusX));
                 radiusY = Math.Min(rect.Height * (1.0 / 2.0), Math.Abs(radiusY));
 
-                double bezierX = ((1.0 - EllipseGeometry.c_arcAsBezier) * radiusX);
-                double bezierY = ((1.0 - EllipseGeometry.c_arcAsBezier) * radiusY);
+                double bezierX = ((1.0 - EllipseGeometry.ArcAsBezier) * radiusX);
+                double bezierY = ((1.0 - EllipseGeometry.ArcAsBezier) * radiusY);
 
                 points[1].X = points[0].X = points[15].X = points[14].X = rect.X;
                 points[2].X = points[13].X = rect.X + bezierX;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/TickBar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/TickBar.cs
@@ -478,9 +478,7 @@ namespace System.Windows.Controls.Primitives
                 // This property is rarely set so let's try to avoid the GetValue
                 // caching of the mutable default value
                 DoubleCollection ticks = null;
-                bool hasModifiers;
-                if (GetValueSource(TicksProperty, null, out hasModifiers)
-                    != BaseValueSourceInternal.Default || hasModifiers)
+                if ((GetValueSource(TicksProperty, null, out bool hasModifiers) != BaseValueSourceInternal.Default) || hasModifiers)
                 {
                     ticks = Ticks;
                 }
@@ -534,11 +532,7 @@ namespace System.Windows.Controls.Primitives
                     Point pt1 = new Point(startPoint.X + tickLen2, y0);
                     Point pt2 = new Point(startPoint.X + tickLen2, y0 + Math.Abs(tickLen2) * progression);
 
-                    PathSegment[] segments = new PathSegment[] {
-                        new LineSegment(pt2, true),
-                        new LineSegment(pt0, true),
-                    };
-                    PathGeometry geo = new PathGeometry(new PathFigure[] { new PathFigure(pt1, segments, true) });
+                    PathGeometry geo = new PathGeometry(new PathFigure(pt1, [new LineSegment(pt2, true), new LineSegment(pt0, true)], true));
 
                     dc.DrawGeometry(Fill, pen, geo);
 
@@ -547,11 +541,7 @@ namespace System.Windows.Controls.Primitives
                     pt1 = new Point(startPoint.X + tickLen2, y0);
                     pt2 = new Point(startPoint.X + tickLen2, y0 - Math.Abs(tickLen2) * progression);
 
-                    segments = new PathSegment[] {
-                        new LineSegment(pt2, true),
-                        new LineSegment(pt0, true),
-                    };
-                    geo = new PathGeometry(new PathFigure[] { new PathFigure(pt1, segments, true) });
+                    geo = new PathGeometry(new PathFigure(pt1, [new LineSegment(pt2, true), new LineSegment(pt0, true)], true));
                     dc.DrawGeometry(Fill, pen, geo);
                 }
             }
@@ -585,9 +575,7 @@ namespace System.Windows.Controls.Primitives
                 // This property is rarely set so let's try to avoid the GetValue
                 // caching of the mutable default value
                 DoubleCollection ticks = null;
-                bool hasModifiers;
-                if (GetValueSource(TicksProperty, null, out hasModifiers)
-                    != BaseValueSourceInternal.Default || hasModifiers)
+                if ((GetValueSource(TicksProperty, null, out bool hasModifiers) != BaseValueSourceInternal.Default) || hasModifiers)
                 {
                     ticks = Ticks;
                 }
@@ -639,11 +627,7 @@ namespace System.Windows.Controls.Primitives
                     Point pt1 = new Point(x0, startPoint.Y + tickLen2);
                     Point pt2 = new Point(x0 + Math.Abs(tickLen2) * progression, startPoint.Y + tickLen2);
 
-                    PathSegment[] segments = new PathSegment[] {
-                        new LineSegment(pt2, true),
-                        new LineSegment(pt0, true),
-                    };
-                    PathGeometry geo = new PathGeometry(new PathFigure[] { new PathFigure(pt1, segments, true) });
+                    PathGeometry geo = new PathGeometry(new PathFigure(pt1, [new LineSegment(pt2, true), new LineSegment(pt0, true)], true));
 
                     dc.DrawGeometry(Fill, pen, geo);
 
@@ -652,11 +636,7 @@ namespace System.Windows.Controls.Primitives
                     pt1 = new Point(x0, startPoint.Y + tickLen2);
                     pt2 = new Point(x0 - Math.Abs(tickLen2) * progression, startPoint.Y + tickLen2);
 
-                    segments = new PathSegment[] {
-                        new LineSegment(pt2, true),
-                        new LineSegment(pt0, true),
-                    };
-                    geo = new PathGeometry(new PathFigure[] { new PathFigure(pt1, segments, true) });
+                    geo = new PathGeometry(new PathFigure(pt1, [new LineSegment(pt2, true), new LineSegment(pt0, true)], true));
                     dc.DrawGeometry(Fill, pen, geo);
                 }
             }


### PR DESCRIPTION
## Description

Removes some unnecessary `gen0` allocations when working with `EllipseGeometry`/`RectangleGeometry` (such as adding them to a `PathGeometry` or combining geometries which serializes them (`Point` array alloc) and when rendering `TickBar`. Also introduces `internal` constructors for `PathFigure`/`PathGeometry` that can be used with inline arrays.

Also changes some `private static` fields to constants, decreasing static allocations.

The savings are not that massive right now, but it will allow for further optimizations (and there's a lot of space for it).

### Define geometry, add to group, get bounds

| Method       | Mean [ns]  | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|---------------- |-----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 9,371.1 ns |   67.37 ns |    56.25 ns | 0.4578 |       9,483 B |        7848 B |
| PR_EDIT | 8,986.0 ns |   55.25 ns |    48.98 ns |  0.4120    |   9,120 B  |        7120 B |

<details>
<summary>Benchmark code</summary>

```csharp
public Rect Original()
{
  PathGeometry abcd =  new PathGeometry();
  RectangleGeometry rectangle =   new RectangleGeometry(s_myRect, 10, 10);
  EllipseGeometry ellipse = new EllipseGeometry(s_myPoint, 10, 10);

  // uses GetPathFigureCollection
  abcd.AddGeometry(rectangle);
  abcd.AddGeometry(ellipse);

  // Retrieve bounds, another alloc
  Rect myBounds = rectangle.Bounds;
  Rect myEllipse = ellipse.Bounds;

  myBounds.Union(myEllipse);

  return myBounds;
}
```

</details>


## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, sample apps, usage of types.

## Risk

Should be low, all the changes were done with using stack-allocated memory
