### PR TITLE
Fix DataGrid hang during scroll to cell when UseLayoutRounding is enabled

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -8519,9 +8519,13 @@ namespace System.Windows.Controls
             IProvideDataGridColumn cell = GetAnyCellOrColumnHeader();
             if (cell != null)
             {
-                CellsPanelHorizontalOffset = DataGridHelper.GetParentCellsPanelHorizontalOffset(cell);
+                // Due to layout rounding, computation of the offset may return a negative value while computing the difference between controls,
+                // however since this offset is used also for Button's Width servicing the DataGrid.SelectAllCommand in all standard styles,
+                // we cannot accept this. Even if we could, the DataGrid[CellsPanel] layout logic depends on this offset being 0 or greater.
+                // See https://github.com/dotnet/wpf/pull/9983 for more information regarding this.
+                CellsPanelHorizontalOffset = Math.Max(0d, DataGridHelper.GetParentCellsPanelHorizontalOffset(cell));
             }
-            else if (!Double.IsNaN(RowHeaderWidth))
+            else if (!double.IsNaN(RowHeaderWidth))
             {
                 CellsPanelHorizontalOffset = RowHeaderWidth;
             }


### PR DESCRIPTION
Fixes #9944 

## Description

Fixes an infinite loop (an application hang) when scrolling to a `Cell` right after layout refresh. This only happens when `UseLayoutRounding` is enabled and you hit the jackpot (e.g. with the repro in the issue, x1.25 on the pixels).

As I've described originally in the issue, with some small adjustments:

Because of layout rounding, `GetParentCellsPanelHorizontalOffset` can return negative (e.g. `-0.4`), which happens here. Doing simple `Math.Max(0d, result)` on the result fixes the hang and prevents breaking the binding for the button in row header that's used in all styles for `DataGrid.SelectAllCommand`.

https://github.com/dotnet/wpf/blob/58c3b2ee8e11749c69a836aa8e87b9a0cd7071c8/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs#L8522

In my humble opinion, this is the right thing to do to constrain it at zero, it fixes the immediate problem but also the other options will pass zero or greater; `RowHeaderWidth` is also constrained with `FrameworkElement`'s `Width`.

By the way, the repro to do two layout passes can be simplified to:

```csharp
myDataGrid.MouseUp += (sender, e) =>
{
    myDataGrid.Items.Refresh();
    DataGridColumn currentColumn = myDataGrid.CurrentColumn ?? myDataGrid.Columns[1];
    myDataGrid.CurrentCell = new DataGridCellInfo(myDataGrid.SelectedItem, currentColumn);
};
```

## Customer Impact

Customers will enjoy `DataGrid` without the application randomly hanging.

## Regression

Unlikely.

## Testing

All the other layout calculations that depend on this I've checked seem to be outputting the same before and after fix (the final output, not the infinite loop one), visually I couldn't see any difference either. I've tested it on several different DPIs and everything seems to be in order.

## Risk

Low-to-medium; while it makes sense that it shouldn't be negative due to the binding (and it never will be unless you `UseLayoutRounding` with magical dimensions), we shall not take that as a holy grail. Though the functions called `GetParentCellsPanelHorizontalOffset` are only called by this method where I've done the fix, it made sense to me to make it here where it's being decided and not somewhere in the actual calculation.
