### PR TITLE
Fix ArgumentNullException when Expander is expanded, and Theme is Changed

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Expander.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Expander.xaml
@@ -366,13 +366,6 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
-                                            <SplineDoubleKeyFrame
-                                                KeySpline="0.0, 0.0, 0.0, 1.0"
-                                                KeyTime="0:0:0.333"
-                                                Value="0.0" />
-                                        </DoubleAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.EnterActions>
@@ -383,13 +376,6 @@
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                             <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
-                                            <SplineDoubleKeyFrame
-                                                KeySpline="1.0, 1.0, 0.0, 1.0"
-                                                KeyTime="0:0:0.333"
-                                                Value="1.0" />
-                                        </DoubleAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.ExitActions>
@@ -411,13 +397,6 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="-1.0" />
-                                            <SplineDoubleKeyFrame
-                                                KeySpline="0.0, 0.0, 0.0, 1.0"
-                                                KeyTime="0:0:0.333"
-                                                Value="0.0" />
-                                        </DoubleAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.EnterActions>
@@ -428,13 +407,6 @@
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                             <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
-                                            <SplineDoubleKeyFrame
-                                                KeySpline="1.0, 1.0, 0.0, 1.0"
-                                                KeyTime="0:0:0.333"
-                                                Value="-1.0" />
-                                        </DoubleAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.ExitActions>
@@ -456,13 +428,6 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="-1.0" />
-                                            <SplineDoubleKeyFrame
-                                                KeySpline="0.0, 0.0, 0.0, 1.0"
-                                                KeyTime="0:0:0.333"
-                                                Value="0.0" />
-                                        </DoubleAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.EnterActions>
@@ -473,13 +438,6 @@
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                             <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
-                                            <SplineDoubleKeyFrame
-                                                KeySpline="1.0, 1.0, 0.0, 1.0"
-                                                KeyTime="0:0:0.333"
-                                                Value="-1.0" />
-                                        </DoubleAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.ExitActions>
@@ -501,13 +459,6 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
-                                            <SplineDoubleKeyFrame
-                                                    KeySpline="0.0, 0.0, 0.0, 1.0"
-                                                    KeyTime="0:0:0.333"
-                                                    Value="0.0" />
-                                        </DoubleAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.EnterActions>
@@ -518,13 +469,6 @@
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                             <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
-                                            <SplineDoubleKeyFrame
-                                                    KeySpline="1.0, 1.0, 0.0, 1.0"
-                                                    KeyTime="0:0:0.333"
-                                                    Value="1.0" />
-                                        </DoubleAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.ExitActions>


### PR DESCRIPTION
Fixes https://github.com/microsoft/WPF-Samples/issues/672


## Description

Tag Property wasn't being used, and this was causing ArgumentNullException when the Expander was expanded, and the Theme was changed.
## Customer Impact
Not taking this fix would cause a ArgumentNullException when the Expander is expanded, and the Theme is changed
## Regression


## Testing
Sample App Testing
## Risk
Low
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10086)