### PR TITLE
Keep the Button HorizontalAlignment be Center in Fluent style

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Button.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Button.xaml
@@ -38,7 +38,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
         <Setter Property="BorderThickness" Value="{StaticResource ButtonBorderThemeThickness}" />
         <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
-        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="HorizontalAlignment" Value="Center" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />


### PR DESCRIPTION
Fixes #10077



## Description

In the Fluent style, ensure that the `HorizontalAlignment` property of buttons is set to `Center`. This helps maintain consistent behavior with previous styles.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
Maintaining consistent behavior allows developers to more easily apply the Fluent theme without worrying about layout changes due to style switches.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
See https://github.com/dotnet/wpf/pull/8870

## Testing

<!-- What kind of testing has been done with the fix. -->
Just CI and Snoop

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low. This potentially breaking scenarios where buttons relying on the Fluent style are left-aligned. Therefore, I believe the sooner this change is merged, the lower the risk will be, as fewer developers will depend on buttons being left-aligned.