### PR TITLE
Remove locks on Style/TriggerBase counters, use atomic increments instead

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
@@ -50,6 +50,7 @@ namespace System.Windows
         /// </summary>
         public Style()
         {
+            // Get globally unique ID
             GlobalIndex = Interlocked.Increment(ref s_globalStyleIndex);
         }
 
@@ -61,6 +62,7 @@ namespace System.Windows
         {
             TargetType = targetType;
 
+            // Get globally unique ID
             GlobalIndex = Interlocked.Increment(ref s_globalStyleIndex);
         }
 
@@ -74,6 +76,7 @@ namespace System.Windows
             TargetType = targetType;
             BasedOn = basedOn;
 
+            // Get globally unique ID
             GlobalIndex = Interlocked.Increment(ref s_globalStyleIndex);
         }
 
@@ -1010,8 +1013,11 @@ namespace System.Windows
         internal HybridDictionary DataTriggersWithActions = null;
 
         /// <summary>
-        /// Writes must be done atomically, currently only written via <see cref="GetUniqueGlobalIndex"/>.
+        /// Global indexer for <see cref="Style"/> and its derivates.
         /// </summary>
+        /// <remarks>
+        /// Access must be done atomically, currently only written via constructors.
+        /// </remarks>
         private static int s_globalStyleIndex = 0;
 
         private const int TargetTypeID = 0x01;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
@@ -936,13 +936,10 @@ namespace System.Windows
         /// </summary>
         internal int GlobalIndex { get; }
 
-        // Special equality check that takes into account 'null'
-        private static bool IsEqual(object a, object b)
+        internal bool IsBasedOnModified
         {
-            return (a != null) ? a.Equals(b) : (b == null);
+            get => IsModified(BasedOnID);
         }
-
-        internal bool IsBasedOnModified { get { return IsModified(BasedOnID); } }
 
         private EventHandlersStore _eventHandlersStore = null;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TriggerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TriggerBase.cs
@@ -407,6 +407,9 @@ namespace System.Windows
         /// <summary>
         /// Global indexer for <see cref="TriggerBase"/> and its derivates.
         /// </summary>
+        /// <remarks>
+        /// Access must be done atomically, currently only written via <see cref="EstablishLayer"/>.
+        /// </remarks>
         private static long s_nextGlobalLayerRank = StoryboardLayers.PropertyTriggerStartLayer; // 2
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TriggerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TriggerBase.cs
@@ -2,16 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using StoryboardLayers = System.Windows.Media.Animation.Storyboard.Layers;
+
 using System.Collections.Specialized;
-using System.IO;
-using System.Windows.Markup;
+
+using System.ComponentModel;            // DesignerSerializationVisibilityAttribute & DefaultValue
+using System.Diagnostics;
+using System.Threading;
 
 using MS.Utility;
 using MS.Internal;
-
-using System;
-using System.ComponentModel;            // DesignerSerializationVisibilityAttribute & DefaultValue
-using System.Diagnostics;
 
 namespace System.Windows
 {
@@ -348,25 +348,20 @@ namespace System.Windows
         // This ranking is used when trigger needs to be sorted relative to
         //  the ordering, as when determining precedence for enter/exit
         //  animation composition.  Otherwise, it stays at default value of zero.
-        internal Int64 Layer
+        internal long Layer
         {
-            get { return _globalLayerRank; }
+            get => _globalLayerRank;
         }
 
         // Set self rank to current number, increment global static.
         internal void EstablishLayer()
         {
-            if( _globalLayerRank == 0 )
+            if (_globalLayerRank == 0)
             {
-                lock(Synchronized)
-                {
-                    _globalLayerRank = _nextGlobalLayerRank++;
-                }
+                _globalLayerRank = Interlocked.Increment(ref s_nextGlobalLayerRank);
 
-                if( _nextGlobalLayerRank == Int64.MaxValue )
-                {
+                if (s_nextGlobalLayerRank == long.MaxValue)
                     throw new InvalidOperationException(SR.PropertyTriggerLayerLimitExceeded);
-                }
             }
         }
 
@@ -389,9 +384,6 @@ namespace System.Windows
         // Synchronized (write locks, lock-free reads): Covered by the TriggerBase instance
         /* property */ internal FrugalStructList<System.Windows.PropertyValue> PropertyValues = new FrugalStructList<System.Windows.PropertyValue>();
 
-        // Global, cross-object synchronization
-        private static readonly object Synchronized = new object();
-
         // Conditions
         TriggerCondition[] _triggerConditions;
 
@@ -404,10 +396,17 @@ namespace System.Windows
         private TriggerActionCollection _exitActions = null;
 
 //      On hold - is this a new public API we want to do?
-//        private bool _executeEnterActionsOnApply = false;
-//        private bool _executeExitActionsOnApply = false;
+//      private bool _executeEnterActionsOnApply = false;
+//      private bool _executeExitActionsOnApply = false;
 
-        private Int64 _globalLayerRank = 0;
-        private static Int64 _nextGlobalLayerRank = System.Windows.Media.Animation.Storyboard.Layers.PropertyTriggerStartLayer;
+        /// <summary>
+        /// Global index of this particular instance.
+        /// </summary>
+        private long _globalLayerRank = 0;
+
+        /// <summary>
+        /// Global indexer for <see cref="TriggerBase"/> and its derivates.
+        /// </summary>
+        private static long s_nextGlobalLayerRank = StoryboardLayers.PropertyTriggerStartLayer; // 2
     }
 }


### PR DESCRIPTION
## Description

Similarly as in #9741, we will use simple `Interlocked.Increment` to retrieve the next globally unique index, instead of using a full-blown `Monitor`-type lock for such simple operation. This will contribute to startup performance mostly.

I've also removed `IsEqual` private static method in `Style` as it was just staring there at me, unused.

## Customer Impact

Increased (mostly startup) performance.

## Regression

No.

## Testing

Local build.

## Risk

Low, this is very easy to grasp.
