### PR TITLE
Fixing window theme changes when system's theme is changed

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
@@ -28,13 +28,11 @@ internal static class ThemeManager
 
                 FluentThemeState newFluentThemeState = new FluentThemeState(Application.Current.ThemeMode.Value, useLightColors);
 
-                if (s_currentFluentThemeState == newFluentThemeState)
+                if (s_currentFluentThemeState != newFluentThemeState)
                 {
-                    return;
+                    AddOrUpdateThemeResources(Application.Current.Resources, GetThemeDictionary(Application.Current.ThemeMode));
                 }
-
-                AddOrUpdateThemeResources(Application.Current.Resources, GetThemeDictionary(Application.Current.ThemeMode));
-
+                
                 foreach (Window window in Application.Current.Windows)
                 {
                     if (window.ThemeMode == ThemeMode.None)


### PR DESCRIPTION

## Description
Setting the Application ThemeMode to Light/Dark and changing the system's theme would not reflect on the window when the window is set to System ThemeMode. 


## Regression

Yes
## Testing
Local build pass. Tested with Sample applications

## Risk


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10120)