### PR TITLE
Add null check for `relativeTo` parameter in `GetTabletToElementTransform`

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerStylusDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerStylusDevice.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1142,7 +1142,12 @@ namespace System.Windows.Input.StylusPointer
             Matrix toDevice = _inputSource.CompositionTarget.TransformToDevice;
             toDevice.Invert();
             group.Children.Add(new MatrixTransform(PointerTabletDevice.TabletToScreen * toDevice));
-            group.Children.Add(StylusDevice.GetElementTransform(relativeTo));
+            // If the relativeTo is null, it will add the `Transform.Identity` to the group.
+            // So that we can only add the transform if the relativeTo is not null.
+            if (relativeTo is not null)
+            {
+                group.Children.Add(StylusDevice.GetElementTransform(relativeTo));
+            }
             return group;
         }
 


### PR DESCRIPTION


Fixes # <!-- Issue Number -->

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

Modified the `GetTabletToElementTransform` method to include a null check for the `relativeTo` parameter. The `StylusDevice.GetElementTransform(relativeTo)` is now only added to the `group` when `relativeTo` is not null. This change reduces unnecessary method calls when `relativeTo` is null, minimizes allocations of the FrugalStructList within the `GeneralTransformCollection`, and enhances performance.

## Customer Impact

https://github.com/dotnet/wpf/pull/9663

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->

Just CI

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

Low. There are no logical dependencies. And the behavior before and after the code changes is identical.