### PR TITLE
Optimize lookups in FontEmbeddingManager, use HashSet over Dictionary

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingManager.cs
@@ -27,6 +27,7 @@ using MS.Internal.Shaping;
 using System.Security;
 
 using SR=MS.Internal.PresentationCore.SR;
+using System.Runtime.InteropServices;
 
 // Allow suppression of presharp warnings
 #pragma warning disable 1634, 1691
@@ -72,19 +73,13 @@ namespace System.Windows.Media
         {
             ArgumentNullException.ThrowIfNull(glyphRun);
 
-            // Suppress PRESharp parameter validation warning about glyphRun.GlyphTypeface because
-            // GlyphRun.GlyphTypeface property cannot be null.
-#pragma warning suppress 56506
             Uri glyphTypeface = glyphRun.GlyphTypeface.FontUri;
 
-            HashSet<ushort> glyphSet;
-            
-            if (_collectedGlyphTypefaces.ContainsKey(glyphTypeface))
-                glyphSet = _collectedGlyphTypefaces[glyphTypeface];
-            else
-                glyphSet = _collectedGlyphTypefaces[glyphTypeface] = new HashSet<ushort>();
+            ref HashSet<ushort> glyphSet = ref CollectionsMarshal.GetValueRefOrAddDefault(_collectedGlyphTypefaces, glyphTypeface, out bool exists);
+            if(!exists)
+                glyphSet = new HashSet<ushort>(glyphRun.GlyphIndices.Count);
 
-            foreach(ushort glyphIndex in glyphRun.GlyphIndices)
+            foreach (ushort glyphIndex in glyphRun.GlyphIndices)
             {             
                 glyphSet.Add(glyphIndex);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingManager.cs
@@ -52,7 +52,7 @@ namespace System.Windows.Media
         /// </summary>
         public FontEmbeddingManager()
         {
-            _collectedGlyphTypefaces = new Dictionary<Uri, HashSet<ushort>>(_uriComparer);
+            _collectedGlyphTypefaces = new Dictionary<Uri, HashSet<ushort>>(s_uriComparer);
         }
 
         #endregion Constructors
@@ -127,7 +127,7 @@ namespace System.Windows.Media
             {
                 // We don't use Uri.Equals because it doesn't compare Fragment parts,
                 // and we use Fragment part to store font face index.
-                return String.Equals(x.ToString(), y.ToString(), StringComparison.OrdinalIgnoreCase);
+                return string.Equals(x.ToString(), y.ToString(), StringComparison.OrdinalIgnoreCase);
             }
 
             public int GetHashCode(Uri obj)
@@ -147,12 +147,14 @@ namespace System.Windows.Media
         #region Private Fields
 
         /// <summary>
-        /// bool values in the dictionary don't matter,
-        /// we'll switch to Set class when it becomes available.
+        /// Contains the FontUri and its GlyphIndicies as values.   
         /// </summary>
-        private Dictionary<Uri, HashSet<ushort>>   _collectedGlyphTypefaces;
+        private readonly Dictionary<Uri, HashSet<ushort>> _collectedGlyphTypefaces;
 
-        private static UriComparer _uriComparer = new UriComparer();
+        /// <summary>
+        /// Custom comparer for FontUri used in <see cref="_collectedGlyphTypefaces"/>.
+        /// </summary>
+        private static readonly UriComparer s_uriComparer = new();
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingManager.cs
@@ -51,7 +51,7 @@ namespace System.Windows.Media
         /// </summary>
         public FontEmbeddingManager()
         {
-            _collectedGlyphTypefaces = new Dictionary<Uri, Dictionary<ushort, bool>>(_uriComparer);
+            _collectedGlyphTypefaces = new Dictionary<Uri, HashSet<ushort>>(_uriComparer);
         }
 
         #endregion Constructors
@@ -77,16 +77,16 @@ namespace System.Windows.Media
 #pragma warning suppress 56506
             Uri glyphTypeface = glyphRun.GlyphTypeface.FontUri;
 
-            Dictionary<ushort, bool> glyphSet;
+            HashSet<ushort> glyphSet;
             
             if (_collectedGlyphTypefaces.ContainsKey(glyphTypeface))
                 glyphSet = _collectedGlyphTypefaces[glyphTypeface];
             else
-                glyphSet = _collectedGlyphTypefaces[glyphTypeface] = new Dictionary<ushort, bool>();
+                glyphSet = _collectedGlyphTypefaces[glyphTypeface] = new HashSet<ushort>();
 
             foreach(ushort glyphIndex in glyphRun.GlyphIndices)
             {             
-                glyphSet[glyphIndex] = true;
+                glyphSet.Add(glyphIndex);
             }
         }
 
@@ -114,12 +114,12 @@ namespace System.Windows.Media
         [CLSCompliant(false)]
         public ICollection<ushort> GetUsedGlyphs(Uri glyphTypeface)
         {
-            Dictionary<ushort, bool> glyphsUsed = _collectedGlyphTypefaces[glyphTypeface];
+            HashSet<ushort> glyphsUsed = _collectedGlyphTypefaces[glyphTypeface];
             if (glyphsUsed == null)
             {
-                throw new ArgumentException(SR.GlyphTypefaceNotRecorded, "glyphTypeface");
+                throw new ArgumentException(SR.GlyphTypefaceNotRecorded, nameof(glyphTypeface));
             }
-            return glyphsUsed.Keys;
+            return glyphsUsed;
         }
 
         #endregion Public Methods
@@ -155,7 +155,7 @@ namespace System.Windows.Media
         /// bool values in the dictionary don't matter,
         /// we'll switch to Set class when it becomes available.
         /// </summary>
-        private Dictionary<Uri, Dictionary<ushort, bool>>   _collectedGlyphTypefaces;
+        private Dictionary<Uri, HashSet<ushort>>   _collectedGlyphTypefaces;
 
         private static UriComparer _uriComparer = new UriComparer();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingManager.cs
@@ -38,11 +38,11 @@ namespace System.Windows.Media
             Uri glyphTypeface = glyphRun.GlyphTypeface.FontUri;
 
             ref HashSet<ushort> glyphSet = ref CollectionsMarshal.GetValueRefOrAddDefault(_collectedGlyphTypefaces, glyphTypeface, out bool exists);
-            if(!exists)
+            if (!exists)
                 glyphSet = new HashSet<ushort>(glyphRun.GlyphIndices.Count);
 
             foreach (ushort glyphIndex in glyphRun.GlyphIndices)
-            {             
+            {
                 glyphSet.Add(glyphIndex);
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingManager.cs
@@ -3,50 +3,22 @@
 // See the LICENSE file in the project root for more information.
 
 //
-// 
-//
 // Description: The FontEmbeddingManager class handles physical and composite font embedding.
 //
 //              See spec at http://avalon/text/DesignDocsAndSpecs/Font%20embedding%20APIs.htm
 // 
-//
-//
 
-using System;
-using System.Text;
-using System.IO;
-using System.Globalization;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Windows;
-
-using MS.Internal.FontCache;
-using MS.Internal.FontFace;
-using MS.Internal.Shaping;
-using System.Security;
-
-using SR=MS.Internal.PresentationCore.SR;
+using SR = MS.Internal.PresentationCore.SR;
 using System.Runtime.InteropServices;
-
-// Allow suppression of presharp warnings
-#pragma warning disable 1634, 1691
+using System.Collections.Generic;
 
 namespace System.Windows.Media
 {
     /// <summary>
-    /// The FontEmbeddingManager class handles physical and composite font embedding.
+    /// The <see cref="FontEmbeddingManager"/> class handles physical and composite font embedding.
     /// </summary>
     public class FontEmbeddingManager
     {
-        //------------------------------------------------------
-        //
-        //  Constructors
-        //
-        //------------------------------------------------------
-
-        #region Constructors
-
         /// <summary>
         /// Creates a new instance of font usage manager.
         /// </summary>
@@ -54,16 +26,6 @@ namespace System.Windows.Media
         {
             _collectedGlyphTypefaces = new Dictionary<Uri, HashSet<ushort>>(s_uriComparer);
         }
-
-        #endregion Constructors
-
-        //------------------------------------------------------
-        //
-        //  Public Methods
-        //
-        //------------------------------------------------------
-
-        #region Public Methods
 
         /// <summary>
         /// Collects information about glyph typeface and index used by a glyph run.
@@ -103,26 +65,22 @@ namespace System.Windows.Media
         /// </summary>
         /// <param name="glyphTypeface">Specifies the Uri of a glyph typeface to obtain usage data for.</param>
         /// <returns>A collection of glyph indices recorded previously.</returns>
-        /// <exception cref="System.ArgumentException">
+        /// <exception cref="ArgumentException">
         ///     Glyph typeface Uri does not point to a previously recorded glyph typeface.
         /// </exception>
         [CLSCompliant(false)]
         public ICollection<ushort> GetUsedGlyphs(Uri glyphTypeface)
         {
             HashSet<ushort> glyphsUsed = _collectedGlyphTypefaces[glyphTypeface];
-            if (glyphsUsed == null)
+            if (glyphsUsed == null) // NOTE: This will currently throw KeyNotFoundException instead
             {
                 throw new ArgumentException(SR.GlyphTypefaceNotRecorded, nameof(glyphTypeface));
             }
             return glyphsUsed;
         }
 
-        #endregion Public Methods
-
-        private class UriComparer : IEqualityComparer<Uri>
+        private sealed class UriComparer : IEqualityComparer<Uri>
         {
-            #region IEqualityComparer<Uri> Members
-
             public bool Equals(Uri x, Uri y)
             {
                 // We don't use Uri.Equals because it doesn't compare Fragment parts,
@@ -134,17 +92,7 @@ namespace System.Windows.Media
             {
                 return obj.GetHashCode();
             }
-
-            #endregion
         }
-
-        //------------------------------------------------------
-        //
-        //  Private Fields
-        //
-        //------------------------------------------------------
-
-        #region Private Fields
 
         /// <summary>
         /// Contains the FontUri and its GlyphIndicies as values.   
@@ -156,6 +104,5 @@ namespace System.Windows.Media
         /// </summary>
         private static readonly UriComparer s_uriComparer = new();
 
-        #endregion Private Fields
     }
 }


### PR DESCRIPTION
## Description

Optimizes methods in `FontEmbeddingManager`, using `HashSet<ushort>` over `Dictionary<ushort, bool>` since the `bool` is useless and as the comment says, it was always the plan anyways.

- `GetUsedGlyphs` throws `KeyNotFoundException` over `ArgumentException` but that bug was already present.
    - I'll log an issue for this later.

### 3 Different faces, 9 Glyph Runs

| Method          | Mean [ns]  | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|---------------- |-----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 1,344.4 ns |   13.79 ns |    12.23 ns | 0.1507 |       1,066 B |        2544 B |
| PR_EDIT |   850.7 ns |   11.54 ns |    10.23 ns | 0.1297 |       1,577 B |        2184 B |

<details>
<summary>Benchmark data source</summary>

```csharp
yield return new List<GlyphRun>() { giveme("Consolas", "hello"), giveme("Arial", "hannah"), giveme("Consolas", "test"),
                                    giveme("Arial", "hello"), giveme("Consolas", "hannah"), giveme("Arial", "test"),
                                    giveme("Times New Roman", "hello"), giveme("Times New Roman", "hannah"), giveme("Times New Roman", "test") };

```

</details>

### 1 font, 9 Glyph Runs (XpsFontSubsetter scenario)

| Method          | Mean [ns]  | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|---------------- |-----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 1,401.2 ns |    5.46 ns |     5.11 ns | 0.1087 |       1,063 B |        1832 B |
| PR_EDIT |   878.1 ns |    3.87 ns |     3.43 ns | 0.1020 |       1,394 B |        1712 B |

<details>
<summary>Benchmark data source</summary>

```csharp
yield return new List<GlyphRun>() { giveme("Consolas", "hello"), giveme("Consolas", "hannah"), giveme("Consolas", "test"),
                                    giveme("Consolas", "hello"), giveme("Consolas", "hannah"), giveme("Consolas", "test"),
                                    giveme("Consolas", "hello"), giveme("Consolas", "hannah"), giveme("Consolas", "Okay, lets change this a bit!") };

```

</details>

## Customer Impact

Improved performance, slightly decreased allocations. This is used by the `XpsFontSubsetter`, so it could gain a bit of perf.

## Regression

No.

## Testing

Local build.

## Risk

Low, just a simple swap.
