### PR TITLE
Use Spans and ReadOnlyCollection.Empty in TextBlock/Line, reduce allocs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/ComplexLine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/ComplexLine.cs
@@ -151,7 +151,6 @@ namespace MS.Internal.Text
             Debug.Assert(runs != null, "Cannot retrieve runs collection.");
 
             // Calculate offset shift due to trailing spaces
-            double adjustedXOffset = lineOffset.X + CalculateXOffsetShift();
             foreach (TextSpan<TextRun> textSpan in runs)
             {
                 TextRun run = textSpan.Value;
@@ -160,8 +159,7 @@ namespace MS.Internal.Text
                     InlineObject inlineObject = run as InlineObject;
 
                     // Disconnect visual from its old parent, if necessary.
-                    Visual currentParent = VisualTreeHelper.GetParent(inlineObject.Element) as Visual;
-                    if (currentParent != null)
+                    if (VisualTreeHelper.GetParent(inlineObject.Element) is Visual currentParent)
                     {
                         ContainerVisual parent = currentParent as ContainerVisual;
                         Invariant.Assert(parent != null, "parent should always derives from ContainerVisual");
@@ -169,17 +167,16 @@ namespace MS.Internal.Text
                     }
 
                     // Get position of inline object withing the text line.
-                    FlowDirection flowDirection;
-                    Rect rect = GetBoundsFromPosition(runDcp, inlineObject.Length, out flowDirection);
+                    Rect rect = GetBoundsFromPosition(runDcp, inlineObject.Length, out FlowDirection flowDirection);
                     Debug.Assert(DoubleUtil.GreaterThanOrClose(rect.Width, 0), "Negative inline object's width.");
 
                     ContainerVisual proxyVisual = new ContainerVisual();
-                    if (inlineObject.Element is FrameworkElement)
+                    if (inlineObject.Element is FrameworkElement frameworkElement)
                     {
                         FlowDirection parentFlowDirection = _owner.FlowDirection;
                         // Check parent's FlowDirection to determine if mirroring is needed
 
-                        DependencyObject parent = ((FrameworkElement)inlineObject.Element).Parent; 
+                        DependencyObject parent = frameworkElement.Parent; 
                         if(parent != null)
                         {
                             parentFlowDirection = (FlowDirection)parent.GetValue(FrameworkElement.FlowDirectionProperty);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/Line.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/Line.cs
@@ -169,8 +169,8 @@ namespace MS.Internal.Text
                 textBounds = _line.GetTextBounds(cp, cch);
             }
 
-            // Pre-allocate List as we need it
             Invariant.Assert(textBounds.Count > 0);
+
             Rect[] rectangles = new Rect[textBounds.Count];
 
             for (int boundIndex = 0; boundIndex < rectangles.Length; boundIndex++)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/Line.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/Line.cs
@@ -149,7 +149,7 @@ namespace MS.Internal.Text
         /// it uses those as the bounding rectangles. If not, it returns the rectangle for the first (and only) element
         /// of the text bounds.
         /// </remarks>
-        internal List<Rect> GetRangeBounds(int cp, int cch, double xOffset, double yOffset)
+        internal ReadOnlySpan<Rect> GetRangeBounds(int cp, int cch, double xOffset, double yOffset)
         {       
             // Adjust x offset for trailing spaces
             double delta = CalculateXOffsetShift();
@@ -171,14 +171,14 @@ namespace MS.Internal.Text
 
             // Pre-allocate List as we need it
             Invariant.Assert(textBounds.Count > 0);
-            List<Rect> rectangles = new(textBounds.Count);
+            Rect[] rectangles = new Rect[textBounds.Count];
 
-            for (int boundIndex = 0; boundIndex < textBounds.Count; boundIndex++)
+            for (int boundIndex = 0; boundIndex < rectangles.Length; boundIndex++)
             {
                 Rect rect = textBounds[boundIndex].Rectangle;
                 rect.X += adjustedXOffset;
                 rect.Y += yOffset;
-                rectangles.Add(rect);
+                rectangles[boundIndex] = rect;
             }
 
             return rectangles;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/Line.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/Line.cs
@@ -150,9 +150,7 @@ namespace MS.Internal.Text
         /// of the text bounds.
         /// </remarks>
         internal List<Rect> GetRangeBounds(int cp, int cch, double xOffset, double yOffset)
-        {
-            List<Rect> rectangles = new List<Rect>();
-            
+        {       
             // Adjust x offset for trailing spaces
             double delta = CalculateXOffsetShift();
             double adjustedXOffset = xOffset + delta;
@@ -162,7 +160,7 @@ namespace MS.Internal.Text
             {
                 // We should not shift offset in this case
                 Invariant.Assert(DoubleUtil.AreClose(delta, 0));
-                System.Windows.Media.TextFormatting.TextLine line = _line.Collapse(GetCollapsingProps(_wrappingWidth, _owner.ParagraphProperties));
+                TextLine line = _line.Collapse(GetCollapsingProps(_wrappingWidth, _owner.ParagraphProperties));
                 Invariant.Assert(line.HasCollapsed, "Line has not been collapsed");
                 textBounds = line.GetTextBounds(cp, cch);
             }
@@ -170,8 +168,10 @@ namespace MS.Internal.Text
             {
                 textBounds = _line.GetTextBounds(cp, cch);
             }
-            Invariant.Assert(textBounds.Count > 0);
 
+            // Pre-allocate List as we need it
+            Invariant.Assert(textBounds.Count > 0);
+            List<Rect> rectangles = new(textBounds.Count);
 
             for (int boundIndex = 0; boundIndex < textBounds.Count; boundIndex++)
             {
@@ -180,6 +180,7 @@ namespace MS.Internal.Text
                 rect.Y += yOffset;
                 rectangles.Add(rect);
             }
+
             return rectangles;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/HostedElements.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/HostedElements.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Documents
     ///  Enumerator class for implementation of IContentHost on TextBlock and FlowDocumentPage.
     ///  Used to iterate through descendants of the content host
     /// </summary>
-    internal class HostedElements : IEnumerator<IInputElement>
+    internal sealed class HostedElements : IEnumerator<IInputElement>
     {
         //-------------------------------------------------------------------
         //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -1261,7 +1261,7 @@ namespace System.Windows.Controls
                         // paragraph ellipsis at this time. Since TextBlock is auto-sized we do not know the RenderSize until we finish Measure
                         line.Format(dcp, contentSize.Width, GetLineProperties(dcp == 0, lineProperties), textLineBreakIn, _textBlockCache._textRunCache, /*Show paragraph ellipsis*/ false);
 
-                        double lineHeight = CalcLineAdvance(line.Height, lineProperties);
+                        double lineHeight = CalcLineAdvance(lineProperties, line.Height);
 
     #if DEBUG
                         LineMetrics metrics = new LineMetrics(contentSize.Width, line.Length, line.Width, lineHeight, line.BaselineOffset, line.HasInlineObjects(), textLineBreakIn);
@@ -3048,7 +3048,7 @@ Debug.Assert(lineCount == LineCount);
         //
         // Returns: Line advance distance..
         //-------------------------------------------------------------------
-        private double CalcLineAdvance(double lineHeight, LineProperties lineProperties)
+        private static double CalcLineAdvance(LineProperties lineProperties, double lineHeight)
         {
             return lineProperties.CalcLineAdvance(lineHeight);
         }
@@ -3389,7 +3389,7 @@ Debug.Assert(lineCount == LineCount);
                 {
                     bool ellipsis = ParagraphEllipsisShownOnLine(i, lineOffset);
                     Format(line, lineMetrics.Length, dcp, wrappingWidth, GetLineProperties(dcp == 0, lineProperties), lineMetrics.TextLineBreak, textRunCache, ellipsis);
-                    double lineHeight = CalcLineAdvance(line.Height, lineProperties);
+                    double lineHeight = CalcLineAdvance(lineProperties, line.Height);
 
                     // Check consistency of line formatting
                     Invariant.Assert(lineMetrics.Length == line.Length, "Line length is out of sync");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -1176,7 +1176,7 @@ namespace System.Windows.Controls
             // a) content is dirty (properties or content)
             // b) there are inline objects (they may be dynamically sized)
             int lineCount = LineCount;
-            if ((lineCount > 0) && IsMeasureValid && InlineObjects == null)
+            if ((lineCount > 0) && IsMeasureValid && InlineObjects is null)
             {
                 // Assuming that all of above conditions are true, Measure can be
                 // skipped in following situations:
@@ -1369,9 +1369,9 @@ namespace System.Windows.Controls
             // Remove all existing visuals. If there are inline objects, they will be added below.
             _complexContent?.VisualChildren.Clear();
 
-            ArrayList inlineObjects = InlineObjects;
+            List<InlineObject> inlineObjects = InlineObjects;
             int lineCount = LineCount;
-            if (inlineObjects != null && lineCount > 0)
+            if (inlineObjects is not null && lineCount > 0)
             {
                 bool exceptionThrown = true;
 
@@ -1395,7 +1395,7 @@ namespace System.Windows.Controls
 
                     for (int i = 0; i < lineCount; i++)
                     {
-Debug.Assert(lineCount == LineCount);
+                        Debug.Assert(lineCount == LineCount);
                         LineMetrics lineMetrics = GetLine(i);
 
                         if (lineMetrics.HasInlineObjects)
@@ -1948,20 +1948,20 @@ Debug.Assert(lineCount == LineCount);
                 desiredSize = inlineObject.Element.DesiredSize;
 
                 // Store inline object in the cache.
-                ArrayList inlineObjects = InlineObjects;
+                List<InlineObject> inlineObjects = InlineObjects;
                 bool alreadyCached = false;
-                if (inlineObjects == null)
+                if (inlineObjects is null)
                 {
-                    InlineObjects = inlineObjects = new ArrayList(1);
+                    InlineObjects = inlineObjects = new List<InlineObject>(1);
                 }
                 else
                 {
                     // Find out if inline object is already cached.
                     for (int index = 0; index < inlineObjects.Count; index++)
                     {
-                        if (((InlineObject)inlineObjects[index]).Dcp == inlineObject.Dcp)
+                        if (inlineObjects[index].Dcp == inlineObject.Dcp)
                         {
-                            Debug.Assert(((InlineObject)inlineObjects[index]).Element == inlineObject.Element, "InlineObject cache is out of sync.");
+                            Debug.Assert(inlineObjects[index].Element == inlineObject.Element, "InlineObject cache is out of sync.");
                             alreadyCached = true;
                             break;
                         }
@@ -2744,10 +2744,14 @@ Debug.Assert(lineCount == LineCount);
         //-------------------------------------------------------------------
         // InlineObjects
         //-------------------------------------------------------------------
-        private ArrayList InlineObjects
+        private List<InlineObject> InlineObjects
         {
-            get { return _complexContent?.InlineObjects; }
-            set { _complexContent?.InlineObjects = value; }
+            get => _complexContent?.InlineObjects;
+            set
+            {
+                if (_complexContent is not null)
+                    _complexContent.InlineObjects = value;
+            }
         }
 
         //-------------------------------------------------------------------
@@ -3822,7 +3826,7 @@ Debug.Assert(lineCount == LineCount);
         //-------------------------------------------------------------------
         // Represents complex content.
         //-------------------------------------------------------------------
-        private class ComplexContent
+        private sealed class ComplexContent
         {
             //---------------------------------------------------------------
             // Ctor
@@ -3890,7 +3894,7 @@ Debug.Assert(lineCount == LineCount);
             //---------------------------------------------------------------
             // Collection of inline objects hosted by the TextBlock control.
             //---------------------------------------------------------------
-            internal ArrayList InlineObjects;
+            internal List<InlineObject> InlineObjects;
         }
 
         //-------------------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -1728,7 +1728,7 @@ Debug.Assert(lineCount == LineCount);
             if (!IsLayoutDataValid)
             {
                 // return empty collection
-                return new ReadOnlyCollection<Rect>(new List<Rect>(0));
+                return ReadOnlyCollection<Rect>.Empty;
             }
 
             // Line props may be invalid, even if Measure/Arrange is valid - rendering only props are changing.
@@ -1738,20 +1738,20 @@ Debug.Assert(lineCount == LineCount);
             if (_complexContent == null || !(_complexContent.TextContainer is TextContainer))
             {
                 // return empty collection
-                return new ReadOnlyCollection<Rect>(new List<Rect>(0));
+                return ReadOnlyCollection<Rect>.Empty;
             }
 
             // First find the element start and end position
-            TextPointer start = FindElementPosition((IInputElement)child);
+            TextPointer start = FindElementPosition(child);
             if (start == null)
             {
-                return new ReadOnlyCollection<Rect>(new List<Rect>(0));
+                return ReadOnlyCollection<Rect>.Empty;
             }
 
             TextPointer end = null;
-            if (child is TextElement)
+            if (child is TextElement element)
             {
-                end = new TextPointer(((TextElement)child).ElementEnd);
+                end = new TextPointer(element.ElementEnd);
             }
             else if (child is FrameworkContentElement)
             {
@@ -1761,7 +1761,7 @@ Debug.Assert(lineCount == LineCount);
 
             if (end == null)
             {
-                return new ReadOnlyCollection<Rect>(new List<Rect>(0));
+                return ReadOnlyCollection<Rect>.Empty;
             }
 
             int startOffset = _complexContent.TextContainer.Start.GetOffsetToPosition(start);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -1840,7 +1840,7 @@ Debug.Assert(lineCount == LineCount);
         {
             get
             {
-                if(CheckFlags(Flags.ContentChangeInProgress))
+                if (CheckFlags(Flags.ContentChangeInProgress))
                 {
                     // IEnumerator.Current is documented to throw this exception
                     throw new InvalidOperationException(SR.TextContainerChangingReentrancyInvalid);
@@ -1849,17 +1849,14 @@ Debug.Assert(lineCount == LineCount);
                 if (_complexContent == null || !(_complexContent.TextContainer is TextContainer))
                 {
                     // Return empty collection
-                    return new HostedElements(new ReadOnlyCollection<TextSegment>(new List<TextSegment>(0)));
+                    return new HostedElements(ReadOnlyCollection<TextSegment>.Empty);
                 }
 
                 // Create a TextSegment from TextContainer, use it to return enumerator
-                System.Collections.Generic.List<TextSegment> textSegmentsList = new System.Collections.Generic.List<TextSegment>(1);
-                TextSegment textSegment = new TextSegment(_complexContent.TextContainer.Start, _complexContent.TextContainer.End);
-                textSegmentsList.Insert(0, textSegment);
-                ReadOnlyCollection<TextSegment> textSegments = new ReadOnlyCollection<TextSegment>(textSegmentsList);
+                TextSegment[] textSegment = new TextSegment[1] { new TextSegment(_complexContent.TextContainer.Start, _complexContent.TextContainer.End) };
 
                 // Return enumerator created from textSegments
-                return new HostedElements(textSegments);
+                return new HostedElements(new ReadOnlyCollection<TextSegment>(textSegment));
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -3449,10 +3449,7 @@ Debug.Assert(lineCount == LineCount);
         // ------------------------------------------------------------------
         private static void OnRequestBringIntoView(object sender, RequestBringIntoViewEventArgs args)
         {
-            TextBlock textBlock = sender as TextBlock;
-            ContentElement child = args.TargetObject as ContentElement;
-
-            if (textBlock != null && child != null)
+            if (sender is TextBlock textBlock && args.TargetObject is ContentElement child)
             {
                 if (TextBlock.ContainsContentElement(textBlock, child))
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -324,25 +324,16 @@ namespace System.Windows.Controls
         /// <summary>
         /// Initializes a new instance of TextBlock class.
         /// </summary>
-        public TextBlock() : base()
-        {
-            Initialize();
-        }
+        public TextBlock() : base() { }
 
         /// <summary>
         /// Initializes a new inslace of TextBlock class and adds a first Inline to its Inline collection.
         /// </summary>
-        public TextBlock(Inline inline)
-            : base()
+        public TextBlock(Inline inline) : base()
         {
-            Initialize();
             ArgumentNullException.ThrowIfNull(inline);
 
-            this.Inlines.Add(inline);
-        }
-
-        private void Initialize()
-        {
+            Inlines.Add(inline);
         }
 
         #endregion Constructors

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -2899,19 +2899,6 @@ Debug.Assert(lineCount == LineCount);
         }
 
         // ------------------------------------------------------------------
-        // Make sure that complex content is cleared.
-        // ------------------------------------------------------------------
-        private void ClearComplexContent()
-        {
-            if (_complexContent != null)
-            {
-                _complexContent.Detach(this);
-                _complexContent = null;
-                Invariant.Assert(_contentCache == null, "Content cache should be null when complex content exists.");
-            }
-        }
-
-        // ------------------------------------------------------------------
         // Invalidates a portion of text affected by a highlight change.
         // ------------------------------------------------------------------
         private void OnHighlightChanged(object sender, HighlightChangedEventArgs args)
@@ -3547,55 +3534,20 @@ Debug.Assert(lineCount == LineCount);
         // ------------------------------------------------------------------
         private void VerifyReentrancy()
         {
-            if(CheckFlags(Flags.MeasureInProgress))
+            if (CheckFlags(Flags.MeasureInProgress))
             {
                 throw new InvalidOperationException(SR.MeasureReentrancyInvalid);
             }
 
-            if(CheckFlags(Flags.ArrangeInProgress))
+            if (CheckFlags(Flags.ArrangeInProgress))
             {
                 throw new InvalidOperationException(SR.ArrangeReentrancyInvalid);
             }
 
-            if(CheckFlags(Flags.ContentChangeInProgress))
+            if (CheckFlags(Flags.ContentChangeInProgress))
             {
                 throw new InvalidOperationException(SR.TextContainerChangingReentrancyInvalid);
             }
-        }
-
-        /// <summary>
-        /// Returns index of the line that starts at the given dcp. Returns -1 if
-        /// no line or the line metrics collection starts at the given dcp
-        /// </summary>
-        /// <param name="dcpLine">
-        /// Start dcp of required line
-        /// </param>
-        private int GetLineIndexFromDcp(int dcpLine)
-        {
-            Invariant.Assert(dcpLine >= 0);
-            int lineIndex = 0;
-            int lineStartOffset = 0;
-
-            int lineCount = LineCount;
-            while (lineIndex < lineCount)
-            {
-Debug.Assert(lineCount == LineCount);
-                if (lineStartOffset == dcpLine)
-                {
-                    // Found line that starts at given dcp
-                    return lineIndex;
-                }
-                else
-                {
-                    lineStartOffset += GetLine(lineIndex).Length;
-                    ++lineIndex;
-                }
-            }
-
-            // No line found starting at this position. Return -1.
-            // We should never hit this code
-            Invariant.Assert(false, "Dcp passed is not at start of any line in TextBlock");
-            return -1;
         }
 
         // ------------------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -3397,19 +3397,18 @@ Debug.Assert(lineCount == LineCount);
             LineProperties lineProperties = GetLineProperties();
 
             double wrappingWidth = CalcWrappingWidth(RenderSize.Width);
-            Vector contentOffset = CalcContentOffset(RenderSize, wrappingWidth);
 
             // Create / format all lines.
             // Since we are disposing line object, it can be reused to format following lines.
             Line line = CreateLine(lineProperties);
-            TextRunCache textRunCache = new TextRunCache();
+            TextRunCache textRunCache = new();
 
             int dcp = 0;
             double lineOffset = 0;
             int lineCount = LineCount;
             for (int i = 0; i < lineCount; i++)
             {
-Debug.Assert(lineCount == LineCount);
+                Debug.Assert(lineCount == LineCount);
                 LineMetrics lineMetrics = GetLine(i);
 
                 using (line)
@@ -3419,7 +3418,7 @@ Debug.Assert(lineCount == LineCount);
                     double lineHeight = CalcLineAdvance(line.Height, lineProperties);
 
                     // Check consistency of line formatting
-                    MS.Internal.Invariant.Assert(lineMetrics.Length == line.Length, "Line length is out of sync");
+                    Invariant.Assert(lineMetrics.Length == line.Length, "Line length is out of sync");
                     Debug.Assert(DoubleUtil.AreClose(lineHeight, lineMetrics.Height), "Line height is out of sync.");
 
                     // Calculated line width might be different from measure width in following cases:

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -1634,7 +1634,8 @@ Debug.Assert(lineCount == LineCount);
         protected virtual IInputElement InputHitTestCore(Point point)
         {
             // If layout data is not updated return 'this'.
-            if (!IsLayoutDataValid) { return this; }
+            if (!IsLayoutDataValid)
+                return this;
 
             // Line props may be invalid, even if Measure/Arrange is valid - rendering only props are changing.
             LineProperties lineProperties = GetLineProperties();
@@ -1644,23 +1645,23 @@ Debug.Assert(lineCount == LineCount);
             // a) use cached line information to find which line has been hit,
             // b) re-create the line that has been hit,
             // c) hit-test the line.
-            IInputElement ie = null;
             double wrappingWidth = CalcWrappingWidth(RenderSize.Width);
             Vector contentOffset = CalcContentOffset(RenderSize, wrappingWidth);
             point -= contentOffset; // // Take into account content offset.
 
-            if (point.X < 0 || point.Y < 0) return this;
+            if (point.X < 0 || point.Y < 0)
+                return this;
 
-            ie = null;
+            IInputElement ie = null;
             int dcp = 0;
             double lineOffset = 0;
 
-            TextRunCache textRunCache = new TextRunCache();
+            TextRunCache textRunCache = new();
 
             int lineCount = LineCount;
             for (int i = 0; i < lineCount; i++)
             {
-Debug.Assert(lineCount == LineCount);
+                Debug.Assert(lineCount == LineCount);
                 LineMetrics lineMetrics = GetLine(i);
 
                 if (lineOffset + lineMetrics.Height > point.Y)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -324,7 +324,10 @@ namespace System.Windows.Controls
         /// <summary>
         /// Initializes a new instance of TextBlock class.
         /// </summary>
-        public TextBlock() : base() { }
+        public TextBlock() : base()
+        {
+
+        }
 
         /// <summary>
         /// Initializes a new inslace of TextBlock class and adds a first Inline to its Inline collection.
@@ -2747,11 +2750,7 @@ Debug.Assert(lineCount == LineCount);
         private List<InlineObject> InlineObjects
         {
             get => _complexContent?.InlineObjects;
-            set
-            {
-                if (_complexContent is not null)
-                    _complexContent.InlineObjects = value;
-            }
+            set => _complexContent?.InlineObjects = value;
         }
 
         //-------------------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -1807,8 +1807,8 @@ Debug.Assert(lineCount == LineCount);
 
                         double xOffset = contentOffset.X;
                         double yOffset = contentOffset.Y + lineHeightOffset;
-                        List<Rect> lineBounds = line.GetRangeBounds(boundStart, boundEnd - boundStart, xOffset, yOffset);
-                        Debug.Assert(lineBounds.Count > 0);
+                        ReadOnlySpan<Rect> lineBounds = line.GetRangeBounds(boundStart, boundEnd - boundStart, xOffset, yOffset);
+                        Debug.Assert(lineBounds.Length > 0);
                         rectangles.AddRange(lineBounds);
                     }
                 }
@@ -2291,7 +2291,7 @@ Debug.Assert(lineCount == LineCount);
                         if (Invariant.Strict)
                         {
                             // Check consistency of line formatting
-                            MS.Internal.Invariant.Assert(GetLine(i).Length == line.Length, "Line length is out of sync");
+                            Invariant.Assert(GetLine(i).Length == line.Length, "Line length is out of sync");
                         }
 
                         int dcpStart = Math.Max(dcpLineStart, dcpPositionStart);
@@ -2299,28 +2299,24 @@ Debug.Assert(lineCount == LineCount);
 
                         if (dcpStart != dcpEnd)
                         {
-                            IList<Rect> aryTextBounds = line.GetRangeBounds(dcpStart, dcpEnd - dcpStart, contentOffset.X, contentOffset.Y + lineOffset);
-
-                            if (aryTextBounds.Count > 0)
+                            ReadOnlySpan<Rect> aryTextBounds = line.GetRangeBounds(dcpStart, dcpEnd - dcpStart, contentOffset.X, contentOffset.Y + lineOffset);                            
+                            if (!aryTextBounds.IsEmpty)
                             {
-                                int j = 0;
-                                int c = aryTextBounds.Count;
-
-                                do
+                                // Process the bounds minus the last one
+                                for (int j = 0; j < aryTextBounds.Length - 1; j++)
                                 {
-                                    Rect rect = aryTextBounds[j];
+                                    CaretElement.AddGeometry(ref geometry, new RectangleGeometry(aryTextBounds[j]));
+                                }
 
-                                    if (j == (c - 1)
-                                       && dcpPositionEnd >= dcpLineEnd
-                                       && TextPointerBase.IsNextToAnyBreak(endOfLineTextPointer, LogicalDirection.Backward))
-                                    {
-                                        double endOfParaGlyphWidth = FontSize * CaretElement.c_endOfParaMagicMultiplier;
-                                        rect.Width += endOfParaGlyphWidth;
-                                    }
+                                // Process the last bounds entry
+                                Rect lastRect = aryTextBounds[aryTextBounds.Length - 1];
+                                if (dcpPositionEnd >= dcpLineEnd && TextPointerBase.IsNextToAnyBreak(endOfLineTextPointer, LogicalDirection.Backward))
+                                {
+                                    double endOfParaGlyphWidth = FontSize * CaretElement.c_endOfParaMagicMultiplier;
+                                    lastRect.Width += endOfParaGlyphWidth;
+                                }
 
-                                    RectangleGeometry rectGeometry = new RectangleGeometry(rect);
-                                    CaretElement.AddGeometry(ref geometry, rectGeometry);
-                                } while (++j < c);
+                                CaretElement.AddGeometry(ref geometry, new RectangleGeometry(lastRect));
                             }
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CaretElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CaretElement.cs
@@ -473,6 +473,13 @@ namespace System.Windows.Documents
             }
         }
 
+        /// <summary>
+        /// Combines the <paramref name="geometry"/> using <see cref="Geometry.Combine(Geometry, Geometry, GeometryCombineMode, Transform, double, ToleranceType)"/>
+        /// with the <paramref name="addedGeometry"/> parameter. <para/> In case <paramref name="geometry"/> is <see langword="null"/>,
+        /// it is only assigned from <paramref name="addedGeometry"/>. In case both are <see langword="null"/>, it's a no-op.
+        /// </summary>
+        /// <param name="geometry">The <see cref="Geometry"/> to combine/assign into.</param>
+        /// <param name="addedGeometry">The <see cref="Geometry"/> to be combined/assigned.</param>
         internal static void AddGeometry(ref Geometry geometry, Geometry addedGeometry)
         {
             if (addedGeometry != null)


### PR DESCRIPTION
## Description

Bringing some optimizations to `TextBlock` control and related components (`Line`; `ComplexLine`).

- Empty `Initialize` method in TextBlock's `ctor` has been removed.
- Unused private methods `GetLineIndexFromDcp` and `ClearComplexContent` have been removed (`EnsureComplexContent` handles the detach if its needed)
- Instead of using `new ReadOnlyCollection<T>(new List<T>(0))` numerous times, we swap to the non-allocating, generic singleton variant of `ReadOnlyCollection<T>.Empty`, removing all possible overhead.
- Replaced `ArrayList` for `InlineObjects` in `ComplexContent` with `List<InlineObject>`.
- Unused calculated variable removed in `ComplexLine` - `double adjustedXOffset` (method doesn't modify state either)
- Unused calculated variable removed in `AlignContent` - `Vector contentOffset` (method doesn't modify state either)
- `GetRangeBounds` in `Line` instead of using a `List<Rect>` now uses pre-allocated `Rect[]` that's wrapped in `ReadOnlySpan<Rect>` to its callers on return.
- Instead of creating `List<TextSegment>(1)` and using `Insert` (that's a great combination), we use `TextSegment[]`.
- I've adjusted the weird loop `GetTightBoundingGeometryFromTextPositions` with more thoughtful impl.


### new `ReadOnlyCollection<T>(new List<T>(0))` vs `Empty`
| Method          | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|---------------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 6.0508 ns |  0.1542 ns |   0.2577 ns | 0.0033 |          78 B |          56 B |
| PR_EDIT | 0.6467 ns |  0.0061 ns |   0.0051 ns |      - |          14 B |             - |

`GetRangeBounds` call old vs. new and the loop itself; without combining geometries

### GetTightBoundingGeometryFromTextPositions inner loop (1 rect)

| Method          | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|---------------- |------------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original_string |   131.0 ns |    1.93 ns |     1.71 ns | 0.0210 |       1,682 B |         352 B |
| APR_EDIT_int    |  112.3 ns |    1.14 ns |     1.07 ns | 0.0134 |         975 B |         224 B |

## Customer Impact

Increased performance, decreased allocations.

## Regression

No.

## Testing

Local build, sample apps run.

## Risk

Should be low, the changes are pretty much mechanical.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9993)