### PR TITLE
Update PropertyValues in TriggerBase/FrameworkElementFactory via reference

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DataTrigger.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DataTrigger.cs
@@ -162,7 +162,7 @@ namespace System.Windows
             // Set Condition for all data triggers
             for (int i = 0; i < PropertyValues.Count; i++)
             {
-                PropertyValue propertyValue = PropertyValues[i];
+                ref PropertyValue propertyValue = ref PropertyValues.GetEntryAtRef(i);
 
                 propertyValue.Conditions = TriggerConditions;
                 switch (propertyValue.ValueType)
@@ -176,9 +176,6 @@ namespace System.Windows
                     default:
                         throw new InvalidOperationException(SR.Format(SR.UnexpectedValueTypeForDataTrigger, propertyValue.ValueType));
                 }
-
-                // Put back modified struct
-                PropertyValues[i] = propertyValue;
             }
 
             base.Seal();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElementFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElementFactory.cs
@@ -429,7 +429,7 @@ namespace System.Windows
             if( existingIndex >= 0 )
             {
                 // Overwrite existing value for dp
-                lock (_synchronized)
+                lock (_propertyValuesLock)
                 {
                     ref PropertyValue propertyValue = ref PropertyValues.GetEntryAtRef(existingIndex);
                     propertyValue.ValueType = valueType;
@@ -445,7 +445,7 @@ namespace System.Windows
                 propertyValue.Property = dp;
                 propertyValue.ValueInternal = value;
 
-                lock (_synchronized)
+                lock (_propertyValuesLock)
                 {
                     PropertyValues.Add(propertyValue);
                 }
@@ -583,7 +583,7 @@ namespace System.Windows
             }
 
 
-            lock (_synchronized)
+            lock (_propertyValuesLock)
             {
                 // Set delayed ChildID for all property triggers
                 for (int i = 0; i < PropertyValues.Count; i++)
@@ -1263,6 +1263,9 @@ namespace System.Windows
         // Synchronized (write locks, lock-free reads): Covered by FrameworkElementFactory instance lock
         internal FrugalStructList<PropertyValue> PropertyValues = new();
 
+        // Instance-based synchronization for write locks to PropertyValues
+        private readonly Lock _propertyValuesLock = new();
+
         // Store all the event handlers for this FEF
         // NOTE: We cannot use UnCommonField<T> because that uses property engine
         // storage that can be set only on a DependencyObject
@@ -1287,9 +1290,6 @@ namespace System.Windows
         private FrameworkElementFactory _firstChild;
         private FrameworkElementFactory _lastChild;
         private FrameworkElementFactory _nextSibling;
-
-        // Instance-based synchronization
-        private readonly object _synchronized = new object();
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElementFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElementFactory.cs
@@ -519,7 +519,7 @@ namespace System.Windows
             // Scan for record
             for (int i = 0; i < PropertyValues.Count; i++)
             {
-                var propertyValue = PropertyValues[i];
+                PropertyValue propertyValue = PropertyValues[i];
                 if (propertyValue.ValueType == PropertyValueType.Set &&
                     propertyValue.Property == dp)
                 {
@@ -810,7 +810,7 @@ namespace System.Windows
 
                     for (int i = 0; i < PropertyValues.Count; i++)
                     {
-                        var propertyValue = PropertyValues[i];
+                        PropertyValue propertyValue = PropertyValues[i];
                         if (propertyValue.ValueType == PropertyValueType.Set)
                         {
                             // Get the value out of the table.
@@ -1244,7 +1244,7 @@ namespace System.Windows
         {
             for (int i = 0; i < PropertyValues.Count; i++)
             {
-                var propertyValue = PropertyValues[i];
+                PropertyValue propertyValue = PropertyValues[i];
                 if (propertyValue.Property == dp &&
                     (propertyValue.ValueType == PropertyValueType.Set ||
                      propertyValue.ValueType == PropertyValueType.Resource ||
@@ -1261,7 +1261,7 @@ namespace System.Windows
         private bool _sealed;
 
         // Synchronized (write locks, lock-free reads): Covered by FrameworkElementFactory instance lock
-        /* property */ internal FrugalStructList<System.Windows.PropertyValue> PropertyValues = new FrugalStructList<System.Windows.PropertyValue>();
+        internal FrugalStructList<PropertyValue> PropertyValues = new();
 
         // Store all the event handlers for this FEF
         // NOTE: We cannot use UnCommonField<T> because that uses property engine

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElementFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElementFactory.cs
@@ -431,11 +431,9 @@ namespace System.Windows
                 // Overwrite existing value for dp
                 lock (_synchronized)
                 {
-                    PropertyValue propertyValue = PropertyValues[existingIndex];
+                    ref PropertyValue propertyValue = ref PropertyValues.GetEntryAtRef(existingIndex);
                     propertyValue.ValueType = valueType;
                     propertyValue.ValueInternal = value;
-                    // Put back modified struct
-                    PropertyValues[existingIndex] = propertyValue;
                 }
             }
             else
@@ -590,14 +588,11 @@ namespace System.Windows
                 // Set delayed ChildID for all property triggers
                 for (int i = 0; i < PropertyValues.Count; i++)
                 {
-                    PropertyValue propertyValue = PropertyValues[i];
+                    ref PropertyValue propertyValue = ref PropertyValues.GetEntryAtRef(i);
                     propertyValue.ChildName = _childName;
 
                     // Freeze the FEF property value
                     StyleHelper.SealIfSealable(propertyValue.ValueInternal);
-
-                    // Put back modified struct
-                    PropertyValues[i] = propertyValue;
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MultiDataTrigger.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MultiDataTrigger.cs
@@ -124,7 +124,7 @@ namespace System.Windows
             // Set conditions array for all property triggers
             for (int i = 0; i < PropertyValues.Count; ++i)
             {
-                PropertyValue propertyValue = PropertyValues[i];
+                ref PropertyValue propertyValue = ref PropertyValues.GetEntryAtRef(i);
                 propertyValue.Conditions = TriggerConditions;
                 switch (propertyValue.ValueType)
                 {
@@ -137,9 +137,6 @@ namespace System.Windows
                     default:
                         throw new InvalidOperationException(SR.Format(SR.UnexpectedValueTypeForDataTrigger, propertyValue.ValueType));
                 }
-
-                // Put back modified struct
-                PropertyValues[i] = propertyValue;
             }
 
             base.Seal();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MultiTrigger.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MultiTrigger.cs
@@ -115,10 +115,8 @@ namespace System.Windows
             // Set conditions array for all property triggers
             for (int i = 0; i < PropertyValues.Count; i++)
             {
-                PropertyValue propertyValue = PropertyValues[i];
+                ref PropertyValue propertyValue = ref PropertyValues.GetEntryAtRef(i);
                 propertyValue.Conditions = TriggerConditions;
-                // Put back modified struct
-                PropertyValues[i] = propertyValue;
             }
 
             base.Seal();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
@@ -987,7 +987,7 @@ namespace System.Windows
 
         // Original Style data (not including based-on data)
         // Synchronized (write locks, lock-free reads): Covered by Style instance lock
-        /* property */ internal FrugalStructList<System.Windows.PropertyValue> PropertyValues = new FrugalStructList<System.Windows.PropertyValue>();
+        internal FrugalStructList<PropertyValue> PropertyValues = new();
 
         // Properties driven on the container (by the Style) that should be
         // invalidated when the style gets applied/unapplied. These properties

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
@@ -458,11 +458,9 @@ namespace System.Windows
             if( existingIndex >= 0 )
             {
                 // Overwrite existing value for dp
-                PropertyValue propertyValue = PropertyValues[existingIndex];
+                ref PropertyValue propertyValue = ref PropertyValues.GetEntryAtRef(existingIndex);
                 propertyValue.ValueType = valueType;
                 propertyValue.ValueInternal = value;
-                // Put back modified struct
-                PropertyValues[existingIndex] = propertyValue;
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Trigger.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Trigger.cs
@@ -224,10 +224,8 @@ namespace System.Windows
             // Set Condition for all property triggers
             for (int i = 0; i < PropertyValues.Count; i++)
             {
-                PropertyValue propertyValue = PropertyValues[i];
+                ref PropertyValue propertyValue = ref PropertyValues.GetEntryAtRef(i);
                 propertyValue.Conditions = TriggerConditions;
-                // Put back modified struct
-                PropertyValues[i] = propertyValue;
             }
 
             base.Seal();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TriggerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TriggerBase.cs
@@ -209,6 +209,7 @@ namespace System.Windows
         /// data structures) by Style.Seal(). We keep them around even after
         /// that point should we need to serialize this data back out.
         /// </remarks>
+        // This is only called from ProcessSettersCollection, which is guranteed to be on single thread.
         internal void AddToPropertyValues(string childName, DependencyProperty dp, object value, PropertyValueType valueType)
         {
             // Store original data
@@ -234,7 +235,8 @@ namespace System.Windows
             // Track Dependent/Source relationship for prediction
             for (int i = 0; i < PropertyValues.Count; i++)
             {
-                PropertyValue propertyValue = PropertyValues[i];
+                // We can use ref here as we're guranteed via VerifyAccess() to be on single thread
+                ref PropertyValue propertyValue = ref PropertyValues.GetEntryAtRef(i);
 
                 DependencyProperty dependent = propertyValue.Property;
 
@@ -266,7 +268,11 @@ namespace System.Windows
             DetachFromDispatcher();
         }
 
-        // This will transfer information in the _setters collection to PropertyValues array.
+        /// <summary>
+        /// This will transfer information in the _setters collection to PropertyValues array.
+        /// </summary>
+        // NOTE: This is currently only called in Seal() overrides and it should stay that way
+        // as it gurantees that any changes made to PropertyValues are on single thread!
         internal void ProcessSettersCollection(SetterBaseCollection setters)
         {
             // Add information in Setters collection to PropertyValues array.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TriggerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TriggerBase.cs
@@ -387,7 +387,7 @@ namespace System.Windows
         }
 
         // Synchronized (write locks, lock-free reads): Covered by the TriggerBase instance
-        /* property */ internal FrugalStructList<System.Windows.PropertyValue> PropertyValues = new FrugalStructList<System.Windows.PropertyValue>();
+        internal FrugalStructList<PropertyValue> PropertyValues = new();
 
         // Global, cross-object synchronization
         private static readonly object Synchronized = new object();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TriggerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TriggerBase.cs
@@ -393,6 +393,8 @@ namespace System.Windows
         }
 
         // Synchronized (write locks, lock-free reads): Covered by the TriggerBase instance
+        // NOTE: There are actually no locks performed as any write operations
+        // are done on a Dispatcher thread before the TriggerBase is sealed
         internal FrugalStructList<PropertyValue> PropertyValues = new();
 
         // Global, cross-object synchronization

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
@@ -2110,34 +2110,27 @@ namespace MS.Utility
         {
             get
             {
-                // If no entry, default(T) is returned
-                if ((null != _listStore) && ((index < _listStore.Count) && (index >= 0)))
-                {
-                    return _listStore.EntryAt(index);
-                }
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+                if ((_listStore is null) || ((uint)index >= (uint)_listStore.Count))
+                    throw new ArgumentOutOfRangeException(nameof(index));
 
+                return _listStore.EntryAt(index);
+            }
             set
             {
                 // Ensure write success
-                if ((null != _listStore) && ((index < _listStore.Count) && (index >= 0)))
-                {
-                    _listStore.SetAt(index, value);
-                    return;
-                }
-                throw new ArgumentOutOfRangeException(nameof(index));
+                if ((_listStore is null) || ((uint)index >= (uint)_listStore.Count))
+                    throw new ArgumentOutOfRangeException(nameof(index));
+
+                _listStore.SetAt(index, value);
             }
         }
 
         public ref T GetEntryAtRef(int index)
         {
-            // If no entry, default(T) is returned
-            if ((null != _listStore) && ((index < _listStore.Count) && (index >= 0)))
-            {
-                return ref _listStore.EntryAtRef(index);
-            }
-            throw new ArgumentOutOfRangeException(nameof(index));
+            if ((_listStore is null) || ((uint)index >= (uint)_listStore.Count))
+                throw new ArgumentOutOfRangeException(nameof(index));
+
+            return ref _listStore.EntryAtRef(index);
         }
 
         public int Add(T value)

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
@@ -141,6 +141,8 @@ namespace MS.Utility
         /// </summary>
         public abstract T EntryAt(int index);
 
+        public abstract ref T EntryAtRef(int index);
+
         /// <summary>
         /// Promotes the values in the current store to the next larger
         /// and more complex storage model.
@@ -318,6 +320,11 @@ namespace MS.Utility
         public override T EntryAt(int index)
         {
             return _loneEntry;
+        }
+
+        public override ref T EntryAtRef(int index)
+        {
+            return ref _loneEntry;
         }
 
         public override void Promote(FrugalListBase<T> oldList)
@@ -564,6 +571,24 @@ namespace MS.Utility
 
                 case 2:
                     return _entry2;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+
+        public override ref T EntryAtRef(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ref _entry0;
+
+                case 1:
+                    return ref _entry1;
+
+                case 2:
+                    return ref _entry2;
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(index));
@@ -1019,6 +1044,33 @@ namespace MS.Utility
             }
         }
 
+        public override ref T EntryAtRef(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ref _entry0;
+
+                case 1:
+                    return ref _entry1;
+
+                case 2:
+                    return ref _entry2;
+
+                case 3:
+                    return ref _entry3;
+
+                case 4:
+                    return ref _entry4;
+
+                case 5:
+                    return ref _entry5;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+
         public override void Promote(FrugalListBase<T> oldList)
         {
             int oldCount = oldList.Count;
@@ -1390,6 +1442,11 @@ namespace MS.Utility
         public override T EntryAt(int index)
         {
             return _entries[index];
+        }
+
+        public override ref T EntryAtRef(int index)
+        {
+            return ref _entries[index];
         }
 
         public override void Promote(FrugalListBase<T> oldList)
@@ -2071,6 +2128,16 @@ namespace MS.Utility
                 }
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
+        }
+
+        public ref T GetEntryAtRef(int index)
+        {
+            // If no entry, default(T) is returned
+            if ((null != _listStore) && ((index < _listStore.Count) && (index >= 0)))
+            {
+                return ref _listStore.EntryAtRef(index);
+            }
+            throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         public int Add(T value)


### PR DESCRIPTION
## Description

Adds ability to retrieve elements via `ref` from `FrugalStructList<T>` and the underlying storage formats, allowing for future optimizations. I intentionally did not modify the indexer as this can be done easily later on, so there's a new method for it now, which will allow for incremental optimizations in future on another types, where it makes sense and is safe to do so.

This allows us to update items via reference, which is particularly useful in case of `PropertyValues` used in `TriggerBase` and `FrameworkElementFactory` since it is a struct that needs to be copied everytime on update back and forth.

It is particularly efficient optimization here since the struct is full of managed pointers and ain't blittable, which takes considerable time to track back and forth for a simple update on one property.

I've also updated the getter/setter on `FrugalStructList<T>` for a minor speed boost, since it is used in almost every WPF collection, every branch counts. Nothing extra new, this is used in `List<T>` by default for several releases.

### Original getter/setter prolog:

```assembly
mov rcx, [rcx+8]
test rcx, rcx      
je short L0021 
cmp edx, [rcx+8]     
jge short L0021
test edx, edx
jl short L0021
```

### New getter/setter prolog:

```assembly
mov rcx, [rcx+8]
test rcx, rcx    
je short L001d 
cmp edx, [rcx+8] 
jae short L001d
```

### Updating PropertyValues before/after

| Method          |  Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Allocated [B] |
|---------------- |----------:|-----------:|------------:|--------------:|--------------:|
| Original | 459.11 ns |   2.278 ns |    2.131 ns |       1,072 B |             - |
| PR__EDIT|  58.45 ns |   0.464 ns |    0.434 ns |         469 B |             - |

<details><summary>Minimal benchmark code</summary>

```csharp
[Benchmark]
public static FrugalStructList<PropertyValue> PropertyValues = new();
public static FrugalStructList<PropertyValue> PropertyValues2 = new();

public static IEnumerable<TriggerCondition[]> KeysToTest
{
    get
    {
        yield return new TriggerCondition[] { new TriggerCondition() {  SourceChildIndex = 4}, new TriggerCondition() { SourceChildIndex = 1 }, new TriggerCondition() { SourceChildIndex = 3 } };
    }
}

[GlobalSetup]
public static void Setup()
{
  PropertyValues.Add(new PropertyValue() { ChildName = "abcd", Conditions = new TriggerCondition[5], Property = TextBox.TextProperty, ValueInternal = 45, ValueType = PropertyValueType.Trigger });
  PropertyValues.Add(new PropertyValue() { ChildName = "abcd", Conditions = new TriggerCondition[5], Property = TextBox.TextProperty, ValueInternal = 45, ValueType = PropertyValueType.Trigger });
  PropertyValues.Add(new PropertyValue() { ChildName = "abcd", Conditions = new TriggerCondition[5], Property = TextBox.TextProperty, ValueInternal = 45, ValueType = PropertyValueType.Trigger });
  PropertyValues.Add(new PropertyValue() { ChildName = "abcd", Conditions = new TriggerCondition[5], Property = TextBox.TextProperty, ValueInternal = 45, ValueType = PropertyValueType.Trigger });
  PropertyValues.Add(new PropertyValue() { ChildName = "abcd", Conditions = new TriggerCondition[5], Property = TextBox.TextProperty, ValueInternal = 45, ValueType = PropertyValueType.Trigger });
  PropertyValues.Add(new PropertyValue() { ChildName = "abcd", Conditions = new TriggerCondition[5], Property = TextBox.TextProperty, ValueInternal = 45, ValueType = PropertyValueType.Trigger });

  PropertyValues2.Add(new PropertyValue() { ChildName = "abcd", Conditions = new TriggerCondition[5], Property = TextBox.TextProperty, ValueInternal = 45, ValueType = PropertyValueType.Trigger });
  PropertyValues2.Add(new PropertyValue() { ChildName = "abcd", Conditions = new TriggerCondition[5], Property = TextBox.TextProperty, ValueInternal = 45, ValueType = PropertyValueType.Trigger });
  PropertyValues2.Add(new PropertyValue() { ChildName = "abcd", Conditions = new TriggerCondition[5], Property = TextBox.TextProperty, ValueInternal = 45, ValueType = PropertyValueType.Trigger });
  PropertyValues2.Add(new PropertyValue() { ChildName = "abcd", Conditions = new TriggerCondition[5], Property = TextBox.TextProperty, ValueInternal = 45, ValueType = PropertyValueType.Trigger });
  PropertyValues2.Add(new PropertyValue() { ChildName = "abcd", Conditions = new TriggerCondition[5], Property = TextBox.TextProperty, ValueInternal = 45, ValueType = PropertyValueType.Trigger });
  PropertyValues2.Add(new PropertyValue() { ChildName = "abcd", Conditions = new TriggerCondition[5], Property = TextBox.TextProperty, ValueInternal = 45, ValueType = PropertyValueType.Trigger });
}

[ArgumentsSource(nameof(KeysToTest))]
public void Original(TriggerCondition[] triggerCondition)
{
    // Set Condition for all data triggers
    for (int i = 0; i < PropertyValues.Count; i++)
    {
        PropertyValue propertyValue = PropertyValues[i];

        propertyValue.Conditions = triggerCondition;
        switch (propertyValue.ValueType)
        {
            case PropertyValueType.Trigger:
                propertyValue.ValueType = PropertyValueType.DataTrigger;
                break;
            case PropertyValueType.DataTrigger:
                propertyValue.ValueType = PropertyValueType.Trigger;
                break;
            case PropertyValueType.PropertyTriggerResource:
                propertyValue.ValueType = PropertyValueType.DataTriggerResource;
                break;
            default:
                throw new InvalidOperationException("fail");
        }

        // Put back modified struct
        PropertyValues[i] = propertyValue;
    }
}

[Benchmark]
[ArgumentsSource(nameof(KeysToTest))]
public void PR__EDIT(TriggerCondition[] triggerCondition)
{
    // Set Condition for all data triggers
    for (int i = 0; i < PropertyValues2.Count; i++)
    {
        ref PropertyValue propertyValue = ref PropertyValues2.GetEntryAtRef(i);

        propertyValue.Conditions = triggerCondition;
        switch (propertyValue.ValueType)
        {
            case PropertyValueType.Trigger:
                propertyValue.ValueType = PropertyValueType.DataTrigger;
                break;
            case PropertyValueType.DataTrigger:
                propertyValue.ValueType = PropertyValueType.Trigger;
                break;
            case PropertyValueType.PropertyTriggerResource:
                propertyValue.ValueType = PropertyValueType.DataTriggerResource;
                break;
            default:
                throw new InvalidOperationException("fail");
        }
    }
}
```

</details>

## Customer Impact

Increased startup performance mostly, but also when dynamically creating triggers at runtime and obviously everything related to ContentPresenter, Validation, ItemsControl templates etc. I could observe about several milliseconds improvement with a simple app with a few controls with ScrollViewer (ListBox) etc.

## Regression

No.

## Testing

Local build, sample apps testing with styles/triggers to check they're applied property.

## Risk

Low-to-medium, reviewers shall check that the `ref` is not forwarded/used anywhere while the `FrugalStructList<T>` could be modified (this really means when Grow or for example Remove happens), R/W operations via indexer do not matter as they do not modify the backing store in size/copy it.
