### PR TITLE
Opt-In: Dyanmic Resource Optimization

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
@@ -11,7 +11,7 @@ namespace System
         /// <summary>
         /// This is a partial method. This method is responsible for populating the default values based on a TFM.
         /// It is partial because each library should define this method in their code to contain their defaults.
-        /// </summary> 
+        /// </summary>
         static partial void PopulateDefaultValuesPartial(string platformIdentifier, string profile, int targetFrameworkVersion)
         {
             // When building PresentationFramework, 'LocalAppContext' from WindowsBase.dll conflicts
@@ -32,6 +32,7 @@ namespace System
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.KeyboardNavigationFromHyperlinkInItemsControlIsNotRelativeToFocusedElementSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.ItemAutomationPeerKeepsItsItemAliveSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableFluentThemeWindowBackdropSwitchName, false);
+            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableDynamicResourceOptimizationSwitchName, true);
 
 #pragma warning restore CS0436 // Type conflicts with imported type
         }


### PR DESCRIPTION
Fixes #10020 

## Description
The usage of dynamic resource was optimized as part of our initiative in the changes [here](https://github.com/dotnet/wpf/pull/5610). As in the issue above, we have observed issues related to freezing of resources which are not meant to frozen at a particular stage and this is causing some breaking changes. Following up on the discussions in the issue mentioned above, we have made this feature as an opt-in to garner more such feedbacks if and when available and work on fixing it for the next release.

## Customer Impact
Fixes crashing applications without the need to disable the provided opt-out switch
<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
Sample Application Testing
Failure Testing
Community Test Pass
<!-- What kind of testing has been done with the fix. -->

## Risk
None, changing things back to original case by default. Using Dynamic Resource optimizations via the switch can cause occasional crashing of application, in which case, the switch can be defaulted to true.

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
