### PR TITLE
Fluent backdrop and windows 10 fix

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Appearance/WindowBackdropManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Appearance/WindowBackdropManager.cs
@@ -117,14 +117,8 @@ internal static class WindowBackdropManager
             if (windowSource?.Handle != IntPtr.Zero && windowSource.CompositionTarget != null)
             {
                 // If the window is in light mode, set the background color to #FFFAFAFA and for dark mode set it to #FF202020
-                if(WindowThemeIsLight(windowSource))
-                {
-                    windowSource.CompositionTarget.BackgroundColor = (Color)ColorConverter.ConvertFromString("#FFFAFAFA");
-                }
-                else
-                {
-                    windowSource.CompositionTarget.BackgroundColor = (Color)ColorConverter.ConvertFromString("#FF202020");
-                }
+                windowSource.CompositionTarget.BackgroundColor = WindowOnLightMode(windowSource) ?
+                    (Color)ColorConverter.ConvertFromString(_lightWindowBackgroundCompositionColor) : (Color)ColorConverter.ConvertFromString(_darkWindowBackgroundCompositionColor);;
 
                 return true;
             }
@@ -133,16 +127,22 @@ internal static class WindowBackdropManager
         return false;
     }
 
-    private static bool WindowThemeIsLight(HwndSource hwndSource)
+    /// <summary>
+    /// This method checks if the window associated with the hwndSource should be in light mode or not depending on Window's ThemeMode, Application's ThemeMode and System's Theme.
+    /// </summary>
+    /// <param name="hwndSource"></param>
+    /// <returns>True if window should be in light mode, false otherwise</returns>
+    private static bool WindowOnLightMode(HwndSource hwndSource)
     {
         Window window = hwndSource.RootVisual as Window;
 
         if(window is null)
         {
-            return true; // TODO: We were unconditionally changing the CompositionTarget earlier so this shouldn't really affect what is happening but verify if this is the correct behaviour
+            // We were unconditionally assuming that windowSource needs to have the mode as light even if window was null earlier. Doing the same here to ensure parity.
+            return true;
         }
 
-        if(window.ThemeMode == ThemeMode.Light ||
+        if (window.ThemeMode == ThemeMode.Light ||
             (window.ThemeMode == ThemeMode.System && ThemeManager.IsSystemThemeLight()) ||
             (window.ThemeMode == ThemeMode.None && Application.Current?.ThemeMode == ThemeMode.Light) ||
             (window.ThemeMode == ThemeMode.None && Application.Current?.ThemeMode == ThemeMode.System && ThemeManager.IsSystemThemeLight()))
@@ -173,6 +173,10 @@ internal static class WindowBackdropManager
                                                                         !FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop;
 
     private static bool? _isBackdropEnabled = null;
+
+    private const string _lightWindowBackgroundCompositionColor = "#FFFAFAFA";
+
+    private const string _darkWindowBackgroundCompositionColor = "#FF202020";
 
     #endregion
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Appearance/WindowBackdropManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Appearance/WindowBackdropManager.cs
@@ -113,13 +113,43 @@ internal static class WindowBackdropManager
     {
         if (hwnd != IntPtr.Zero)
         {
-            var windowSource = HwndSource.FromHwnd(hwnd);
+            HwndSource windowSource = HwndSource.FromHwnd(hwnd);
             if (windowSource?.Handle != IntPtr.Zero && windowSource.CompositionTarget != null)
             {
-                windowSource.CompositionTarget.BackgroundColor = SystemColors.WindowColor;
+                // If the window is in light mode, set the background color to #FFFAFAFA and for dark mode set it to #FF202020
+                if(WindowThemeIsLight(windowSource))
+                {
+                    windowSource.CompositionTarget.BackgroundColor = (Color)ColorConverter.ConvertFromString("#FFFAFAFA");
+                }
+                else
+                {
+                    windowSource.CompositionTarget.BackgroundColor = (Color)ColorConverter.ConvertFromString("#FF202020");
+                }
+
                 return true;
             }
         }
+
+        return false;
+    }
+
+    private static bool WindowThemeIsLight(HwndSource hwndSource)
+    {
+        Window window = hwndSource.RootVisual as Window;
+
+        if(window is null)
+        {
+            return true; // TODO: We were unconditionally changing the CompositionTarget earlier so this shouldn't really affect what is happening but verify if this is the correct behaviour
+        }
+
+        if(window.ThemeMode == ThemeMode.Light ||
+            (window.ThemeMode == ThemeMode.System && ThemeManager.IsSystemThemeLight()) ||
+            (window.ThemeMode == ThemeMode.None && Application.Current?.ThemeMode == ThemeMode.Light) ||
+            (window.ThemeMode == ThemeMode.None && Application.Current?.ThemeMode == ThemeMode.System && ThemeManager.IsSystemThemeLight()))
+        {
+            return true;
+        }
+
         return false;
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Appearance/WindowBackdropManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Appearance/WindowBackdropManager.cs
@@ -25,10 +25,7 @@ internal static class WindowBackdropManager
 
     internal static bool SetBackdrop(Window window, WindowBackdropType backdropType)
     {
-        if (window is null ||
-                !IsSupported(backdropType) ||
-                window.AllowsTransparency ||
-                IsBackdropEnabled == false)
+        if (window is null || window.AllowsTransparency)
         {
             return false;
         }
@@ -42,6 +39,11 @@ internal static class WindowBackdropManager
         if (handle == IntPtr.Zero)
         {
             return false;
+        }
+
+        if(!IsSupported(backdropType) || IsBackdropEnabled == false)
+        {
+            return SetBackdropCore(handle, WindowBackdropType.None);
         }
 
         return SetBackdropCore(handle, backdropType);
@@ -99,7 +101,7 @@ internal static class WindowBackdropManager
             var windowSource = HwndSource.FromHwnd(hwnd);
             if (windowSource.CompositionTarget != null)
             {
-                // TODO : Save the previous background color and reapply in RestoreBackground 
+                // TODO : Save the previous background color and reapply in RestoreBackground
                 windowSource.CompositionTarget.BackgroundColor = Colors.Transparent;
                 return true;
             }
@@ -137,7 +139,7 @@ internal static class WindowBackdropManager
 
     #region Internal Properties
 
-    internal static bool IsBackdropEnabled => _isBackdropEnabled ??= Utility.IsWindows11_22H2OrNewer && 
+    internal static bool IsBackdropEnabled => _isBackdropEnabled ??= Utility.IsWindows11_22H2OrNewer &&
                                                                         !FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop;
 
     private static bool? _isBackdropEnabled = null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
@@ -1,7 +1,7 @@
 using Standard;
 using Microsoft.Win32;
 using System.Collections;
-using System.Collections.ObjectModel; 
+using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -133,7 +133,7 @@ internal static class ThemeManager
             Application.Current.ThemeMode = themeMode;
             return themeMode == ThemeMode.None ? false : true;
         }
-        
+
         return false;
     }
 
@@ -186,14 +186,14 @@ internal static class ThemeManager
 
         ResourceDictionary rd = null;
         bool useLightColors = GetUseLightColors(themeMode);
-        
+
         if (themeMode == ThemeMode.System)
         {
             rd = new ResourceDictionary() { Source = new Uri(FluentThemeResourceDictionaryUri + "Fluent.xaml", UriKind.Absolute) };
 
             var colorFileName = useLightColors ? "Light.xaml" : "Dark.xaml";
             Uri dictionaryUri = new Uri(FluentColorDictionaryUri + colorFileName, UriKind.Absolute);
-            rd.MergedDictionaries.Insert(0, new ResourceDictionary() { Source = dictionaryUri });            
+            rd.MergedDictionaries.Insert(0, new ResourceDictionary() { Source = dictionaryUri });
         }
         else
         {
@@ -291,7 +291,7 @@ internal static class ThemeManager
         if (window == null || window.IsDisposed)
             return;
 
-        // We only apply Style on window, if the Window.Style has not already been set to avoid overriding users setting. 
+        // We only apply Style on window, if the Window.Style has not already been set to avoid overriding users setting.
         if (window.Style == null)
         {
             window.SetResourceReference(FrameworkElement.StyleProperty, typeof(Window));
@@ -450,7 +450,7 @@ internal static class ThemeManager
         return indices;
     }
 
-    private static bool IsSystemThemeLight()
+    internal static bool IsSystemThemeLight()
     {
         var useLightTheme = Registry.GetValue(RegPersonalizeKeyPath,
             "AppsUseLightTheme", null) as int?;

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Window.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Window.xaml
@@ -75,9 +75,6 @@
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
                 <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
             </DataTrigger>
-            <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
-                <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
-            </DataTrigger>  
         </Style.Triggers>
     </Style>
 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -4804,9 +4804,6 @@
       <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
         <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
       </DataTrigger>
-      <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
-        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
-      </DataTrigger>
     </Style.Triggers>
   </Style>
   <Style BasedOn="{StaticResource DefaultWindowStyle}" TargetType="{x:Type Window}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -4782,9 +4782,6 @@
       <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
         <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
       </DataTrigger>
-      <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
-        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
-      </DataTrigger>
     </Style.Triggers>
   </Style>
   <Style BasedOn="{StaticResource DefaultWindowStyle}" TargetType="{x:Type Window}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -4802,9 +4802,6 @@
       <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
         <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
       </DataTrigger>
-      <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
-        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
-      </DataTrigger>
     </Style.Triggers>
   </Style>
   <Style BasedOn="{StaticResource DefaultWindowStyle}" TargetType="{x:Type Window}" />


### PR DESCRIPTION
## Description
Fluent applications require disabling of backdrop for them to work in windows 10. The changes here make fluent themes work without any additional requirements in windows 10. This is a draft of changes to track the problem, magnitude of changes and test things out in release/9.0. Will be raising a same set of changes for the main branch (with better explanation of the fix) after verifying/resolving a few more aspects.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10097)