### PR TITLE
Use ReadOnlySpan<HwndWrapperHook> instead of a temporary heap array

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Common/Graphics/wgx_render.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/Graphics/wgx_render.cs
@@ -721,13 +721,7 @@ namespace MS.Internal
         // TRUE if the effect supports multi-resolution
 
         [MarshalAs(UnmanagedType.Bool)] bool fSupportMultiResolution;
-};
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct HWND
-    {
-        public int hwnd;
-    }
+    };
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct MILAVInstruction

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
@@ -227,20 +227,6 @@ namespace System.Windows.Interop
 
             _publicHook = new HwndWrapperHook(PublicHooksFilterMessage);
 
-            _restoreFocusMode = parameters.RestoreFocusMode;
-            _acquireHwndFocusInMenuMode = parameters.AcquireHwndFocusInMenuMode;
-
-            if (parameters.EffectivePerPixelOpacity)
-            {
-                parameters.ExtendedWindowStyle |= NativeMethods.WS_EX_LAYERED;
-            }
-            else
-            {
-                parameters.ExtendedWindowStyle &= (~NativeMethods.WS_EX_LAYERED);
-            }
-
-            _constructionParameters = parameters;
-
             // When processing WM_SIZE, LayoutFilterMessage must be invoked before
             // HwndTargetFilterMessage. This way layout will be updated before resizing
             // HwndTarget, resulting in single render per resize. This means that
@@ -266,6 +252,20 @@ namespace System.Windows.Interop
                 // In this case, we do not need the _publicHook
                 hooks = hooks.Slice(0, 3);
             }
+
+            _restoreFocusMode = parameters.RestoreFocusMode;
+            _acquireHwndFocusInMenuMode = parameters.AcquireHwndFocusInMenuMode;
+
+            if (parameters.EffectivePerPixelOpacity)
+            {
+                parameters.ExtendedWindowStyle |= NativeMethods.WS_EX_LAYERED;
+            }
+            else
+            {
+                parameters.ExtendedWindowStyle &= (~NativeMethods.WS_EX_LAYERED);
+            }
+
+            _constructionParameters = parameters;
 
             _hwndWrapper = new HwndWrapper(parameters.WindowClassStyle, parameters.WindowStyle, parameters.ExtendedWindowStyle,
                                            parameters.PositionX, parameters.PositionY, parameters.Width, parameters.Height,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -2567,19 +2567,7 @@ namespace System.Windows.Interop
                     // (HwndWrapper keeps a WeakReference to the hook)
 
                     _notificationHook = new HwndWrapperHook(NotificationFilterMessage);
-                    HwndWrapperHook[] wrapperHooks = { _notificationHook };
-
-                    _notificationHwnd = new HwndWrapper(
-                                                0,
-                                                0,
-                                                0,
-                                                0,
-                                                0,
-                                                0,
-                                                0,
-                                                "",
-                                                IntPtr.Zero,
-                                                wrapperHooks);
+                    _notificationHwnd = new HwndWrapper(0, 0, 0, 0, 0, 0, 0, string.Empty, IntPtr.Zero, _notificationHook);
 
                     Guid monitorGuid = new Guid(NativeMethods.GUID_MONITOR_POWER_ON.ToByteArray());
                     unsafe

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContextNotificationWindow.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContextNotificationWindow.cs
@@ -66,12 +66,9 @@ namespace System.Windows.Media
 
             // Create a top-level, invisible window so we can get the WM_DWMCOMPOSITIONCHANGED
             // and other DWM notifications that are broadcasted to top-level windows only.
-            HwndWrapper hwndNotification;
-            hwndNotification = new HwndWrapper(0, NativeMethods.WS_POPUP, 0, 0, 0, 0, 0, "MediaContextNotificationWindow", IntPtr.Zero, null);
-
             _hwndNotificationHook = new HwndWrapperHook(MessageFilter);
 
-            _hwndNotification = hwndNotification;
+            _hwndNotification = new HwndWrapper(0, NativeMethods.WS_POPUP, 0, 0, 0, 0, 0, "MediaContextNotificationWindow", parent: IntPtr.Zero);
             _hwndNotification.AddHook(_hwndNotificationHook);
 
             _isDisposed = false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonDialog.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Win32
                 // prevent breaking UIAutomation.
                 if (hwndOwner == IntPtr.Zero)
                 {
-                    tempParentHwnd = new HwndWrapper(0, 0, 0, 0, 0, 0, 0, "", IntPtr.Zero, null);
+                    tempParentHwnd = new HwndWrapper(0, 0, 0, 0, 0, 0, 0, string.Empty, IntPtr.Zero);
                     hwndOwner = tempParentHwnd.Handle;
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -2143,19 +2143,7 @@ namespace System.Windows
                 // (HwndWrapper keeps a WeakReference to the hook)
 
                 _appFilterHook = new HwndWrapperHook(AppFilterMessage);
-                HwndWrapperHook[] wrapperHooks = {_appFilterHook};
-
-                _parkingHwnd = new HwndWrapper(
-                                0,
-                                0,
-                                0,
-                                0,
-                                0,
-                                0,
-                                0,
-                                "",
-                                IntPtr.Zero,
-                                wrapperHooks);
+                _parkingHwnd = new HwndWrapper(0, 0, 0, 0, 0, 0, 0, string.Empty, IntPtr.Zero, _appFilterHook);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -1115,18 +1115,15 @@ namespace System.Windows
             {
                 // Create a top-level, invisible window so we can get the WM_THEMECHANGE notification
                 // and for HwndHost to park non-visible HwndHosts.
-                var hwndNotify =
-                    new HwndWrapper(
-                    classStyle: 0,
-                    style: NativeMethods.WS_POPUP | NativeMethods.WS_DISABLED,
-                    exStyle: 0,
-                    x: x,
-                    y: y,
-                    width: 0,
-                    height: 0,
-                    name: "SystemResourceNotifyWindow",
-                    parent: IntPtr.Zero,
-                    hooks: null);
+                HwndWrapper hwndNotify = new(classStyle: 0,
+                                             style: NativeMethods.WS_POPUP | NativeMethods.WS_DISABLED,
+                                             exStyle: 0,
+                                             x: x,
+                                             y: y,
+                                             width: 0,
+                                             height: 0,
+                                             name: "SystemResourceNotifyWindow",
+                                             parent: IntPtr.Zero);
 
                 // Do not call into DpiUtil.GetExtendedDpiInfoForWindow()
                 // unless IsPerMonitorDpiscalingActive == true. DpiUtil.GetExtendedDpiInfoForWindow()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -6377,21 +6377,15 @@ namespace System.Windows
         /// </summary>
         private HwndWrapper EnsureHiddenWindow()
         {
-            if (_hiddenWindow == null)
-            {
-                _hiddenWindow = new HwndWrapper(
-                    0, // classStyle
-                    NativeMethods.WS_OVERLAPPEDWINDOW, // style
-                    0, // exStyle
-                    NativeMethods.CW_USEDEFAULT, // x
-                    NativeMethods.CW_USEDEFAULT, // y
-                    NativeMethods.CW_USEDEFAULT, // width
-                    NativeMethods.CW_USEDEFAULT, // height
-                    "Hidden Window", // name
-                    IntPtr.Zero,
-                    null
-                );
-            }
+            _hiddenWindow ??= new HwndWrapper(classStyle: 0,
+                                              NativeMethods.WS_OVERLAPPEDWINDOW, // style
+                                              exStyle: 0,
+                                              NativeMethods.CW_USEDEFAULT, // x
+                                              NativeMethods.CW_USEDEFAULT, // y
+                                              NativeMethods.CW_USEDEFAULT, // width
+                                              NativeMethods.CW_USEDEFAULT, // height
+                                              "Hidden Window", // name
+                                              IntPtr.Zero);
 
             return _hiddenWindow;
         }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
@@ -2,29 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
-using MS.Internal;
-using MS.Internal.Interop;
-using MS.Utility;
-using System.Windows;
 using System.Windows.Threading;
-using System.Security;                       // CAS
-using System.Threading;                      // Thread
+using MS.Internal.Interop;
+using System.Threading;
+using System;
 
-// The SecurityHelper class differs between assemblies and could not actually be
-//  shared, so it is duplicated across namespaces to prevent name collision.
-#if WINDOWS_BASE
-    using MS.Internal.WindowsBase;
-#elif PRESENTATION_CORE
-    using MS.Internal.PresentationCore;
-#elif PRESENTATIONFRAMEWORK
-    using MS.Internal.PresentationFramework;
-#elif DRT
-    using MS.Internal.Drt;
-#else
-#error Attempt to use a class (duplicated across multiple namespaces) from an unknown assembly.
-#endif
+using SR = MS.Internal.WindowsBase.SR;
 
 namespace MS.Win32
 {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
@@ -33,7 +33,6 @@ namespace MS.Win32
     ///     is not thread safe and will be operated on by the thread that owns
     ///     the window.
     /// </summary>
-    /// <remarks> Not available to partial trust callers</remarks>
     internal class HwndSubclass : IDisposable
     {
         static HwndSubclass()

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
@@ -217,7 +217,7 @@ namespace MS.Win32
 
         public void AddHook(HwndWrapperHook hook)
         {
-            _hooks ??= [];
+            _hooks ??= new WeakReferenceList();
             _hooks.Insert(0, hook);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
@@ -37,32 +37,19 @@ namespace MS.Win32
             s_msgGCMemory = UnsafeNativeMethods.RegisterWindowMessage("HwndWrapper.GetGCMemMessage");
         }
 
-        public HwndWrapper(
-            int classStyle,
-            int style,
-            int exStyle,
-            int x,
-            int y,
-            int width,
-            int height,
-            string name,
-            IntPtr parent,
-            HwndWrapperHook[] hooks)
+        public HwndWrapper(int classStyle, int style, int exStyle, int x, int y, int width, int height,
+                           string name, IntPtr parent, params ReadOnlySpan<HwndWrapperHook> hooks)
         {
             _ownerThreadID = Environment.CurrentManagedThreadId;
 
 
-            // First, add the set of hooks.  This allows the hooks to receive the
+            // First, add the set of hooks. This allows the hooks to receive the
             // messages sent to the window very early in the process.
-            if(hooks != null)
+            foreach (HwndWrapperHook hook in hooks)
             {
-                for(int i = 0, iEnd = hooks.Length; i < iEnd; i++)
-                {
-                    if(null != hooks[i])
-                        AddHook(hooks[i]);
-                }
+                if (hook is not null)
+                    AddHook(hook);
             }
-
 
             _wndProc = new HwndWrapperHook(WndProc);
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
@@ -2,30 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Security;
-using System.Collections.Generic;
-using System.Threading;
-using System.Windows.Threading;
 using System.Runtime.InteropServices;
-using System.Diagnostics;
-using MS.Internal;
+using System.Windows.Threading;
 using MS.Internal.Interop;
-
-#if WINDOWS_BASE
-    using MS.Internal.WindowsBase;
-#elif PRESENTATION_CORE
-    using MS.Internal.PresentationCore;
-#elif PRESENTATIONFRAMEWORK
-    using MS.Internal.PresentationFramework;
-#elif DRT
-    using MS.Internal.Drt;
-#else
-using MS.Internal.YourAssemblyName;
-#endif
-
-// Disable pragma warnings to enable PREsharp pragmas
-#pragma warning disable 1634, 1691
+using System.Threading;
+using MS.Internal;
+using System;
 
 namespace MS.Win32
 {
@@ -45,8 +27,7 @@ namespace MS.Win32
             // messages sent to the window very early in the process.
             foreach (HwndWrapperHook hook in hooks)
             {
-                if (hook is not null)
-                    AddHook(hook);
+                AddHook(hook);
             }
 
             _wndProc = new HwndWrapperHook(WndProc);
@@ -161,17 +142,14 @@ namespace MS.Win32
                 return;
             }
 
-            if(disposing)
+            if (disposing)
             {
                 // diposing == false means we're being called from the finalizer
                 // and can't follow any reference types that may themselves be
                 // finalizable - thus don't call the Disposed callback.
 
                 // Notify listeners that we are being disposed.
-                if(Disposed != null)
-                {
-                    Disposed(this, EventArgs.Empty);
-                }
+                Disposed?.Invoke(this, EventArgs.Empty);
             }
 
             // We are now considered disposed.
@@ -223,7 +201,7 @@ namespace MS.Win32
 
         internal void AddHookLast(HwndWrapperHook hook)
         {
-            _hooks ??= [];
+            _hooks ??= new WeakReferenceList();
             _hooks.Add(hook);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapperHook.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapperHook.cs
@@ -3,19 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Security;
-
-#if WINDOWS_BASE
-    using MS.Internal.WindowsBase;
-#elif PRESENTATION_CORE
-    using MS.Internal.PresentationCore;
-#elif PRESENTATIONFRAMEWORK
-    using MS.Internal.PresentationFramework;
-#elif DRT
-    using MS.Internal.Drt;
-#else
-using MS.Internal.YourAssemblyName;
-#endif
 
 namespace MS.Win32
 {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/MessageOnlyHwndWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/MessageOnlyHwndWrapper.cs
@@ -2,19 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Threading;
-using System.Security ; 
-using System.Runtime.InteropServices;
-
 namespace MS.Win32
 {
-    // Specialized version of HwndWrapper for message-only windows.
-
-    internal class MessageOnlyHwndWrapper : HwndWrapper
+    /// <summary>
+    /// Specialized version of <see cref="HwndWrapper"/> for message-only windows.
+    /// </summary>
+    internal sealed class MessageOnlyHwndWrapper : HwndWrapper
     {
-        public MessageOnlyHwndWrapper() : base(0, 0, 0, 0, 0, 0, 0, "", NativeMethods.HWND_MESSAGE)
-        {
-        }
+        public MessageOnlyHwndWrapper() : base(0, 0, 0, 0, 0, 0, 0, string.Empty, NativeMethods.HWND_MESSAGE) { }
+
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/MessageOnlyHwndWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/MessageOnlyHwndWrapper.cs
@@ -13,7 +13,7 @@ namespace MS.Win32
 
     internal class MessageOnlyHwndWrapper : HwndWrapper
     {
-        public MessageOnlyHwndWrapper() : base(0, 0, 0, 0, 0, 0, 0, "", NativeMethods.HWND_MESSAGE, null)
+        public MessageOnlyHwndWrapper() : base(0, 0, 0, 0, 0, 0, 0, "", NativeMethods.HWND_MESSAGE)
         {
         }
     }


### PR DESCRIPTION
## Description

Avoids creation of temporary heap array when initiating `HwndWrapper`, contributing to startup performance.

- I've also replaced `""` with `string.Empty` to use singletons in the API calls.
- I've also modified the hwnd class-name creation to avoid some allocations, logic of course stays the same. (to be honest, the best would be to cache the assembly name in case you're creating multiple windows, this needs to be retrieved everytime though #8567 has optimized this to at least be just 1 call per invocation but could be zero after 1st retrieval, really).
- Tons of unnecessary usings from touched files were removed.
- Also removes `HWND` struct as a bonus (one of many, this one is unsed and also not particularly perfect).

## Customer Impact

Increased performance, decreased allocations.

## Regression

No.

## Testing

Local build, app run.

## Risk

Low.
