### PR TITLE
Keep apphostpack version in sync with targeting and runtime pack version

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <RuntimeIdentifier Condition="'$(PlatformTarget)' == ''">win-x86</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(PlatformTarget)' != ''">win-$(PlatformTarget)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(Platform)' == ''">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(Platform)' != ''">win-$(Platform)</RuntimeIdentifier>
   </PropertyGroup>
 
   <!-- Pre-download vcxproj dependencies as vcxprojs in this repo don't support NuGet package download. -->

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -1,0 +1,15 @@
+<Project>
+
+  <PropertyGroup>
+    <RuntimeIdentifier Condition="'$(PlatformTarget)' == ''">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(PlatformTarget)' != ''">win-$(PlatformTarget)</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <!-- Pre-download vcxproj dependencies as vcxprojs in this repo don't support NuGet package download. -->
+  <ItemGroup>
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(MicrosoftNETCoreAppRefVersion)]" Condition="'$(MicrosoftNETCoreAppRefVersion)' != ''" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)" Version="[$(MicrosoftNETCoreAppRuntimewinx64Version)]" Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''" />
+    <PackageDownload Include="Microsoft.NETCore.App.Host.$(RuntimeIdentifier)" Version="[$(MicrosoftNETCoreAppRuntimewinx64Version)]" Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''" />
+  </ItemGroup>
+
+</Project>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -1,15 +1,15 @@
 <Project>
 
   <PropertyGroup>
-    <RuntimeIdentifier Condition="'$(Platform)' == ''">win-x86</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(Platform)' != ''">win-$(Platform)</RuntimeIdentifier>
+    <_RuntimeIdentifier Condition="'$(Platform)' == ''">win-x86</_RuntimeIdentifier>
+    <_RuntimeIdentifier Condition="'$(Platform)' != ''">win-$(Platform)</_RuntimeIdentifier>
   </PropertyGroup>
 
   <!-- Pre-download vcxproj dependencies as vcxprojs in this repo don't support NuGet package download. -->
   <ItemGroup>
     <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(MicrosoftNETCoreAppRefVersion)]" Condition="'$(MicrosoftNETCoreAppRefVersion)' != ''" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)" Version="[$(MicrosoftNETCoreAppRuntimewinx64Version)]" Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''" />
-    <PackageDownload Include="Microsoft.NETCore.App.Host.$(RuntimeIdentifier)" Version="[$(MicrosoftNETCoreAppRuntimewinx64Version)]" Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.$(_RuntimeIdentifier)" Version="[$(MicrosoftNETCoreAppRuntimewinx64Version)]" Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''" />
+    <PackageDownload Include="Microsoft.NETCore.App.Host.$(_RuntimeIdentifier)" Version="[$(MicrosoftNETCoreAppRuntimewinx64Version)]" Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''" />
   </ItemGroup>
 
 </Project>

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -21,6 +21,10 @@
       <TargetingPackVersion>$(MicrosoftNETCoreAppRefVersion)</TargetingPackVersion>
     </FrameworkReference>
 
+    <KnownAppHostPack Update="Microsoft.NETCore.App"
+                      AppHostPackVersion="$(RuntimeFrameworkVersion)"
+                      Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''" />
+
     <!--
       Workaround - this should be removed when our tests are converted from Microsoft.NET.Sdk.WindowsDesktop => Microsoft.NET.Sdk
       project

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -19,6 +19,7 @@
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <!-- The below logic intentionally doesn't consider multiple .NETCoreApp TFMs as that isn't necessary at this point. -->
   <PropertyGroup>
     <UseOOBNETCoreAppTargetingPack Condition="'$(UseOOBNETCoreAppTargetingPack)' == ''">true</UseOOBNETCoreAppTargetingPack>
     <UseOOBNETCoreAppRuntimePack Condition="'$(UseOOBNETCoreAppRuntimePack)' == ''">true</UseOOBNETCoreAppRuntimePack>
@@ -51,7 +52,8 @@
   </ItemGroup>
 
   <!-- Update paths for resolved packs which is necessary when the packs couldn't be resolved.
-       This happens when package download is disabled and the package isn't available in the SDK's packs folder. -->
+       This happens when package download is disabled and the package isn't available in the SDK's packs folder.
+       This entire target can be removed when vcxproj's NuGet support gets enabled. -->
   <Target Name="UpdateOOBPacks"
           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
           AfterTargets="ResolveFrameworkReferences">

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -20,9 +20,9 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <UseOOBNETCoreAppTargetingPack>true</UseOOBNETCoreAppTargetingPack>
-    <UseOOBNETCoreAppRuntimePack>true</UseOOBNETCoreAppRuntimePack>
-    <UseOOBNETCoreAppAppHostPack>true</UseOOBNETCoreAppAppHostPack>
+    <UseOOBNETCoreAppTargetingPack Condition="'$(UseOOBNETCoreAppTargetingPack)' == ''">true</UseOOBNETCoreAppTargetingPack>
+    <UseOOBNETCoreAppRuntimePack Condition="'$(UseOOBNETCoreAppRuntimePack)' == ''">true</UseOOBNETCoreAppRuntimePack>
+    <UseOOBNETCoreAppAppHostPack Condition="'$(UseOOBNETCoreAppAppHostPack)' == ''">true</UseOOBNETCoreAppAppHostPack>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -53,6 +53,7 @@
   <!-- Update paths for resolved packs which is necessary when the packs couldn't be resolved.
        This happens when package download is disabled and the package isn't available in the SDK's packs folder. -->
   <Target Name="UpdateOOBPacks"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
           AfterTargets="ResolveFrameworkReferences">
     <ItemGroup>
       <Error Text="'MicrosoftNETCoreAppRefVersion' is not set. Please set it to the version of the targeting pack you want to use." Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(MicrosoftNETCoreAppRefVersion)' == ''" />
@@ -66,11 +67,17 @@
       <ResolvedRuntimePack PackageDirectory="$(NuGetPackageRoot)microsoft.netcore.app.runtime.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRuntimewinx64Version)"
                            NuGetPackageVersion="$(MicrosoftNETCoreAppRuntimewinx64Version)"
                            Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(EnableRuntimePackDownload)' == 'false' and '%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App'" />
+    </ItemGroup>
 
+    <PropertyGroup>
+      <_ResolvedRuntimePackPath>@(ResolvedRuntimePack->WithMetdataValue('FrameworkName', 'Microsoft.NETCore.App')->Metadata('Path'))</_ResolvedRuntimePackPath>
+    </PropertyGroup>
+
+    <ItemGroup>
       <ResolvedFrameworkReference Condition="'%(Identity)' == 'Microsoft.NETCore.App'">
         <TargetingPackPath Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(EnableTargetingPackDownload)' == 'false'">$(NuGetPackageRoot)microsoft.netcore.app.ref\$(MicrosoftNETCoreAppRefVersion)</TargetingPackPath>
         <TargetingPackVersion Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(EnableTargetingPackDownload)' == 'false'">$(MicrosoftNETCoreAppRefVersion)</TargetingPackVersion>
-        <RuntimePackPath Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(EnableRuntimePackDownload)' == 'false'">$(NuGetPackageRoot)microsoft.netcore.app.runtime.win-x86\$(MicrosoftNETCoreAppRuntimewinx64Version)</RuntimePackPath>
+        <RuntimePackPath Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(EnableRuntimePackDownload)' == 'false'">$(_ResolvedRuntimePackPath)</RuntimePackPath>
         <RuntimePackVersion Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(EnableRuntimePackDownload)' == 'false'">$(MicrosoftNETCoreAppRuntimewinx64Version)</RuntimePackVersion>
       </ResolvedFrameworkReference>
 

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -12,19 +12,6 @@
                                 Version="$(MicrosoftNETCorePlatformsVersion)"
                                 Condition="'$(ManagedCxx)'=='true'"/>
 
-    <FrameworkReference Update="Microsoft.NETCore.App"
-                      Condition="'$(MicrosoftNETCoreAppRefVersion)'!=''
-                             And '$(NoTargets)'!='true'
-                             And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-                             And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0'))
-                             And '$(MSBuildProjectExtension)'!='.vcxproj'">
-      <TargetingPackVersion>$(MicrosoftNETCoreAppRefVersion)</TargetingPackVersion>
-    </FrameworkReference>
-
-    <KnownAppHostPack Update="Microsoft.NETCore.App"
-                      AppHostPackVersion="$(RuntimeFrameworkVersion)"
-                      Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''" />
-
     <!--
       Workaround - this should be removed when our tests are converted from Microsoft.NET.Sdk.WindowsDesktop => Microsoft.NET.Sdk
       project
@@ -33,10 +20,76 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)'!='' And
-                                        '$(NoTargets)'!='true' And
-                                        '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
-                                        $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0')) And
-                                        '$(MSBuildProjectExtension)'!='.vcxproj'">$(MicrosoftNETCoreAppRuntimewinx64Version)</RuntimeFrameworkVersion>
+    <UseOOBNETCoreAppTargetingPack>true</UseOOBNETCoreAppTargetingPack>
+    <UseOOBNETCoreAppRuntimePack>true</UseOOBNETCoreAppRuntimePack>
+    <UseOOBNETCoreAppAppHostPack>true</UseOOBNETCoreAppAppHostPack>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- vcxproj don't support restore -->
+    <EnableTargetingPackDownload Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(MSBuildProjectExtension)' == '.vcxproj'">false</EnableTargetingPackDownload>
+    <EnableRuntimePackDownload Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(MSBuildProjectExtension)' == '.vcxproj'">false</EnableRuntimePackDownload>
+    <GenerateErrorForMissingTargetingPacks Condition="'$(EnableTargetingPackDownload)' == 'false'">false</GenerateErrorForMissingTargetingPacks>
+
+    <EnableAppHostPackDownload Condition="'$(UseOOBNETCoreAppAppHostPack)' == 'true' and '$(MSBuildProjectExtension)' == '.vcxproj'">false</EnableAppHostPackDownload>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <KnownFrameworkReference Update="Microsoft.NETCore.App">
+      <TargetingPackVersion Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true'">$(MicrosoftNETCoreAppRefVersion)</TargetingPackVersion>
+      <DefaultRuntimeFrameworkVersion Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true'">$(MicrosoftNETCoreAppRuntimewinx64Version)</DefaultRuntimeFrameworkVersion>
+      <LatestRuntimeFrameworkVersion Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true'">$(MicrosoftNETCoreAppRuntimewinx64Version)</LatestRuntimeFrameworkVersion>
+    </KnownFrameworkReference>
+
+    <KnownRuntimePack Update="Microsoft.NETCore.App"
+                      LatestRuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimewinx64Version)"
+                      Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true'" />
+
+    <KnownAppHostPack Update="Microsoft.NETCore.App"
+                      AppHostPackVersion="$(MicrosoftNETCoreAppRuntimewinx64Version)"
+                      Condition="'$(UseOOBNETCoreAppAppHostPack)' == 'true'" />
+  </ItemGroup>
+
+  <!-- Update paths for resolved packs which is necessary when the packs couldn't be resolved.
+       This happens when package download is disabled and the package isn't available in the SDK's packs folder. -->
+  <Target Name="UpdateOOBPacks"
+          AfterTargets="ResolveFrameworkReferences">
+    <ItemGroup>
+      <Error Text="'MicrosoftNETCoreAppRefVersion' is not set. Please set it to the version of the targeting pack you want to use." Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(MicrosoftNETCoreAppRefVersion)' == ''" />
+      <Error Text="'MicrosoftNETCoreAppRuntimewinx64Version' is not set. Please set it to the version of the runtime pack you want to use." Condition="('$(UseOOBNETCoreAppRuntimePack)' == 'true' or '$(UseOOBNETCoreAppAppHostPack)' == 'true') and '$(MicrosoftNETCoreAppRuntimewinx64Version)' == ''" />
+
+      <ResolvedTargetingPack Path="$(NuGetPackageRoot)microsoft.netcore.app.ref\$(MicrosoftNETCoreAppRefVersion)"
+                             NuGetPackageVersion="$(MicrosoftNETCoreAppRefVersion)"
+                             PackageDirectory="$(NuGetPackageRoot)microsoft.netcore.app.ref\$(MicrosoftNETCoreAppRefVersion)"
+                             Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(EnableTargetingPackDownload)' == 'false' and '%(ResolvedTargetingPack.RuntimeFrameworkName)' == 'Microsoft.NETCore.App'" />
+
+      <ResolvedRuntimePack PackageDirectory="$(NuGetPackageRoot)microsoft.netcore.app.runtime.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRuntimewinx64Version)"
+                           NuGetPackageVersion="$(MicrosoftNETCoreAppRuntimewinx64Version)"
+                           Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(EnableRuntimePackDownload)' == 'false' and '%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App'" />
+
+      <ResolvedFrameworkReference Condition="'%(Identity)' == 'Microsoft.NETCore.App'">
+        <TargetingPackPath Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(EnableTargetingPackDownload)' == 'false'">$(NuGetPackageRoot)microsoft.netcore.app.ref\$(MicrosoftNETCoreAppRefVersion)</TargetingPackPath>
+        <TargetingPackVersion Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(EnableTargetingPackDownload)' == 'false'">$(MicrosoftNETCoreAppRefVersion)</TargetingPackVersion>
+        <RuntimePackPath Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(EnableRuntimePackDownload)' == 'false'">$(NuGetPackageRoot)microsoft.netcore.app.runtime.win-x86\$(MicrosoftNETCoreAppRuntimewinx64Version)</RuntimePackPath>
+        <RuntimePackVersion Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(EnableRuntimePackDownload)' == 'false'">$(MicrosoftNETCoreAppRuntimewinx64Version)</RuntimePackVersion>
+      </ResolvedFrameworkReference>
+
+      <ResolvedAppHostPack Path="$(NuGetPackageRoot)microsoft.netcore.app.host.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRuntimewinx64Version)\%(ResolvedAppHostPack.PathInPackage)"
+                           PackageDirectory="$(NuGetPackageRoot)microsoft.netcore.app.host.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRuntimewinx64Version)"
+                           Condition="'$(UseOOBNETCoreAppAppHostPack)' == 'true' and '$(EnableAppHostPackDownload)' == 'false'" />
+
+      <ResolvedIjwHostPack Path="$(NuGetPackageRoot)microsoft.netcore.app.host.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRuntimewinx64Version)\%(ResolvedIjwHostPack.PathInPackage)"
+                           PackageDirectory="$(NuGetPackageRoot)microsoft.netcore.app.host.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRuntimewinx64Version)"
+                           Condition="'$(UseOOBNETCoreAppAppHostPack)' == 'true' and '$(EnableAppHostPackDownload)' == 'false'" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'@(ResolvedAppHostPack)' != '' And '$(AppHostSourcePath)' == ''">
+      <AppHostSourcePath>@(ResolvedAppHostPack->'%(Path)')</AppHostSourcePath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'@(ResolvedIjwHostPack)' != '' And '$(IjwHostSourcePath)' == ''">
+      <IjwHostSourcePath>@(ResolvedIjwHostPack->'%(Path)')</IjwHostSourcePath>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -70,7 +70,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_ResolvedRuntimePackPath>@(ResolvedRuntimePack->WithMetdataValue('FrameworkName', 'Microsoft.NETCore.App')->Metadata('Path'))</_ResolvedRuntimePackPath>
+      <_ResolvedRuntimePackPath>@(ResolvedRuntimePack->WithMetadataValue('FrameworkName', 'Microsoft.NETCore.App')->Metadata('Path'))</_ResolvedRuntimePackPath>
     </PropertyGroup>
 
     <ItemGroup>

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -21,18 +21,9 @@
 
   <!-- The below logic intentionally doesn't consider multiple .NETCoreApp TFMs as that isn't necessary at this point. -->
   <PropertyGroup>
-    <UseOOBNETCoreAppTargetingPack Condition="'$(UseOOBNETCoreAppTargetingPack)' == ''">true</UseOOBNETCoreAppTargetingPack>
-    <UseOOBNETCoreAppRuntimePack Condition="'$(UseOOBNETCoreAppRuntimePack)' == ''">true</UseOOBNETCoreAppRuntimePack>
-    <UseOOBNETCoreAppAppHostPack Condition="'$(UseOOBNETCoreAppAppHostPack)' == ''">true</UseOOBNETCoreAppAppHostPack>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <!-- vcxproj don't support restore -->
-    <EnableTargetingPackDownload Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(MSBuildProjectExtension)' == '.vcxproj'">false</EnableTargetingPackDownload>
-    <EnableRuntimePackDownload Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(MSBuildProjectExtension)' == '.vcxproj'">false</EnableRuntimePackDownload>
-    <GenerateErrorForMissingTargetingPacks Condition="'$(EnableTargetingPackDownload)' == 'false'">false</GenerateErrorForMissingTargetingPacks>
-
-    <EnableAppHostPackDownload Condition="'$(UseOOBNETCoreAppAppHostPack)' == 'true' and '$(MSBuildProjectExtension)' == '.vcxproj'">false</EnableAppHostPackDownload>
+    <UseOOBNETCoreAppTargetingPack Condition="'$(UseOOBNETCoreAppTargetingPack)' == '' and '$(MicrosoftNETCoreAppRefVersion)' != ''">true</UseOOBNETCoreAppTargetingPack>
+    <UseOOBNETCoreAppRuntimePack Condition="'$(UseOOBNETCoreAppRuntimePack)' == '' and '$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''">true</UseOOBNETCoreAppRuntimePack>
+    <UseOOBNETCoreAppAppHostPack Condition="'$(UseOOBNETCoreAppAppHostPack)' == '' and '$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''">true</UseOOBNETCoreAppAppHostPack>
   </PropertyGroup>
 
   <ItemGroup>
@@ -50,6 +41,15 @@
                       AppHostPackVersion="$(MicrosoftNETCoreAppRuntimewinx64Version)"
                       Condition="'$(UseOOBNETCoreAppAppHostPack)' == 'true'" />
   </ItemGroup>
+
+  <!-- These properties can be removed when vcxproj's NuGet support gets enabled. -->
+  <PropertyGroup>
+    <EnableTargetingPackDownload Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(MSBuildProjectExtension)' == '.vcxproj'">false</EnableTargetingPackDownload>
+    <EnableRuntimePackDownload Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(MSBuildProjectExtension)' == '.vcxproj'">false</EnableRuntimePackDownload>
+    <GenerateErrorForMissingTargetingPacks Condition="'$(EnableTargetingPackDownload)' == 'false'">false</GenerateErrorForMissingTargetingPacks>
+
+    <EnableAppHostPackDownload Condition="'$(UseOOBNETCoreAppAppHostPack)' == 'true' and '$(MSBuildProjectExtension)' == '.vcxproj'">false</EnableAppHostPackDownload>
+  </PropertyGroup>
 
   <!-- Update paths for resolved packs which is necessary when the packs couldn't be resolved.
        This happens when package download is disabled and the package isn't available in the SDK's packs folder.


### PR DESCRIPTION
Unblocks https://github.com/dotnet/sdk/pull/43015
Alternative to https://github.com/dotnet/wpf/pull/10028

WPF uses vcxprojs which don't support downloading PackageReferences via NuGet. There's an experimental feature switch but enabling that didn't work (see https://github.com/dotnet/wpf/pull/10028). Therefore, vcxprojs are dependent on the pre-downloaded "packs" folder content in the SDK layout.
Today, wpf projects target `net9.0` with a 9.0 SDK but when building the repo inside the VMR, a 10.0.100-alpha SDK is used. That SDK only contains 10.0.0-alpha targeting packs, runtime packs and apphosts. But as wpf targets net9.0 it needs the 9.0.0 assets. The solution to that is using the "live" runtime assets to not depend on the SDK.
This repo already uses live assets from runtime but that logic is disabled for vcxprojs and didn't include apphost packs. This PR enables that.

The Tools.props change and the added target in `RuntimeFrameworkReference.targets` can be deleted when vcxprojs support NuGet restore. I don't want to block the SDK PR on such a change though as that might take longer.

Fixes # <!-- Issue Number -->

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10030)