### PR TITLE
Fix: RadioButton incorrect Uncheck when VisualRoot is null 

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -161,7 +161,7 @@ namespace System.Windows.Controls
                         else
                         {
                             // Uncheck all checked RadioButtons different from the current one
-                            if (rb != this && (rb.IsChecked == true) && rootScope == KeyboardNavigation.GetVisualRoot(rb) && rootScope != null)
+                            if (rb != this && (rb.IsChecked == true) && rootScope == KeyboardNavigation.GetVisualRoot(rb))
                                 rb.UncheckRadioButton();
                             i++;
                         }


### PR DESCRIPTION
This reverts commit 647fadd7ffd5601dbbfb8812f62878d03a132919.

Fixes #10087

## Description
As described in the issue above, this is an unintended side-effect of the original fix. Reverting the same here. 
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Expected behaviour of a radio button within a group, operating on pop-up like windows.

<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local build pass.
Verified that the reported issue is resolved.
Multiple sample application testings.
<!-- What kind of testing has been done with the fix. -->

## Risk
Low, Restoring to previous behaviour.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10105)