### PR TITLE
[StyleCleanUp] Addressing SA warnings Part 1

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -317,9 +317,6 @@ dotnet_diagnostic.SA1121.severity = suggestion
 # SA1129: Do not use default value type constructor
 dotnet_diagnostic.SA1129.severity = suggestion
 
-# SA1131: Constant values should appear on the right-hand side of comparisons
-dotnet_diagnostic.SA1131.severity = suggestion
-
 # SA1206: Keyword ordering
 dotnet_diagnostic.SA1206.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -329,9 +329,6 @@ dotnet_diagnostic.SA1400.severity = suggestion
 # SA1404: Code analysis suppression should have justification
 dotnet_diagnostic.SA1404.severity = suggestion
 
-# SA1408: Conditional expressions should declare precedence
-dotnet_diagnostic.SA1408.severity = suggestion
-
 # SA1500: Braces for multi-line statements should not share line
 dotnet_diagnostic.SA1500.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -326,9 +326,6 @@ dotnet_diagnostic.SA1206.severity = suggestion
 # SA1400: Member should declare an access modifier
 dotnet_diagnostic.SA1400.severity = suggestion
 
-# SA1404: Code analysis suppression should have justification
-dotnet_diagnostic.SA1404.severity = suggestion
-
 # SA1500: Braces for multi-line statements should not share line
 dotnet_diagnostic.SA1500.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
@@ -241,7 +241,7 @@ namespace MS.Utility
         {
             // If we don't have any entries or the existing entry is being overwritten,
             // then we can use this store. Otherwise we have to promote.
-            if (0 == _count)
+            if (_count == 0)
             {
                 _loneEntry = value;
                 ++_count;
@@ -322,7 +322,7 @@ namespace MS.Utility
 
         public override void Promote(FrugalListBase<T> oldList)
         {
-            if (SIZE == oldList.Count)
+            if (oldList.Count == SIZE)
             {
                 SetCount(SIZE);
                 SetAt(0, oldList.EntryAt(0));
@@ -424,7 +424,7 @@ namespace MS.Utility
 
         public override bool Contains(T value)
         {
-            return (-1 != IndexOf(value));
+            return (IndexOf(value) != -1);
         }
 
         public override int IndexOf(T value)
@@ -439,7 +439,7 @@ namespace MS.Utility
                 {
                     return 1;
                 }
-                if ((3 == _count) && EqualityComparer<T>.Default.Equals(_entry2, value))
+                if ((_count == 3) && EqualityComparer<T>.Default.Equals(_entry2, value))
                 {
                     return 2;
                 }
@@ -517,7 +517,7 @@ namespace MS.Utility
                     RemoveAt(1);
                     return true;
                 }
-                else if ((3 == _count) && EqualityComparer<T>.Default.Equals(_entry2, value))
+                else if ((_count == 3) && EqualityComparer<T>.Default.Equals(_entry2, value))
                 {
                     RemoveAt(2);
                     return true;
@@ -573,7 +573,7 @@ namespace MS.Utility
         public override void Promote(FrugalListBase<T> oldList)
         {
             int oldCount = oldList.Count;
-            if (SIZE >= oldCount)
+            if (oldCount <= SIZE)
             {
                 SetCount(oldList.Count);
 
@@ -761,7 +761,7 @@ namespace MS.Utility
 
         public override bool Contains(T value)
         {
-            return (-1 != IndexOf(value));
+            return (IndexOf(value) != -1);
         }
 
         public override int IndexOf(T value)
@@ -794,7 +794,7 @@ namespace MS.Utility
                             {
                                 return 4;
                             }
-                            if ((6 == _count) && EqualityComparer<T>.Default.Equals(_entry5, value))
+                            if ((_count == 6) && EqualityComparer<T>.Default.Equals(_entry5, value))
                             {
                                 return 5;
                             }
@@ -932,7 +932,7 @@ namespace MS.Utility
                                 RemoveAt(4);
                                 return true;
                             }
-                            else if ((6 == _count) && EqualityComparer<T>.Default.Equals(_entry5, value))
+                            else if ((_count == 6) && EqualityComparer<T>.Default.Equals(_entry5, value))
                             {
                                 RemoveAt(5);
                                 return true;
@@ -1022,7 +1022,7 @@ namespace MS.Utility
         public override void Promote(FrugalListBase<T> oldList)
         {
             int oldCount = oldList.Count;
-            if (SIZE >= oldCount)
+            if (oldCount <= SIZE)
             {
                 SetCount(oldList.Count);
 
@@ -1085,7 +1085,7 @@ namespace MS.Utility
         public void Promote(ThreeItemList<T> oldList)
         {
             int oldCount = oldList.Count;
-            if (SIZE <= oldCount)
+            if (oldCount >= SIZE)
             {
                 SetCount(oldList.Count);
 
@@ -1396,7 +1396,7 @@ namespace MS.Utility
         {
             for (int index = 0; index < oldList.Count; ++index)
             {
-                if (FrugalListStoreState.Success == Add(oldList.EntryAt(index)))
+                if (Add(oldList.EntryAt(index)) == FrugalListStoreState.Success)
                 {
                     continue;
                 }
@@ -1618,7 +1618,7 @@ namespace MS.Utility
         {
             get
             {
-                if (null != _listStore)
+                if (_listStore != null)
                 {
                     return _listStore.Capacity;
                 }
@@ -1627,7 +1627,7 @@ namespace MS.Utility
             set
             {
                 int capacity = 0;
-                if (null != _listStore)
+                if (_listStore != null)
                 {
                     capacity = _listStore.Capacity;
                 }
@@ -1653,7 +1653,7 @@ namespace MS.Utility
                         newStore = new ArrayItemList<T>(value);
                     }
 
-                    if (null != _listStore)
+                    if (_listStore != null)
                     {
                         // Move entries in the old store to the new one
                         newStore.Promote(_listStore);
@@ -1668,7 +1668,7 @@ namespace MS.Utility
         {
             get
             {
-                if (null != _listStore)
+                if (_listStore != null)
                 {
                     return _listStore.Count;
                 }
@@ -1682,7 +1682,7 @@ namespace MS.Utility
             get
             {
                 // If no entry, default(T) is returned
-                if ((null != _listStore) && ((index < _listStore.Count) && (index >= 0)))
+                if ((_listStore != null) && ((index < _listStore.Count) && (index >= 0)))
                 {
                     return _listStore.EntryAt(index);
                 }
@@ -1692,7 +1692,7 @@ namespace MS.Utility
             set
             {
                 // Ensure write success
-                if ((null != _listStore) && ((index < _listStore.Count) && (index >= 0)))
+                if ((_listStore != null) && ((index < _listStore.Count) && (index >= 0)))
                 {
                     _listStore.SetAt(index, value);
                     return;
@@ -1703,7 +1703,7 @@ namespace MS.Utility
 
         public int Add(T value)
         {
-            if (null != _listStore)
+            if (_listStore != null)
             {
                 // This is done because forward branches
                 // default prediction is not to be taken
@@ -1716,7 +1716,7 @@ namespace MS.Utility
             }
 
             FrugalListStoreState myState = _listStore.Add(value);
-            if (FrugalListStoreState.Success == myState)
+            if (myState == FrugalListStoreState.Success)
             {
             }
             else
@@ -1725,7 +1725,7 @@ namespace MS.Utility
                 // Allocate the store, promote, and add using the derived classes
                 // to avoid virtual method calls
 
-                if (FrugalListStoreState.ThreeItemList == myState)
+                if (myState == FrugalListStoreState.ThreeItemList)
                 {
                     ThreeItemList<T> newStore = new ThreeItemList<T>();
 
@@ -1736,7 +1736,7 @@ namespace MS.Utility
                     newStore.Add(value);
                     _listStore = newStore;
                 }
-                else if (FrugalListStoreState.SixItemList == myState)
+                else if (myState == FrugalListStoreState.SixItemList)
                 {
                     SixItemList<T> newStore = new SixItemList<T>();
 
@@ -1748,7 +1748,7 @@ namespace MS.Utility
                     newStore.Add(value);
                     _listStore = newStore;
                 }
-                else if (FrugalListStoreState.Array == myState)
+                else if (myState == FrugalListStoreState.Array)
                 {
                     ArrayItemList<T> newStore = new ArrayItemList<T>(_listStore.Count + 1);
 
@@ -1770,7 +1770,7 @@ namespace MS.Utility
 
         public void Clear()
         {
-            if (null != _listStore)
+            if (_listStore != null)
             {
                 _listStore.Clear();
             }
@@ -1778,7 +1778,7 @@ namespace MS.Utility
 
         public bool Contains(T value)
         {
-            if ((null != _listStore) && (_listStore.Count > 0))
+            if ((_listStore != null) && (_listStore.Count > 0))
             {
                 return _listStore.Contains(value);
             }
@@ -1787,7 +1787,7 @@ namespace MS.Utility
 
         public int IndexOf(T value)
         {
-            if ((null != _listStore) && (_listStore.Count > 0))
+            if ((_listStore != null) && (_listStore.Count > 0))
             {
                 return _listStore.IndexOf(value);
             }
@@ -1796,12 +1796,12 @@ namespace MS.Utility
 
         public void Insert(int index, T value)
         {
-            if ((index == 0) || ((null != _listStore) && ((index <= _listStore.Count) && (index >= 0))))
+            if ((index == 0) || ((_listStore != null) && ((index <= _listStore.Count) && (index >= 0))))
             {
                 // Make sure we have a place to put the item
                 int minCapacity = 1;
 
-                if ((null != _listStore) && (_listStore.Count == _listStore.Capacity))
+                if ((_listStore != null) && (_listStore.Count == _listStore.Capacity))
                 {
                     // Store is full
                     minCapacity = Capacity + 1;
@@ -1818,7 +1818,7 @@ namespace MS.Utility
 
         public bool Remove(T value)
         {
-            if ((null != _listStore) && (_listStore.Count > 0))
+            if ((_listStore != null) && (_listStore.Count > 0))
             {
                 return _listStore.Remove(value);
             }
@@ -1827,7 +1827,7 @@ namespace MS.Utility
 
         public void RemoveAt(int index)
         {
-            if ((null != _listStore) && ((index < _listStore.Count) && (index >= 0)))
+            if ((_listStore != null) && ((index < _listStore.Count) && (index >= 0)))
             {
                 _listStore.RemoveAt(index);
                 return;
@@ -1857,7 +1857,7 @@ namespace MS.Utility
 
         public T[] ToArray()
         {
-            if ((null != _listStore) && (_listStore.Count > 0))
+            if ((_listStore != null) && (_listStore.Count > 0))
             {
                 return _listStore.ToArray();
             }
@@ -1866,7 +1866,7 @@ namespace MS.Utility
 
         public void CopyTo(T[] array, int index)
         {
-            if ((null != _listStore) && (_listStore.Count > 0))
+            if ((_listStore != null) && (_listStore.Count > 0))
             {
                 _listStore.CopyTo(array, index);
             }
@@ -1876,7 +1876,7 @@ namespace MS.Utility
         {
             FrugalObjectList<T> myClone = new FrugalObjectList<T>();
 
-            if (null != _listStore)
+            if (_listStore != null)
             {
                 myClone._listStore = (FrugalListBase<T>)_listStore.Clone();
             }
@@ -1990,7 +1990,7 @@ namespace MS.Utility
         {
             get
             {
-                if (null != _listStore)
+                if (_listStore != null)
                 {
                     return _listStore.Capacity;
                 }
@@ -1999,7 +1999,7 @@ namespace MS.Utility
             set
             {
                 int capacity = 0;
-                if (null != _listStore)
+                if (_listStore != null)
                 {
                     capacity = _listStore.Capacity;
                 }
@@ -2025,7 +2025,7 @@ namespace MS.Utility
                         newStore = new ArrayItemList<T>(value);
                     }
 
-                    if (null != _listStore)
+                    if (_listStore != null)
                     {
                         // Move entries in the old store to the new one
                         newStore.Promote(_listStore);
@@ -2040,7 +2040,7 @@ namespace MS.Utility
         {
             get
             {
-                if (null != _listStore)
+                if (_listStore != null)
                 {
                     return _listStore.Count;
                 }
@@ -2054,7 +2054,7 @@ namespace MS.Utility
             get
             {
                 // If no entry, default(T) is returned
-                if ((null != _listStore) && ((index < _listStore.Count) && (index >= 0)))
+                if ((_listStore != null) && ((index < _listStore.Count) && (index >= 0)))
                 {
                     return _listStore.EntryAt(index);
                 }
@@ -2064,7 +2064,7 @@ namespace MS.Utility
             set
             {
                 // Ensure write success
-                if ((null != _listStore) && ((index < _listStore.Count) && (index >= 0)))
+                if ((_listStore != null) && ((index < _listStore.Count) && (index >= 0)))
                 {
                     _listStore.SetAt(index, value);
                     return;
@@ -2075,7 +2075,7 @@ namespace MS.Utility
 
         public int Add(T value)
         {
-            if (null != _listStore)
+            if (_listStore != null)
             {
                 // This is done because forward branches
                 // default prediction is not to be taken
@@ -2088,7 +2088,7 @@ namespace MS.Utility
             }
 
             FrugalListStoreState myState = _listStore.Add(value);
-            if (FrugalListStoreState.Success == myState)
+            if (myState == FrugalListStoreState.Success)
             {
             }
             else
@@ -2097,7 +2097,7 @@ namespace MS.Utility
                 // Allocate the store, promote, and add using the derived classes
                 // to avoid virtual method calls
 
-                if (FrugalListStoreState.ThreeItemList == myState)
+                if (myState == FrugalListStoreState.ThreeItemList)
                 {
                     ThreeItemList<T> newStore = new ThreeItemList<T>();
 
@@ -2108,7 +2108,7 @@ namespace MS.Utility
                     newStore.Add(value);
                     _listStore = newStore;
                 }
-                else if (FrugalListStoreState.SixItemList == myState)
+                else if (myState == FrugalListStoreState.SixItemList)
                 {
                     SixItemList<T> newStore = new SixItemList<T>();
 
@@ -2120,7 +2120,7 @@ namespace MS.Utility
                     newStore.Add(value);
                     _listStore = newStore;
                 }
-                else if (FrugalListStoreState.Array == myState)
+                else if (myState == FrugalListStoreState.Array)
                 {
                     ArrayItemList<T> newStore = new ArrayItemList<T>(_listStore.Count + 1);
 
@@ -2142,7 +2142,7 @@ namespace MS.Utility
 
         public void Clear()
         {
-            if (null != _listStore)
+            if (_listStore != null)
             {
                 _listStore.Clear();
             }
@@ -2150,7 +2150,7 @@ namespace MS.Utility
 
         public bool Contains(T value)
         {
-            if ((null != _listStore) && (_listStore.Count > 0))
+            if ((_listStore != null) && (_listStore.Count > 0))
             {
                 return _listStore.Contains(value);
             }
@@ -2159,7 +2159,7 @@ namespace MS.Utility
 
         public int IndexOf(T value)
         {
-            if ((null != _listStore) && (_listStore.Count > 0))
+            if ((_listStore != null) && (_listStore.Count > 0))
             {
                 return _listStore.IndexOf(value);
             }
@@ -2168,12 +2168,12 @@ namespace MS.Utility
 
         public void Insert(int index, T value)
         {
-            if ((index == 0) || ((null != _listStore) && ((index <= _listStore.Count) && (index >= 0))))
+            if ((index == 0) || ((_listStore != null) && ((index <= _listStore.Count) && (index >= 0))))
             {
                 // Make sure we have a place to put the item
                 int minCapacity = 1;
 
-                if ((null != _listStore) && (_listStore.Count == _listStore.Capacity))
+                if ((_listStore != null) && (_listStore.Count == _listStore.Capacity))
                 {
                     // Store is full
                     minCapacity = Capacity + 1;
@@ -2190,7 +2190,7 @@ namespace MS.Utility
 
         public bool Remove(T value)
         {
-            if ((null != _listStore) && (_listStore.Count > 0))
+            if ((_listStore != null) && (_listStore.Count > 0))
             {
                 return _listStore.Remove(value);
             }
@@ -2199,7 +2199,7 @@ namespace MS.Utility
 
         public void RemoveAt(int index)
         {
-            if ((null != _listStore) && ((index < _listStore.Count) && (index >= 0)))
+            if ((_listStore != null) && ((index < _listStore.Count) && (index >= 0)))
             {
                 _listStore.RemoveAt(index);
                 return;
@@ -2229,7 +2229,7 @@ namespace MS.Utility
 
         public T[] ToArray()
         {
-            if ((null != _listStore) && (_listStore.Count > 0))
+            if ((_listStore != null) && (_listStore.Count > 0))
             {
                 return _listStore.ToArray();
             }
@@ -2238,7 +2238,7 @@ namespace MS.Utility
 
         public void CopyTo(T[] array, int index)
         {
-            if ((null != _listStore) && (_listStore.Count > 0))
+            if ((_listStore != null) && (_listStore.Count > 0))
             {
                 _listStore.CopyTo(array, index);
             }
@@ -2248,7 +2248,7 @@ namespace MS.Utility
         {
             FrugalStructList<T> myClone = new FrugalStructList<T>();
 
-            if (null != _listStore)
+            if (_listStore != null)
             {
                 myClone._listStore = (FrugalListBase<T>)_listStore.Clone();
             }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -130,7 +130,7 @@ namespace System.Xaml
         internal static bool IsInternalType(Type type)
         {
             Type origType = type;
-            Debug.Assert(null != type, "Type passed to IsInternalType is null");
+            Debug.Assert(type != null, "Type passed to IsInternalType is null");
 
             // If this is an internal nested type or a parent nested public type, walk up the declaring types.
             while (type.IsNestedAssembly || type.IsNestedFamORAssem || (origType != type && type.IsNestedPublic))
@@ -151,7 +151,7 @@ namespace System.Xaml
         /// <returns>True if type is public</returns>
         internal static bool IsPublicType(Type type)
         {
-            Debug.Assert(null != type, "Type passed to IsPublicType is null");
+            Debug.Assert(type != null, "Type passed to IsPublicType is null");
 
             // If this is a nested internal type, walk up the declaring types.
             while (type.IsNestedPublic)

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
@@ -709,7 +709,7 @@ namespace System.Windows.Markup
                 XmlTextReader xmlTextReader = Reader as XmlTextReader;
 
                 // review, what if not the XmlTextReader.
-                if (null != xmlTextReader)
+                if (xmlTextReader != null)
                 {
                     xmlTextReader.Normalization = value;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/GlobalSuppressions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/GlobalSuppressions.cs
@@ -24,12 +24,12 @@ using System.Diagnostics.CodeAnalysis;
 #endregion
 
 #region Microsoft.Performance suppressions
-[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "MS.Internal.Xaml.Context.ObjectWriterFrame")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "MS.Internal.Xaml.Context.ObjectWriterFrame", Justification = "Non-Breaking")]
 
 // New since v4 RTM:
 
 //this is used by subclasses, bad FxCop detection
-[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "System.Xaml.MS.Impl.FrugalObjectList`1+Compacter")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "System.Xaml.MS.Impl.FrugalObjectList`1+Compacter", Justification = "Non-Breaking")]
 #endregion
 
 #region Microsoft.Naming Suppressions
@@ -42,39 +42,39 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Scope = "member", Target = "System.Windows.Markup.ArrayExtension.#Type", Justification = "Kept for compatibility.")]
 [assembly: SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Scope = "member", Target = "System.Windows.Markup.TypeExtension.#Type", Justification = "Kept for compatibility.")]
 [assembly: SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Scope = "member", Target = "System.Windows.Markup.NameScopePropertyAttribute.#Type", Justification = "Kept for compatibility.")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Uid", Scope = "type", Target = "System.Windows.Markup.UidPropertyAttribute")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Uid", Scope = "member", Target = "System.Xaml.XamlLanguage.#Uid")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Namescope", Scope = "member", Target = "System.Xaml.XamlObjectWriterSettings.#RegisterNamesOnExternalNamescope")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Uids", Scope = "member", Target = "System.Xaml.XamlReaderSettings.#IgnoreUidsOnPropertyElements")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Arity", Scope = "member", Target = "System.Xaml.XamlSchemaContext.#SupportMarkupExtensionsWithDuplicateArity")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Arity", Scope = "member", Target = "System.Xaml.XamlSchemaContextSettings.#SupportMarkupExtensionsWithDuplicateArity")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1703:ResourceStringsShouldBeSpelledCorrectly", MessageId = "Arity", Scope = "resource", Target = "ExceptionStringTable.resources")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#String")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Double")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Int32")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Object")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Char")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Single")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Int16")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Int64")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Decimal")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Uid", Scope = "type", Target = "System.Windows.Markup.UidPropertyAttribute", Justification = "Short for unique identifiers.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Uid", Scope = "member", Target = "System.Xaml.XamlLanguage.#Uid", Justification = "Short for unique identifiers.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Namescope", Scope = "member", Target = "System.Xaml.XamlObjectWriterSettings.#RegisterNamesOnExternalNamescope", Justification ="Will require changes in public API contract.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Uids", Scope = "member", Target = "System.Xaml.XamlReaderSettings.#IgnoreUidsOnPropertyElements", Justification = "Short for unique identifiers.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Arity", Scope = "member", Target = "System.Xaml.XamlSchemaContext.#SupportMarkupExtensionsWithDuplicateArity", Justification ="Will require changes in public API contract.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Arity", Scope = "member", Target = "System.Xaml.XamlSchemaContextSettings.#SupportMarkupExtensionsWithDuplicateArity", Justification ="Will require changes in public API contract.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1703:ResourceStringsShouldBeSpelledCorrectly", MessageId = "Arity", Scope = "resource", Target = "ExceptionStringTable.resources", Justification="Alligns with other instances of same resource.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#String", Justification="Will require changes in public API contract.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Double", Justification="Will require changes in public API contract.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Int32", Justification="Will require changes in public API contract.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Object", Justification="Will require changes in public API contract.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Char", Justification="Will require changes in public API contract.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Single", Justification="Will require changes in public API contract.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Int16", Justification="Will require changes in public API contract.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Int64", Justification="Will require changes in public API contract.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Scope = "member", Target = "System.Xaml.XamlLanguage.#Decimal", Justification="Will require changes in public API contract.")]
 #endregion
 
 #region Microsoft.Usage Suppressions
-[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.ThreeItemList`1.Promote(System.Xaml.MS.Impl.ThreeItemList`1<T>):System.Void")]
-[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.ThreeItemList`1.SetCount(System.Int32):System.Void")]
-[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.ThreeItemList`1.Promote(System.Xaml.MS.Impl.FrugalListBase`1<T>):System.Void")]
-[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.ArrayItemList`1.Promote(System.Xaml.MS.Impl.SixItemList`1<T>):System.Void")]
-[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.ArrayItemList`1.SetCount(System.Int32):System.Void")]
-[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.SingleItemList`1.SetCount(System.Int32):System.Void")]
-[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.SixItemList`1.Promote(System.Xaml.MS.Impl.SixItemList`1<T>):System.Void")]
-[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.SixItemList`1.Promote(System.Xaml.MS.Impl.ThreeItemList`1<T>):System.Void")]
-[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.SixItemList`1.SetCount(System.Int32):System.Void")]
-[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.SixItemList`1.Promote(System.Xaml.MS.Impl.FrugalListBase`1<T>):System.Void")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.ThreeItemList`1.Promote(System.Xaml.MS.Impl.ThreeItemList`1<T>):System.Void", Justification = "Kept for compatibility.")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.ThreeItemList`1.SetCount(System.Int32):System.Void", Justification = "Kept for compatibility.")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.ThreeItemList`1.Promote(System.Xaml.MS.Impl.FrugalListBase`1<T>):System.Void", Justification = "Kept for compatibility.")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.ArrayItemList`1.Promote(System.Xaml.MS.Impl.SixItemList`1<T>):System.Void", Justification = "Kept for compatibility.")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.ArrayItemList`1.SetCount(System.Int32):System.Void", Justification = "Kept for compatibility.")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.SingleItemList`1.SetCount(System.Int32):System.Void", Justification = "Kept for compatibility.")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.SixItemList`1.Promote(System.Xaml.MS.Impl.SixItemList`1<T>):System.Void", Justification = "Kept for compatibility.")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.SixItemList`1.Promote(System.Xaml.MS.Impl.ThreeItemList`1<T>):System.Void", Justification = "Kept for compatibility.")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.SixItemList`1.SetCount(System.Int32):System.Void", Justification = "Kept for compatibility.")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "System.Xaml.MS.Impl.SixItemList`1.Promote(System.Xaml.MS.Impl.FrugalListBase`1<T>):System.Void", Justification = "Kept for compatibility.")]
 #endregion
 
 #region Microsoft.Reliablity Suppressions
 [module: SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", Scope = "member", Target = "System.Xaml.Schema.ClrNamespace.#ParseClrNamespaceUri(System.String)", MessageId = "System.Reflection.Assembly.LoadWithPartialName", Justification = "Back compat.")]
-[module: SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadFile", Scope = "member", Target = "System.Xaml.ReflectionHelper.#LoadAssemblyHelper(System.String,System.String)")]
+[module: SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadFile", Scope = "member", Target = "System.Xaml.ReflectionHelper.#LoadAssemblyHelper(System.String,System.String)", Justification = "Kept for compatibility.")]
 [module: SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadWithPartialName", Scope = "member", Target = "System.Xaml.XamlSchemaContext.#ResolveAssembly(System.String)", Justification = "Need to support load of assemblies from GAC by short name.")]
 #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachablePropertyServices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachablePropertyServices.cs
@@ -83,7 +83,7 @@ namespace System.Xaml
             attachedProperties.SetProperty(instance, name, value);
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1007")]
+        [SuppressMessage("Microsoft.Design", "CA1007", Justification = "Kept for compatibility.")]
         public static bool TryGetProperty(object instance, AttachableMemberIdentifier name, out object value)
         {
             return TryGetProperty<object>(instance, name, out value);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
@@ -267,7 +267,7 @@ namespace MS.Internal.Xaml.Context
         {
             get
             {
-                if (null == _serviceProviderContext)
+                if (_serviceProviderContext != null)
                 {
                     _serviceProviderContext = new ServiceProviderContext(this);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
@@ -267,7 +267,7 @@ namespace MS.Internal.Xaml.Context
         {
             get
             {
-                if (_serviceProviderContext != null)
+                if (_serviceProviderContext is null)
                 {
                     _serviceProviderContext = new ServiceProviderContext(this);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlContext.cs
@@ -185,7 +185,7 @@ namespace MS.Internal.Xaml
                 XamlDirective directive = SchemaContext.GetXamlDirective(propUsageNamespace, propName.Name);
                 if (directive != null)
                 {
-                    if (AllowedMemberLocations.None == (directive.AllowedLocation & AllowedMemberLocations.Attribute))
+                    if ((directive.AllowedLocation & AllowedMemberLocations.Attribute) == AllowedMemberLocations.None)
                     {
                         // Need a way to surface up this usage error now that
                         // we don't have UnknownProperty.Exception

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlParserContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlParserContext.cs
@@ -40,7 +40,7 @@ namespace MS.Internal.Xaml.Context
         {
             string xamlNs;
 
-            if (null != _prescopeNamespaces)
+            if (_prescopeNamespaces != null)
             {
                 if (_prescopeNamespaces.TryGetValue(prefix, out xamlNs))
                 {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IAttachedPropertyStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IAttachedPropertyStore.cs
@@ -29,7 +29,7 @@ namespace System.Xaml
         //  this 'name' then returns false. If the value of the attached property
         //  for this instance with this 'name' cannot be cast to T then returns
         //  false.
-        [SuppressMessage("Microsoft.Design", "CA1007")]
+        [SuppressMessage("Microsoft.Design", "CA1007", Justification = "Kept for compatibility.")]
         bool TryGetProperty(AttachableMemberIdentifier attachableMemberIdentifier, out object value);
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -1096,7 +1096,7 @@ namespace System.Xaml
             }
             if (xamlMember == XamlLanguage.Uid)
             {
-                if (null == xamlType.GetAliasedProperty(XamlLanguage.Uid))
+                if (xamlType.GetAliasedProperty(XamlLanguage.Uid) == null)
                 {
                     return true;
                 }
@@ -1210,7 +1210,7 @@ namespace System.Xaml
             object[] argInstances = new object[rawArgs.Count];
             IList<XamlType> paramTypes = meType.GetPositionalParameters(rawArgs.Count);
 
-            if (null == paramTypes)
+            if (paramTypes == null)
             {
                 // A constructor with the specified number of arguments doesn't exist
                 string msg = string.Format(TypeConverterHelper.InvariantEnglishUS, SR.NoSuchConstructor, rawArgs.Count, meType.Name);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -1687,7 +1687,7 @@ namespace System.Xaml
             // or it is the live root instance. ME.ProvideValue must be invoked in each case, except where a ME is the
             // live root instance and _skipProvideValueOnRoot is true. This allows live root instances of templates to
             // remain as MEs where necessary.
-            Debug.Assert(parentInstance != null || parentProperty != null && parentProperty.IsDirective || ctx.LiveDepth == 1);
+            Debug.Assert(parentInstance != null || (parentProperty != null && parentProperty.IsDirective) || ctx.LiveDepth == 1);
             object value = me;
             if (ctx.LiveDepth != 1 || !_skipProvideValueOnRoot)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/Reflector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/Reflector.cs
@@ -336,9 +336,9 @@ namespace System.Xaml.Schema
         protected static bool? GetFlag(int bitMask, int bitToCheck)
         {
             int validBit = GetValidMask(bitToCheck);
-            if (0 != (bitMask & validBit))
+            if ((bitMask & validBit) != 0)
             {
-                return 0 != (bitMask & bitToCheck);
+                return (bitMask & bitToCheck) != 0;
             }
             return null;
         }


### PR DESCRIPTION
## Description
This work is a part of our initiative to set code-style guidelines, align WPF and WinForms, and ensure PR standards with respect to styles. This in turn will help us in better maintainability and readability of the repo overall. The changes follow up from the PR #10080 and references to the issue #10017.

The current changes addresses the following Errors/Warnings in the src folder of WPF:
- **SA1408:** Conditional expressions should declare precedence
- **SA1404:** Code analysis suppression should have justification
- **SA1131:** Constant values should appear on the right-hand side of comparisons

A good way to go about reviewing this is to go commit by commit which pans over individual errors/warnings, and hence easing out the overall understanding.

## Customer Impact
_None_

## Regression
_None_

## Testing
Local Build Pass
The current set of changes looks fairly mechanical and probably don't need a Test Pass, but these set of PRs can be clubbed to do so at a later stage.

## Risk
Low.
