### PR TITLE
[release/9.0] Fixes window backdrop and background in Windows 10 and window theme interactions with system changes

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
@@ -28,12 +28,10 @@ internal static class ThemeManager
 
                 FluentThemeState newFluentThemeState = new FluentThemeState(Application.Current.ThemeMode.Value, useLightColors);
 
-                if (s_currentFluentThemeState == newFluentThemeState)
+                if (s_currentFluentThemeState != newFluentThemeState)
                 {
-                    return;
+                    AddOrUpdateThemeResources(Application.Current.Resources, GetThemeDictionary(Application.Current.ThemeMode));
                 }
-
-                AddOrUpdateThemeResources(Application.Current.Resources, GetThemeDictionary(Application.Current.ThemeMode));
 
                 foreach (Window window in Application.Current.Windows)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/Themes/Generator/ThemeGenerator.Fluent.ps1
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/Generator/ThemeGenerator.Fluent.ps1
@@ -20,7 +20,8 @@ foreach($themeColor in $themeColors)
                             xmlns:system="clr-namespace:System;assembly=System.Runtime"
                             xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI"
                             xmlns:theme="clr-namespace:Microsoft.Windows.Themes"
-                            xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework"
+                            xmlns:ms="clr-namespace:MS.Internal;assembly=PresentationFramework"
+                            xmlns:standard="clr-namespace:Standard;assembly=PresentationFramework"
                             xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
                         </ResourceDictionary>'
                         

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Window.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Window.xaml
@@ -8,7 +8,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework"
+    xmlns:ms="clr-namespace:MS.Internal;assembly=PresentationFramework"
+    xmlns:standard="clr-namespace:Standard;assembly=PresentationFramework"
     xmlns:controls="clr-namespace:Fluent.Controls">
 
     <ControlTemplate x:Key="WindowTemplateKey"
@@ -46,6 +47,15 @@
                         Property="Visibility"
                         Value="Visible"/>
             </MultiTrigger>
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
+                <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(ms:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+                <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>  
+            <DataTrigger Binding="{Binding Path=(standard:Utility.IsOSWindows11OrNewer)}" Value="False">
+                <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
@@ -63,6 +73,17 @@
                                 <ContentPresenter x:Name="ContentPresenter" />
                         </AdornerDecorator>
                     </Border>
+                    <ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Path=(ms:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+                        </DataTrigger>  
+                        <DataTrigger Binding="{Binding Path=(standard:Utility.IsOSWindows11OrNewer)}" Value="False">
+                            <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+                        </DataTrigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -75,9 +96,12 @@
             <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
                 <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
             </DataTrigger>
-            <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+            <DataTrigger Binding="{Binding Path=(ms:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
                 <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
             </DataTrigger>  
+            <DataTrigger Binding="{Binding Path=(standard:Utility.IsOSWindows11OrNewer)}" Value="False">
+                <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
         </Style.Triggers>
     </Style>
 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" xmlns:fluentcontrols="clr-namespace:Fluent.Controls" xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI" xmlns:theme="clr-namespace:Microsoft.Windows.Themes" xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework" xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" xmlns:fluentcontrols="clr-namespace:Fluent.Controls" xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI" xmlns:theme="clr-namespace:Microsoft.Windows.Themes" xmlns:ms="clr-namespace:MS.Internal;assembly=PresentationFramework" xmlns:standard="clr-namespace:Standard;assembly=PresentationFramework" xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
   <ContextMenu x:Key="DefaultControlContextMenu">
     <MenuItem Command="ApplicationCommands.Copy" />
     <MenuItem Command="ApplicationCommands.Cut" />
@@ -4780,6 +4780,15 @@
         </MultiTrigger.Conditions>
         <Setter TargetName="WindowResizeGrip" Property="Visibility" Value="Visible" />
       </MultiTrigger>
+      <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=(ms:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=(standard:Utility.IsOSWindows11OrNewer)}" Value="False">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <Style x:Key="DefaultWindowStyle" TargetType="{x:Type Window}">
@@ -4794,6 +4803,17 @@
               <ContentPresenter x:Name="ContentPresenter" />
             </AdornerDecorator>
           </Border>
+          <ControlTemplate.Triggers>
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
+              <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(ms:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+              <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(standard:Utility.IsOSWindows11OrNewer)}" Value="False">
+              <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
+          </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
@@ -4804,7 +4824,10 @@
       <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
         <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
       </DataTrigger>
-      <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+      <DataTrigger Binding="{Binding Path=(ms:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=(standard:Utility.IsOSWindows11OrNewer)}" Value="False">
         <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
       </DataTrigger>
     </Style.Triggers>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" xmlns:fluentcontrols="clr-namespace:Fluent.Controls" xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI" xmlns:theme="clr-namespace:Microsoft.Windows.Themes" xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework" xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" xmlns:fluentcontrols="clr-namespace:Fluent.Controls" xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI" xmlns:theme="clr-namespace:Microsoft.Windows.Themes" xmlns:ms="clr-namespace:MS.Internal;assembly=PresentationFramework" xmlns:standard="clr-namespace:Standard;assembly=PresentationFramework" xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
   <ContextMenu x:Key="DefaultControlContextMenu">
     <MenuItem Command="ApplicationCommands.Copy" />
     <MenuItem Command="ApplicationCommands.Cut" />
@@ -4758,6 +4758,15 @@
         </MultiTrigger.Conditions>
         <Setter TargetName="WindowResizeGrip" Property="Visibility" Value="Visible" />
       </MultiTrigger>
+      <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=(ms:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=(standard:Utility.IsOSWindows11OrNewer)}" Value="False">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <Style x:Key="DefaultWindowStyle" TargetType="{x:Type Window}">
@@ -4772,6 +4781,17 @@
               <ContentPresenter x:Name="ContentPresenter" />
             </AdornerDecorator>
           </Border>
+          <ControlTemplate.Triggers>
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
+              <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(ms:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+              <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(standard:Utility.IsOSWindows11OrNewer)}" Value="False">
+              <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
+          </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
@@ -4782,7 +4802,10 @@
       <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
         <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
       </DataTrigger>
-      <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+      <DataTrigger Binding="{Binding Path=(ms:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=(standard:Utility.IsOSWindows11OrNewer)}" Value="False">
         <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
       </DataTrigger>
     </Style.Triggers>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" xmlns:fluentcontrols="clr-namespace:Fluent.Controls" xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI" xmlns:theme="clr-namespace:Microsoft.Windows.Themes" xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework" xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" xmlns:fluentcontrols="clr-namespace:Fluent.Controls" xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI" xmlns:theme="clr-namespace:Microsoft.Windows.Themes" xmlns:ms="clr-namespace:MS.Internal;assembly=PresentationFramework" xmlns:standard="clr-namespace:Standard;assembly=PresentationFramework" xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
   <ContextMenu x:Key="DefaultControlContextMenu">
     <MenuItem Command="ApplicationCommands.Copy" />
     <MenuItem Command="ApplicationCommands.Cut" />
@@ -4778,6 +4778,15 @@
         </MultiTrigger.Conditions>
         <Setter TargetName="WindowResizeGrip" Property="Visibility" Value="Visible" />
       </MultiTrigger>
+      <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=(ms:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=(standard:Utility.IsOSWindows11OrNewer)}" Value="False">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <Style x:Key="DefaultWindowStyle" TargetType="{x:Type Window}">
@@ -4792,6 +4801,17 @@
               <ContentPresenter x:Name="ContentPresenter" />
             </AdornerDecorator>
           </Border>
+          <ControlTemplate.Triggers>
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
+              <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(ms:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+              <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(standard:Utility.IsOSWindows11OrNewer)}" Value="False">
+              <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
+          </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
@@ -4802,7 +4822,10 @@
       <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
         <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
       </DataTrigger>
-      <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+      <DataTrigger Binding="{Binding Path=(ms:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=(standard:Utility.IsOSWindows11OrNewer)}" Value="False">
         <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
       </DataTrigger>
     </Style.Triggers>


### PR DESCRIPTION
Fixes # <!-- Issue Number --> #10096 

## Description
In Windows 10, when using Fluent theme the background of the window appears black. This PR fixes the issue by including a DataTrigger that checks the OS version and in case of Windows 10, it sets the background accordingly as Windows 10 doesn't support the backdrop operations through DWM.

Secondly, when Application is Light / Dark ( not System ) the Window's with ThemeMode set to system didn't react to system theme changes. This was because, when application is in light or dark, the state of fluent theme state for application didn't change and we returned it from the function without checking the window's thememode. We enabled that behavior in this PR.

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Developers can use Fluent theme in Windows 10 without using the backdrop switch. Enables the correct behavior for Window System theme mode when Application's theme mode is set to Light and Dark. 

<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes. This worked in .NET 9 Preview 4
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Sample app testing + Unit tests
<!-- What kind of testing has been done with the fix. -->

## Risk
Minimal. Fixes the behavior of Fluent theme in Windows 10 and when application theme is set to Light / Dark
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10136)