### PR TITLE
[Cleanup] Use named arguments in System.Xaml

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
@@ -168,7 +168,7 @@ namespace MS.Internal.Xaml.Context
 
         internal AmbientPropertyValue ServiceProvider_GetFirstAmbientValue(IEnumerable<XamlType> ceilingTypes, XamlMember[] properties)
         {
-            List<AmbientPropertyValue> valueList = FindAmbientValues(ceilingTypes, /*searchLiveStackOnly*/false, /*types*/null, properties, true);
+            List<AmbientPropertyValue> valueList = FindAmbientValues(ceilingTypes, searchLiveStackOnly: false, types: null, properties, true);
             return (valueList.Count == 0) ? null : valueList[0];
         }
 
@@ -180,7 +180,7 @@ namespace MS.Internal.Xaml.Context
 
         internal IEnumerable<AmbientPropertyValue> ServiceProvider_GetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, XamlMember[] properties)
         {
-            List<AmbientPropertyValue> valueList = FindAmbientValues(ceilingTypes, /*searchLiveStackOnly*/false, /*types*/null, properties, /*stopAfterFirst*/ false);
+            List<AmbientPropertyValue> valueList = FindAmbientValues(ceilingTypes, searchLiveStackOnly: false, types: null, properties, stopAfterFirst: false);
             return valueList;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -129,7 +129,7 @@ namespace System.Xaml
             }
             if (result is null)
             {
-                result = new ClrObjectRuntime(runtimeSettings, true /*isWriter*/);
+                result = new ClrObjectRuntime(runtimeSettings, isWriter: true);
             }
             result.LineInfo = this;
             return result;
@@ -604,7 +604,7 @@ namespace System.Xaml
 
             // Duplicate Property Setting Check.
             //
-            Logic_DuplicatePropertyCheck(_context, property, false /*onParent*/);
+            Logic_DuplicatePropertyCheck(_context, property, onParent: false);
 
             // If we haven't created the object yet then consider creating it now.
             // We need an object instance to set property values on.
@@ -1529,7 +1529,7 @@ namespace System.Xaml
                     }
                     else
                     {
-                        Logic_ApplyPropertyValue(ctx, prop, value, false /*onParent*/);
+                        Logic_ApplyPropertyValue(ctx, prop, value, onParent: false);
                     }
                 }
             }
@@ -2009,7 +2009,7 @@ namespace System.Xaml
 
                         if (!ctx.CurrentIsObjectFromMember)
                         {
-                            Logic_ApplyPropertyValue(ctx, parentProperty, value, true /*onParent*/);
+                            Logic_ApplyPropertyValue(ctx, parentProperty, value, onParent: true);
 
                             // registered a named object
                             if (parentProperty == parentType.GetAliasedProperty(XamlLanguage.Name))

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlTextReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlTextReader.cs
@@ -111,7 +111,7 @@ namespace System.Xaml
             _endOfStreamNode = new InternalNode(InternalNodeType.EndOfStream);
 
             _context = (XamlParserContext)XamlContext.CreateContext(UsageMode.Parser, schemaContext,
-                                                            _mergedSettings.LocalAssembly, false /*ignoreCanConvert*/);
+                                                            _mergedSettings.LocalAssembly, ignoreCanConvert: false);
 
             XamlScanner xamlScanner = new XamlScanner(_context, myXmlReader, _mergedSettings);
             XamlPullParser parser = new XamlPullParser(_context, xamlScanner, _mergedSettings);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
@@ -321,14 +321,14 @@ namespace MS.Internal.Xaml.Parser
 
             if (propName.IsDotted)
             {
-                prop = _context.GetDottedProperty(tagType, tagNamespace, propName, false /*tagIsRoot*/);
+                prop = _context.GetDottedProperty(tagType, tagNamespace, propName, tagIsRoot: false);
             }
             // Regular property p
             else
             {
                 string ns = _context.GetAttributeNamespace(propName, Namespace);
                 declaringType = _context.CurrentType;
-                prop = _context.GetNoDotAttributeProperty(declaringType, propName, Namespace, ns, false /*tagIsRoot*/);
+                prop = _context.GetNoDotAttributeProperty(declaringType, propName, Namespace, ns, tagIsRoot: false);
             }
             _tokenProperty = prop;
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlAttribute.cs
@@ -152,7 +152,7 @@ namespace MS.Internal.Xaml.Parser
                 if (propName.IsDotted)
                 {
                     XamlType attachedOwnerType = new XamlType(string.Empty, propName.OwnerName, null, context.SchemaContext);
-                    unknownProperty = new XamlMember(propName.Name, attachedOwnerType, true /*isAttachable*/);
+                    unknownProperty = new XamlMember(propName.Name, attachedOwnerType, isAttachable: true);
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/DynamicMethodRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/DynamicMethodRuntime.cs
@@ -122,7 +122,7 @@ namespace MS.Internal.Xaml.Runtime
 
         internal DynamicMethodRuntime(XamlRuntimeSettings settings, XamlSchemaContext schemaContext,
             XamlAccessLevel accessLevel)
-            : base(settings, true /*isWriter*/)
+            : base(settings, isWriter: true)
         {
             Debug.Assert(schemaContext is not null);
             Debug.Assert(accessLevel is not null);
@@ -130,7 +130,7 @@ namespace MS.Internal.Xaml.Runtime
             _localAssembly = Assembly.Load(accessLevel.AssemblyAccessToAssemblyName);
             if (accessLevel.PrivateAccessToTypeName is not null)
             {
-                _localType = _localAssembly.GetType(accessLevel.PrivateAccessToTypeName, true /*throwOnError*/);
+                _localType = _localAssembly.GetType(accessLevel.PrivateAccessToTypeName, throwOnError: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/PartialTrustTolerantRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/PartialTrustTolerantRuntime.cs
@@ -37,7 +37,7 @@ namespace MS.Internal.Xaml.Runtime
 
         public PartialTrustTolerantRuntime(XamlRuntimeSettings runtimeSettings, XamlAccessLevel accessLevel, XamlSchemaContext schemaContext)
         {
-            _transparentRuntime = new ClrObjectRuntime(runtimeSettings, true /*isWriter*/);
+            _transparentRuntime = new ClrObjectRuntime(runtimeSettings, isWriter: true);
             _accessLevel = accessLevel;
             _schemaContext = schemaContext;
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/CollectionReflector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/CollectionReflector.cs
@@ -65,11 +65,11 @@ namespace System.Xaml.Schema
             }
 
             // If the type doesn't match any of the interfaces, check for Add methods
-            if (TryGetDictionaryAdder(type, false /*mayBeIDictionary*/, out addMethod))
+            if (TryGetDictionaryAdder(type, mayBeIDictionary: false, out addMethod))
             {
                 return XamlCollectionKind.Dictionary;
             }
-            if (TryGetCollectionAdder(type, false /*mayBeICollection*/, out addMethod))
+            if (TryGetCollectionAdder(type, mayBeICollection: false, out addMethod))
             {
                 return XamlCollectionKind.Collection;
             }
@@ -83,14 +83,14 @@ namespace System.Xaml.Schema
             switch (collectionKind)
             {
                 case XamlCollectionKind.Collection:
-                    bool isCollection = TryGetCollectionAdder(type, true /*mayBeICollection*/, out result);
+                    bool isCollection = TryGetCollectionAdder(type, mayBeICollection: true, out result);
                     if (isCollection && result is null)
                     {
                         throw new XamlSchemaException(SR.Format(SR.AmbiguousCollectionItemType, type));
                     }
                     break;
                 case XamlCollectionKind.Dictionary:
-                    bool isDictionary = TryGetDictionaryAdder(type, true /*mayBeIDictionary*/, out result);
+                    bool isDictionary = TryGetDictionaryAdder(type, mayBeIDictionary: true, out result);
                     if (isDictionary && result is null)
                     {
                         throw new XamlSchemaException(SR.Format(SR.AmbiguousDictionaryItemType, type));

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/Reflector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/Reflector.cs
@@ -66,7 +66,7 @@ namespace System.Xaml.Schema
                 // Passes inherit=true for reasons explained in comment on XamlType.TryGetAttributeString
                 checkedInherited = true;
 
-                object[] attributes = CustomAttributeProvider.GetCustomAttributes(attributeType, true /*inherit*/);
+                object[] attributes = CustomAttributeProvider.GetCustomAttributes(attributeType, inherit: true);
                 if (attributes.Length == 0)
                 {
                     return null;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeReflector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeReflector.cs
@@ -754,7 +754,7 @@ namespace System.Xaml.Schema
             string adderName = KnownStrings.Add + name + KnownStrings.Handler;
             MemberInfo[] adders = UnderlyingType.GetMember(adderName, MemberTypes.Method, AttachableProperties_BF);
             List<MethodInfo> preferredAdders, otherAdders;
-            PrioritizeAccessors(adders, true /*isEvent*/, false /*isGetter*/, out preferredAdders, out otherAdders);
+            PrioritizeAccessors(adders, isEvent: true, isGetter: false, out preferredAdders, out otherAdders);
             return preferredAdders ?? otherAdders;
         }
 
@@ -762,7 +762,7 @@ namespace System.Xaml.Schema
         {
             MemberInfo[] getters = UnderlyingType.GetMember(KnownStrings.Get + name, MemberTypes.Method, AttachableProperties_BF);
             List<MethodInfo> preferredGetters, otherGetters;
-            PrioritizeAccessors(getters, false /*isEvent*/, true /*isGetter*/, out preferredGetters, out otherGetters);
+            PrioritizeAccessors(getters, isEvent: false, isGetter: true, out preferredGetters, out otherGetters);
             return preferredGetters ?? otherGetters;
         }
 
@@ -770,7 +770,7 @@ namespace System.Xaml.Schema
         {
             MemberInfo[] setters = UnderlyingType.GetMember(KnownStrings.Set + name, MemberTypes.Method, AttachableProperties_BF);
             List<MethodInfo> preferredSetters, otherSetters;
-            PrioritizeAccessors(setters, false /*isEvent*/, false /*isGetter*/, out preferredSetters, out otherSetters);
+            PrioritizeAccessors(setters, isEvent: false, isGetter: false, out preferredSetters, out otherSetters);
             return preferredSetters ?? otherSetters;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XmlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XmlNamespace.cs
@@ -75,7 +75,7 @@ namespace System.Xaml.Schema
             if (directive == null)
             {
                 directive = new UnknownProperty(name,
-                                                null, /*declaringType - xml directives don't have one. */
+                                                declaringType: null, /* xml directives don't have a declaring type. */
                                                 XmlDirectives.Uri);
             }
             return directive;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMember.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMember.cs
@@ -45,7 +45,7 @@ namespace System.Xaml
         }
 
         public XamlMember(PropertyInfo propertyInfo, XamlSchemaContext schemaContext, XamlMemberInvoker invoker)
-            : this(propertyInfo, schemaContext, invoker, new MemberReflector(false /*isEvent*/))
+            : this(propertyInfo, schemaContext, invoker, new MemberReflector(isEvent: false))
         {
         }
 
@@ -68,7 +68,7 @@ namespace System.Xaml
         }
 
         public XamlMember(EventInfo eventInfo, XamlSchemaContext schemaContext, XamlMemberInvoker invoker)
-            :this(eventInfo, schemaContext, invoker, new MemberReflector(true /*isEvent*/))
+            :this(eventInfo, schemaContext, invoker, new MemberReflector(isEvent: true))
         {
         }
 
@@ -93,7 +93,7 @@ namespace System.Xaml
 
         public XamlMember(string attachablePropertyName, MethodInfo getter, MethodInfo setter,
             XamlSchemaContext schemaContext, XamlMemberInvoker invoker)
-            :this(attachablePropertyName, getter, setter, schemaContext, invoker, new MemberReflector(getter, setter, false /*isEvent*/))
+            :this(attachablePropertyName, getter, setter, schemaContext, invoker, new MemberReflector(getter, setter, isEvent: false))
         {
         }
 
@@ -126,7 +126,7 @@ namespace System.Xaml
 
         public XamlMember(string attachableEventName, MethodInfo adder, XamlSchemaContext schemaContext,
             XamlMemberInvoker invoker)
-            : this(attachableEventName, adder, schemaContext, invoker, new MemberReflector(null, adder, true /*isEvent*/))
+            : this(attachableEventName, adder, schemaContext, invoker, new MemberReflector(null, adder, isEvent: true))
         {
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
@@ -529,7 +529,7 @@ namespace System.Xaml
 
             static MemberMarkupInfo ForSequence(object source, XamlMember property, SerializerContext context, bool isAttachable)
             {
-                var itemsInfo = ForSequenceItems(source, isAttachable ? null : property, property.Type, context, false /*allowReadOnly*/);
+                var itemsInfo = ForSequenceItems(source, isAttachable ? null : property, property.Type, context, allowReadOnly: false);
                 if (itemsInfo is not null && itemsInfo.Children.Count != 0)
                 {
                     return new MemberMarkupInfo
@@ -1197,7 +1197,7 @@ namespace System.Xaml
                 }
                 else if (xamlType.IsCollection)
                 {
-                    propertyInfo = MemberMarkupInfo.ForSequenceItems(value, null, xamlType, context, true /*allowReadOnly*/);
+                    propertyInfo = MemberMarkupInfo.ForSequenceItems(value, null, xamlType, context, allowReadOnly: true);
                 }
 
                 if (propertyInfo is not null && propertyInfo.Children.Count != 0)
@@ -2485,7 +2485,7 @@ namespace System.Xaml
                 prefixToNamespaceMap = new Dictionary<string, string>();
                 ReferenceTable = new ReferenceTable(null);
                 this.schemaContext = schemaContext;
-                runtime = new ClrObjectRuntime(null, false /*isWriter*/);
+                runtime = new ClrObjectRuntime(null, isWriter: false);
                 this.settings = settings;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
@@ -334,7 +334,7 @@ namespace System.Xaml
             XamlMember result;
             if (!_reflector.Members.TryGetValue(name, out result) && !_reflector.Members.IsComplete)
             {
-                result = LookupMember(name, false /*skipReadOnlyCheck*/);
+                result = LookupMember(name, skipReadOnlyCheck: false);
                 result = _reflector.Members.TryAdd(name, result);
             }
             return result;
@@ -755,7 +755,7 @@ namespace System.Xaml
                 {
                     return null;
                 }
-                return GetPropertyOrUnknown(contentPropertyName, false /*skipReadOnlyCheck*/);
+                return GetPropertyOrUnknown(contentPropertyName, skipReadOnlyCheck: false);
             }
             if (BaseType is not null)
             {
@@ -1430,7 +1430,7 @@ namespace System.Xaml
             XamlMember result = skipReadOnlyCheck ? LookupMember(propertyName, true) : GetMember(propertyName);
             if (result is null)
             {
-                result = new XamlMember(propertyName, this /*declaringType*/, false /*isAttachable*/);
+                result = new XamlMember(propertyName, declaringType: this, isAttachable: false);
             }
             return result;
         }


### PR DESCRIPTION
Contributes to dotnet/wpf#10018

## Description
I replaced comments specifying an argument name with named arguments, which were introduced in C# 7. This improves readability and maintainability.

**Note: The compiled IL is identical.**

## Customer Impact
None.

## Regression
No.

## Testing
Local build + validated IL.

## Risk
Low to none.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10061)