### PR TITLE
fixing build error for PrintSystemPathResolver

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/src/PrintSystemPathResolver.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/src/PrintSystemPathResolver.cpp
@@ -305,7 +305,7 @@ ValidateAndCaptureServerName(
         {
             if (serverName->StartsWith("\\\\", StringComparison::Ordinal))
             {
-                isValid = isValid & (serverName->IndexOf('\\', 3) < 0);
+                isValid = isValid & (serverName->IndexOf(L'\\', 3) < 0);
             }
         }
     }
@@ -414,7 +414,7 @@ ValidateUNCName(
            (!(name->IndexOf(',') >= 0))             &&
            name->StartsWith("\\\\", StringComparison::Ordinal)                 &&
            (!(name->StartsWith("\\\\\\", StringComparison::Ordinal)))          &&
-           (name->IndexOf('\\', 3) >= 0))
+           (name->IndexOf(L'\\', 3) >= 0))
         {
             isValid = true;
         }
@@ -470,7 +470,7 @@ ValidateUNCPath(
            (!(name->IndexOf(',') >= 0))             &&
            name->StartsWith("\\\\", StringComparison::Ordinal)                 &&
            (!(name->StartsWith("\\\\\\", StringComparison::Ordinal)))          &&
-           (name->IndexOf('\\', 3) >= 0)            &&
+           (name->IndexOf(L'\\', 3) >= 0)            &&
            (!(name->StartsWith("\\\\http://", StringComparison::OrdinalIgnoreCase))))
         {
             isValid = true;


### PR DESCRIPTION
## Description

We recently encountered the following build error in WPF:

C:\Users\X\source\repos\wpf\src\Microsoft.DotNet.Wpf\src\System.Printing\CPP\src\PrintSystemPathResolver.cpp(308,50): error C5307: 'int System::String::IndexOf(wchar_t,int)': argument (1) converted from 'char' to 'wchar_t'. Missing 'L' encoding-prefix for character literal? [C:\Users\ X\source\repos\wpf\src\Microsoft.DotNet.Wpf\src\System.Printing\System.Printing.vcxproj]

**Cause**
The error suggests that the IndexOf method expects a wchar_t type for the character literal, but a char is currently being passed. This is due to recent changes in the IndexOf method for System::String or updates in compiler behavior.

**Fix**
This PR addresses the issue by converting the character to a wide character using the L prefix, ensuring compatibility with the expected wchar_t type.

## Testing

Built locally

## Risk

Low, doesn't introduce any behavior change

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10056)