### PR TITLE
[StyleCleanUp] Addressing SA warnings Part 3

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -323,9 +323,6 @@ dotnet_diagnostic.SA1131.severity = suggestion
 # SA1206: Keyword ordering
 dotnet_diagnostic.SA1206.severity = suggestion
 
-# SA1400: Member should declare an access modifier
-dotnet_diagnostic.SA1400.severity = suggestion
-
 # SA1404: Code analysis suppression should have justification
 dotnet_diagnostic.SA1404.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
@@ -121,12 +121,12 @@ namespace System.Xaml
         // This cache is bound (gated) by the number of assemblies in the appdomain.
         // We use a callback on GC to purge out collected assemblies, so we don't grow indefinitely.
         //
-        static Dictionary<object, AssemblyName> _assemblies; // get key via GetKeyForAssembly
-        static object syncObject = new object();
-        static bool _isGCCallbackPending;
+        private static Dictionary<object, AssemblyName> _assemblies; // get key via GetKeyForAssembly
+        private static object syncObject = new object();
+        private static bool _isGCCallbackPending;
 
         // PERF: Cache delegate for CleanupCollectedAssemblies to avoid allocating it each time.
-        static readonly WaitCallback _cleanupCollectedAssemblies = CleanupCollectedAssemblies;
+        private static readonly WaitCallback _cleanupCollectedAssemblies = CleanupCollectedAssemblies;
 
         /// <summary>
         ///     This function iterates through the assemblies loaded in the current
@@ -158,7 +158,7 @@ namespace System.Xaml
             return null;
         }
 
-        static AssemblyName GetAssemblyName(Assembly assembly)
+        private static AssemblyName GetAssemblyName(Assembly assembly)
         {
             object key = assembly.IsDynamic ? (object)new WeakRefKey(assembly) : assembly;
             lock (syncObject)
@@ -194,7 +194,7 @@ namespace System.Xaml
         }
 
         // After a GC, clean up the weakrefs to any collected dynamic assemblies
-        static void CleanupCollectedAssemblies(object state) // dummy parameter required by WaitCallback definition
+        private static void CleanupCollectedAssemblies(object state) // dummy parameter required by WaitCallback definition
         {
             bool foundLiveDynamicAssemblies = false;
             List<object> keysToRemove = null;
@@ -301,7 +301,7 @@ namespace System.Xaml
 #if WINDOWS_BASE || PRESENTATION_CORE || SYSTEM_XAML
     // for use as the key to a dictionary, when the "real" key is an object
     // that we should not keep alive by a strong reference.
-    class WeakRefKey : WeakReference
+    internal class WeakRefKey : WeakReference
     {
         public WeakRefKey(object target)
             :base(target)
@@ -345,18 +345,18 @@ namespace System.Xaml
             return !(left == right);
         }
 
-        readonly int _hashCode;  // cache target's hashcode, lest it get GC'd out from under us
+        private readonly int _hashCode;  // cache target's hashcode, lest it get GC'd out from under us
     }
 
     // This cleanup token will be immediately thrown away and as a result it will
     // (a couple of GCs later) make it into the finalization queue and when finalized
     // will kick off a thread-pool job that you can use to purge a weakref cache.
-    class GCNotificationToken
+    internal class GCNotificationToken
     {
-        WaitCallback callback;
-        object state;
+        private WaitCallback callback;
+        private object state;
 
-        GCNotificationToken(WaitCallback callback, object state)
+        private GCNotificationToken(WaitCallback callback, object state)
         {
             this.callback = callback;
             this.state = state;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlContextStack.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlContextStack.cs
@@ -15,12 +15,12 @@ namespace MS.Internal.Xaml.Context
     //This stack has the following features:
     //  1) it recycles frames
     //  2) it is <T>, and avoids activator.createinstance with the creationDelegate
-    class XamlContextStack<T> where T : XamlFrame
+    internal class XamlContextStack<T> where T : XamlFrame
     {
         private int _depth;
-        T _currentFrame;
-        T _recycledFrame;
-        Func<T> _creationDelegate;
+        private T _currentFrame;
+        private T _recycledFrame;
+        private Func<T> _creationDelegate;
 
         public XamlContextStack(Func<T> creationDelegate)
         {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlFrame.cs
@@ -11,7 +11,7 @@ using System.Diagnostics;
 
 namespace MS.Internal.Xaml.Context
 {
-    abstract class XamlFrame
+    internal abstract class XamlFrame
     {
         private int _depth;
         private XamlFrame _previous;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
@@ -70,7 +70,7 @@ namespace MS.Utility
         Array
     }
 
-    abstract class FrugalListBase<T>
+    internal abstract class FrugalListBase<T>
     {
         /// <summary>
         /// Number of entries in this store
@@ -1592,9 +1592,9 @@ namespace MS.Utility
                 return _targetStore;
             }
 
-            ArrayItemList<T> _targetStore;
-            T[] _sourceArray;
-            T[] _targetArray;
+            private ArrayItemList<T> _targetStore;
+            private T[] _sourceArray;
+            private T[] _targetArray;
         }
 
         #endregion Compacter
@@ -1923,8 +1923,8 @@ namespace MS.Utility
                 }
             }
 
-            FrugalObjectList<T> _list;
-            FrugalListBase<T>.Compacter _storeCompacter;
+            private FrugalObjectList<T> _list;
+            private FrugalListBase<T>.Compacter _storeCompacter;
         }
         #endregion Compacter
     }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
@@ -40,8 +40,8 @@ namespace System.Windows.Markup
     // if the passed in namespace is subsumed, then newXmlNamespace returns the subsuming namespace.
     // </param>
     internal delegate bool IsXmlNamespaceSupportedCallback(string xmlNamespace, out string newXmlNamespace);
-    delegate void HandleElementCallback(int elementDepth, ref bool more);
-    delegate void HandleAttributeCallback(int elementDepth);
+    internal delegate void HandleElementCallback(int elementDepth, ref bool more);
+    internal delegate void HandleAttributeCallback(int elementDepth);
 
     internal sealed class XmlCompatibilityReader : XmlWrappingReader
     {
@@ -1599,7 +1599,7 @@ namespace System.Windows.Markup
         }
         #endregion Private Properties
         #region Nested Classes
-        struct NamespaceElementPair
+        private struct NamespaceElementPair
         {
             public string namespaceName;
             public string itemName;
@@ -1618,18 +1618,18 @@ namespace System.Windows.Markup
         /// </summary>
         private class CompatibilityScope
         {
-            CompatibilityScope _previous;
-            int _depth;
-            bool _fallbackSeen;
-            bool _inAlternateContent;
-            bool _inProcessContent;
-            bool _choiceTaken;
-            bool _choiceSeen;
-            XmlCompatibilityReader _reader;
-            Dictionary<string, object> _ignorables;
-            Dictionary<string, ProcessContentSet> _processContents;
-            Dictionary<string, PreserveItemSet> _preserveElements;
-            Dictionary<string, PreserveItemSet> _preserveAttributes;
+            private CompatibilityScope _previous;
+            private int _depth;
+            private bool _fallbackSeen;
+            private bool _inAlternateContent;
+            private bool _inProcessContent;
+            private bool _choiceTaken;
+            private bool _choiceSeen;
+            private XmlCompatibilityReader _reader;
+            private Dictionary<string, object> _ignorables;
+            private Dictionary<string, ProcessContentSet> _processContents;
+            private Dictionary<string, PreserveItemSet> _preserveElements;
+            private Dictionary<string, PreserveItemSet> _preserveAttributes;
 
             public CompatibilityScope(CompatibilityScope previous, int depth, XmlCompatibilityReader reader)
             {
@@ -1908,12 +1908,12 @@ namespace System.Windows.Markup
             }
         }
 
-        class ProcessContentSet
+        private class ProcessContentSet
         {
-            bool _all;
-            string _namespaceName;
-            XmlCompatibilityReader _reader;
-            HashSet<string> _names;
+            private bool _all;
+            private string _namespaceName;
+            private XmlCompatibilityReader _reader;
+            private HashSet<string> _names;
 
             public ProcessContentSet(string namespaceName, XmlCompatibilityReader reader)
             {
@@ -1963,12 +1963,12 @@ namespace System.Windows.Markup
             }
 }
 
-        class PreserveItemSet
+        private class PreserveItemSet
         {
-            bool _all;
-            string _namespaceName;
-            XmlCompatibilityReader _reader;
-            Dictionary<string, string> _names;
+            private bool _all;
+            private string _namespaceName;
+            private XmlCompatibilityReader _reader;
+            private Dictionary<string, string> _names;
 
             public PreserveItemSet(string namespaceName, XmlCompatibilityReader reader)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachableMemberIdentifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachableMemberIdentifier.cs
@@ -8,8 +8,8 @@ namespace System.Xaml
 {
     public class AttachableMemberIdentifier : IEquatable<AttachableMemberIdentifier>
     {
-        readonly Type declaringType;
-        readonly string memberName;
+        private readonly Type declaringType;
+        private readonly string memberName;
 
         public AttachableMemberIdentifier(Type declaringType, string memberName)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachablePropertyServices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachablePropertyServices.cs
@@ -12,7 +12,7 @@ namespace System.Xaml
 {
     public static class AttachablePropertyServices
     {
-        static DefaultAttachedPropertyStore attachedProperties = new DefaultAttachedPropertyStore();
+        private static DefaultAttachedPropertyStore attachedProperties = new DefaultAttachedPropertyStore();
 
         public static int GetAttachedPropertyCount(object instance)
         {
@@ -121,9 +121,9 @@ namespace System.Xaml
         // global attached properties for types which don't implement IAttachedProperties or DO/Dependency Property
         // integration for their attached properties.
 
-        sealed class DefaultAttachedPropertyStore
+        private sealed class DefaultAttachedPropertyStore
         {
-            Lazy<ConditionalWeakTable<object, Dictionary<AttachableMemberIdentifier, object>>> instanceStorage =
+            private Lazy<ConditionalWeakTable<object, Dictionary<AttachableMemberIdentifier, object>>> instanceStorage =
                 new Lazy<ConditionalWeakTable<object, Dictionary<AttachableMemberIdentifier, object>>>();
 
             public void CopyPropertiesTo(object instance, KeyValuePair<AttachableMemberIdentifier, object>[] array, int index)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/NameFixupGraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/NameFixupGraph.cs
@@ -20,26 +20,26 @@ namespace MS.Internal.Xaml.Context
     internal class NameFixupGraph
     {
         // Node -> out-edges (other objects the parent is dependent on)
-        Dictionary<object, FrugalObjectList<NameFixupToken>> _dependenciesByParentObject;
+        private Dictionary<object, FrugalObjectList<NameFixupToken>> _dependenciesByParentObject;
 
         // Node -> in-edge (other object that is dependent on this child)
-        Dictionary<object, NameFixupToken> _dependenciesByChildObject;
+        private Dictionary<object, NameFixupToken> _dependenciesByChildObject;
 
         // Node -> in-edges (other objects that are dependent on this name)
-        Dictionary<string, FrugalObjectList<NameFixupToken>> _dependenciesByName;
+        private Dictionary<string, FrugalObjectList<NameFixupToken>> _dependenciesByName;
 
         // Queue of tokens whose dependencies have been resolved, and are awaiting processing
-        Queue<NameFixupToken> _resolvedTokensPendingProcessing;
+        private Queue<NameFixupToken> _resolvedTokensPendingProcessing;
 
         // Token for a pending call to ProvideValue on the root object. Can't store this in
         // _dependenciesByParentObject because it has no parent.
-        NameFixupToken _deferredRootProvideValue;
+        private NameFixupToken _deferredRootProvideValue;
 
         // At the end of the parse, we start running reparses on partially initialized objects,
         // and remove those dependencies. But we still want to be able to inform MEs/TCs that
         // the named objects they're getting aren't actually fully initialized. So we save this list
         // of incompletely initialized objects at the point we start completing references.
-        HashSet <object> _uninitializedObjectsAtParseEnd;
+        private HashSet <object> _uninitializedObjectsAtParseEnd;
 
         public NameFixupGraph()
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/NameFixupToken.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/NameFixupToken.cs
@@ -102,8 +102,8 @@ namespace MS.Internal.Xaml.Context
 
     internal class NameFixupToken : IAddLineInfo
     {
-        List<string> _names;
-        List<XAML3.INameScopeDictionary> _nameScopeDictionaryList;
+        private List<string> _names;
+        private List<XAML3.INameScopeDictionary> _nameScopeDictionaryList;
 
         public NameFixupToken()
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
@@ -21,12 +21,12 @@ namespace MS.Internal.Xaml.Context
 
         private object _rootInstance;
 
-        ServiceProviderContext _serviceProviderContext;
-        XamlRuntime _runtime;
-        int _savedDepth;     // The depth of the "saved" part this context is based on.
-        bool _nameResolutionComplete;
-        XamlObjectWriterSettings _settings;
-        List<NameScopeInitializationCompleteSubscriber> _nameScopeInitializationCompleteSubscribers;
+        private ServiceProviderContext _serviceProviderContext;
+        private XamlRuntime _runtime;
+        private int _savedDepth;     // The depth of the "saved" part this context is based on.
+        private bool _nameResolutionComplete;
+        private XamlObjectWriterSettings _settings;
+        private List<NameScopeInitializationCompleteSubscriber> _nameScopeInitializationCompleteSubscribers;
 
         public ObjectWriterContext(XamlSavedContext savedContext,
             XamlObjectWriterSettings settings, XAML3.INameScope rootNameScope, XamlRuntime runtime)
@@ -1030,7 +1030,7 @@ namespace MS.Internal.Xaml.Context
 
         internal class NameScopeInitializationCompleteSubscriber
         {
-            List<XAML3.INameScopeDictionary> _nameScopeDictionaryList = new List<XAML3.INameScopeDictionary>();
+            private List<XAML3.INameScopeDictionary> _nameScopeDictionaryList = new List<XAML3.INameScopeDictionary>();
 
             public EventHandler Handler
             {
@@ -1045,7 +1045,7 @@ namespace MS.Internal.Xaml.Context
 
         private class StackWalkNameResolver : IXamlNameResolver
         {
-            List<XAML3.INameScopeDictionary> _nameScopeDictionaryList;
+            private List<XAML3.INameScopeDictionary> _nameScopeDictionaryList;
 
             public StackWalkNameResolver(List<XAML3.INameScopeDictionary> nameScopeDictionaryList)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ServiceProviderContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ServiceProviderContext.cs
@@ -26,7 +26,7 @@ internal class ServiceProviderContext : ITypeDescriptorContext,  // derives from
                                   IDestinationTypeProvider,
                                   IXamlLineInfo
     {
-        ObjectWriterContext _xamlContext;
+        private ObjectWriterContext _xamlContext;
 
         public ServiceProviderContext(ObjectWriterContext context)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlObjectWriterFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlObjectWriterFactory.cs
@@ -10,8 +10,8 @@ namespace MS.Internal.Xaml.Context
 {
     internal class XamlObjectWriterFactory: IXamlObjectWriterFactory
     {
-        XamlSavedContext _savedContext;
-        XamlObjectWriterSettings _parentSettings;
+        private XamlSavedContext _savedContext;
+        private XamlObjectWriterSettings _parentSettings;
 
         public XamlObjectWriterFactory(ObjectWriterContext context)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IAmbientProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IAmbientProvider.cs
@@ -27,8 +27,8 @@ namespace System.Xaml
 
     public class AmbientPropertyValue
     {
-        XamlMember _property;
-        object _value;
+        private XamlMember _property;
+        private object _value;
 
         public AmbientPropertyValue(XamlMember property, object value)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/DeferredWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/DeferredWriter.cs
@@ -19,13 +19,13 @@ namespace System.Xaml
 
     internal class DeferringWriter : XamlWriter, IXamlLineInfoConsumer
     {
-        DeferringMode _mode;
-        bool _handled;
-        ObjectWriterContext _context;
-        XamlNodeList _deferredList;
-        XamlWriter _deferredWriter;
-        IXamlLineInfoConsumer _deferredLineInfoConsumer;
-        int _deferredTreeDepth;
+        private DeferringMode _mode;
+        private bool _handled;
+        private ObjectWriterContext _context;
+        private XamlNodeList _deferredList;
+        private XamlWriter _deferredWriter;
+        private IXamlLineInfoConsumer _deferredLineInfoConsumer;
+        private int _deferredTreeDepth;
 
         public DeferringWriter(ObjectWriterContext context)
         {
@@ -71,7 +71,7 @@ namespace System.Xaml
             WriteObject(xamlType, false, "WriteStartObject");
         }
 
-        void WriteObject(XamlType xamlType, bool fromMember, string methodName)
+        private void WriteObject(XamlType xamlType, bool fromMember, string methodName)
         {
             _handled = false;
             switch (_mode)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
@@ -30,8 +30,8 @@ namespace System.Xaml
     {
         internal enum InternalNodeType:byte { None, StartOfStream, EndOfStream, EndOfAttributes, LineInfo }
 
-        XamlNodeType _nodeType;
-        InternalNodeType _internalNodeType;
+        private XamlNodeType _nodeType;
+        private InternalNodeType _internalNodeType;
         private object _data;
 
         public XamlNodeType NodeType

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -22,10 +22,10 @@ namespace System.Xaml
 {
     public class XamlObjectWriter : XamlWriter, IXamlLineInfoConsumer, IAddLineInfo, ICheckIfInitialized
     {
-        object _lastInstance;
-        bool _inDispose;
-        ObjectWriterContext _context;
-        DeferringWriter _deferringWriter;
+        private object _lastInstance;
+        private bool _inDispose;
+        private ObjectWriterContext _context;
+        private DeferringWriter _deferringWriter;
         private EventHandler<XamlObjectEventArgs> _afterBeginInitHandler;
         private EventHandler<XamlObjectEventArgs> _beforePropertiesHandler;
         private EventHandler<XamlObjectEventArgs> _afterPropertiesHandler;
@@ -34,12 +34,12 @@ namespace System.Xaml
 
         private object _rootObjectInstance;
         private bool _skipDuplicatePropertyCheck;
-        NameFixupGraph _nameFixupGraph;
+        private NameFixupGraph _nameFixupGraph;
         private Dictionary<object, List<PendingCollectionAdd>> _pendingCollectionAdds;
-        XAML3.INameScope _rootNamescope;
-        bool _skipProvideValueOnRoot;
-        bool _nextNodeMustBeEndMember;
-        bool _preferUnconvertedDictionaryKeys;
+        private XAML3.INameScope _rootNamescope;
+        private bool _skipProvideValueOnRoot;
+        private bool _nextNodeMustBeEndMember;
+        private bool _preferUnconvertedDictionaryKeys;
         private Dictionary<object, ObjectWriterContext> _pendingKeyConversionContexts;
 
 #if DEBUG
@@ -68,7 +68,7 @@ namespace System.Xaml
             Initialize(savedContext.SchemaContext, savedContext, settings);
         }
 
-        void Initialize(XamlSchemaContext schemaContext, XamlSavedContext savedContext, XamlObjectWriterSettings settings)
+        private void Initialize(XamlSchemaContext schemaContext, XamlSavedContext savedContext, XamlObjectWriterSettings settings)
         {
             _inDispose = false;
             //ObjectWriter must be passed in a non-null SchemaContext.  We check that here, since the CreateContext method
@@ -1065,7 +1065,7 @@ namespace System.Xaml
         }
 
         // These are the all the directives that affect Construction of object.
-        bool IsConstructionDirective(XamlMember xamlMember)
+        private bool IsConstructionDirective(XamlMember xamlMember)
         {
             return xamlMember == XamlLanguage.Arguments
                 || xamlMember == XamlLanguage.Base
@@ -1077,7 +1077,7 @@ namespace System.Xaml
 
         // BAML sometimes sends the x:base directive later than it should
         // so these are the Ctor Directives we worry about 'Users' messing up.
-        bool IsTextConstructionDirective(XamlMember xamlMember)
+        private bool IsTextConstructionDirective(XamlMember xamlMember)
         {
             return xamlMember == XamlLanguage.Arguments
                 || xamlMember == XamlLanguage.FactoryMethod
@@ -1088,7 +1088,7 @@ namespace System.Xaml
         // Non Ctor directives that are also allowed before object creation.
         // These are compat issues with BAML recording x:Key x:Uid earlier than
         // it current XAML standards.
-        bool IsDirectiveAllowedOnNullInstance(XamlMember xamlMember, XamlType xamlType)
+        private bool IsDirectiveAllowedOnNullInstance(XamlMember xamlMember, XamlType xamlType)
         {
             if (xamlMember == XamlLanguage.Key)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReader.cs
@@ -18,14 +18,14 @@ namespace System.Xaml
 {
     public class XamlXmlReader : XamlReader, IXamlLineInfo
     {
-        XamlParserContext _context;
-        IEnumerator<XamlNode> _nodeStream;
+        private XamlParserContext _context;
+        private IEnumerator<XamlNode> _nodeStream;
 
-        XamlNode _current;
-        LineInfo _currentLineInfo;
-        XamlNode _endOfStreamNode;
+        private XamlNode _current;
+        private LineInfo _currentLineInfo;
+        private XamlNode _endOfStreamNode;
 
-        XamlXmlReaderSettings _mergedSettings;
+        private XamlXmlReaderSettings _mergedSettings;
 
         public XamlXmlReader(XmlReader xmlReader)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
@@ -12,8 +12,8 @@ namespace System.Xaml.MS.Impl
     [DebuggerDisplay("{ClrNamespace} {Assembly.FullName}")]
     internal class AssemblyNamespacePair
     {
-        WeakReference _assembly;
-        String _clrNamespace;
+        private WeakReference _assembly;
+        private String _clrNamespace;
 
         public AssemblyNamespacePair(Assembly asm, String clrNamespace)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/XmlNsInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/XmlNsInfo.cs
@@ -16,7 +16,7 @@ using System.Xaml.Schema;
 
 namespace System.Xaml.MS.Impl
 {
-    class XmlNsInfo
+    internal class XmlNsInfo
     {
         // Thread-safety: any lazily initalized fields in this class must be assigned idempotently.
         // I.e. never assign until the result is complete; and if multiple threads are assigning
@@ -115,7 +115,7 @@ namespace System.Xaml.MS.Impl
             _fullyQualifyAssemblyName = fullyQualifyAssemblyName;
         }
 
-        void EnsureReflectionOnlyAttributeData()
+        private void EnsureReflectionOnlyAttributeData()
         {
             if (_attributeData == null)
             {
@@ -144,7 +144,7 @@ namespace System.Xaml.MS.Impl
             return prefix2;
         }
 
-        IList<XmlNsDefinition> LoadNsDefs()
+        private IList<XmlNsDefinition> LoadNsDefs()
         {
             IList<XmlNsDefinition> result = new List<XmlNsDefinition>();
 
@@ -183,7 +183,7 @@ namespace System.Xaml.MS.Impl
             return result;
         }
 
-        void LoadNsDefHelper(IList<XmlNsDefinition> result, string xmlns, string clrns, Assembly assembly)
+        private void LoadNsDefHelper(IList<XmlNsDefinition> result, string xmlns, string clrns, Assembly assembly)
         {
             if (String.IsNullOrEmpty(xmlns) || clrns == null)
             {
@@ -193,7 +193,7 @@ namespace System.Xaml.MS.Impl
             result.Add(new XmlNsDefinition { ClrNamespace = clrns, XmlNamespace = xmlns });
         }
 
-        ConcurrentDictionary<string, IList<string>> LoadClrToXmlNs()
+        private ConcurrentDictionary<string, IList<string>> LoadClrToXmlNs()
         {
             ConcurrentDictionary<string, IList<string>> result =
                 XamlSchemaContext.CreateDictionary<string, IList<string>>();
@@ -231,7 +231,7 @@ namespace System.Xaml.MS.Impl
             return result;
         }
 
-        ICollection<AssemblyName> LoadInternalsVisibleTo()
+        private ICollection<AssemblyName> LoadInternalsVisibleTo()
         {
             var result = new List<AssemblyName>();
 
@@ -264,7 +264,7 @@ namespace System.Xaml.MS.Impl
             return result;
         }
 
-        void LoadInternalsVisibleToHelper(List<AssemblyName> result, string assemblyName, Assembly assembly)
+        private void LoadInternalsVisibleToHelper(List<AssemblyName> result, string assemblyName, Assembly assembly)
         {
             if (assemblyName == null)
             {
@@ -285,7 +285,7 @@ namespace System.Xaml.MS.Impl
             }
         }
 
-        Dictionary<string, string> LoadOldToNewNs()
+        private Dictionary<string, string> LoadOldToNewNs()
         {
             Dictionary<string, string> result = new Dictionary<string, string>(StringComparer.Ordinal);
 
@@ -322,7 +322,7 @@ namespace System.Xaml.MS.Impl
             return result;
         }
 
-        void LoadOldToNewNsHelper(Dictionary<string, string> result, string oldns, string newns, Assembly assembly)
+        private void LoadOldToNewNsHelper(Dictionary<string, string> result, string oldns, string newns, Assembly assembly)
         {
             if (String.IsNullOrEmpty(newns) || String.IsNullOrEmpty(oldns))
             {
@@ -336,7 +336,7 @@ namespace System.Xaml.MS.Impl
             result.Add(oldns, newns);
         }
 
-        Dictionary<string, string> LoadPrefixes()
+        private Dictionary<string, string> LoadPrefixes()
         {
             Dictionary<string, string> result = new Dictionary<string, string>(StringComparer.Ordinal);
 
@@ -371,7 +371,7 @@ namespace System.Xaml.MS.Impl
             return result;
         }
 
-        void LoadPrefixesHelper(Dictionary<string, string> result, string xmlns, string prefix, Assembly assembly)
+        private void LoadPrefixesHelper(Dictionary<string, string> result, string xmlns, string prefix, Assembly assembly)
         {
             if (String.IsNullOrEmpty(prefix) || String.IsNullOrEmpty(xmlns))
             {
@@ -386,7 +386,7 @@ namespace System.Xaml.MS.Impl
             }
         }
 
-        string LoadRootNamespace()
+        private string LoadRootNamespace()
         {
             Assembly assembly = Assembly;
             if (assembly == null)
@@ -414,7 +414,7 @@ namespace System.Xaml.MS.Impl
             }
         }
 
-        void MakeListsImmutable(IDictionary<string, IList<string>> dict)
+        private void MakeListsImmutable(IDictionary<string, IList<string>> dict)
         {
             // Need to copy the keys because we can't change a dictionary while iterating
             string[] keys = new string[dict.Count];
@@ -428,8 +428,8 @@ namespace System.Xaml.MS.Impl
 
         private class NamespaceComparer
         {
-            XmlNsInfo _nsInfo;
-            IDictionary<string, int> _subsumeCount;
+            private XmlNsInfo _nsInfo;
+            private IDictionary<string, int> _subsumeCount;
 
             public NamespaceComparer(XmlNsInfo nsInfo, Assembly assembly)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameScope.cs
@@ -99,7 +99,7 @@ namespace System.Xaml
         // This is a HybridDictionary of Name-Object maps
         private HybridDictionary _nameMap;
 
-        IEnumerator<KeyValuePair<string, object>> GetEnumerator() => new Enumerator(_nameMap);
+        private IEnumerator<KeyValuePair<string, object>> GetEnumerator() => new Enumerator(_nameMap);
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameScopeDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameScopeDictionary.cs
@@ -125,13 +125,13 @@ namespace System.Xaml
 
         internal INameScope UnderlyingNameScope { get { return _underlyingNameScope; } }
 
-        class Enumerator : IEnumerator<KeyValuePair<string, object>>
+        private class Enumerator : IEnumerator<KeyValuePair<string, object>>
         {
-            int index;
-            IDictionaryEnumerator dictionaryEnumerator;
-            HybridDictionary _nameMap;
-            INameScope _underlyingNameScope;
-            FrugalObjectList<string> _names;
+            private int index;
+            private IDictionaryEnumerator dictionaryEnumerator;
+            private HybridDictionary _nameMap;
+            private INameScope _underlyingNameScope;
+            private FrugalObjectList<string> _names;
 
             public Enumerator(NameScopeDictionary nameScopeDictionary)
             {
@@ -222,7 +222,7 @@ namespace System.Xaml
             }
         }
 
-        IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        private IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
             return new Enumerator(this);
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameParser.cs
@@ -12,10 +12,10 @@ using System.Xaml.Schema;
 
 namespace MS.Internal.Xaml.Parser
 {
-    class GenericTypeNameParser
+    internal class GenericTypeNameParser
     {
         [Serializable]
-        class TypeNameParserException : Exception
+        private class TypeNameParserException : Exception
         {
             public TypeNameParserException(string message)
                 : base(message)
@@ -31,7 +31,7 @@ namespace MS.Internal.Xaml.Parser
         private GenericTypeNameScanner _scanner;
         private string _inputText;
         private Func<string, string> _prefixResolver;
-        Stack<TypeNameFrame> _stack;
+        private Stack<TypeNameFrame> _stack;
 
         public GenericTypeNameParser(Func<string, string> prefixResolver)
         {
@@ -261,7 +261,7 @@ namespace MS.Internal.Xaml.Parser
             _stack.Push(frame);
         }
 
-        void Callout_FoundName(string prefix, string name)
+        private void Callout_FoundName(string prefix, string name)
         {
             TypeNameFrame frame = new TypeNameFrame();
             frame.Name = name;
@@ -270,7 +270,7 @@ namespace MS.Internal.Xaml.Parser
             _stack.Push(frame);
         }
 
-        void Callout_EndOfType()
+        private void Callout_EndOfType()
         {
             TypeNameFrame frame = _stack.Pop();
             XamlTypeName typeName = new XamlTypeName(frame.Namespace, frame.Name, frame.TypeArgs);
@@ -283,7 +283,7 @@ namespace MS.Internal.Xaml.Parser
             frame.TypeArgs.Add(typeName);
         }
 
-        void Callout_Subscript(string subscript)
+        private void Callout_Subscript(string subscript)
         {
             TypeNameFrame frame = _stack.Peek();
             frame.Name += subscript;
@@ -320,9 +320,9 @@ namespace MS.Internal.Xaml.Parser
         }
     }
 
-    class TypeNameFrame
+    internal class TypeNameFrame
     {
-        List<XamlTypeName> _typeArgs;
+        private List<XamlTypeName> _typeArgs;
 
         public string Namespace { get; set; }
         public string Name { get; set; }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MePullParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MePullParser.cs
@@ -14,10 +14,10 @@ namespace MS.Internal.Xaml.Parser
 {
     internal class MePullParser
     {
-        XamlParserContext _context;
-        string _originalText;
-        MeScanner _tokenizer;
-        string _brokenRule;
+        private XamlParserContext _context;
+        private string _originalText;
+        private MeScanner _tokenizer;
+        private string _brokenRule;
 
         [DebuggerDisplay("{found}")]
         private class Found

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
@@ -17,7 +17,7 @@ namespace MS.Internal.Xaml.Parser
 {
     // Markup Extension Tokenizer AKA Scanner.
 
-    enum MeTokenType
+    internal enum MeTokenType
     {
         None,
         Open         = '{',
@@ -50,20 +50,20 @@ namespace MS.Internal.Xaml.Parser
         public const char Backslash = '\\';
         public const char NullChar = '\0';
 
-        enum StringState { Value, Type, Property };
+        private enum StringState { Value, Type, Property };
 
-        XamlParserContext _context;
-        string _inputText;
-        int _idx;
-        MeTokenType _token;
-        XamlType _tokenXamlType;
-        XamlMember _tokenProperty;
-        string _tokenNamespace;
-        string _tokenText;
-        StringState _state;
-        bool _hasTrailingWhitespace;
-        int _lineNumber;
-        int _startPosition;
+        private XamlParserContext _context;
+        private string _inputText;
+        private int _idx;
+        private MeTokenType _token;
+        private XamlType _tokenXamlType;
+        private XamlMember _tokenProperty;
+        private string _tokenNamespace;
+        private string _tokenText;
+        private StringState _state;
+        private bool _hasTrailingWhitespace;
+        private int _lineNumber;
+        private int _startPosition;
         private string _currentParameterName;
         private SpecialBracketCharacters _currentSpecialBracketCharacters;
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
@@ -17,27 +17,27 @@ namespace MS.Internal.Xaml
 {
     internal class NodeStreamSorter: IEnumerator<XamlNode>
     {
-        XamlParserContext _context;
-        XamlXmlReaderSettings _settings;
-        IEnumerator<XamlNode> _source;
-        Queue<XamlNode> _buffer;
-        XamlNode _current;
+        private XamlParserContext _context;
+        private XamlXmlReaderSettings _settings;
+        private IEnumerator<XamlNode> _source;
+        private Queue<XamlNode> _buffer;
+        private XamlNode _current;
 
-        ReorderInfo[] _sortingInfoArray;
-        XamlNode[] _originalNodesInOrder;
+        private ReorderInfo[] _sortingInfoArray;
+        private XamlNode[] _originalNodesInOrder;
 
-        Dictionary<string, string> _xmlnsDictionary;
+        private Dictionary<string, string> _xmlnsDictionary;
 
-        class SeenCtorDirectiveFlags
+        private class SeenCtorDirectiveFlags
         {
             public bool SeenInstancingProperty;
             public bool SeenOutOfOrderCtorDirective;
         }
 
-        List<SeenCtorDirectiveFlags> _seenStack = new List<SeenCtorDirectiveFlags>();
-        int _startObjectDepth;
+        private List<SeenCtorDirectiveFlags> _seenStack = new List<SeenCtorDirectiveFlags>();
+        private int _startObjectDepth;
 
-        List<int> _moveList;
+        private List<int> _moveList;
 
         private void InitializeObjectFrameStack()
         {
@@ -65,19 +65,19 @@ namespace MS.Internal.Xaml
             _startObjectDepth -= 1;
         }
 
-        bool HaveSeenInstancingProperty
+        private bool HaveSeenInstancingProperty
         {
             get { return _seenStack[_startObjectDepth].SeenInstancingProperty; }
             set { _seenStack[_startObjectDepth].SeenInstancingProperty = value; }
         }
 
-        bool HaveSeenOutOfOrderCtorDirective
+        private bool HaveSeenOutOfOrderCtorDirective
         {
             get { return _seenStack[_startObjectDepth].SeenOutOfOrderCtorDirective; }
             set { _seenStack[_startObjectDepth].SeenOutOfOrderCtorDirective = value; }
         }
 
-        struct ReorderInfo
+        private struct ReorderInfo
         {
             public int Depth { get; set; }
             public int OriginalOrderIndex { get; set; }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPullParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPullParser.cs
@@ -15,9 +15,9 @@ namespace MS.Internal.Xaml.Parser
 {
     internal class XamlPullParser
     {
-        XamlParserContext _context;
-        XamlScanner _xamlScanner;
-        XamlXmlReaderSettings _settings;
+        private XamlParserContext _context;
+        private XamlScanner _xamlScanner;
+        private XamlXmlReaderSettings _settings;
 
         public XamlPullParser(XamlParserContext context, XamlScanner scanner, XamlXmlReaderSettings settings)
         {
@@ -1184,7 +1184,7 @@ namespace MS.Internal.Xaml.Parser
     }
 
     [Serializable]  // FxCop advised this be Serializable.
-    class XamlUnexpectedParseException : XamlParseException
+    internal class XamlUnexpectedParseException : XamlParseException
     {
         public XamlUnexpectedParseException() { }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScanner.cs
@@ -15,10 +15,10 @@ using MS.Internal.Xaml.Context;
 
 namespace MS.Internal.Xaml.Parser
 {
-    class XamlScanner
+    internal class XamlScanner
     {
-        XmlReader _xmlReader;
-        IXmlLineInfo _xmlLineInfo;
+        private XmlReader _xmlReader;
+        private IXmlLineInfo _xmlLineInfo;
 
         // XamlParserContext vs. XamlScannerStack
         // The XamlScannerStack belongs to the Scanner (aka XamlScanner) exclusively.
@@ -28,17 +28,17 @@ namespace MS.Internal.Xaml.Parser
         // Except the scanner loads namespaces into the Parser's XamlParserContext,
         // and reads from it to resolve type names and namespace prefixes.
         //
-        XamlScannerStack _scannerStack;
-        XamlParserContext _parserContext;
+        private XamlScannerStack _scannerStack;
+        private XamlParserContext _parserContext;
 
-        XamlText _accumulatedText;
-        List<XamlAttribute> _attributes;
-        int _nextAttribute;
-        XamlScannerNode _currentNode;
-        Queue<XamlScannerNode> _readNodesQueue;
-        XamlXmlReaderSettings _settings;
-        XamlAttribute _typeArgumentAttribute;
-        bool _hasKeyAttribute;
+        private XamlText _accumulatedText;
+        private List<XamlAttribute> _attributes;
+        private int _nextAttribute;
+        private XamlScannerNode _currentNode;
+        private Queue<XamlScannerNode> _readNodesQueue;
+        private XamlXmlReaderSettings _settings;
+        private XamlAttribute _typeArgumentAttribute;
+        private bool _hasKeyAttribute;
 
         internal XamlScanner(XamlParserContext context, XmlReader xmlReader, XamlXmlReaderSettings settings)
         {
@@ -859,7 +859,7 @@ namespace MS.Internal.Xaml.Parser
                 KS.Eq(XamlLanguage.XData.Name, name);
         }
 
-        XamlException LineInfo(XamlException e)
+        private XamlException LineInfo(XamlException e)
         {
             if (_xmlLineInfo != null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScannerStack.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScannerStack.cs
@@ -27,7 +27,7 @@ namespace MS.Internal.Xaml.Parser
 
     internal class XamlScannerStack
     {
-        Stack<XamlScannerFrame> _stack;
+        private Stack<XamlScannerFrame> _stack;
 
         public XamlScannerStack()
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlText.cs
@@ -177,7 +177,7 @@ namespace MS.Internal.Xaml.Parser
 
         // ===========================================================
 
-        static bool IsWhitespace(string text)
+        private static bool IsWhitespace(string text)
         {
             for (int i=0; i<text.Length; i++)
             {
@@ -187,7 +187,7 @@ namespace MS.Internal.Xaml.Parser
             return true;
         }
 
-        static bool IsWhitespaceChar(Char ch)
+        private static bool IsWhitespaceChar(Char ch)
         {
             return (ch == SPACE || ch == TAB || ch == NEWLINE || ch == RETURN);
         }
@@ -195,7 +195,7 @@ namespace MS.Internal.Xaml.Parser
         // This removes all leading and trailing whitespace, and it
         // collapses any internal runs of whitespace to a single space.
         //
-        static string CollapseWhitespace(string text)
+        private static string CollapseWhitespace(string text)
         {
             StringBuilder sb = new StringBuilder(text.Length);
             int firstIdx=0;
@@ -259,7 +259,7 @@ namespace MS.Internal.Xaml.Parser
         // ---- Asian newline suppression code ------
 
         // this code was modeled from the 3.5 XamlReaderHelper.cs
-        static bool HasSurroundingEastAsianChars(int start, int end, string text)
+        private static bool HasSurroundingEastAsianChars(int start, int end, string text)
         {
             Debug.Assert(start > 0);
             Debug.Assert(end < text.Length);
@@ -294,7 +294,7 @@ namespace MS.Internal.Xaml.Parser
             return false;
         }
 
-        static int ComputeUnicodeScalarValue(int takeOneIdx, int takeTwoIdx, string text)
+        private static int ComputeUnicodeScalarValue(int takeOneIdx, int takeTwoIdx, string text)
         {
             int unicodeScalarValue=0;
             bool isSurrogate = false;
@@ -317,7 +317,7 @@ namespace MS.Internal.Xaml.Parser
             return unicodeScalarValue;
         }
 
-        struct CodePointRange
+        private struct CodePointRange
         {
             public readonly int Min;
             public readonly int Max;
@@ -328,7 +328,7 @@ namespace MS.Internal.Xaml.Parser
             }
         }
 
-        static CodePointRange[] EastAsianCodePointRanges = new CodePointRange[]
+        private static CodePointRange[] EastAsianCodePointRanges = new CodePointRange[]
         {
             new CodePointRange ( 0x1100, 0x11FF ),     // Hangul
             new CodePointRange ( 0x2E80, 0x2FD5 ),     // CJK and KangXi Radicals
@@ -357,7 +357,7 @@ namespace MS.Internal.Xaml.Parser
         };
 
         // taken directly from WPF 3.5
-        static bool IsEastAsianCodePoint(int unicodeScalarValue)
+        private static bool IsEastAsianCodePoint(int unicodeScalarValue)
         {
             for (int i = 0; i < EastAsianCodePointRanges.Length; i++)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/ReaderDelegate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/ReaderDelegate.cs
@@ -11,10 +11,10 @@ namespace System.Xaml
     // of nodes with a "Next" delegate.
     // So is suitable for Queues and other simple single reader situations.
     //
-    class ReaderDelegate : ReaderBaseDelegate
+    internal class ReaderDelegate : ReaderBaseDelegate
     {
         // InfosetNode _currentNode is inherited.
-        XamlNodeNextDelegate _nextDelegate;
+        private XamlNodeNextDelegate _nextDelegate;
 
         public ReaderDelegate(XamlSchemaContext schemaContext, XamlNodeNextDelegate next, bool hasLineInfo)
             : base(schemaContext)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/ReaderMultiIndexDelegate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/ReaderMultiIndexDelegate.cs
@@ -19,12 +19,12 @@ namespace System.Xaml
     //
     internal class ReaderMultiIndexDelegate : ReaderBaseDelegate, IXamlIndexingReader
     {
-        static XamlNode s_StartOfStream = new XamlNode(XamlNode.InternalNodeType.StartOfStream);
-        static XamlNode s_EndOfStream = new XamlNode(XamlNode.InternalNodeType.EndOfStream);
+        private static XamlNode s_StartOfStream = new XamlNode(XamlNode.InternalNodeType.StartOfStream);
+        private static XamlNode s_EndOfStream = new XamlNode(XamlNode.InternalNodeType.EndOfStream);
 
-        XamlNodeIndexDelegate _indexDelegate;
-        int _count;
-        int _idx;
+        private XamlNodeIndexDelegate _indexDelegate;
+        private int _count;
+        private int _idx;
 
         public ReaderMultiIndexDelegate(XamlSchemaContext schemaContext, XamlNodeIndexDelegate indexDelegate, int count, bool hasLineInfo)
             : base(schemaContext)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/RefOnly/LooseTypeExtensions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/RefOnly/LooseTypeExtensions.cs
@@ -9,10 +9,10 @@ using System.Windows.Markup;
 
 namespace System.Xaml
 {
-    static class LooseTypeExtensions
+    internal static class LooseTypeExtensions
     {
-        const string WindowsBase = "WindowsBase";
-        static readonly byte[] WindowsBaseToken = { 49, 191, 56, 86, 173, 54, 78, 53 };
+        private const string WindowsBase = "WindowsBase";
+        private static readonly byte[] WindowsBaseToken = { 49, 191, 56, 86, 173, 54, 78, 53 };
 
         // Note: this is a version-tolerant comparison, i.e. the types are considered equal if their
         // names, namespaces, assembly short names, culture infos, and public keys match.
@@ -48,7 +48,7 @@ namespace System.Xaml
 
         // When doing a version-tolerant comparison against System.Xaml types, we also need to
         // support references to types that were type-forwarded from WindowsBase.
-        static bool IsWindowsBaseToSystemXamlComparison(Assembly a1, Assembly a2,
+        private static bool IsWindowsBaseToSystemXamlComparison(Assembly a1, Assembly a2,
             AssemblyName name1, AssemblyName name2)
         {
             AssemblyName windowsBaseName = null;
@@ -102,7 +102,7 @@ namespace System.Xaml
             return true;
         }
 
-        static bool LooselyImplementInterface(Type t, Type interfaceType)
+        private static bool LooselyImplementInterface(Type t, Type interfaceType)
         {
             for (Type type = t; type != null; type = type.BaseType)
             {
@@ -119,7 +119,7 @@ namespace System.Xaml
             return false;
         }
 
-        static bool IsLooseSubClassOf(Type t1, Type t2)
+        private static bool IsLooseSubClassOf(Type t1, Type t2)
         {
             if (t1 == null || t2 == null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/ClrObjectRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/ClrObjectRuntime.cs
@@ -17,7 +17,7 @@ using XAML3 = System.Windows.Markup;
 
 namespace MS.Internal.Xaml.Runtime
 {
-    class ClrObjectRuntime : XamlRuntime
+    internal class ClrObjectRuntime : XamlRuntime
     {
         private bool _ignoreCanConvert;
         private bool _isWriter;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/DynamicMethodRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/DynamicMethodRuntime.cs
@@ -30,24 +30,24 @@ namespace MS.Internal.Xaml.Runtime
 
     internal class DynamicMethodRuntime : ClrObjectRuntime
     {
-        const BindingFlags BF_AllInstanceMembers =
+        private const BindingFlags BF_AllInstanceMembers =
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-        const BindingFlags BF_AllStaticMembers =
+        private const BindingFlags BF_AllStaticMembers =
             BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
 
-        static MethodInfo s_GetTypeFromHandleMethod;
-        static MethodInfo s_InvokeMemberMethod;
+        private static MethodInfo s_GetTypeFromHandleMethod;
+        private static MethodInfo s_InvokeMemberMethod;
 
-        delegate void PropertySetDelegate(object target, object value);
-        delegate object PropertyGetDelegate(object target);
-        delegate object FactoryDelegate(object[] args);
-        delegate Delegate DelegateCreator(Type delegateType, object target, string methodName);
+        private delegate void PropertySetDelegate(object target, object value);
+        private delegate object PropertyGetDelegate(object target);
+        private delegate object FactoryDelegate(object[] args);
+        private delegate Delegate DelegateCreator(Type delegateType, object target, string methodName);
 
-        Assembly _localAssembly;
+        private Assembly _localAssembly;
 
-        Type _localType;
+        private Type _localType;
 
-        XamlSchemaContext _schemaContext;
+        private XamlSchemaContext _schemaContext;
 
         // We cache based on MemberInfo instead of XamlMember for two reasons:
         // 1. Equivalent XamlMembers can actually have different MemberInfos. Caching based on
@@ -57,12 +57,12 @@ namespace MS.Internal.Xaml.Runtime
         //    we don't have to worry that we're keeping it rooted. If this ever becomes a concern,
         //    we can switch to a ConditionalWeakTable here.
 
-        Dictionary<MethodInfo, PropertyGetDelegate> _propertyGetDelegates;
-        Dictionary<MethodInfo, PropertySetDelegate> _propertySetDelegates;
-        Dictionary<MethodBase, FactoryDelegate> _factoryDelegates;
-        Dictionary<Type, object> _converterInstances;
-        Dictionary<Type, DelegateCreator> _delegateCreators;
-        DelegateCreator _delegateCreatorWithoutHelper;
+        private Dictionary<MethodInfo, PropertyGetDelegate> _propertyGetDelegates;
+        private Dictionary<MethodInfo, PropertySetDelegate> _propertySetDelegates;
+        private Dictionary<MethodBase, FactoryDelegate> _factoryDelegates;
+        private Dictionary<Type, object> _converterInstances;
+        private Dictionary<Type, DelegateCreator> _delegateCreators;
+        private DelegateCreator _delegateCreatorWithoutHelper;
 
         private Dictionary<MethodInfo, PropertyGetDelegate> PropertyGetDelegates
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/PartialTrustTolerantRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/PartialTrustTolerantRuntime.cs
@@ -29,13 +29,13 @@ namespace MS.Internal.Xaml.Runtime
     // We start out by forwarding all calls to the transparent runtime.
     // If a call fails with a MethodAccessException, we fall back to the elevated runtime.
     // After the first failure, we automatically go to the elevated runtime for non-public types.
-    class PartialTrustTolerantRuntime : XamlRuntime
+    internal class PartialTrustTolerantRuntime : XamlRuntime
     {
-        bool _memberAccessPermissionDenied;
-        ClrObjectRuntime _transparentRuntime;
-        ClrObjectRuntime _elevatedRuntime;
-        XamlAccessLevel _accessLevel;
-        XamlSchemaContext _schemaContext;
+        private bool _memberAccessPermissionDenied;
+        private ClrObjectRuntime _transparentRuntime;
+        private ClrObjectRuntime _elevatedRuntime;
+        private XamlAccessLevel _accessLevel;
+        private XamlSchemaContext _schemaContext;
 
         public PartialTrustTolerantRuntime(XamlRuntimeSettings runtimeSettings, XamlAccessLevel accessLevel, XamlSchemaContext schemaContext)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/SafeReflectionInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/SafeReflectionInvoker.cs
@@ -11,9 +11,9 @@ using System.Security;
 
 namespace System.Xaml.Schema
 {
-    static class SafeReflectionInvoker
+    internal static class SafeReflectionInvoker
     {
-        static readonly Assembly SystemXaml = typeof(SafeReflectionInvoker).Assembly;
+        private static readonly Assembly SystemXaml = typeof(SafeReflectionInvoker).Assembly;
 
         public static bool IsInSystemXaml(Type type)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeReflector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeReflector.cs
@@ -16,7 +16,7 @@ using XAML3 = System.Windows.Markup;
 namespace System.Xaml.Schema
 {
     [Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2002:Do not lock on objects with weak identity", Justification = "This type is internal.")]
-    class TypeReflector : Reflector
+    internal class TypeReflector : Reflector
     {
         private const XamlCollectionKind XamlCollectionKindInvalid = (XamlCollectionKind)byte.MaxValue;
 
@@ -1092,7 +1092,7 @@ namespace System.Xaml.Schema
 
         internal class ThreadSafeDictionary<K,V> : Dictionary<K, V> where V : class
         {
-            bool _isComplete;
+            private bool _isComplete;
 
             internal ThreadSafeDictionary()
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/WriterDelegate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/WriterDelegate.cs
@@ -10,11 +10,11 @@ namespace System.Xaml
     // It turns XamlWriter calls into nodes and passes them up to the
     // provided _addDelegate.
     //
-    class WriterDelegate : XamlWriter, IXamlLineInfoConsumer
+    internal class WriterDelegate : XamlWriter, IXamlLineInfoConsumer
     {
-        XamlNodeAddDelegate _addDelegate;
-        XamlLineInfoAddDelegate _addLineInfoDelegate;
-        XamlSchemaContext _schemaContext;
+        private XamlNodeAddDelegate _addDelegate;
+        private XamlLineInfoAddDelegate _addLineInfoDelegate;
+        private XamlSchemaContext _schemaContext;
 
         public WriterDelegate(XamlNodeAddDelegate add, XamlLineInfoAddDelegate addlineInfoDelegate, XamlSchemaContext xamlSchemaContext)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlBackgroundReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlBackgroundReader.cs
@@ -15,27 +15,27 @@ namespace System.Xaml
 
     public class XamlBackgroundReader : XamlReader, IXamlLineInfo
     {
-        EventWaitHandle _providerFullEvent;
-        EventWaitHandle _dataReceivedEvent;
+        private EventWaitHandle _providerFullEvent;
+        private EventWaitHandle _dataReceivedEvent;
 
-        XamlNode[] _incoming;
-        int _inIdx;
-        XamlNode[] _outgoing;
-        int _outIdx;
-        int _outValid;
+        private XamlNode[] _incoming;
+        private int _inIdx;
+        private XamlNode[] _outgoing;
+        private int _outIdx;
+        private int _outValid;
 
-        XamlNode _currentNode;
+        private XamlNode _currentNode;
 
-        XamlReader _wrappedReader;
-        XamlReader _internalReader;
-        XamlWriter _writer;
+        private XamlReader _wrappedReader;
+        private XamlReader _internalReader;
+        private XamlWriter _writer;
 
-        bool _wrappedReaderHasLineInfo;
-        int _lineNumber;
-        int _linePosition;
+        private bool _wrappedReaderHasLineInfo;
+        private int _lineNumber;
+        private int _linePosition;
 
-        Thread _thread;
-        Exception _caughtException;
+        private Thread _thread;
+        private Exception _caughtException;
 
         public XamlBackgroundReader(XamlReader wrappedReader)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlException.cs
@@ -180,7 +180,7 @@ namespace System.Xaml
     [Serializable]  // FxCop advised this be Serializable.
     public class XamlInternalException : XamlException
     {
-        const string MessagePrefix = "Internal XAML system error: ";
+        private const string MessagePrefix = "Internal XAML system error: ";
 
         // FxCop required this, default constructor.
         public XamlInternalException()

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
@@ -9,15 +9,15 @@ using System.Text;
 
 namespace System.Xaml
 {
-    class XamlMarkupExtensionWriter : XamlWriter
+    internal class XamlMarkupExtensionWriter : XamlWriter
     {
-        StringBuilder sb;
-        Stack<Node> nodes;
-        WriterState currentState;
-        XamlXmlWriter xamlXmlWriter;
-        XamlXmlWriterSettings settings;
-        XamlMarkupExtensionWriterSettings meSettings;
-        bool failed;
+        private StringBuilder sb;
+        private Stack<Node> nodes;
+        private WriterState currentState;
+        private XamlXmlWriter xamlXmlWriter;
+        private XamlXmlWriterSettings settings;
+        private XamlMarkupExtensionWriterSettings meSettings;
+        private bool failed;
 
         public XamlMarkupExtensionWriter(XamlXmlWriter xamlXmlWriter)
         {
@@ -30,7 +30,7 @@ namespace System.Xaml
             Initialize(xamlXmlWriter);
         }
 
-        void Initialize(XamlXmlWriter xamlXmlWriter)
+        private void Initialize(XamlXmlWriter xamlXmlWriter)
         {
             this.xamlXmlWriter = xamlXmlWriter;
             settings = xamlXmlWriter.Settings; // This will clone, only want to do this once
@@ -91,7 +91,7 @@ namespace System.Xaml
             }
         }
 
-        string LookupPrefix(XamlType type)
+        private string LookupPrefix(XamlType type)
         {
             string prefix = xamlXmlWriter.LookupPrefix(type.GetXamlNamespaces(), out _);
 
@@ -108,7 +108,7 @@ namespace System.Xaml
             return prefix;
         }
 
-        string LookupPrefix(XamlMember property)
+        private string LookupPrefix(XamlMember property)
         {
             string prefix = xamlXmlWriter.LookupPrefix(property.GetXamlNamespaces(), out _);
 
@@ -125,7 +125,7 @@ namespace System.Xaml
             return prefix;
         }
 
-        void CheckMemberForUniqueness(Node objectNode, XamlMember property)
+        private void CheckMemberForUniqueness(Node objectNode, XamlMember property)
         {
             if (!settings.AssumeValidInput)
             {
@@ -183,7 +183,7 @@ namespace System.Xaml
             currentState.WriteValue(this, s);
         }
 
-        class Node
+        private class Node
         {
             public XamlMember XamlProperty
             {
@@ -207,10 +207,10 @@ namespace System.Xaml
             }
         }
 
-        abstract class WriterState
+        private abstract class WriterState
         {
             //according to the BNF, CharactersToEscape ::= ['",={}\]
-            static char[] specialChars = new char[] { '\'', '"', ',', '=', '{', '}', '\\', ' ' };
+            private static char[] specialChars = new char[] { '\'', '"', ',', '=', '{', '}', '\\', ' ' };
 
             public virtual void WriteStartObject(XamlMarkupExtensionWriter writer, XamlType type)
             {
@@ -293,10 +293,10 @@ namespace System.Xaml
         // XamlMarkupExtensionWriter returns to this state after a markup extension has been completed,
         // i.e. when the number of closing curly bracket "}" matches the number of opening curly bracket "{".
         // At this state, XamlMarkupExtensionWriter is ready to start writing a markup extension
-        class Start : WriterState
+        private class Start : WriterState
         {
-            static WriterState state = new Start();
-            Start()
+            private static WriterState state = new Start();
+            private Start()
             {
             }
             public static WriterState State
@@ -319,7 +319,7 @@ namespace System.Xaml
             }
         }
 
-        abstract class InObject : WriterState
+        private abstract class InObject : WriterState
         {
             protected InObject()
             {
@@ -427,10 +427,10 @@ namespace System.Xaml
             }
         }
 
-        class InObjectBeforeMember : InObject
+        private class InObjectBeforeMember : InObject
         {
-            static WriterState state = new InObjectBeforeMember();
-            InObjectBeforeMember()
+            private static WriterState state = new InObjectBeforeMember();
+            private InObjectBeforeMember()
             {
             }
             public static WriterState State
@@ -457,10 +457,10 @@ namespace System.Xaml
             }
         }
 
-        class InObjectAfterMember : InObject
+        private class InObjectAfterMember : InObject
         {
-            static WriterState state = new InObjectAfterMember();
-            InObjectAfterMember()
+            private static WriterState state = new InObjectAfterMember();
+            private InObjectAfterMember()
             {
             }
             public static WriterState State
@@ -480,7 +480,7 @@ namespace System.Xaml
             }
         }
 
-        abstract class InPositionalParameters : WriterState
+        private abstract class InPositionalParameters : WriterState
         {
             protected InPositionalParameters()
             {
@@ -506,10 +506,10 @@ namespace System.Xaml
             }
         }
 
-        class InPositionalParametersBeforeValue : InPositionalParameters
+        private class InPositionalParametersBeforeValue : InPositionalParameters
         {
-            static WriterState state = new InPositionalParametersBeforeValue();
-            InPositionalParametersBeforeValue()
+            private static WriterState state = new InPositionalParametersBeforeValue();
+            private InPositionalParametersBeforeValue()
             {
             }
             public static WriterState State
@@ -523,10 +523,10 @@ namespace System.Xaml
             }
         }
 
-        class InPositionalParametersAfterValue : InPositionalParameters
+        private class InPositionalParametersAfterValue : InPositionalParameters
         {
-            static WriterState state = new InPositionalParametersAfterValue();
-            InPositionalParametersAfterValue()
+            private static WriterState state = new InPositionalParametersAfterValue();
+            private InPositionalParametersAfterValue()
             {
             }
             public static WriterState State
@@ -551,10 +551,10 @@ namespace System.Xaml
             }
         }
 
-        class InMember : WriterState
+        private class InMember : WriterState
         {
-            static WriterState state = new InMember();
-            InMember()
+            private static WriterState state = new InMember();
+            private InMember()
             {
             }
             public static WriterState State
@@ -587,10 +587,10 @@ namespace System.Xaml
             }
         }
 
-        class InMemberAfterValueOrEndObject : WriterState
+        private class InMemberAfterValueOrEndObject : WriterState
         {
-            static WriterState state = new InMemberAfterValueOrEndObject();
-            InMemberAfterValueOrEndObject()
+            private static WriterState state = new InMemberAfterValueOrEndObject();
+            private InMemberAfterValueOrEndObject()
             {
             }
             public static WriterState State

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMember.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMember.cs
@@ -1035,7 +1035,7 @@ namespace System.Xaml
 
         #endregion
 
-        enum MemberType : byte
+        private enum MemberType : byte
         {
             Instance,
             Attachable,

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlNodeList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlNodeList.cs
@@ -17,10 +17,10 @@ namespace System.Xaml
 
     public class XamlNodeList
     {
-        List<XamlNode> _nodeList;
-        bool _readMode;
-        XamlWriter _writer;
-        bool _hasLineInfo;
+        private List<XamlNode> _nodeList;
+        private bool _readMode;
+        private XamlWriter _writer;
+        private bool _hasLineInfo;
 
         public XamlNodeList(XamlSchemaContext schemaContext)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlNodeQueue.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlNodeQueue.cs
@@ -16,12 +16,12 @@ namespace System.Xaml
 
     public class XamlNodeQueue
     {
-        Queue<XamlNode> _nodeQueue;
-        XamlNode _endOfStreamNode;
+        private Queue<XamlNode> _nodeQueue;
+        private XamlNode _endOfStreamNode;
 
-        ReaderDelegate _reader;
-        XamlWriter _writer;
-        bool _hasLineInfo;
+        private ReaderDelegate _reader;
+        private XamlWriter _writer;
+        private bool _hasLineInfo;
 
         public XamlNodeQueue(XamlSchemaContext schemaContext)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
@@ -26,11 +26,11 @@ namespace System.Xaml
 
     public class XamlObjectReader : XamlReader
     {
-        XamlObjectReaderSettings settings;
-        XamlSchemaContext schemaContext;
-        XamlNode currentXamlNode;
-        object currentInstance;
-        Stack<MarkupInfo> nodes;
+        private XamlObjectReaderSettings settings;
+        private XamlSchemaContext schemaContext;
+        private XamlNode currentXamlNode;
+        private object currentInstance;
+        private Stack<MarkupInfo> nodes;
 
         public XamlObjectReader(object instance)
             : this(instance, (XamlObjectReaderSettings)null)
@@ -214,7 +214,7 @@ namespace System.Xaml
             return false;
         }
 
-        class NameScopeMarkupInfo : ObjectMarkupInfo
+        private class NameScopeMarkupInfo : ObjectMarkupInfo
         {
             public ReferenceTable ParentTable { get; set; }
             public object SourceObject { get; set; }
@@ -233,7 +233,7 @@ namespace System.Xaml
             }
         }
 
-        class ObjectReferenceEqualityComparer : IEqualityComparer<object>
+        private class ObjectReferenceEqualityComparer : IEqualityComparer<object>
         {
             new public bool Equals(object x, object y)
             {
@@ -247,13 +247,13 @@ namespace System.Xaml
             }
         }
 
-        class ValueMarkupInfo : ObjectOrValueMarkupInfo
+        private class ValueMarkupInfo : ObjectOrValueMarkupInfo
         {
         }
 
-        class MemberMarkupInfo : MarkupInfo
+        private class MemberMarkupInfo : MarkupInfo
         {
-            List<MarkupInfo> children = new List<MarkupInfo>();
+            private List<MarkupInfo> children = new List<MarkupInfo>();
 
             public bool IsContent { get; set; }
             public bool IsFactoryMethod { get; set; }
@@ -335,7 +335,7 @@ namespace System.Xaml
                 }
             }
 
-            bool MemberRequiresNamespaceHoisting(XamlMember member)
+            private bool MemberRequiresNamespaceHoisting(XamlMember member)
             {
                 return (member.IsAttachable || (member.IsDirective && !XamlXmlWriter.IsImplicit(member)))
                     && (member.PreferredXamlNamespace != XamlLanguage.Xml1998Namespace);
@@ -532,7 +532,7 @@ namespace System.Xaml
                 return null;
             }
 
-            static MemberMarkupInfo ForSequence(object source, XamlMember property, SerializerContext context, bool isAttachable)
+            private static MemberMarkupInfo ForSequence(object source, XamlMember property, SerializerContext context, bool isAttachable)
             {
                 var itemsInfo = ForSequenceItems(source, isAttachable ? null : property, property.Type, context, false /*allowReadOnly*/);
                 if (itemsInfo != null && itemsInfo.Children.Count != 0)
@@ -560,7 +560,7 @@ namespace System.Xaml
                 }
             }
 
-            static MemberMarkupInfo ForDictionary(object source, XamlMember property, SerializerContext context, bool isAttachable)
+            private static MemberMarkupInfo ForDictionary(object source, XamlMember property, SerializerContext context, bool isAttachable)
             {
                 var itemsInfo = ForDictionaryItems(source, isAttachable ? null : property, property.Type, context);
                 if (itemsInfo != null && itemsInfo.Children.Count != 0)
@@ -587,7 +587,7 @@ namespace System.Xaml
                 }
             }
 
-            static MemberMarkupInfo ForXmlSerializable(object source, XamlMember property, SerializerContext context)
+            private static MemberMarkupInfo ForXmlSerializable(object source, XamlMember property, SerializerContext context)
             {
                 var serializer = (IXmlSerializable)context.Runtime.GetValue(source, property);
                 if (serializer == null) { return null; }
@@ -638,7 +638,7 @@ namespace System.Xaml
                 return null;
             }
 
-            static MemberMarkupInfo ForReadWriteProperty(
+            private static MemberMarkupInfo ForReadWriteProperty(
                 object source, XamlMember xamlProperty, SerializerContext context)
             {
                 var propertyValue = context.Runtime.GetValue(source, xamlProperty);
@@ -667,7 +667,7 @@ namespace System.Xaml
                 return memberInfo;
             }
 
-            static void RemoveObjectNodesForCollectionOrDictionary(MemberMarkupInfo memberInfo)
+            private static void RemoveObjectNodesForCollectionOrDictionary(MemberMarkupInfo memberInfo)
             {
                 var memberType = memberInfo.XamlNode.Member.Type;
                 if (memberType.IsCollection || memberType.IsDictionary)
@@ -806,7 +806,7 @@ namespace System.Xaml
             // 1. It has 2 consecutive spaces or non space whitespace (tabs, new line, etc)
             // 2. Last Element has trailing whitespace
             // 3. First element has leading whitespace
-            static bool ShouldUnwrapDueToWhitespace(string value, XamlType xamlType, bool isFirstElementOfCollection, bool isLastElementOfCollection)
+            private static bool ShouldUnwrapDueToWhitespace(string value, XamlType xamlType, bool isFirstElementOfCollection, bool isLastElementOfCollection)
             {
                 if(XamlXmlWriter.HasSignificantWhitespace(value))
                 {
@@ -841,7 +841,7 @@ namespace System.Xaml
                 }
             }
 
-            static ObjectOrValueMarkupInfo GetPropertyValueInfo(
+            private static ObjectOrValueMarkupInfo GetPropertyValueInfo(
                 object propertyValue, XamlMember xamlProperty, SerializerContext context)
             {
                 return GetPropertyValueInfoInternal(propertyValue,
@@ -852,7 +852,7 @@ namespace System.Xaml
                     context);
             }
 
-            static ObjectOrValueMarkupInfo GetPropertyValueInfoInternal(
+            private static ObjectOrValueMarkupInfo GetPropertyValueInfoInternal(
                 object propertyValue, ValueSerializer propertyValueSerializer, TypeConverter propertyConverter, bool isXamlTemplate, XamlMember xamlProperty, SerializerContext context)
             {
                 ObjectOrValueMarkupInfo valueInfo = null;
@@ -905,7 +905,7 @@ namespace System.Xaml
                 return valueInfo;
             }
 
-            static void ThrowIfPropertiesAreAttached(object value, XamlMember property, SerializerContext context)
+            private static void ThrowIfPropertiesAreAttached(object value, XamlMember property, SerializerContext context)
             {
                 var props = context.Runtime.GetAttachedProperties(value);
                 if (props != null)
@@ -922,7 +922,7 @@ namespace System.Xaml
             }
 
             // Reproduce the logic of System.ComponentModel.ReflectPropertyDescriptor.ShouldSerializeValue
-            static bool ShouldWriteProperty(object source, XamlMember property, SerializerContext context)
+            private static bool ShouldWriteProperty(object source, XamlMember property, SerializerContext context)
             {
                 bool isReadOnly = !context.IsPropertyWriteVisible(property);
 
@@ -959,44 +959,44 @@ namespace System.Xaml
             }
         }
 
-        abstract class MarkupInfo
+        private abstract class MarkupInfo
         {
             public XamlNode XamlNode { get; set; }
             public virtual void FindNamespace(SerializerContext context) { }
             public virtual List<MarkupInfo> Decompose() { return null; }
         }
 
-        class EndObjectMarkupInfo : MarkupInfo
+        private class EndObjectMarkupInfo : MarkupInfo
         {
-            static EndObjectMarkupInfo instance = new EndObjectMarkupInfo();
+            private static EndObjectMarkupInfo instance = new EndObjectMarkupInfo();
 
-            EndObjectMarkupInfo() { XamlNode = new XamlNode(XamlNodeType.EndObject); }
+            private EndObjectMarkupInfo() { XamlNode = new XamlNode(XamlNodeType.EndObject); }
 
             public static EndObjectMarkupInfo Instance { get { return instance; } }
         }
 
-        class EndMemberMarkupInfo : MarkupInfo
+        private class EndMemberMarkupInfo : MarkupInfo
         {
-            static EndMemberMarkupInfo instance = new EndMemberMarkupInfo();
+            private static EndMemberMarkupInfo instance = new EndMemberMarkupInfo();
 
-            EndMemberMarkupInfo() { XamlNode = new XamlNode(XamlNodeType.EndMember); }
+            private EndMemberMarkupInfo() { XamlNode = new XamlNode(XamlNodeType.EndMember); }
 
             public static EndMemberMarkupInfo Instance { get { return instance; } }
         }
 
-        class NamespaceMarkupInfo : MarkupInfo
+        private class NamespaceMarkupInfo : MarkupInfo
         {
         }
 
-        abstract class ObjectOrValueMarkupInfo : MarkupInfo
+        private abstract class ObjectOrValueMarkupInfo : MarkupInfo
         {
             public virtual void EnsureNoDuplicateNames(Stack<HashSet<string>> namesInCurrentScope) { }
         }
 
-        class ObjectMarkupInfo : ObjectOrValueMarkupInfo
+        private class ObjectMarkupInfo : ObjectOrValueMarkupInfo
         {
-            List<MarkupInfo> properties = new List<MarkupInfo>();
-            bool? isAttributableMarkupExtension;
+            private List<MarkupInfo> properties = new List<MarkupInfo>();
+            private bool? isAttributableMarkupExtension;
 
             public List<MarkupInfo> Properties { get { return properties; } }
             public string Name { get; set; }
@@ -1011,7 +1011,7 @@ namespace System.Xaml
                 return properties;
             }
 
-            void SortProperties()
+            private void SortProperties()
             {
                 if (IsAttributableMarkupExtension)
                 {
@@ -1025,7 +1025,7 @@ namespace System.Xaml
                 ReorderPropertiesWithDO();
             }
 
-            void ReorderPropertiesWithDO()
+            private void ReorderPropertiesWithDO()
             {
                 List<MarkupInfo> removedProperties;
                 SelectAndRemovePropertiesWithDO(out removedProperties);
@@ -1036,7 +1036,7 @@ namespace System.Xaml
                 }
             }
 
-            void InsertPropertiesWithDO(List<MarkupInfo> propertiesWithDO)
+            private void InsertPropertiesWithDO(List<MarkupInfo> propertiesWithDO)
             {
                 int posOfFirstNonAttributableProperty;
                 HashSet<string> namesOfAttributableProperties = FindAllAttributableProperties(out posOfFirstNonAttributableProperty);
@@ -1059,7 +1059,7 @@ namespace System.Xaml
                 }
             }
 
-            bool IsMemberOnlyDependentOnAttributableMembers(XamlMember member, HashSet<string> namesOfAttributableProperties)
+            private bool IsMemberOnlyDependentOnAttributableMembers(XamlMember member, HashSet<string> namesOfAttributableProperties)
             {
                 foreach (var dependingProperty in member.DependsOn)
                 {
@@ -1071,7 +1071,7 @@ namespace System.Xaml
                 return true;
             }
 
-            HashSet<string> FindAllAttributableProperties(out int posOfFirstNonAttributableProperty)
+            private HashSet<string> FindAllAttributableProperties(out int posOfFirstNonAttributableProperty)
             {
                 int i;
                 HashSet<string> namesOfAttributableProperties = new HashSet<string>();
@@ -1088,7 +1088,7 @@ namespace System.Xaml
                 return namesOfAttributableProperties;
             }
 
-            void SelectAndRemovePropertiesWithDO(out List<MarkupInfo> removedProperties)
+            private void SelectAndRemovePropertiesWithDO(out List<MarkupInfo> removedProperties)
             {
                 removedProperties = null;
                 PartiallyOrderedList<string, MarkupInfo> propertiesWithDO = null;
@@ -1178,7 +1178,7 @@ namespace System.Xaml
                 }
             }
 
-            void FindNamespaceForTypeArguments(IList<XamlType> types, SerializerContext context)
+            private void FindNamespaceForTypeArguments(IList<XamlType> types, SerializerContext context)
             {
                 if (types == null || types.Count == 0)
                 {
@@ -1192,7 +1192,7 @@ namespace System.Xaml
                 }
             }
 
-            void AddItemsProperty(object value, SerializerContext context, XamlType xamlType)
+            private void AddItemsProperty(object value, SerializerContext context, XamlType xamlType)
             {
                 MemberMarkupInfo propertyInfo = null;
 
@@ -1211,7 +1211,7 @@ namespace System.Xaml
                 }
             }
 
-            ParameterInfo[] GetMethodParams(MemberInfo memberInfo)
+            private ParameterInfo[] GetMethodParams(MemberInfo memberInfo)
             {
                 ParameterInfo[] methodParams = null;
                 MethodBase method = memberInfo as MethodBase;
@@ -1223,7 +1223,7 @@ namespace System.Xaml
                 return methodParams;
             }
 
-            void AddFactoryMethodAndValidateArguments(Type valueType, MemberInfo memberInfo, ICollection arguments, SerializerContext context, out ParameterInfo[] methodParams)
+            private void AddFactoryMethodAndValidateArguments(Type valueType, MemberInfo memberInfo, ICollection arguments, SerializerContext context, out ParameterInfo[] methodParams)
             {
                 methodParams = null;
 
@@ -1300,7 +1300,7 @@ namespace System.Xaml
                 }
             }
 
-            void AddArgumentsMembers(ICollection arguments, SerializerContext context)
+            private void AddArgumentsMembers(ICollection arguments, SerializerContext context)
             {
                 if (arguments != null && arguments.Count > 0)
                 {
@@ -1323,7 +1323,7 @@ namespace System.Xaml
                 }
             }
 
-            bool TryAddPositionalParameters(XamlType xamlType, MemberInfo member, ICollection arguments, SerializerContext context)
+            private bool TryAddPositionalParameters(XamlType xamlType, MemberInfo member, ICollection arguments, SerializerContext context)
             {
                 if (arguments != null && arguments.Count > 0)
                 {
@@ -1392,7 +1392,7 @@ namespace System.Xaml
                 AddRecordMembers(value, context, null);
             }
 
-            bool TryGetInstanceDescriptorInfo(object value, SerializerContext context, TypeConverter converter, out MemberInfo member, out ICollection arguments, out bool isComplete)
+            private bool TryGetInstanceDescriptorInfo(object value, SerializerContext context, TypeConverter converter, out MemberInfo member, out ICollection arguments, out bool isComplete)
             {
                 bool result = false;
                 member = null;
@@ -1408,7 +1408,7 @@ namespace System.Xaml
                 return result;
             }
 
-            void ConvertToInstanceDescriptor(SerializerContext context, object instance, TypeConverter converter,
+            private void ConvertToInstanceDescriptor(SerializerContext context, object instance, TypeConverter converter,
                 out MemberInfo member, out ICollection arguments, out bool isComplete)
             {
                 var descriptor = context.ConvertTo<InstanceDescriptor>(converter, instance);
@@ -1419,8 +1419,7 @@ namespace System.Xaml
                 isComplete = descriptor.IsComplete;
             }
 
-
-            bool TryGetDefaultConstructorInfo(XamlType type, out MemberInfo member, out ICollection arguments, out bool isComplete)
+            private bool TryGetDefaultConstructorInfo(XamlType type, out MemberInfo member, out ICollection arguments, out bool isComplete)
             {
                 arguments = null;
                 isComplete = false;
@@ -1461,7 +1460,7 @@ namespace System.Xaml
                 }
             }
 
-            void AddRecordMembers(object value,
+            private void AddRecordMembers(object value,
                 SerializerContext context,
                 ParameterInfo[] methodParameters,
                 XamlType xamlType)
@@ -1511,7 +1510,7 @@ namespace System.Xaml
                 AddAttachedProperties(value, this, context);
             }
 
-            void AddRecordConstructionMembers(object value, XamlType valueXamlType, SerializerContext context,
+            private void AddRecordConstructionMembers(object value, XamlType valueXamlType, SerializerContext context,
                 TypeConverter converter, out bool isComplete, out ParameterInfo[] methodParams)
             {
                 MemberInfo member = null;
@@ -1588,7 +1587,7 @@ namespace System.Xaml
                 AddFactoryMethodAndValidateArguments(value.GetType(), member, arguments, context, out methodParams);
             }
 
-            bool IsPropertyContent(MemberMarkupInfo propertyInfo, XamlType containingType)
+            private bool IsPropertyContent(MemberMarkupInfo propertyInfo, XamlType containingType)
             {
                 var property = propertyInfo.XamlNode.Member;
                 if (property != containingType.ContentProperty)
@@ -1604,7 +1603,7 @@ namespace System.Xaml
                 return true;
             }
 
-            void GetConstructorInfo(object value, XamlType valueXamlType, SerializerContext context, out MemberInfo member, out ICollection arguments, out bool isComplete)
+            private void GetConstructorInfo(object value, XamlType valueXamlType, SerializerContext context, out MemberInfo member, out ICollection arguments, out bool isComplete)
             {
                 // Walk the constructors of the type and find the ones with signatures that match the types of
                 // the properties we found above and whose param names match the names we found above
@@ -1701,7 +1700,7 @@ namespace System.Xaml
                 }
             }
 
-            static void CheckTypeCanRoundtrip(ObjectMarkupInfo objInfo)
+            private static void CheckTypeCanRoundtrip(ObjectMarkupInfo objInfo)
             {
                 var xamlType = objInfo.XamlNode.XamlType;
                 if (!xamlType.IsConstructible)
@@ -1788,14 +1787,14 @@ namespace System.Xaml
                 }
             }
 
-            static string ConvertTypeAndMethodToString(Type type, string methodName, SerializerContext context)
+            private static string ConvertTypeAndMethodToString(Type type, string methodName, SerializerContext context)
             {
                 string typestring = context.ConvertXamlTypeToString(context.LocalAssemblyAwareGetXamlType(type));
 
                 return $"{typestring}.{methodName}";
             }
 
-            static ObjectMarkupInfo ForArray(Array value, SerializerContext context)
+            private static ObjectMarkupInfo ForArray(Array value, SerializerContext context)
             {
                 if (value.Rank > 1)
                 {
@@ -1861,7 +1860,7 @@ namespace System.Xaml
                 return objectInfo;
             }
 
-            static void AddAttachedProperties(object value, ObjectMarkupInfo objectInfo, SerializerContext context)
+            private static void AddAttachedProperties(object value, ObjectMarkupInfo objectInfo, SerializerContext context)
             {
                 var props = context.Runtime.GetAttachedProperties(value);
                 if (props != null)
@@ -1894,7 +1893,7 @@ namespace System.Xaml
                 }
             }
 
-            static ObjectMarkupInfo ForNull()
+            private static ObjectMarkupInfo ForNull()
             {
                 return new ObjectMarkupInfo { XamlNode = new XamlNode(XamlNodeType.StartObject, XamlLanguage.Null) };
             }
@@ -2011,7 +2010,7 @@ namespace System.Xaml
                 return objectInfo;
             }
 
-            static ObjectMarkupInfo ForObjectInternal(object value, SerializerContext context, TypeConverter converter)
+            private static ObjectMarkupInfo ForObjectInternal(object value, SerializerContext context, TypeConverter converter)
             {
                 ObjectMarkupInfo recordInfo;
                 XamlType xamlType = context.LocalAssemblyAwareGetXamlType(value.GetType());
@@ -2049,12 +2048,12 @@ namespace System.Xaml
                 return recordInfo;
             }
 
-            static void AddReference(object value, ObjectMarkupInfo objectInfo, SerializerContext context)
+            private static void AddReference(object value, ObjectMarkupInfo objectInfo, SerializerContext context)
             {
                 context.ReferenceTable.Add(value, objectInfo);
             }
 
-            static ObjectMarkupInfo ForTypeConverted(string value, object originalValue, SerializerContext context)
+            private static ObjectMarkupInfo ForTypeConverted(string value, object originalValue, SerializerContext context)
             {
                 var xamlType = context.LocalAssemblyAwareGetXamlType(originalValue.GetType());
                 var objectInfo = new ObjectMarkupInfo
@@ -2078,7 +2077,7 @@ namespace System.Xaml
                 return objectInfo;
             }
 
-            static bool IsEmptyString(MemberMarkupInfo propertyInfo)
+            private static bool IsEmptyString(MemberMarkupInfo propertyInfo)
             {
                 if (propertyInfo.Children.Count == 1)
                 {
@@ -2091,14 +2090,14 @@ namespace System.Xaml
                 return false;
             }
 
-            static bool IsNull(MemberMarkupInfo propertyInfo)
+            private static bool IsNull(MemberMarkupInfo propertyInfo)
             {
                 return propertyInfo.Children.Count == 1 &&
                        propertyInfo.Children[0] is ObjectMarkupInfo objectInfo &&
                        objectInfo.XamlNode.XamlType == XamlLanguage.Null;
             }
 
-            static bool PropertyUsedInMethodSignature(XamlMember property, ParameterInfo[] methodParameters)
+            private static bool PropertyUsedInMethodSignature(XamlMember property, ParameterInfo[] methodParameters)
             {
                 if (methodParameters != null)
                 {
@@ -2118,7 +2117,7 @@ namespace System.Xaml
                 return false;
             }
 
-            static string ValidateNamePropertyAndFindName(MemberMarkupInfo propertyInfo)
+            private static string ValidateNamePropertyAndFindName(MemberMarkupInfo propertyInfo)
             {
                 // The name property needs to be a single value that is an atomic string. If it isn't, then it's not
                 // a valid name.
@@ -2174,10 +2173,10 @@ namespace System.Xaml
             //    writer.WriteEndRecord();
             //}
 
-            class PropertySorterForXmlSyntax : IComparer<MarkupInfo>
+            private class PropertySorterForXmlSyntax : IComparer<MarkupInfo>
             {
-                const int XFirst = -1;
-                const int YFirst = 1;
+                private const int XFirst = -1;
+                private const int YFirst = 1;
 
                 public static readonly PropertySorterForXmlSyntax Instance = new PropertySorterForXmlSyntax();
 
@@ -2250,12 +2249,12 @@ namespace System.Xaml
                 }
             }
 
-            class PropertySorterForCurlySyntax : IComparer<MarkupInfo>
+            private class PropertySorterForCurlySyntax : IComparer<MarkupInfo>
             {
                 [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Could possibly break clients that use reflection")]
-                const int Equal = 0;
-                const int XFirst = -1;
-                const int YFirst = 1;
+                private const int Equal = 0;
+                private const int XFirst = -1;
+                private const int YFirst = 1;
 
                 public static readonly PropertySorterForCurlySyntax Instance = new PropertySorterForCurlySyntax();
 
@@ -2316,7 +2315,7 @@ namespace System.Xaml
                     (context.IsPropertyWriteVisible(property) || property.Type.IsUsableAsReadOnly);
             }
 
-            static List<XamlMember> GetXamlSerializableProperties(XamlType type, SerializerContext context)
+            private static List<XamlMember> GetXamlSerializableProperties(XamlType type, SerializerContext context)
             {
                 List<XamlMember> propertyList = new List<XamlMember>();
                 foreach (XamlMember property in type.GetAllMembers())
@@ -2330,11 +2329,11 @@ namespace System.Xaml
             }
         }
 
-        class ReferenceMarkupInfo : ObjectMarkupInfo
+        private class ReferenceMarkupInfo : ObjectMarkupInfo
         {
             public ObjectMarkupInfo Target { get; set; }
 
-            MemberMarkupInfo nameProperty;
+            private MemberMarkupInfo nameProperty;
             public ReferenceMarkupInfo(ObjectMarkupInfo target)
             {
                 XamlNode = new XamlNode(XamlNodeType.StartObject, XamlLanguage.Reference);
@@ -2411,16 +2410,16 @@ namespace System.Xaml
         //    }
         }
 
-        class ReferenceTable
+        private class ReferenceTable
         {
-            ReferenceTable parent;
+            private ReferenceTable parent;
 
             // table that remembers all objects seen in the current namescope
-            Dictionary<object, ObjectMarkupInfo> objectGraphTable;
+            private Dictionary<object, ObjectMarkupInfo> objectGraphTable;
 
             // table that remembers all the objects whose names are requested by TCs, MEs,
             // and the names assigned to them.
-            Dictionary<object, string> serviceProviderTable;
+            private Dictionary<object, string> serviceProviderTable;
 
             public ReferenceTable(ReferenceTable parent)
             {
@@ -2468,17 +2467,17 @@ namespace System.Xaml
             }
         }
 
-        class SerializerContext
+        private class SerializerContext
         {
-            int lastIdentifier;
-            Queue<NameScopeMarkupInfo> pendingNameScopes;
-            ITypeDescriptorContext typeDescriptorContext;
-            IValueSerializerContext valueSerializerContext;
-            Dictionary<string, string> namespaceToPrefixMap;
-            Dictionary<string, string> prefixToNamespaceMap;
-            XamlSchemaContext schemaContext;
-            ClrObjectRuntime runtime;
-            XamlObjectReaderSettings settings;
+            private int lastIdentifier;
+            private Queue<NameScopeMarkupInfo> pendingNameScopes;
+            private ITypeDescriptorContext typeDescriptorContext;
+            private IValueSerializerContext valueSerializerContext;
+            private Dictionary<string, string> namespaceToPrefixMap;
+            private Dictionary<string, string> prefixToNamespaceMap;
+            private XamlSchemaContext schemaContext;
+            private ClrObjectRuntime runtime;
+            private XamlObjectReaderSettings settings;
 
             public SerializerContext(XamlSchemaContext schemaContext, XamlObjectReaderSettings settings)
             {
@@ -2557,7 +2556,7 @@ namespace System.Xaml
 
             public Type RootType { get; set; }
 
-            static int CompareByValue(KeyValuePair<string, string> x, KeyValuePair<string, string> y)
+            private static int CompareByValue(KeyValuePair<string, string> x, KeyValuePair<string, string> y)
             {
                 // we sort the list in reverse alphabetical order of prefixes
                 return string.Compare(y.Value, x.Value, false, TypeConverterHelper.InvariantEnglishUS);
@@ -2790,9 +2789,9 @@ namespace System.Xaml
             }
         }
 
-        class TypeDescriptorAndValueSerializerContext : IValueSerializerContext, INamespacePrefixLookup, IXamlSchemaContextProvider, IXamlNameProvider
+        private class TypeDescriptorAndValueSerializerContext : IValueSerializerContext, INamespacePrefixLookup, IXamlSchemaContextProvider, IXamlNameProvider
         {
-            SerializerContext context;
+            private SerializerContext context;
 
             public TypeDescriptorAndValueSerializerContext(SerializerContext context)
             {
@@ -2857,10 +2856,10 @@ namespace System.Xaml
             }
         }
 
-        class XamlTemplateMarkupInfo : ObjectMarkupInfo
+        private class XamlTemplateMarkupInfo : ObjectMarkupInfo
         {
-            List<MarkupInfo> nodes = new List<MarkupInfo>();
-            int objectPosition;
+            private List<MarkupInfo> nodes = new List<MarkupInfo>();
+            private int objectPosition;
 
             // This is kinda fancy-- XamlFactories are converted to XamlReaders, and then the XAML from those
             // readers is supposed to be inserted into the XAML verbatim. The problem is that we are supposed to

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -29,14 +29,14 @@ namespace System.Xaml
 
         // We don't expect a lot of contention on our dictionaries, so avoid the overhead of
         // extra lock partitioning
-        const int ConcurrencyLevel = 1;
-        const int DictionaryCapacity = 17;
+        private const int ConcurrencyLevel = 1;
+        private const int DictionaryCapacity = 17;
 
         // Immutable, initialized in constructor
         private readonly ReadOnlyCollection<Assembly> _referenceAssemblies;
 
         // take this lock when iterating new assemblies in the AppDomain/RefAssm
-        object _syncExaminingAssemblies;
+        private object _syncExaminingAssemblies;
 
         #endregion
 
@@ -166,7 +166,7 @@ namespace System.Xaml
             return result;
         }
 
-        string GetPrefixForClrNs(string clrNs, string assemblyName)
+        private string GetPrefixForClrNs(string clrNs, string assemblyName)
         {
             if (string.IsNullOrEmpty(assemblyName))
             {
@@ -205,7 +205,7 @@ namespace System.Xaml
             }
         }
 
-        void InitializePreferredPrefixes()
+        private void InitializePreferredPrefixes()
         {
             // To avoid an assignment race condition, prevent new assemblies from being processed while we're
             // iterating the existing list
@@ -220,7 +220,7 @@ namespace System.Xaml
             }
         }
 
-        void UpdatePreferredPrefixes(XmlNsInfo newNamespaces, ConcurrentDictionary<string, string> prefixDict)
+        private void UpdatePreferredPrefixes(XmlNsInfo newNamespaces, ConcurrentDictionary<string, string> prefixDict)
         {
             foreach (KeyValuePair<string, string> nsToPrefix in newNamespaces.Prefixes)
             {
@@ -686,15 +686,15 @@ namespace System.Xaml
         private ConcurrentDictionary<Assembly, XmlNsInfo> _xmlnsInfoForUnreferencedAssemblies;
 
         // immutable, initialized in ctor
-        AssemblyLoadHandler _assemblyLoadHandler;
+        private AssemblyLoadHandler _assemblyLoadHandler;
 
         // tracks new assemblies seen by the AssemblyLoad handler, but not yet reflected
         private IList<Assembly> _unexaminedAssemblies;
-        bool _isGCCallbackPending;
+        private bool _isGCCallbackPending;
 
         // take this lock when modifying _unexaminedAssemblies or _isGCCallbackPending
         // Acquisition order: If also taking _syncExaminingAssemblies, take it first
-        object _syncAccessingUnexaminedAssemblies;
+        private object _syncAccessingUnexaminedAssemblies;
 
         // This dictionary is also thread-safe for single reads and writes, but if you're
         // iterating them, lock on _syncExaminingAssemblies to ensure consistent results
@@ -1055,7 +1055,7 @@ namespace System.Xaml
             }
         }
 
-        void SchemaContextAssemblyLoadEventHandler(object sender, AssemblyLoadEventArgs args)
+        private void SchemaContextAssemblyLoadEventHandler(object sender, AssemblyLoadEventArgs args)
         {
             lock (_syncAccessingUnexaminedAssemblies)
             {
@@ -1145,7 +1145,7 @@ namespace System.Xaml
             return foundNew;
         }
 
-        bool UpdateNamespaceByUriList(XmlNsInfo nsInfo)
+        private bool UpdateNamespaceByUriList(XmlNsInfo nsInfo)
         {
             bool foundNew = false;
             IList<XmlNsInfo.XmlNsDefinition> xmlnsDefs = nsInfo.NsDefs;
@@ -1343,7 +1343,7 @@ namespace System.Xaml
         // WeakRef wrapper around XSC so that it can hook AppDomain event without getting rooted
         private class AssemblyLoadHandler
         {
-            WeakReference schemaContextRef;
+            private WeakReference schemaContextRef;
 
             public AssemblyLoadHandler(XamlSchemaContext schemaContext)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSubreader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSubreader.cs
@@ -8,12 +8,12 @@ namespace System.Xaml
 {
     internal class XamlSubreader : XamlReader, IXamlLineInfo
     {
-        XamlReader _reader;
-        IXamlLineInfo _lineInfoReader;
-        bool _done;
-        bool _firstRead;
-        bool _rootIsStartMember;
-        int _depth;
+        private XamlReader _reader;
+        private IXamlLineInfo _lineInfoReader;
+        private bool _done;
+        private bool _firstRead;
+        private bool _rootIsStartMember;
+        private int _depth;
 
         public XamlSubreader(XamlReader reader)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
@@ -22,12 +22,12 @@ namespace System.Xaml
     public class XamlType : IEquatable<XamlType>
     {
         // Initialized in constructor
-        readonly string _name;
-        XamlSchemaContext _schemaContext;
-        readonly IList<XamlType> _typeArguments;
+        private readonly string _name;
+        private XamlSchemaContext _schemaContext;
+        private readonly IList<XamlType> _typeArguments;
 
         // Thread safety: if setting outside ctor, do an interlocked compare against null
-        TypeReflector _reflector;
+        private TypeReflector _reflector;
 
         /// <summary>
         /// Lazy init: NullableReference.IsSet is null when not initialized
@@ -36,8 +36,8 @@ namespace System.Xaml
 
         // Lazy init: null until initialized
         // Thread safety: idempotent, assignment races are okay; do not assign incomplete values
-        ReadOnlyCollection<string> _namespaces;
-        ThreeValuedBool _isNameValid;
+        private ReadOnlyCollection<string> _namespaces;
+        private ThreeValuedBool _isNameValid;
 
         protected XamlType(string typeName, IList<XamlType> typeArguments, XamlSchemaContext schemaContext)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
@@ -14,7 +14,7 @@ namespace System.Xaml.Schema
     [DebuggerDisplay("{ToString()}")]
     public class XamlTypeName
     {
-        List<XamlTypeName> _typeArguments;
+        private List<XamlTypeName> _typeArguments;
 
         public string Name { get; set; }
         public string Namespace { get; set; }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
@@ -20,30 +20,30 @@ namespace System.Xaml
         // Each state of the writer is represented by a singleton that
         // implements an abstract class.
         //
-        WriterState currentState;
+        private WriterState currentState;
 
-        XmlWriter output;
-        XamlXmlWriterSettings settings;
+        private XmlWriter output;
+        private XamlXmlWriterSettings settings;
 
-        Stack<Frame> namespaceScopes;
+        private Stack<Frame> namespaceScopes;
 
         // A stack of lists that stores nodes we have tried to write in curly form so far.
         // Each list keeps track of the nodes in a markup extension
-        Stack<List<XamlNode>> meNodesStack;
-        XamlMarkupExtensionWriter meWriter;
+        private Stack<List<XamlNode>> meNodesStack;
+        private XamlMarkupExtensionWriter meWriter;
 
-        PositionalParameterStateInfo ppStateInfo;
+        private PositionalParameterStateInfo ppStateInfo;
 
-        string deferredValue;
-        bool deferredValueIsME;
-        bool isFirstElementOfWhitespaceSignificantCollection;
+        private string deferredValue;
+        private bool deferredValueIsME;
+        private bool isFirstElementOfWhitespaceSignificantCollection;
 
-        XamlSchemaContext schemaContext;
+        private XamlSchemaContext schemaContext;
 
         // a dictionary that keeps track of all the mappings from prefixes to namespaces
         // in the entire writing history.  If a prefix is used for two different namespaces
         // (in different scopes), then the entry for the prefix in the dictionary is null
-        Dictionary<string, string> prefixAssignmentHistory;
+        private Dictionary<string, string> prefixAssignmentHistory;
 
         public XamlXmlWriter(Stream stream, XamlSchemaContext schemaContext)
             : this(stream, schemaContext, null)
@@ -95,7 +95,7 @@ namespace System.Xaml
             InitializeXamlXmlWriter(xmlWriter, schemaContext, settings);
         }
 
-        void InitializeXamlXmlWriter(XmlWriter xmlWriter, XamlSchemaContext schemaContext, XamlXmlWriterSettings settings)
+        private void InitializeXamlXmlWriter(XmlWriter xmlWriter, XamlSchemaContext schemaContext, XamlXmlWriterSettings settings)
         {
             this.schemaContext = schemaContext ?? throw new ArgumentNullException(nameof(schemaContext));
 
@@ -259,12 +259,12 @@ namespace System.Xaml
             }
         }
 
-        void CheckIsDisposed()
+        private void CheckIsDisposed()
         {
             ObjectDisposedException.ThrowIf(IsDisposed, typeof(XamlXmlWriter));
         }
 
-        static bool StringStartsWithCurly(string s)
+        private static bool StringStartsWithCurly(string s)
         {
             if (string.IsNullOrEmpty(s))
             {
@@ -333,12 +333,12 @@ namespace System.Xaml
             return false;
         }
 
-        static void WriteXmlSpace(XamlXmlWriter writer)
+        private static void WriteXmlSpace(XamlXmlWriter writer)
         {
             writer.output.WriteAttributeString("xml", "space", "http://www.w3.org/XML/1998/namespace", "preserve");
         }
 
-        static XamlType GetContainingXamlType(XamlXmlWriter writer)
+        private static XamlType GetContainingXamlType(XamlXmlWriter writer)
         {
             Debug.Assert(writer.namespaceScopes.Peek().AllocatingNodeType == XamlNodeType.StartMember);
             Stack<Frame>.Enumerator enumerator = writer.namespaceScopes.GetEnumerator();
@@ -360,7 +360,7 @@ namespace System.Xaml
             return containingXamlType;
         }
 
-        void AssignNamespacePrefix(string ns, string prefix)
+        private void AssignNamespacePrefix(string ns, string prefix)
         {
             namespaceScopes.Peek().AssignNamespacePrefix(ns, prefix);
 
@@ -378,7 +378,7 @@ namespace System.Xaml
             }
         }
 
-        bool IsShadowed(string ns, string prefix)
+        private bool IsShadowed(string ns, string prefix)
         {
             Debug.Assert(ns != null);
             Debug.Assert(prefix != null);
@@ -401,7 +401,7 @@ namespace System.Xaml
         // Caveat: if the prefix found is shadowed (by a re-definition), FindPrefix will
         // redefine it.
         //
-        string FindPrefix(IList<string> namespaces, out string chosenNamespace)
+        private string FindPrefix(IList<string> namespaces, out string chosenNamespace)
         {
             string prefix = LookupPrefix(namespaces, out chosenNamespace);
 
@@ -445,7 +445,7 @@ namespace System.Xaml
             return null;
         }
 
-        bool IsPrefixEverUsedForAnotherNamespace(string prefix, string ns)
+        private bool IsPrefixEverUsedForAnotherNamespace(string prefix, string ns)
         {
             string registeredNamespace;
             return (prefixAssignmentHistory.TryGetValue(prefix, out registeredNamespace) && (ns != registeredNamespace));
@@ -456,7 +456,7 @@ namespace System.Xaml
         // Caveat: if the default prefix has never been used in the xaml document, DefinePrefix
         // chooses it.
         //
-        string DefinePrefix(string ns)
+        private string DefinePrefix(string ns)
         {
             // default namespace takes precedance if it has not been used, or has been used for the same namespace
             if (!IsPrefixEverUsedForAnotherNamespace(string.Empty, ns))
@@ -484,7 +484,7 @@ namespace System.Xaml
             return prefix;
         }
 
-        void CheckMemberForUniqueness(XamlMember property)
+        private void CheckMemberForUniqueness(XamlMember property)
         {
             // If we're not assuming the input is valid, then we need to do the checking...
             if (!settings.AssumeValidInput)
@@ -514,7 +514,7 @@ namespace System.Xaml
             }
         }
 
-        void WriteDeferredNamespaces(XamlNodeType nodeType)
+        private void WriteDeferredNamespaces(XamlNodeType nodeType)
         {
             Frame frame = namespaceScopes.Peek();
             if (frame.AllocatingNodeType != nodeType)
@@ -533,7 +533,7 @@ namespace System.Xaml
             }
         }
 
-        void WriteTypeArguments(XamlType type)
+        private void WriteTypeArguments(XamlType type)
         {
             if (TypeArgumentsContainNamespaceThatNeedsDefinition(type))
             {
@@ -545,7 +545,7 @@ namespace System.Xaml
             WriteEndMember();
         }
 
-        void WriteUndefinedNamespaces(XamlType type)
+        private void WriteUndefinedNamespaces(XamlType type)
         {
             string chosenNamespace;
             var namespaces = type.GetXamlNamespaces();
@@ -572,7 +572,7 @@ namespace System.Xaml
             }
         }
 
-        bool TypeArgumentsContainNamespaceThatNeedsDefinition(XamlType type)
+        private bool TypeArgumentsContainNamespaceThatNeedsDefinition(XamlType type)
         {
             string chosenNamespace;
             string prefix = LookupPrefix(type.GetXamlNamespaces(), out chosenNamespace);
@@ -599,7 +599,7 @@ namespace System.Xaml
             return false;
         }
 
-        string BuildTypeArgumentsString(IList<XamlType> typeArguments)
+        private string BuildTypeArgumentsString(IList<XamlType> typeArguments)
         {
             var builder = new StringBuilder();
             foreach (XamlType type in typeArguments)
@@ -615,14 +615,14 @@ namespace System.Xaml
             return builder.ToString();
         }
 
-        string ConvertXamlTypeToString(XamlType typeArgument)
+        private string ConvertXamlTypeToString(XamlType typeArgument)
         {
             var builder = new StringBuilder();
             ConvertXamlTypeToStringHelper(typeArgument, builder);
             return builder.ToString();
         }
 
-        void ConvertXamlTypeToStringHelper(XamlType type, StringBuilder builder)
+        private void ConvertXamlTypeToStringHelper(XamlType type, StringBuilder builder)
         {
             string prefix = LookupPrefix(type.GetXamlNamespaces(), out _);
             string typeName = GetTypeName(type);
@@ -666,10 +666,10 @@ namespace System.Xaml
             return typeName;
         }
 
-        class Frame
+        private class Frame
         {
-            Dictionary<string, string> namespaceMap = new Dictionary<string, string>(); //namespace to prefix map
-            Dictionary<string, string> prefixMap = new Dictionary<string, string>(); //prefix to namespace map
+            private Dictionary<string, string> namespaceMap = new Dictionary<string, string>(); //namespace to prefix map
+            private Dictionary<string, string> prefixMap = new Dictionary<string, string>(); //prefix to namespace map
 
             public XamlType Type
             {
@@ -760,13 +760,13 @@ namespace System.Xaml
                 return prefixMapList;
             }
 
-            static int CompareByKey(KeyValuePair<string, string> x, KeyValuePair<string, string> y)
+            private static int CompareByKey(KeyValuePair<string, string> x, KeyValuePair<string, string> y)
             {
                 return string.Compare(x.Key, y.Key, false, TypeConverterHelper.InvariantEnglishUS);
             }
         }
 
-        abstract class WriterState
+        private abstract class WriterState
         {
             public virtual void WriteObject(XamlXmlWriter writer, XamlType type, bool isObjectFromMember)
             {
@@ -866,7 +866,7 @@ namespace System.Xaml
                 writer.output.WriteStartElement(prefix, local, ns);
             }
 
-            static void WriteStartAttribute(XamlXmlWriter writer, string prefix, string local, string ns)
+            private static void WriteStartAttribute(XamlXmlWriter writer, string prefix, string local, string ns)
             {
                 if (string.IsNullOrEmpty(prefix))
                 {
@@ -926,10 +926,10 @@ namespace System.Xaml
             }
         }
 
-        class Start : WriterState
+        private class Start : WriterState
         {
-            static WriterState state = new Start();
-            Start()
+            private static WriterState state = new Start();
+            private Start()
             {
             }
             public static WriterState State
@@ -961,10 +961,10 @@ namespace System.Xaml
             }
         }
 
-        class End : WriterState
+        private class End : WriterState
         {
-            static WriterState state = new End();
-            End()
+            private static WriterState state = new End();
+            private End()
             {
             }
             public static WriterState State
@@ -973,10 +973,10 @@ namespace System.Xaml
             }
         }
 
-        class InRecord : WriterState
+        private class InRecord : WriterState
         {
-            static WriterState state = new InRecord();
-            InRecord()
+            private static WriterState state = new InRecord();
+            private InRecord()
             {
             }
             public static WriterState State
@@ -1097,10 +1097,10 @@ namespace System.Xaml
             }
         }
 
-        class InRecordTryAttributes : WriterState
+        private class InRecordTryAttributes : WriterState
         {
-            static WriterState state = new InRecordTryAttributes();
-            InRecordTryAttributes()
+            private static WriterState state = new InRecordTryAttributes();
+            private InRecordTryAttributes()
             {
             }
             public static WriterState State
@@ -1209,10 +1209,10 @@ namespace System.Xaml
 
         // Follows InObject after Start Member
         //
-        class InMember : WriterState
+        private class InMember : WriterState
         {
-            static WriterState state = new InMember();
-            InMember()
+            private static WriterState state = new InMember();
+            private InMember()
             {
             }
             public static WriterState State
@@ -1308,7 +1308,7 @@ namespace System.Xaml
                 }
             }
 
-            void WriteXmlSpaceOrThrow(XamlXmlWriter writer, string value)
+            private void WriteXmlSpaceOrThrow(XamlXmlWriter writer, string value)
             {
                 var frameWithXmlSpacePreserve = FindFrameWithXmlSpacePreserve(writer);
                 if (frameWithXmlSpacePreserve.AllocatingNodeType == XamlNodeType.StartMember)
@@ -1320,7 +1320,7 @@ namespace System.Xaml
             }
 
             // this method finds the SO or SM where "xml:space = preserve" will actually be attached to
-            Frame FindFrameWithXmlSpacePreserve(XamlXmlWriter writer)
+            private Frame FindFrameWithXmlSpacePreserve(XamlXmlWriter writer)
             {
                 var frameEnumerator = writer.namespaceScopes.GetEnumerator();
 
@@ -1396,10 +1396,10 @@ namespace System.Xaml
         // Follows InMember after an Atom and prevents writing two atoms
         // in a row
         //
-        class InMemberAfterValue : WriterState
+        private class InMemberAfterValue : WriterState
         {
-            static WriterState state = new InMemberAfterValue();
-            InMemberAfterValue()
+            private static WriterState state = new InMemberAfterValue();
+            private InMemberAfterValue()
             {
             }
             public static WriterState State
@@ -1439,10 +1439,10 @@ namespace System.Xaml
         // or throw depending on whether the next element is another collection element of
         // end member
         //
-        class InMemberAfterValueWithSignificantWhitespace : WriterState
+        private class InMemberAfterValueWithSignificantWhitespace : WriterState
         {
-            static WriterState state = new InMemberAfterValueWithSignificantWhitespace();
-            InMemberAfterValueWithSignificantWhitespace()
+            private static WriterState state = new InMemberAfterValueWithSignificantWhitespace();
+            private InMemberAfterValueWithSignificantWhitespace()
             {
             }
             public static WriterState State
@@ -1487,10 +1487,10 @@ namespace System.Xaml
         // Follows InObject after an End Object.
         // Like InMember but also allows End Member.
         //
-        class InMemberAfterEndObject : WriterState
+        private class InMemberAfterEndObject : WriterState
         {
-            static WriterState state = new InMemberAfterEndObject();
-            InMemberAfterEndObject()
+            private static WriterState state = new InMemberAfterEndObject();
+            private InMemberAfterEndObject()
             {
             }
             public static WriterState State
@@ -1524,10 +1524,10 @@ namespace System.Xaml
         }
 
         // From InMemberTryAttributesAfterAtom, we are sure that this is an attributable member.
-        class InMemberAttributedMember : WriterState
+        private class InMemberAttributedMember : WriterState
         {
-            static WriterState state = new InMemberAttributedMember();
-            InMemberAttributedMember()
+            private static WriterState state = new InMemberAttributedMember();
+            private InMemberAttributedMember()
             {
             }
             public static WriterState State
@@ -1558,10 +1558,10 @@ namespace System.Xaml
             }
         }
 
-        class InMemberTryAttributes : WriterState
+        private class InMemberTryAttributes : WriterState
         {
-            static WriterState state = new InMemberTryAttributes();
-            InMemberTryAttributes()
+            private static WriterState state = new InMemberTryAttributes();
+            private InMemberTryAttributes()
             {
             }
             public static WriterState State
@@ -1616,10 +1616,10 @@ namespace System.Xaml
         // record -- for mixed content -- which would force us out of
         // attribute form.
         //
-        class InMemberTryAttributesAfterValue : WriterState
+        private class InMemberTryAttributesAfterValue : WriterState
         {
-            static WriterState state = new InMemberTryAttributesAfterValue();
-            InMemberTryAttributesAfterValue()
+            private static WriterState state = new InMemberTryAttributesAfterValue();
+            private InMemberTryAttributesAfterValue()
             {
             }
             public static WriterState State
@@ -1661,10 +1661,10 @@ namespace System.Xaml
             }
         }
 
-        class TryContentProperty : WriterState
+        private class TryContentProperty : WriterState
         {
-            static WriterState state = new TryContentProperty();
-            TryContentProperty()
+            private static WriterState state = new TryContentProperty();
+            private TryContentProperty()
             {
             }
             public static WriterState State
@@ -1703,10 +1703,10 @@ namespace System.Xaml
             }
         }
 
-        class TryContentPropertyInTryAttributesState : WriterState
+        private class TryContentPropertyInTryAttributesState : WriterState
         {
-            static WriterState state = new TryContentPropertyInTryAttributesState();
-            TryContentPropertyInTryAttributesState()
+            private static WriterState state = new TryContentPropertyInTryAttributesState();
+            private TryContentPropertyInTryAttributesState()
             {
             }
             public static WriterState State
@@ -1753,10 +1753,10 @@ namespace System.Xaml
             }
         }
 
-        class TryCurlyForm : WriterState
+        private class TryCurlyForm : WriterState
         {
-            static WriterState state = new TryCurlyForm();
-            TryCurlyForm()
+            private static WriterState state = new TryCurlyForm();
+            private TryCurlyForm()
             {
             }
             public static WriterState State
@@ -1764,7 +1764,7 @@ namespace System.Xaml
                 get { return state; }
             }
 
-            void WriteNodesInXmlForm(XamlXmlWriter writer)
+            private void WriteNodesInXmlForm(XamlXmlWriter writer)
             {
                 writer.WriteDeferredNamespaces(XamlNodeType.StartObject);
                 WriteMemberAsElement(writer);
@@ -1867,10 +1867,10 @@ namespace System.Xaml
             }
         }
 
-        class ExpandPositionalParameters : WriterState
+        private class ExpandPositionalParameters : WriterState
         {
-            static WriterState state = new ExpandPositionalParameters();
-            ExpandPositionalParameters()
+            private static WriterState state = new ExpandPositionalParameters();
+            private ExpandPositionalParameters()
             {
             }
 
@@ -1879,7 +1879,7 @@ namespace System.Xaml
                 get { return state; }
             }
 
-            void ExpandPositionalParametersIntoProperties(XamlXmlWriter writer)
+            private void ExpandPositionalParametersIntoProperties(XamlXmlWriter writer)
             {
                 Frame frame = writer.namespaceScopes.Peek();
                 Debug.Assert(frame.AllocatingNodeType == XamlNodeType.StartObject);
@@ -1937,7 +1937,7 @@ namespace System.Xaml
                 }
             }
 
-            ParameterInfo[] GetParametersInfo(XamlType objectXamlType, int numOfParameters)
+            private ParameterInfo[] GetParametersInfo(XamlType objectXamlType, int numOfParameters)
             {
                 IList<XamlType> paramXamlTypes = objectXamlType.GetPositionalParameters(numOfParameters);
 
@@ -1972,7 +1972,7 @@ namespace System.Xaml
                 return constructor.GetParameters();
             }
 
-            List<XamlMember> GetAllPropertiesWithCAA(XamlType objectXamlType)
+            private List<XamlMember> GetAllPropertiesWithCAA(XamlType objectXamlType)
             {
                 // Pull out all the properties that are attributed with ConstructorArgumentAttribute
                 //
@@ -1997,7 +1997,7 @@ namespace System.Xaml
                 return ctorArgProps;
             }
 
-            void WriteNodes(XamlXmlWriter writer)
+            private void WriteNodes(XamlXmlWriter writer)
             {
                 var ppNodesList = writer.ppStateInfo.NodesList;
                 writer.ppStateInfo.Reset();
@@ -2012,7 +2012,7 @@ namespace System.Xaml
                 }
             }
 
-            void ThrowIfFailed(bool fail, string operation)
+            private void ThrowIfFailed(bool fail, string operation)
             {
                 if (fail)
                 {
@@ -2105,7 +2105,7 @@ namespace System.Xaml
             }
         }
 
-        class PositionalParameterStateInfo
+        private class PositionalParameterStateInfo
         {
             public PositionalParameterStateInfo(XamlXmlWriter xamlXmlWriter)
             {
@@ -2165,7 +2165,7 @@ namespace System.Xaml
     // HashSet<T> lives in System.Core.dll
     internal class XamlPropertySet
     {
-        Dictionary<XamlMember, bool> dictionary = new Dictionary<XamlMember, bool>();
+        private Dictionary<XamlMember, bool> dictionary = new Dictionary<XamlMember, bool>();
 
         public bool Contains(XamlMember member)
         {


### PR DESCRIPTION
## Description
This work is a part of our initiative to set code-style guidelines, align WPF and WinForms, and ensure PR standards with respect to styles. This in turn will help us in better maintainability and readability of the repo overall. The changes follow up from the PR #10080 and references to the issue #10017.

The current changes addresses the following Errors/Warnings in the src folder of WPF:
- **SA1400:** Member should declare an access modifier

## Customer Impact
_None_

## Regression
_None_

## Testing
Local Build Pass

## Risk
Medium, could cause issues with reflection.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10125)