### PR TITLE
Start using System.Private.Windows.Core.TestUtilities

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -84,7 +84,7 @@
   </PropertyGroup>
   <!-- XUnit-related (not extensions) -->
   <PropertyGroup>
-    <XUnitVersion>2.9.0</XUnitVersion>
+    <XUnitVersion>2.9.2</XUnitVersion>
     <XUnitAssertVersion>$(XUnitVersion)</XUnitAssertVersion>
     <XUnitRunnerConsoleVersion>$(XUnitVersion)</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualStudioVersion>2.8.1</XUnitRunnerVisualStudioVersion>
@@ -99,6 +99,8 @@
     <SystemDrawingCommonTestDataVersion>8.0.0-beta.23107.1</SystemDrawingCommonTestDataVersion>
     <SystemWindowsExtensionsTestDataVersion>8.0.0-beta.23107.1</SystemWindowsExtensionsTestDataVersion>
     <VerifyXunitVersion>14.2.0</VerifyXunitVersion>
+    <!-- Shared test utilities with WinForms -->
+    <SystemPrivateWindowsCoreTestUtilitiesVersion>10.0.0-alpha.1.24571.3</SystemPrivateWindowsCoreTestUtilitiesVersion>
   </PropertyGroup>
   <!-- Code Coverage -->
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/ArrayTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/ArrayTests.cs
@@ -1,11 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace PresentationCore.Tests.BinaryFormat;
 
 public class ArrayTests
 {
-    public static TheoryData<string?[]> StringArray_Parse_Data => new()
+    public static TheoryData<Array> StringArray_Parse_Data => new()
      {
          new string?[] { "one", "two" },
          new string?[] { "yes", "no", null },
@@ -20,7 +20,7 @@ public class ArrayTests
          new DateTime[] { DateTime.MaxValue }
      };
 
-    public static IEnumerable<object[]> Array_TestData => StringArray_Parse_Data.Concat(PrimitiveArray_Parse_Data);
+    public static IEnumerable<object[]> Array_TestData => ((IEnumerable<object[]>)StringArray_Parse_Data).Concat(PrimitiveArray_Parse_Data);
 
     public static TheoryData<Array> Array_UnsupportedTestData => new()
      {

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/BinaryFormatWriterTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/BinaryFormatWriterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -102,7 +102,7 @@ public class BinaryFormatWriterTests
     }
 
     public static IEnumerable<object[]?> TryWriteObject_SupportedObjects_TestData =>
-        HashtableTests.Hashtables_TestData.Concat(
+        ((IEnumerable<object[]?>)HashtableTests.Hashtables_TestData).Concat(
             ListTests.PrimitiveLists_TestData).Concat(
             ListTests.ArrayLists_TestData).Concat(
             PrimitiveTypeTests.Primitive_Data).Concat(
@@ -110,7 +110,7 @@ public class BinaryFormatWriterTests
             ArrayTests.Array_TestData);
 
     public static IEnumerable<object[]?> TryWriteObject_UnsupportedObjects_TestData =>
-        HashtableTests.Hashtables_UnsupportedTestData.Concat(
+        ((IEnumerable<object[]?>)HashtableTests.Hashtables_UnsupportedTestData).Concat(
             ListTests.Lists_UnsupportedTestData).Concat(
             ListTests.ArrayLists_UnsupportedTestData).Concat(
             ArrayTests.Array_UnsupportedTestData);

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/System/Windows/SplashScreenTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/System/Windows/SplashScreenTests.cs
@@ -15,6 +15,8 @@ public class SplashScreenTests
     public void Create()
     {
         SplashScreen splash = new(typeof(SplashScreenTests).Assembly, "Needle");
+        string resourceName = splash.TestAccessor().Dynamic._resourceName;
+        resourceName.Should().Be("needle");
         splash.Show(autoClose: true);
     }
 }

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/WindowsBase.Tests.csproj
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/WindowsBase.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
+    <PackageReference Include="System.Private.Windows.Core.TestUtilities" Version="$(SystemPrivateWindowsCoreTestUtilitiesVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`System.Private.Windows.Core.TestUtilities` is a test utilities package that comes from WinForms that is meant to be shared with WPF to take advantage of test utilities that we have in WinForms such as `TestAccessors`. This change takes the test utilities package in `WindowsBase.Tests` (bumping xunit version is needed) and shows how TestAccessors can be used to validate private fields within a class.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10104)