### PR TITLE
Remove ShowMessageBoxHelper from SecurityHelper (CAS remnants)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentViewerHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentViewerHelper.cs
@@ -274,13 +274,9 @@ namespace MS.Internal.Documents
         /// <param name="findToolBar">FindToolBar instance.</param>
         internal static void ShowFindUnsuccessfulMessage(FindToolBar findToolBar)
         {
-            string messageString;
-
             // No, we did not find anything. Alert the user.
-            messageString = findToolBar.SearchUp ?
-                        SR.DocumentViewerSearchUpCompleteLabel :
-                        SR.DocumentViewerSearchDownCompleteLabel;
-            messageString = String.Format(System.Globalization.CultureInfo.CurrentCulture, messageString, findToolBar.SearchText);
+            string messageString = findToolBar.SearchUp ? SR.DocumentViewerSearchUpCompleteLabel : SR.DocumentViewerSearchDownCompleteLabel;
+            messageString = string.Format(CultureInfo.CurrentCulture, messageString, findToolBar.SearchText);
 
             IntPtr hwnd = PresentationSource.CriticalFromVisual(findToolBar) is HwndSource hwndSource ? hwndSource.Handle : IntPtr.Zero;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentViewerHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentViewerHelper.cs
@@ -282,15 +282,10 @@ namespace MS.Internal.Documents
                         SR.DocumentViewerSearchDownCompleteLabel;
             messageString = String.Format(System.Globalization.CultureInfo.CurrentCulture, messageString, findToolBar.SearchText);
 
-            HwndSource hwndSource = PresentationSource.CriticalFromVisual(findToolBar) as HwndSource;
-            IntPtr hwnd = (hwndSource != null) ? hwndSource.CriticalHandle : IntPtr.Zero;
+            IntPtr hwnd = PresentationSource.CriticalFromVisual(findToolBar) is HwndSource hwndSource ? hwndSource.Handle : IntPtr.Zero;
 
-            PresentationFramework.SecurityHelper.ShowMessageBoxHelper(
-                hwnd,
-                messageString,
-                SR.DocumentViewerSearchCompleteTitle,
-                MessageBoxButton.OK,
-                MessageBoxImage.Asterisk);
+            MessageBox.ShowCore(hwnd, messageString, SR.DocumentViewerSearchCompleteTitle,
+                                MessageBoxButton.OK, MessageBoxImage.Asterisk, MessageBoxResult.None, MessageBoxOptions.None);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DocumentViewer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DocumentViewer.cs
@@ -2208,27 +2208,16 @@ namespace System.Windows.Controls
                         // No, we did not find anything.  Alert the user.
 
                         // build our message string.
-                        string messageString = _findToolbar.SearchUp ?
-                            SR.DocumentViewerSearchUpCompleteLabel :
-                            SR.DocumentViewerSearchDownCompleteLabel;
+                        string messageString = _findToolbar.SearchUp ? SR.DocumentViewerSearchUpCompleteLabel : SR.DocumentViewerSearchDownCompleteLabel;
+                        messageString = string.Format(CultureInfo.CurrentCulture, messageString, _findToolbar.SearchText);
 
-                        messageString = String.Format(
-                            CultureInfo.CurrentCulture,
-                            messageString,
-                            _findToolbar.SearchText);
+                        // If we have a parent window, use it when alerting the user, otherwise fallback.
+                        Window parentWindow = Application.Current?.CheckAccess() ?? false ? Application.Current.MainWindow : null;
 
-                        Window wnd = null;
-                        if (Application.Current != null && Application.Current.CheckAccess())
-                        {
-                            wnd = Application.Current.MainWindow;
-                        }
-
-                        MS.Internal.PresentationFramework.SecurityHelper.ShowMessageBoxHelper(
-                            wnd,
-                            messageString,
-                            SR.DocumentViewerSearchCompleteTitle,
-                            MessageBoxButton.OK,
-                            MessageBoxImage.Asterisk);
+                        if (parentWindow is not null)
+                            MessageBox.Show(parentWindow, messageString, SR.DocumentViewerSearchCompleteTitle, MessageBoxButton.OK, MessageBoxImage.Asterisk);
+                        else
+                            MessageBox.Show(messageString, SR.DocumentViewerSearchCompleteTitle, MessageBoxButton.OK, MessageBoxImage.Asterisk);
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
@@ -161,36 +161,6 @@ internal static class SecurityHelper
 
             return hr;
         }
-
-#endif
-
-#if PRESENTATIONFRAMEWORK
-
-        /// <summary>
-        /// A helper method to do the necessary work to display a standard MessageBox.  This method performs
-        /// and necessary elevations to make the dialog work as well.
-        /// </summary>
-        internal
-        static
-        void
-        ShowMessageBoxHelper(
-            System.Windows.Window parent,
-            string text,
-            string title,
-            System.Windows.MessageBoxButton buttons,
-            System.Windows.MessageBoxImage image
-            )
-        {
-            // if we have a known parent window set, let's use it when alerting the user.
-            if (parent != null)
-            {
-                System.Windows.MessageBox.Show(parent, text, title, buttons, image);
-            }
-            else
-            {
-                System.Windows.MessageBox.Show(text, title, buttons, image);
-            }
-        }
 #endif
 
 #if WINDOWS_BASE

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
@@ -191,24 +191,6 @@ internal static class SecurityHelper
                 System.Windows.MessageBox.Show(text, title, buttons, image);
             }
         }
-        /// <summary>
-        /// A helper method to do the necessary work to display a standard MessageBox.  This method performs
-        /// and necessary elevations to make the dialog work as well.
-        /// </summary>
-        internal
-        static
-        void
-        ShowMessageBoxHelper(
-            IntPtr parentHwnd,
-            string text,
-            string title,
-            System.Windows.MessageBoxButton buttons,
-            System.Windows.MessageBoxImage image
-            )
-        {
-            // NOTE: the last param must always be MessageBoxOptions.None for this to be considered TreatAsSafe
-            System.Windows.MessageBox.ShowCore(parentHwnd, text, title, buttons, image, MessageBoxResult.None, MessageBoxOptions.None);
-        }
 #endif
 
 #if WINDOWS_BASE


### PR DESCRIPTION
## Description

Continues the work on removing CAS remnants, this time again method proxies and "helpers" from `SecurityHelper`, which makes it almost finished effort with the rest of the PRs currently submitted.

This just removes `MessageBox` proxies used by `DocumentsViewer` control.

## Customer Impact

Decreased size of assemblies, cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low.
