### PR TITLE
Fluent: Adding Resource Key to TabItem and TabControl styles

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TabControl.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TabControl.xaml
@@ -179,7 +179,7 @@
         </Grid>
     </ControlTemplate>
 
-    <Style TargetType="{x:Type TabControl}">
+    <Style x:Key="DefaultTabControlStyle" TargetType="{x:Type TabControl}">
         <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
         <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
@@ -207,7 +207,7 @@
             </Style.Triggers>
     </Style>
 
-    <Style TargetType="{x:Type TabItem}">
+    <Style x:Key="DefaultTabItemStyle" TargetType="{x:Type TabItem}">
         <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackground}" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -299,5 +299,8 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style BasedOn="{StaticResource DefaultTabControlStyle}" TargetType="{x:Type TabControl}" />
+    <Style BasedOn="{StaticResource DefaultTabItemStyle}" TargetType="{x:Type TabItem}" />
 
 </ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -4007,7 +4007,7 @@
       </VisualStateManager.VisualStateGroups>
     </Grid>
   </ControlTemplate>
-  <Style TargetType="{x:Type TabControl}">
+  <Style x:Key="DefaultTabControlStyle" TargetType="{x:Type TabControl}">
     <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
     <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
@@ -4032,7 +4032,7 @@
       </Trigger>
     </Style.Triggers>
   </Style>
-  <Style TargetType="{x:Type TabItem}">
+  <Style x:Key="DefaultTabItemStyle" TargetType="{x:Type TabItem}">
     <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackground}" />
     <Setter Property="BorderBrush" Value="Transparent" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -4100,6 +4100,8 @@
       </Setter.Value>
     </Setter>
   </Style>
+  <Style BasedOn="{StaticResource DefaultTabControlStyle}" TargetType="{x:Type TabControl}" />
+  <Style BasedOn="{StaticResource DefaultTabItemStyle}" TargetType="{x:Type TabItem}" />
   <sys:Double x:Key="CaptionTextBlockFontSize">12</sys:Double>
   <sys:Double x:Key="BodyTextBlockFontSize">14</sys:Double>
   <sys:Double x:Key="SubtitleTextBlockFontSize">20</sys:Double>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -3985,7 +3985,7 @@
       </VisualStateManager.VisualStateGroups>
     </Grid>
   </ControlTemplate>
-  <Style TargetType="{x:Type TabControl}">
+  <Style x:Key="DefaultTabControlStyle" TargetType="{x:Type TabControl}">
     <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
     <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
@@ -4010,7 +4010,7 @@
       </Trigger>
     </Style.Triggers>
   </Style>
-  <Style TargetType="{x:Type TabItem}">
+  <Style x:Key="DefaultTabItemStyle" TargetType="{x:Type TabItem}">
     <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackground}" />
     <Setter Property="BorderBrush" Value="Transparent" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -4078,6 +4078,8 @@
       </Setter.Value>
     </Setter>
   </Style>
+  <Style BasedOn="{StaticResource DefaultTabControlStyle}" TargetType="{x:Type TabControl}" />
+  <Style BasedOn="{StaticResource DefaultTabItemStyle}" TargetType="{x:Type TabItem}" />
   <sys:Double x:Key="CaptionTextBlockFontSize">12</sys:Double>
   <sys:Double x:Key="BodyTextBlockFontSize">14</sys:Double>
   <sys:Double x:Key="SubtitleTextBlockFontSize">20</sys:Double>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -4005,7 +4005,7 @@
       </VisualStateManager.VisualStateGroups>
     </Grid>
   </ControlTemplate>
-  <Style TargetType="{x:Type TabControl}">
+  <Style x:Key="DefaultTabControlStyle" TargetType="{x:Type TabControl}">
     <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
     <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
@@ -4030,7 +4030,7 @@
       </Trigger>
     </Style.Triggers>
   </Style>
-  <Style TargetType="{x:Type TabItem}">
+  <Style x:Key="DefaultTabItemStyle" TargetType="{x:Type TabItem}">
     <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackground}" />
     <Setter Property="BorderBrush" Value="Transparent" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -4098,6 +4098,8 @@
       </Setter.Value>
     </Setter>
   </Style>
+  <Style BasedOn="{StaticResource DefaultTabControlStyle}" TargetType="{x:Type TabControl}" />
+  <Style BasedOn="{StaticResource DefaultTabItemStyle}" TargetType="{x:Type TabItem}" />
   <sys:Double x:Key="CaptionTextBlockFontSize">12</sys:Double>
   <sys:Double x:Key="BodyTextBlockFontSize">14</sys:Double>
   <sys:Double x:Key="SubtitleTextBlockFontSize">20</sys:Double>


### PR DESCRIPTION
Provides a workaround for: https://github.com/dotnet/wpf/issues/10054

## Description
The changes here add a `DefaultTabControlStyle` and `DefaultTabItemStyle` in Fluent styles.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Provides a way to use `BasedOn` when overriding tab control styles in Fluent theme. This is also a part of our initiative to have consistent theme style, and resource key value.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
None
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
Sample Application Testing
Testing the Gallery Application
<!-- What kind of testing has been done with the fix. -->

## Risk
Low, simply adding a resource key to the existing style.
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10116)