### PR TITLE
Modified Expander animation mechanism in Fluent to avoid Argument Null Exception

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Controls/AnimationFactorToValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Controls/AnimationFactorToValueConverter.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Data;
 using System.Globalization;
+using System.Diagnostics;
 
 namespace Fluent.Controls
 {
@@ -17,7 +18,7 @@ namespace Fluent.Controls
                 return 0.0;
             }
 
-            if (values[1] is not double factor)
+            if (values[1] is not double factor || factor == double.NaN)
             {
                 return 0.0;
             }

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Controls/AnimationFactorToValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Controls/AnimationFactorToValueConverter.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Data;
 using System.Globalization;
-using System.Diagnostics;
 
 namespace Fluent.Controls
 {

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Expander.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Expander.xaml
@@ -316,6 +316,8 @@
                         </Border>
 
                         <Grid x:Name="ContentPresenterGrid" DockPanel.Dock="Bottom" ClipToBounds="True">
+                            <!-- Dummy border to store Animation factor for expander -->
+                            <Border x:Name="AnimationFactorBorder" Width="0" Visibility="Collapsed" />
                             <Border x:Name="ContentPresenterBorder"
                                     Background="{DynamicResource ExpanderContentBackground}"
                                     BorderBrush="{TemplateBinding BorderBrush}"
@@ -327,23 +329,36 @@
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                   Content="{TemplateBinding Content}" />
-                                <Border.Tag>
-                                    <system:Double>0.0</system:Double>
-                                </Border.Tag>
                                 <Border.Resources>
-                                    <TranslateTransform x:Key="HeightAnimation">
+                                    <TranslateTransform x:Key="HeightAnimationNegative">
                                         <TranslateTransform.Y>
                                             <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="negative">
                                                 <Binding ElementName="ContentPresenterBorder" Path="ActualHeight" />
-                                                <Binding ElementName="ContentPresenterBorder" Path="Tag" />
+                                                <Binding ElementName="AnimationFactorBorder" Path="Width" />
                                             </MultiBinding>
                                         </TranslateTransform.Y>
                                     </TranslateTransform>
-                                    <TranslateTransform x:Key="WidthAnimation">
+                                    <TranslateTransform x:Key="WidthAnimationNegative">
                                         <TranslateTransform.X>
                                             <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="negative">
                                                 <Binding ElementName="ContentPresenterBorder" Path="ActualWidth" />
-                                                <Binding ElementName="ContentPresenterBorder" Path="Tag" />
+                                                <Binding ElementName="AnimationFactorBorder" Path="Width" />
+                                            </MultiBinding>
+                                        </TranslateTransform.X>
+                                    </TranslateTransform>
+                                    <TranslateTransform x:Key="HeightAnimationPositive">
+                                        <TranslateTransform.Y>
+                                            <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="positive">
+                                                <Binding ElementName="ContentPresenterBorder" Path="ActualHeight" />
+                                                <Binding ElementName="AnimationFactorBorder" Path="Width" />
+                                            </MultiBinding>
+                                        </TranslateTransform.Y>
+                                    </TranslateTransform>
+                                    <TranslateTransform x:Key="WidthAnimationPositive">
+                                        <TranslateTransform.X>
+                                            <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="positive">
+                                                <Binding ElementName="ContentPresenterBorder" Path="ActualWidth" />
+                                                <Binding ElementName="AnimationFactorBorder" Path="Width" />
                                             </MultiBinding>
                                         </TranslateTransform.X>
                                     </TranslateTransform>
@@ -366,7 +381,7 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                                             <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                                             <SplineDoubleKeyFrame
                                                 KeySpline="0.0, 0.0, 0.0, 1.0"
@@ -381,9 +396,9 @@
                                     <Storyboard>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
-                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:5" Value="{x:Static Visibility.Collapsed}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                                             <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
                                             <SplineDoubleKeyFrame
                                                 KeySpline="1.0, 1.0, 0.0, 1.0"
@@ -411,8 +426,8 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="-1.0" />
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                                             <SplineDoubleKeyFrame
                                                 KeySpline="0.0, 0.0, 0.0, 1.0"
                                                 KeyTime="0:0:0.333"
@@ -428,12 +443,12 @@
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                             <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                                             <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
                                             <SplineDoubleKeyFrame
                                                 KeySpline="1.0, 1.0, 0.0, 1.0"
                                                 KeyTime="0:0:0.333"
-                                                Value="-1.0" />
+                                                Value="1.0" />
                                         </DoubleAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </BeginStoryboard>
@@ -456,8 +471,8 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="-1.0" />
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                                             <SplineDoubleKeyFrame
                                                 KeySpline="0.0, 0.0, 0.0, 1.0"
                                                 KeyTime="0:0:0.333"
@@ -473,12 +488,12 @@
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                             <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                                             <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
                                             <SplineDoubleKeyFrame
                                                 KeySpline="1.0, 1.0, 0.0, 1.0"
                                                 KeyTime="0:0:0.333"
-                                                Value="-1.0" />
+                                                Value="1.0" />
                                         </DoubleAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </BeginStoryboard>
@@ -501,7 +516,7 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                                             <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                                             <SplineDoubleKeyFrame
                                                     KeySpline="0.0, 0.0, 0.0, 1.0"
@@ -518,7 +533,7 @@
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                             <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                                             <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
                                             <SplineDoubleKeyFrame
                                                     KeySpline="1.0, 1.0, 0.0, 1.0"
@@ -542,7 +557,7 @@
                                     Value="{StaticResource DefaultExpanderToggleButtonRightStyle}"
                                     TargetName="HeaderSite"/>
                             <Setter Property="RenderTransform"
-                                    Value="{DynamicResource WidthAnimation}"
+                                    Value="{DynamicResource WidthAnimationNegative}"
                                     TargetName="ContentPresenterBorder" />
                         </Trigger>
 
@@ -558,14 +573,14 @@
                                     Value="{StaticResource DefaultExpanderToggleButtonUpStyle}"
                                     TargetName="HeaderSite"/>
                             <Setter Property="RenderTransform"
-                                    Value="{DynamicResource HeightAnimation}"
+                                    Value="{DynamicResource HeightAnimationPositive}"
                                     TargetName="ContentPresenterBorder" />
                         </Trigger>
 
                         <Trigger Property="ExpandDirection"
                                  Value="Down">
                             <Setter Property="RenderTransform"
-                                    Value="{DynamicResource HeightAnimation}"
+                                    Value="{DynamicResource HeightAnimationNegative}"
                                     TargetName="ContentPresenterBorder" />
                         </Trigger>
 
@@ -581,7 +596,7 @@
                                     Value="{StaticResource DefaultExpanderToggleButtonLeftStyle}"
                                     TargetName="HeaderSite"/>
                             <Setter Property="RenderTransform"
-                                    Value="{DynamicResource WidthAnimation}"
+                                    Value="{DynamicResource WidthAnimationPositive}"
                                     TargetName="ContentPresenterBorder" />
                         </Trigger>
 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -2401,25 +2401,40 @@
               <ToggleButton x:Name="HeaderSite" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" Margin="0" Padding="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" FontFamily="{TemplateBinding FontFamily}" FontSize="{TemplateBinding FontSize}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontWeight="{TemplateBinding FontWeight}" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}" IsEnabled="{TemplateBinding IsEnabled}" OverridesDefaultStyle="True" Template="{StaticResource DefaultExpanderToggleButtonDownStyle}" FocusVisualStyle="{DynamicResource DefaultControlFocusVisualStyle}" />
             </Border>
             <Grid x:Name="ContentPresenterGrid" DockPanel.Dock="Bottom" ClipToBounds="True">
+              <!-- Dummy border to store Animation factor for expander -->
+              <Border x:Name="AnimationFactorBorder" Width="0" Visibility="Collapsed" />
               <Border x:Name="ContentPresenterBorder" Background="{DynamicResource ExpanderContentBackground}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,0,1,1" CornerRadius="0,0,4,4" Visibility="Collapsed">
                 <ContentPresenter x:Name="ContentPresenter" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" />
-                <Border.Tag>
-                  <system:Double>0.0</system:Double>
-                </Border.Tag>
                 <Border.Resources>
-                  <TranslateTransform x:Key="HeightAnimation">
+                  <TranslateTransform x:Key="HeightAnimationNegative">
                     <TranslateTransform.Y>
                       <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="negative">
                         <Binding ElementName="ContentPresenterBorder" Path="ActualHeight" />
-                        <Binding ElementName="ContentPresenterBorder" Path="Tag" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
                       </MultiBinding>
                     </TranslateTransform.Y>
                   </TranslateTransform>
-                  <TranslateTransform x:Key="WidthAnimation">
+                  <TranslateTransform x:Key="WidthAnimationNegative">
                     <TranslateTransform.X>
                       <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="negative">
                         <Binding ElementName="ContentPresenterBorder" Path="ActualWidth" />
-                        <Binding ElementName="ContentPresenterBorder" Path="Tag" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
+                      </MultiBinding>
+                    </TranslateTransform.X>
+                  </TranslateTransform>
+                  <TranslateTransform x:Key="HeightAnimationPositive">
+                    <TranslateTransform.Y>
+                      <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="positive">
+                        <Binding ElementName="ContentPresenterBorder" Path="ActualHeight" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
+                      </MultiBinding>
+                    </TranslateTransform.Y>
+                  </TranslateTransform>
+                  <TranslateTransform x:Key="WidthAnimationPositive">
+                    <TranslateTransform.X>
+                      <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="positive">
+                        <Binding ElementName="ContentPresenterBorder" Path="ActualWidth" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
                       </MultiBinding>
                     </TranslateTransform.X>
                   </TranslateTransform>
@@ -2441,7 +2456,7 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                       <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
                     </DoubleAnimationUsingKeyFrames>
@@ -2453,9 +2468,9 @@
                   <Storyboard>
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
-                      <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
+                      <DiscreteObjectKeyFrame KeyTime="0:0:5" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
                       <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
                     </DoubleAnimationUsingKeyFrames>
@@ -2479,8 +2494,8 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                      <DiscreteDoubleKeyFrame KeyTime="0" Value="-1.0" />
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                       <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
                     </DoubleAnimationUsingKeyFrames>
                   </Storyboard>
@@ -2493,9 +2508,9 @@
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                       <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
-                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="-1.0" />
+                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
                     </DoubleAnimationUsingKeyFrames>
                   </Storyboard>
                 </BeginStoryboard>
@@ -2517,8 +2532,8 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                      <DiscreteDoubleKeyFrame KeyTime="0" Value="-1.0" />
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                       <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
                     </DoubleAnimationUsingKeyFrames>
                   </Storyboard>
@@ -2531,9 +2546,9 @@
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                       <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
-                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="-1.0" />
+                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
                     </DoubleAnimationUsingKeyFrames>
                   </Storyboard>
                 </BeginStoryboard>
@@ -2555,7 +2570,7 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                       <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
                     </DoubleAnimationUsingKeyFrames>
@@ -2569,7 +2584,7 @@
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                       <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
                       <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
                     </DoubleAnimationUsingKeyFrames>
@@ -2581,22 +2596,22 @@
               <Setter Property="DockPanel.Dock" Value="Right" TargetName="ContentPresenterGrid" />
               <Setter Property="DockPanel.Dock" Value="Left" TargetName="ToggleButtonBorder" />
               <Setter Property="Template" Value="{StaticResource DefaultExpanderToggleButtonRightStyle}" TargetName="HeaderSite" />
-              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimation}" TargetName="ContentPresenterBorder" />
+              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimationNegative}" TargetName="ContentPresenterBorder" />
             </Trigger>
             <Trigger Property="ExpandDirection" Value="Up">
               <Setter Property="DockPanel.Dock" Value="Top" TargetName="ContentPresenterGrid" />
               <Setter Property="DockPanel.Dock" Value="Bottom" TargetName="ToggleButtonBorder" />
               <Setter Property="Template" Value="{StaticResource DefaultExpanderToggleButtonUpStyle}" TargetName="HeaderSite" />
-              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimation}" TargetName="ContentPresenterBorder" />
+              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimationPositive}" TargetName="ContentPresenterBorder" />
             </Trigger>
             <Trigger Property="ExpandDirection" Value="Down">
-              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimation}" TargetName="ContentPresenterBorder" />
+              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimationNegative}" TargetName="ContentPresenterBorder" />
             </Trigger>
             <Trigger Property="ExpandDirection" Value="Left">
               <Setter Property="DockPanel.Dock" Value="Left" TargetName="ContentPresenterGrid" />
               <Setter Property="DockPanel.Dock" Value="Right" TargetName="ToggleButtonBorder" />
               <Setter Property="Template" Value="{StaticResource DefaultExpanderToggleButtonLeftStyle}" TargetName="HeaderSite" />
-              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimation}" TargetName="ContentPresenterBorder" />
+              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimationPositive}" TargetName="ContentPresenterBorder" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="False">
               <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ExpanderHeaderDisabledForeground}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -2379,25 +2379,40 @@
               <ToggleButton x:Name="HeaderSite" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" Margin="0" Padding="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" FontFamily="{TemplateBinding FontFamily}" FontSize="{TemplateBinding FontSize}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontWeight="{TemplateBinding FontWeight}" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}" IsEnabled="{TemplateBinding IsEnabled}" OverridesDefaultStyle="True" Template="{StaticResource DefaultExpanderToggleButtonDownStyle}" FocusVisualStyle="{DynamicResource DefaultControlFocusVisualStyle}" />
             </Border>
             <Grid x:Name="ContentPresenterGrid" DockPanel.Dock="Bottom" ClipToBounds="True">
+              <!-- Dummy border to store Animation factor for expander -->
+              <Border x:Name="AnimationFactorBorder" Width="0" Visibility="Collapsed" />
               <Border x:Name="ContentPresenterBorder" Background="{DynamicResource ExpanderContentBackground}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,0,1,1" CornerRadius="0,0,4,4" Visibility="Collapsed">
                 <ContentPresenter x:Name="ContentPresenter" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" />
-                <Border.Tag>
-                  <system:Double>0.0</system:Double>
-                </Border.Tag>
                 <Border.Resources>
-                  <TranslateTransform x:Key="HeightAnimation">
+                  <TranslateTransform x:Key="HeightAnimationNegative">
                     <TranslateTransform.Y>
                       <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="negative">
                         <Binding ElementName="ContentPresenterBorder" Path="ActualHeight" />
-                        <Binding ElementName="ContentPresenterBorder" Path="Tag" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
                       </MultiBinding>
                     </TranslateTransform.Y>
                   </TranslateTransform>
-                  <TranslateTransform x:Key="WidthAnimation">
+                  <TranslateTransform x:Key="WidthAnimationNegative">
                     <TranslateTransform.X>
                       <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="negative">
                         <Binding ElementName="ContentPresenterBorder" Path="ActualWidth" />
-                        <Binding ElementName="ContentPresenterBorder" Path="Tag" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
+                      </MultiBinding>
+                    </TranslateTransform.X>
+                  </TranslateTransform>
+                  <TranslateTransform x:Key="HeightAnimationPositive">
+                    <TranslateTransform.Y>
+                      <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="positive">
+                        <Binding ElementName="ContentPresenterBorder" Path="ActualHeight" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
+                      </MultiBinding>
+                    </TranslateTransform.Y>
+                  </TranslateTransform>
+                  <TranslateTransform x:Key="WidthAnimationPositive">
+                    <TranslateTransform.X>
+                      <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="positive">
+                        <Binding ElementName="ContentPresenterBorder" Path="ActualWidth" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
                       </MultiBinding>
                     </TranslateTransform.X>
                   </TranslateTransform>
@@ -2419,7 +2434,7 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                       <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
                     </DoubleAnimationUsingKeyFrames>
@@ -2431,9 +2446,9 @@
                   <Storyboard>
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
-                      <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
+                      <DiscreteObjectKeyFrame KeyTime="0:0:5" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
                       <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
                     </DoubleAnimationUsingKeyFrames>
@@ -2457,8 +2472,8 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                      <DiscreteDoubleKeyFrame KeyTime="0" Value="-1.0" />
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                       <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
                     </DoubleAnimationUsingKeyFrames>
                   </Storyboard>
@@ -2471,9 +2486,9 @@
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                       <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
-                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="-1.0" />
+                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
                     </DoubleAnimationUsingKeyFrames>
                   </Storyboard>
                 </BeginStoryboard>
@@ -2495,8 +2510,8 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                      <DiscreteDoubleKeyFrame KeyTime="0" Value="-1.0" />
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                       <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
                     </DoubleAnimationUsingKeyFrames>
                   </Storyboard>
@@ -2509,9 +2524,9 @@
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                       <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
-                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="-1.0" />
+                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
                     </DoubleAnimationUsingKeyFrames>
                   </Storyboard>
                 </BeginStoryboard>
@@ -2533,7 +2548,7 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                       <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
                     </DoubleAnimationUsingKeyFrames>
@@ -2547,7 +2562,7 @@
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                       <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
                       <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
                     </DoubleAnimationUsingKeyFrames>
@@ -2559,22 +2574,22 @@
               <Setter Property="DockPanel.Dock" Value="Right" TargetName="ContentPresenterGrid" />
               <Setter Property="DockPanel.Dock" Value="Left" TargetName="ToggleButtonBorder" />
               <Setter Property="Template" Value="{StaticResource DefaultExpanderToggleButtonRightStyle}" TargetName="HeaderSite" />
-              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimation}" TargetName="ContentPresenterBorder" />
+              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimationNegative}" TargetName="ContentPresenterBorder" />
             </Trigger>
             <Trigger Property="ExpandDirection" Value="Up">
               <Setter Property="DockPanel.Dock" Value="Top" TargetName="ContentPresenterGrid" />
               <Setter Property="DockPanel.Dock" Value="Bottom" TargetName="ToggleButtonBorder" />
               <Setter Property="Template" Value="{StaticResource DefaultExpanderToggleButtonUpStyle}" TargetName="HeaderSite" />
-              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimation}" TargetName="ContentPresenterBorder" />
+              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimationPositive}" TargetName="ContentPresenterBorder" />
             </Trigger>
             <Trigger Property="ExpandDirection" Value="Down">
-              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimation}" TargetName="ContentPresenterBorder" />
+              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimationNegative}" TargetName="ContentPresenterBorder" />
             </Trigger>
             <Trigger Property="ExpandDirection" Value="Left">
               <Setter Property="DockPanel.Dock" Value="Left" TargetName="ContentPresenterGrid" />
               <Setter Property="DockPanel.Dock" Value="Right" TargetName="ToggleButtonBorder" />
               <Setter Property="Template" Value="{StaticResource DefaultExpanderToggleButtonLeftStyle}" TargetName="HeaderSite" />
-              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimation}" TargetName="ContentPresenterBorder" />
+              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimationPositive}" TargetName="ContentPresenterBorder" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="False">
               <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ExpanderHeaderDisabledForeground}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -2399,25 +2399,40 @@
               <ToggleButton x:Name="HeaderSite" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" Margin="0" Padding="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" FontFamily="{TemplateBinding FontFamily}" FontSize="{TemplateBinding FontSize}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontWeight="{TemplateBinding FontWeight}" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}" IsEnabled="{TemplateBinding IsEnabled}" OverridesDefaultStyle="True" Template="{StaticResource DefaultExpanderToggleButtonDownStyle}" FocusVisualStyle="{DynamicResource DefaultControlFocusVisualStyle}" />
             </Border>
             <Grid x:Name="ContentPresenterGrid" DockPanel.Dock="Bottom" ClipToBounds="True">
+              <!-- Dummy border to store Animation factor for expander -->
+              <Border x:Name="AnimationFactorBorder" Width="0" Visibility="Collapsed" />
               <Border x:Name="ContentPresenterBorder" Background="{DynamicResource ExpanderContentBackground}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,0,1,1" CornerRadius="0,0,4,4" Visibility="Collapsed">
                 <ContentPresenter x:Name="ContentPresenter" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" />
-                <Border.Tag>
-                  <system:Double>0.0</system:Double>
-                </Border.Tag>
                 <Border.Resources>
-                  <TranslateTransform x:Key="HeightAnimation">
+                  <TranslateTransform x:Key="HeightAnimationNegative">
                     <TranslateTransform.Y>
                       <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="negative">
                         <Binding ElementName="ContentPresenterBorder" Path="ActualHeight" />
-                        <Binding ElementName="ContentPresenterBorder" Path="Tag" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
                       </MultiBinding>
                     </TranslateTransform.Y>
                   </TranslateTransform>
-                  <TranslateTransform x:Key="WidthAnimation">
+                  <TranslateTransform x:Key="WidthAnimationNegative">
                     <TranslateTransform.X>
                       <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="negative">
                         <Binding ElementName="ContentPresenterBorder" Path="ActualWidth" />
-                        <Binding ElementName="ContentPresenterBorder" Path="Tag" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
+                      </MultiBinding>
+                    </TranslateTransform.X>
+                  </TranslateTransform>
+                  <TranslateTransform x:Key="HeightAnimationPositive">
+                    <TranslateTransform.Y>
+                      <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="positive">
+                        <Binding ElementName="ContentPresenterBorder" Path="ActualHeight" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
+                      </MultiBinding>
+                    </TranslateTransform.Y>
+                  </TranslateTransform>
+                  <TranslateTransform x:Key="WidthAnimationPositive">
+                    <TranslateTransform.X>
+                      <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="positive">
+                        <Binding ElementName="ContentPresenterBorder" Path="ActualWidth" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
                       </MultiBinding>
                     </TranslateTransform.X>
                   </TranslateTransform>
@@ -2439,7 +2454,7 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                       <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
                     </DoubleAnimationUsingKeyFrames>
@@ -2451,9 +2466,9 @@
                   <Storyboard>
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
-                      <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
+                      <DiscreteObjectKeyFrame KeyTime="0:0:5" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
                       <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
                     </DoubleAnimationUsingKeyFrames>
@@ -2477,8 +2492,8 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                      <DiscreteDoubleKeyFrame KeyTime="0" Value="-1.0" />
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                       <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
                     </DoubleAnimationUsingKeyFrames>
                   </Storyboard>
@@ -2491,9 +2506,9 @@
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                       <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
-                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="-1.0" />
+                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
                     </DoubleAnimationUsingKeyFrames>
                   </Storyboard>
                 </BeginStoryboard>
@@ -2515,8 +2530,8 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
-                      <DiscreteDoubleKeyFrame KeyTime="0" Value="-1.0" />
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                       <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
                     </DoubleAnimationUsingKeyFrames>
                   </Storyboard>
@@ -2529,9 +2544,9 @@
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                       <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
-                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="-1.0" />
+                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
                     </DoubleAnimationUsingKeyFrames>
                   </Storyboard>
                 </BeginStoryboard>
@@ -2553,7 +2568,7 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
                       <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
                     </DoubleAnimationUsingKeyFrames>
@@ -2567,7 +2582,7 @@
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                       <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
-                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="Tag">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
                       <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
                       <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
                     </DoubleAnimationUsingKeyFrames>
@@ -2579,22 +2594,22 @@
               <Setter Property="DockPanel.Dock" Value="Right" TargetName="ContentPresenterGrid" />
               <Setter Property="DockPanel.Dock" Value="Left" TargetName="ToggleButtonBorder" />
               <Setter Property="Template" Value="{StaticResource DefaultExpanderToggleButtonRightStyle}" TargetName="HeaderSite" />
-              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimation}" TargetName="ContentPresenterBorder" />
+              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimationNegative}" TargetName="ContentPresenterBorder" />
             </Trigger>
             <Trigger Property="ExpandDirection" Value="Up">
               <Setter Property="DockPanel.Dock" Value="Top" TargetName="ContentPresenterGrid" />
               <Setter Property="DockPanel.Dock" Value="Bottom" TargetName="ToggleButtonBorder" />
               <Setter Property="Template" Value="{StaticResource DefaultExpanderToggleButtonUpStyle}" TargetName="HeaderSite" />
-              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimation}" TargetName="ContentPresenterBorder" />
+              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimationPositive}" TargetName="ContentPresenterBorder" />
             </Trigger>
             <Trigger Property="ExpandDirection" Value="Down">
-              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimation}" TargetName="ContentPresenterBorder" />
+              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimationNegative}" TargetName="ContentPresenterBorder" />
             </Trigger>
             <Trigger Property="ExpandDirection" Value="Left">
               <Setter Property="DockPanel.Dock" Value="Left" TargetName="ContentPresenterGrid" />
               <Setter Property="DockPanel.Dock" Value="Right" TargetName="ToggleButtonBorder" />
               <Setter Property="Template" Value="{StaticResource DefaultExpanderToggleButtonLeftStyle}" TargetName="HeaderSite" />
-              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimation}" TargetName="ContentPresenterBorder" />
+              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimationPositive}" TargetName="ContentPresenterBorder" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="False">
               <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ExpanderHeaderDisabledForeground}" />


### PR DESCRIPTION

Fixes https://github.com/microsoft/WPF-Samples/issues/672

## Description
While changing the ResourceDictionaries, during the invalidation, Tag property was being set to null ( default value ) which was causing an error with the animation. Replaced it with a dummy border and instead of using Tag, now I use Width property of the border which is a double and it's default value is not null. This avoids the ArgumentNullException when the expander is expanded and the Theme is changed.

## Customer Impact
Not taking this fix would cause a ArgumentNullException when the Expander is expanded, and the Theme is changed

## Regression
No

## Testing
Sample App Testing

## Risk
Low

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10130)