### PR TITLE
Don't enable transitive references in tests

### DIFF
--- a/Microsoft.Dotnet.Wpf.sln
+++ b/Microsoft.Dotnet.Wpf.sln
@@ -379,6 +379,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Windows.Primitives",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Windows.Primitives-ref", "src\Microsoft.DotNet.Wpf\src\System.Windows.Primitives\ref\System.Windows.Primitives-ref.csproj", "{0EFFC7C4-B486-4852-8CED-EDEB46E02C42}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PresentationFramework.Fluent.Tests", "src\Microsoft.DotNet.Wpf\tests\UnitTests\PresentationFramework.Fluent.Tests\PresentationFramework.Fluent.Tests.csproj", "{56833D74-2D0B-5516-C1D6-B93D4FFF7612}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|arm64 = Debug|arm64
@@ -1639,6 +1641,18 @@ Global
 		{0EFFC7C4-B486-4852-8CED-EDEB46E02C42}.Release|x64.Build.0 = Release|Any CPU
 		{0EFFC7C4-B486-4852-8CED-EDEB46E02C42}.Release|x86.ActiveCfg = Release|Any CPU
 		{0EFFC7C4-B486-4852-8CED-EDEB46E02C42}.Release|x86.Build.0 = Release|Any CPU
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612}.Debug|arm64.ActiveCfg = Debug|arm64
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612}.Debug|arm64.Build.0 = Debug|arm64
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612}.Debug|x64.ActiveCfg = Debug|x64
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612}.Debug|x64.Build.0 = Debug|x64
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612}.Debug|x86.ActiveCfg = Debug|x86
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612}.Debug|x86.Build.0 = Debug|x86
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612}.Release|arm64.ActiveCfg = Release|arm64
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612}.Release|arm64.Build.0 = Release|arm64
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612}.Release|x64.ActiveCfg = Release|x64
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612}.Release|x64.Build.0 = Release|x64
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612}.Release|x86.ActiveCfg = Release|x86
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1765,6 +1779,7 @@ Global
 		{C70269FA-2569-48B7-B246-A263BBC5698F} = {8F62A3BF-C618-49B1-8B09-82C32C3427BB}
 		{5306FA93-178C-4535-ADEE-86B1DE1B68CB} = {2EE4A2DA-70B3-4767-9D18-618DA0FE3105}
 		{0EFFC7C4-B486-4852-8CED-EDEB46E02C42} = {D0AED517-9972-41CB-8751-983E4EB8F511}
+		{56833D74-2D0B-5516-C1D6-B93D4FFF7612} = {A48B585E-6AB0-4F8D-8484-77F37CB44437}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B4340004-DAC0-497D-B69D-CFA7CD93F567}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/LibraryAssemblyInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/LibraryAssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("WindowsBase.Tests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("PresentationFramework.Fluent.Tests, PublicKey=00000000000000000400000000000000")]

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <Compile Include="$(WpfCommonDir)\src\System\LocalAppContext.cs" />
     <Compile Include="$(WpfCommonDir)\src\System\AppContextDefaultValues.cs" />
+    <Compile Include="LibraryAssemblyInfo.cs" />
     <Compile Include="System\AppContextDefaultValues.cs" />
 
     <Compile Include="$(WpfCommonDir)src\System\SR.cs">

--- a/src/Microsoft.DotNet.Wpf/tests/Directory.Build.props
+++ b/src/Microsoft.DotNet.Wpf/tests/Directory.Build.props
@@ -4,6 +4,6 @@
     <IsShipping>false</IsShipping>
     <CLSCompliant>false</CLSCompliant>
     <CopyTransitiveReferences>true</CopyTransitiveReferences>
-    <DisableTransitiveProjectReferences>false</DisableTransitiveProjectReferences>
+    <DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/GlobalUsings.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/GlobalUsings.cs
@@ -1,0 +1,7 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+global using Xunit;
+#pragma warning disable IDE0005 // Using directive is unnecessary. New project, this will be used.
+global using FluentAssertions;
+#pragma warning restore IDE0005

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/PresentationFramework.Fluent.Tests.csproj
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/PresentationFramework.Fluent.Tests.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
+    <Platforms>x64;x86;arm64</Platforms>
+    <RootNamespace />
+    <TargetFramework Condition="!$(TargetFramework.Contains('windows'))">$(TargetFramework)-windows</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
+    <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MicrosoftPrivateWinFormsReference Include="System.Private.Windows.Core" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)System.Windows.Primitives\System.Windows.Primitives.csproj" />
+
+    <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)DirectWriteForwarder\DirectWriteForwarder.vcxproj">
+      <UndefineProperties>TargetFramework;TargetFrameworks</UndefineProperties>
+    </ProjectReference>
+    <ProjectReference Include="$(WpfSourceDir)System.Xaml\System.Xaml.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)UIAutomation\UIAutomationTypes\UIAutomationTypes.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)UIAutomation\UIAutomationProvider\UIAutomationProvider.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/System/Windows/Controls/ButtonTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/System/Windows/Controls/ButtonTests.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Controls;
+
+public class ButtonTests
+{
+    [WpfFact]
+    public void Button_Create()
+    {
+        Button button = new();
+    }
+}


### PR DESCRIPTION
Most of the projects include references to ref and cycle breaker projects. This breaks tests as they will pick the wrong assemblies.

Create a stub PresentationFramework.Fluent.Tests project to validate.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10103)