### PR TITLE
[StyleCleanUp] Addressing CA warnings Part 1

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -105,15 +105,6 @@ dotnet_diagnostic.CA1834.severity = suggestion
 # CA1838: Avoid StringBuilder parameters for P/Invokes
 dotnet_diagnostic.CA1838.severity = suggestion
 
-# CA1845: Use span-based 'string.Concat'
-dotnet_diagnostic.CA1845.severity = suggestion
-
-# CA1846: Prefer AsSpan over Substring
-dotnet_diagnostic.CA1846.severity = suggestion
-
-# CA1847: Use string.Contains(char) instead of string.Contains(string) with single characters
-dotnet_diagnostic.CA1847.severity = suggestion
-
 # CA1851: Possible multiple enumerations of IEnumerable collection
 dotnet_diagnostic.CA1851.severity = suggestion
 
@@ -160,12 +151,6 @@ dotnet_diagnostic.CA2219.severity = suggestion
 
 # CA2242: Test for NaN correctly
 dotnet_diagnostic.CA2242.severity = suggestion
-
-# CA2249: Consider using 'string.Contains' instead of 'string.IndexOf'
-dotnet_diagnostic.CA2249.severity = suggestion
-
-# CA2251: Use String.Equals over String.Compare
-dotnet_diagnostic.CA2251.severity = suggestion
 
 # CA2300: Do not use insecure deserializer BinaryFormatter
 dotnet_diagnostic.CA2300.severity = suggestion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -483,7 +483,7 @@ namespace MS.Internal
                 }
 
                 int pathEndIndex = SourceFileInfo.RelativeSourceFilePath.LastIndexOf(Path.DirectorySeparatorChar);
-                string targetPath = TargetPath + SourceFileInfo.RelativeSourceFilePath.Substring(0, pathEndIndex + 1);
+                string targetPath = string.Concat(TargetPath, SourceFileInfo.RelativeSourceFilePath.Substring(0, pathEndIndex + 1));
 
                 // Create if not already exists
                 if (targetPath.Length > 0 && !Directory.Exists(targetPath))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
@@ -203,7 +203,7 @@ namespace MS.Internal.Tasks
             while (e.InnerException != null)
             {
                 Exception eInner = e.InnerException;
-                if (e.Message.IndexOf(eInner.Message, StringComparison.Ordinal) == -1)
+                if (!e.Message.Contains(eInner.Message))
                 {
                     message += ", ";
                     message += eInner.Message;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
@@ -203,11 +203,9 @@ namespace MS.Internal.Tasks
             while (e.InnerException != null)
             {
                 Exception eInner = e.InnerException;
-#if NET
-                if (!e.Message.Contains(eInner.Message, StringComparison.Ordinal))
-#else
+#pragma warning disable CA2249
                 if (e.Message.IndexOf(eInner.Message, StringComparison.Ordinal) == -1)
-#endif
+#pragma warning restore CA2249
                 {
                     message += ", ";
                     message += eInner.Message;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
@@ -203,9 +203,11 @@ namespace MS.Internal.Tasks
             while (e.InnerException != null)
             {
                 Exception eInner = e.InnerException;
-#pragma warning disable CA2249
+#if NET
+                if (!e.Message.Contains(eInner.Message, StringComparison.Ordinal))
+#else
                 if (e.Message.IndexOf(eInner.Message, StringComparison.Ordinal) == -1)
-#pragma warning restore CA2249
+#endif
                 {
                     message += ", ";
                     message += eInner.Message;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
@@ -203,7 +203,11 @@ namespace MS.Internal.Tasks
             while (e.InnerException != null)
             {
                 Exception eInner = e.InnerException;
+#if NET
                 if (!e.Message.Contains(eInner.Message, StringComparison.Ordinal))
+#else
+                if (e.Message.IndexOf(eInner.Message, StringComparison.Ordinal) == -1)
+#endif
                 {
                     message += ", ";
                     message += eInner.Message;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
@@ -203,7 +203,7 @@ namespace MS.Internal.Tasks
             while (e.InnerException != null)
             {
                 Exception eInner = e.InnerException;
-#if NET
+#if !NETFX
                 if (!e.Message.Contains(eInner.Message, StringComparison.Ordinal))
 #else
                 if (e.Message.IndexOf(eInner.Message, StringComparison.Ordinal) == -1)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
@@ -203,7 +203,7 @@ namespace MS.Internal.Tasks
             while (e.InnerException != null)
             {
                 Exception eInner = e.InnerException;
-                if (!e.Message.Contains(eInner.Message))
+                if (!e.Message.Contains(eInner.Message, StringComparison.Ordinal))
                 {
                     message += ", ";
                     message += eInner.Message;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -518,9 +518,11 @@ namespace Microsoft.Build.Tasks.Windows
                                 collector.RootElementLinePosition = reader.LinePosition;
                             }
 
-#pragma warning disable CA1847
+#if NET
+                            if (reader.Name.Contains('.'))
+#else
                             if (reader.Name.Contains("."))
-#pragma warning restore CA1847
+#endif
                             {
                                 // the name has a dot, which suggests it is a property tag.
                                 // we will ignore adding uid

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -518,7 +518,11 @@ namespace Microsoft.Build.Tasks.Windows
                                 collector.RootElementLinePosition = reader.LinePosition;
                             }
 
-                            if (reader.Name.IndexOf('.') >= 0)
+#if NET
+                            if (reader.Name.Contains('.'))
+#else
+                            if (reader.Name.Contains("."))
+#endif
                             {
                                 // the name has a dot, which suggests it is a property tag.
                                 // we will ignore adding uid

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -518,7 +518,7 @@ namespace Microsoft.Build.Tasks.Windows
                                 collector.RootElementLinePosition = reader.LinePosition;
                             }
 
-#if NET
+#if !NETFX
                             if (reader.Name.Contains('.'))
 #else
                             if (reader.Name.Contains("."))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -518,11 +518,9 @@ namespace Microsoft.Build.Tasks.Windows
                                 collector.RootElementLinePosition = reader.LinePosition;
                             }
 
-#if NET
-                            if (reader.Name.Contains('.'))
-#else
+#pragma warning disable CA1847
                             if (reader.Name.Contains("."))
-#endif
+#pragma warning restore CA1847
                             {
                                 // the name has a dot, which suggests it is a property tag.
                                 // we will ignore adding uid

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/RBNode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/RBNode.cs
@@ -822,21 +822,21 @@ namespace MS.Internal.Data
             s = s.Substring(1);
 
             index = s.IndexOf(',');         // read LeftSize
-            node.LeftSize = Int32.Parse(s.Substring(0, index), TypeConverterHelper.InvariantEnglishUS);
+            node.LeftSize = Int32.Parse(s.AsSpan(0, index), TypeConverterHelper.InvariantEnglishUS);
             s = s.Substring(index + 1);
 
             index = s.IndexOf(',');         // read Size
-            node.Size = Int32.Parse(s.Substring(0, index), TypeConverterHelper.InvariantEnglishUS);
+            node.Size = Int32.Parse(s.AsSpan(0, index), TypeConverterHelper.InvariantEnglishUS);
             s = s.Substring(index+1);
 
             for (int k = 0; k < node.Size-1; ++k) // read data
             {
                 index = s.IndexOf(',');
-                node.SetItemAt(k, AsT(Int32.Parse(s.Substring(0, index), TypeConverterHelper.InvariantEnglishUS)));
+                node.SetItemAt(k, AsT(Int32.Parse(s.AsSpan(0, index), TypeConverterHelper.InvariantEnglishUS)));
                 s = s.Substring(index+1);
             }
             index = s.IndexOf('(');
-            node.SetItemAt(node.Size - 1, AsT(Int32.Parse(s.Substring(0, index), TypeConverterHelper.InvariantEnglishUS)));
+            node.SetItemAt(node.Size - 1, AsT(Int32.Parse(s.AsSpan(0, index), TypeConverterHelper.InvariantEnglishUS)));
             s = s.Substring(index);
 
             node.LeftChild = LoadTree(ref s);   // read subtrees

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/RBTree.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/RBTree.cs
@@ -659,7 +659,7 @@ namespace MS.Internal.Data
         {
             if (s.StartsWith("\"", StringComparison.Ordinal)) s = s.Substring(1);
             int index = s.IndexOf('(');
-            LeftSize = Int32.Parse(s.Substring(0, index), TypeConverterHelper.InvariantEnglishUS);
+            LeftSize = Int32.Parse(s.AsSpan(0, index), TypeConverterHelper.InvariantEnglishUS);
             s = s.Substring(index);
             this.LeftChild = LoadTree(ref s);
             this.LeftChild.Parent = this;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Interop/InternalDispatchObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Interop/InternalDispatchObject.cs
@@ -119,7 +119,7 @@ internal abstract class InternalDispatchObject<IDispInterface> : IReflect
         // We never expect to get a real method name here--see the explanation in GetMethods().
         if (name.StartsWith("[DISPID=", StringComparison.OrdinalIgnoreCase))
         {
-            int dispid = int.Parse(name.Substring(8, name.Length-9), CultureInfo.InvariantCulture);
+            int dispid = int.Parse(name.AsSpan(8, name.Length-9), CultureInfo.InvariantCulture);
             MethodInfo method;
             if (_dispId2MethodMap.TryGetValue(dispid, out method))
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
@@ -3672,11 +3672,11 @@ namespace System.Windows.Documents
             {
                 ulState = ULState.ULNone;
                 strikeState = StrikeState.StrikeNone;
-                if (decoration.IndexOf("Underline", StringComparison.OrdinalIgnoreCase) != -1)
+                if (decoration.Contains("Underline"))
                 {
                     ulState = ULState.ULNormal;
                 }
-                if (decoration.IndexOf("Strikethrough", StringComparison.OrdinalIgnoreCase) != -1)
+                if (decoration.Contains("Strikethrough"))
                 {
                     strikeState = StrikeState.StrikeNormal;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
@@ -3672,11 +3672,11 @@ namespace System.Windows.Documents
             {
                 ulState = ULState.ULNone;
                 strikeState = StrikeState.StrikeNone;
-                if (decoration.Contains("Underline"))
+                if (decoration.Contains("Underline", StringComparison.OrdinalIgnoreCase))
                 {
                     ulState = ULState.ULNormal;
                 }
-                if (decoration.Contains("Strikethrough"))
+                if (decoration.Contains("Strikethrough", StringComparison.OrdinalIgnoreCase))
                 {
                     strikeState = StrikeState.StrikeNormal;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/DependencyPropertyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/DependencyPropertyConverter.cs
@@ -142,7 +142,7 @@ namespace System.Windows.Markup
             {
                 value = value.Trim();
                 // If it contains a . it means that it is a full name with type and property.
-                if (value.Contains("."))
+                if (value.Contains('.'))
                 {
                     // Prefixes could have .'s so we take the last one and do a type resolve against that
                     int lastIndex = value.LastIndexOf('.');

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/MarkupExtensionParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/MarkupExtensionParser.cs
@@ -1465,11 +1465,9 @@ namespace System.Windows.Markup
                 // if the prefix was "" then
                 // 1) normal properties resolve to the parent Tag namespace.
                 // 2) Attached properties resolve to the "" default namespace.
-#if NET
-                if (!name.Contains('.'))
-#else
+#pragma warning disable CA1847
                 if (!name.Contains("."))
-#endif
+#pragma warning restore CA1847
                     attribNamespaceURI = parentURI;
                 else
                     attribNamespaceURI = _parserHelper.LookupNamespace("");
@@ -1628,11 +1626,9 @@ namespace System.Windows.Markup
                     if (builder == null)
                     {
                         builder = new StringBuilder(value.Length);
-#if NET
-                        builder.Append(value.AsSpan(0,i));
-#else
+#pragma warning disable CA1846
                         builder.Append(value.Substring(0,i));
-#endif
+#pragma warning restore CA1846
                     }
                     noEscape = false;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/MarkupExtensionParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/MarkupExtensionParser.cs
@@ -1465,8 +1465,11 @@ namespace System.Windows.Markup
                 // if the prefix was "" then
                 // 1) normal properties resolve to the parent Tag namespace.
                 // 2) Attached properties resolve to the "" default namespace.
-                int dotIndex = name.IndexOf('.');
-                if (-1 == dotIndex)
+#if NET
+                if (!name.Contains('.'))
+#else
+                if (!name.Contains("."))
+#endif
                     attribNamespaceURI = parentURI;
                 else
                     attribNamespaceURI = _parserHelper.LookupNamespace("");
@@ -1625,7 +1628,11 @@ namespace System.Windows.Markup
                     if (builder == null)
                     {
                         builder = new StringBuilder(value.Length);
+#if NET
+                        builder.Append(value.AsSpan(0,i));
+#else
                         builder.Append(value.Substring(0,i));
+#endif
                     }
                     noEscape = false;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/MarkupExtensionParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/MarkupExtensionParser.cs
@@ -1465,7 +1465,7 @@ namespace System.Windows.Markup
                 // if the prefix was "" then
                 // 1) normal properties resolve to the parent Tag namespace.
                 // 2) Attached properties resolve to the "" default namespace.
-#if NET
+#if !NETFX
                 if (!name.Contains('.'))
 #else
                 if (!name.Contains("."))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/MarkupExtensionParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/MarkupExtensionParser.cs
@@ -1465,9 +1465,11 @@ namespace System.Windows.Markup
                 // if the prefix was "" then
                 // 1) normal properties resolve to the parent Tag namespace.
                 // 2) Attached properties resolve to the "" default namespace.
-#pragma warning disable CA1847
+#if NET
+                if (!name.Contains('.'))
+#else
                 if (!name.Contains("."))
-#pragma warning restore CA1847
+#endif
                     attribNamespaceURI = parentURI;
                 else
                     attribNamespaceURI = _parserHelper.LookupNamespace("");
@@ -1626,9 +1628,11 @@ namespace System.Windows.Markup
                     if (builder == null)
                     {
                         builder = new StringBuilder(value.Length);
-#pragma warning disable CA1846
+#if NET
+                        builder.Append(value.AsSpan(0,i));
+#else
                         builder.Append(value.Substring(0,i));
-#pragma warning restore CA1846
+#endif
                     }
                     noEscape = false;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/MarkupExtensionParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/MarkupExtensionParser.cs
@@ -1628,11 +1628,7 @@ namespace System.Windows.Markup
                     if (builder == null)
                     {
                         builder = new StringBuilder(value.Length);
-#if NET
-                        builder.Append(value.AsSpan(0,i));
-#else
-                        builder.Append(value.Substring(0,i));
-#endif
+                        builder.Append(value, 0, i);
                     }
                     noEscape = false;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -2738,11 +2738,9 @@ namespace System.Windows.Markup
                 // if the prefix was "" then
                 // 1) normal properties resolve to the parent Tag namespace.
                 // 2) Attached properties resolve to the "" default namespace.
-#if NET
-                if (!name.Contains('.'))
-#else
+#pragma warning disable CA1847
                 if (!name.Contains("."))
-#endif
+#pragma warning restore CA1847
                     attribNamespaceURI = parentURI;
                 else
                     attribNamespaceURI = XmlReader.LookupNamespace("");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -2738,9 +2738,11 @@ namespace System.Windows.Markup
                 // if the prefix was "" then
                 // 1) normal properties resolve to the parent Tag namespace.
                 // 2) Attached properties resolve to the "" default namespace.
-#pragma warning disable CA1847
+#if NET
+                if (!name.Contains('.'))
+#else
                 if (!name.Contains("."))
-#pragma warning restore CA1847
+#endif
                     attribNamespaceURI = parentURI;
                 else
                     attribNamespaceURI = XmlReader.LookupNamespace("");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -2738,8 +2738,11 @@ namespace System.Windows.Markup
                 // if the prefix was "" then
                 // 1) normal properties resolve to the parent Tag namespace.
                 // 2) Attached properties resolve to the "" default namespace.
-                int dotIndex = name.IndexOf('.');
-                if (-1 == dotIndex)
+#if NET
+                if (!name.Contains('.'))
+#else
+                if (!name.Contains("."))
+#endif
                     attribNamespaceURI = parentURI;
                 else
                     attribNamespaceURI = XmlReader.LookupNamespace("");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -2738,7 +2738,7 @@ namespace System.Windows.Markup
                 // if the prefix was "" then
                 // 1) normal properties resolve to the parent Tag namespace.
                 // 2) Attached properties resolve to the "" default namespace.
-#if NET
+#if !NETFX
                 if (!name.Contains('.'))
 #else
                 if (!name.Contains("."))

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ColorTypeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ColorTypeConverter.cs
@@ -160,7 +160,7 @@ namespace System.Windows.Xps.Serialization
             {
                 colorString = color.ToString(culture);
 
-                if (colorString.StartsWith("sc#", StringComparison.Ordinal) && colorString.Contains("E"))
+                if (colorString.StartsWith("sc#", StringComparison.Ordinal) && colorString.Contains('E'))
                 {
                     //
                     // Fix bug 1588888: Serialization produces non-compliant scRGB color string.

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/VisualTreeFlattener.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/VisualTreeFlattener.cs
@@ -148,7 +148,7 @@ namespace MS.Internal.ReachFramework
                 index = m_mainFile.Length;
             }
 
-            string uri = m_mainFile.Substring(0, index) + "_" + bitmapName;
+            string uri = string.Concat(m_mainFile.Substring(0, index), "_", bitmapName);
 
             Stream bitmapStreamDest = new System.IO.FileStream(uri, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonKeyTipAndContentSyncHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonKeyTipAndContentSyncHelper.cs
@@ -46,8 +46,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                         {
                             if (accessKeyIndex == -1)
                             {
-                                int accessorIndex = stringContent.IndexOf(keyTip[0]);
-                                if (accessorIndex != -1)
+                                if (stringContent.Contains(keyTip[0]))
                                 {
                                     syncElement.KeepKeyTipAndContentInSync = true;
                                     syncElement.IsKeyTipSyncSource = true;
@@ -155,7 +154,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                             if (accessorIndex >= 0)
                             {
                                 syncElement.KeepKeyTipAndContentInSync = true;
-                                return stringContent.Substring(0, accessorIndex) + '_' + stringContent.Substring(accessorIndex);
+                                return string.Concat(stringContent.Substring(0, accessorIndex), '_', stringContent.Substring(accessorIndex));
                             }
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameParser.cs
@@ -40,9 +40,7 @@ namespace MS.Internal.Xaml.Parser
 
         public static XamlTypeName ParseIfTrivalName(string text, Func<string, string> prefixResolver, out string error)
         {
-            int parenIdx = text.IndexOf('(');
-            int bracketIdx = text.IndexOf('[');
-            if (parenIdx != -1 || bracketIdx != -1)
+            if (text.Contains('(') || text.Contains('['))
             {
                 error = string.Empty;
                 return null;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ProxyManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ProxyManager.cs
@@ -671,14 +671,14 @@ namespace MS.Internal.Automation
                             break;
 
                         case ProxyScoping.PartialMatchApparentClassName:
-                            if (classNameForPartialMatch.Contains(pi.ClassName))
+                            if (classNameForPartialMatch.Contains(pi.ClassName, StringComparison.Ordinal))
                             {
                                 factoryCallback = pi.ClientSideProviderFactoryCallback;
                             }
                             break;
 
                         case ProxyScoping.PartialMatchRealClassName:
-                            if (classNameForPartialMatch.Contains(pi.ClassName)
+                            if (classNameForPartialMatch.Contains(pi.ClassName, StringComparison.Ordinal)
                                 && ((pi.Flags & ClientSideProviderMatchIndicator.DisallowBaseClassNameMatch) == 0))
                             {
                                 factoryCallback = pi.ClientSideProviderFactoryCallback;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ProxyManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ProxyManager.cs
@@ -671,14 +671,14 @@ namespace MS.Internal.Automation
                             break;
 
                         case ProxyScoping.PartialMatchApparentClassName:
-                            if (classNameForPartialMatch.IndexOf(pi.ClassName, StringComparison.Ordinal) >= 0)
+                            if (classNameForPartialMatch.Contains(pi.ClassName))
                             {
                                 factoryCallback = pi.ClientSideProviderFactoryCallback;
                             }
                             break;
 
                         case ProxyScoping.PartialMatchRealClassName:
-                            if (classNameForPartialMatch.IndexOf(pi.ClassName, StringComparison.Ordinal) >= 0
+                            if (classNameForPartialMatch.Contains(pi.ClassName)
                                 && ((pi.Flags & ClientSideProviderMatchIndicator.DisallowBaseClassNameMatch) == 0))
                             {
                                 factoryCallback = pi.ClientSideProviderFactoryCallback;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WinFormsSpinner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WinFormsSpinner.cs
@@ -154,7 +154,7 @@ namespace MS.Internal.AutomationProxies
                 IntPtr hwndSpin;
 
                 // Find the Edit control.  Typically the UpDown is first so we'll start with the other window.                                
-                if (Misc.ProxyGetClassName(hwndLastChild).Contains("Edit"))
+                if (Misc.ProxyGetClassName(hwndLastChild).Contains("Edit", StringComparison.OrdinalIgnoreCase))
                 {
                     hwndEdit = hwndLastChild;
                     hwndSpin = hwndFirstChild;
@@ -162,7 +162,7 @@ namespace MS.Internal.AutomationProxies
                 else
                 {
                     // Haven't seen this but suppose it's possible.  Subsequent test will confirm.
-                    if (Misc.ProxyGetClassName(hwndFirstChild).Contains("Edit"))
+                    if (Misc.ProxyGetClassName(hwndFirstChild).Contains("Edit", StringComparison.OrdinalIgnoreCase))
                     {
                         hwndEdit = hwndFirstChild;
                         hwndSpin = hwndLastChild;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WinFormsSpinner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WinFormsSpinner.cs
@@ -154,7 +154,7 @@ namespace MS.Internal.AutomationProxies
                 IntPtr hwndSpin;
 
                 // Find the Edit control.  Typically the UpDown is first so we'll start with the other window.                                
-                if (Misc.ProxyGetClassName(hwndLastChild).IndexOf("Edit", StringComparison.OrdinalIgnoreCase) != -1)
+                if (Misc.ProxyGetClassName(hwndLastChild).Contains("Edit"))
                 {
                     hwndEdit = hwndLastChild;
                     hwndSpin = hwndFirstChild;
@@ -162,7 +162,7 @@ namespace MS.Internal.AutomationProxies
                 else
                 {
                     // Haven't seen this but suppose it's possible.  Subsequent test will confirm.
-                    if (Misc.ProxyGetClassName(hwndFirstChild).IndexOf("Edit", StringComparison.OrdinalIgnoreCase) != -1)
+                    if (Misc.ProxyGetClassName(hwndFirstChild).Contains("Edit"))
                     {
                         hwndEdit = hwndFirstChild;
                         hwndSpin = hwndLastChild;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsContainer.cs
@@ -37,7 +37,7 @@ namespace MS.Internal.AutomationProxies
                 {
                     _sType = SR.LocalizedControlTypeDialog;
                 }
-                else if (className.IndexOf("AfxControlBar", StringComparison.Ordinal) != -1)
+                else if (className.Contains("AfxControlBar"))
                 {
                     _sType = SR.LocalizedControlTypeContainer;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsContainer.cs
@@ -37,7 +37,7 @@ namespace MS.Internal.AutomationProxies
                 {
                     _sType = SR.LocalizedControlTypeDialog;
                 }
-                else if (className.Contains("AfxControlBar"))
+                else if (className.Contains("AfxControlBar", StringComparison.Ordinal))
                 {
                     _sType = SR.LocalizedControlTypeContainer;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -2460,7 +2460,7 @@ namespace MS.Internal.AutomationProxies
                         {
                             // Take the remaining string from the Keyword
                             // Case Alt+Enter
-                            return sCanonicalsKeyword + menuRawText.Substring(pos + cKeyChars + 1, cMenuChars - (pos + cKeyChars + 1));
+                            return string.Concat(sCanonicalsKeyword, menuRawText.Substring(pos + cKeyChars + 1, cMenuChars - (pos + cKeyChars + 1)));
                         }
                     }
                 }
@@ -2482,7 +2482,7 @@ namespace MS.Internal.AutomationProxies
                 // Check that it is the form Fxx
                 if (pos < cChars - 1 && pos > 0 && menuText [pos] == 'f')
                 {
-                    int iKey = int.Parse(menuText.Substring(pos + 1, cChars - (pos + 1)), CultureInfo.InvariantCulture);
+                    int iKey = int.Parse(menuText.AsSpan(pos + 1, cChars - (pos + 1)), CultureInfo.InvariantCulture);
                     if (iKey > 0 && iKey <= 12)
                     {
                         return "F" + iKey.ToString(CultureInfo.CurrentCulture);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEdit.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEdit.cs
@@ -534,7 +534,7 @@ namespace MS.Internal.AutomationProxies
                     object embeddedObject;
                     while (start < end && embeddedObjectOffset != -1)
                     {
-                        sbText.Append(text.Substring(start, embeddedObjectOffset - start));
+                        sbText.Append(text.AsSpan(start, embeddedObjectOffset - start));
                         range.SetRange(embeddedObjectOffset, end);
                         if (range.GetEmbeddedObject(out embeddedObject) == NativeMethods.S_OK && embeddedObject != null)
                         {
@@ -552,7 +552,7 @@ namespace MS.Internal.AutomationProxies
 
                     if (start < end)
                     {
-                        sbText.Append(text.Substring(start, end - start));
+                        sbText.Append(text.AsSpan(start, end - start));
                     }
 
                     text = sbText.ToString();

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsSpinner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsSpinner.cs
@@ -67,7 +67,7 @@ namespace MS.Internal.AutomationProxies
                     return null;
                 }
 
-                if (!Misc.ProxyGetClassName(hwndBuddy).Contains("EDIT"))
+                if (!Misc.ProxyGetClassName(hwndBuddy).Contains("EDIT", StringComparison.OrdinalIgnoreCase))
                 {
                     return null;
                 }
@@ -281,7 +281,7 @@ namespace MS.Internal.AutomationProxies
                 while (hwndChild != IntPtr.Zero)
                 {
                     string className = Misc.ProxyGetClassName(hwndChild);
-                    if (className.Contains("msctls_updown32"))
+                    if (className.Contains("msctls_updown32", StringComparison.OrdinalIgnoreCase))
                     {
                         IntPtr hwndBuddy = Misc.ProxySendMessage(hwndChild, NativeMethods.UDM_GETBUDDY, IntPtr.Zero, IntPtr.Zero);
                         if (hwnd == hwndBuddy)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsSpinner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsSpinner.cs
@@ -67,7 +67,7 @@ namespace MS.Internal.AutomationProxies
                     return null;
                 }
 
-                if (Misc.ProxyGetClassName(hwndBuddy).IndexOf("EDIT", StringComparison.OrdinalIgnoreCase) == -1)
+                if (!Misc.ProxyGetClassName(hwndBuddy).Contains("EDIT"))
                 {
                     return null;
                 }
@@ -281,7 +281,7 @@ namespace MS.Internal.AutomationProxies
                 while (hwndChild != IntPtr.Zero)
                 {
                     string className = Misc.ProxyGetClassName(hwndChild);
-                    if (className.IndexOf("msctls_updown32", StringComparison.OrdinalIgnoreCase) != -1)
+                    if (className.Contains("msctls_updown32"))
                     {
                         IntPtr hwndBuddy = Misc.ProxySendMessage(hwndChild, NativeMethods.UDM_GETBUDDY, IntPtr.Zero, IntPtr.Zero);
                         if (hwnd == hwndBuddy)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsSysHeader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsSysHeader.cs
@@ -80,7 +80,7 @@ namespace MS.Internal.AutomationProxies
                     IntPtr hwndParent = NativeMethodsSetLastError.GetAncestor (hwnd, NativeMethods.GA_PARENT);
                     if (hwndParent != IntPtr.Zero)
                     {
-                        if (Misc.GetClassName(hwndParent).IndexOf("SysListView32", StringComparison.Ordinal) >= 0)
+                        if (Misc.GetClassName(hwndParent).Contains("SysListView32"))
                         {
                             // Notify the Listview that the header Change
                             WindowsListView wlv = (WindowsListView) WindowsListView.Create (hwndParent, 0);
@@ -251,7 +251,7 @@ namespace MS.Internal.AutomationProxies
             IntPtr hwndParent = NativeMethodsSetLastError.GetAncestor (_hwnd, NativeMethods.GA_PARENT);
             if (hwndParent != IntPtr.Zero)
             {
-                if (Misc.GetClassName(hwndParent).IndexOf("SysListView32", StringComparison.Ordinal) >= 0)
+                if (Misc.GetClassName(hwndParent).Contains("SysListView32"))
                 {
                     // Determine the number of pixels or columns to scroll horizontally.
                     int pixels = 0;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsSysHeader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsSysHeader.cs
@@ -80,7 +80,7 @@ namespace MS.Internal.AutomationProxies
                     IntPtr hwndParent = NativeMethodsSetLastError.GetAncestor (hwnd, NativeMethods.GA_PARENT);
                     if (hwndParent != IntPtr.Zero)
                     {
-                        if (Misc.GetClassName(hwndParent).Contains("SysListView32"))
+                        if (Misc.GetClassName(hwndParent).Contains("SysListView32", StringComparison.Ordinal))
                         {
                             // Notify the Listview that the header Change
                             WindowsListView wlv = (WindowsListView) WindowsListView.Create (hwndParent, 0);
@@ -251,7 +251,7 @@ namespace MS.Internal.AutomationProxies
             IntPtr hwndParent = NativeMethodsSetLastError.GetAncestor (_hwnd, NativeMethods.GA_PARENT);
             if (hwndParent != IntPtr.Zero)
             {
-                if (Misc.GetClassName(hwndParent).Contains("SysListView32"))
+                if (Misc.GetClassName(hwndParent).Contains("SysListView32", StringComparison.Ordinal))
                 {
                     // Determine the number of pixels or columns to scroll horizontally.
                     int pixels = 0;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsUpDown.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsUpDown.cs
@@ -373,7 +373,7 @@ namespace MS.Internal.AutomationProxies
             // If this is a Spinner UpDown Control, the buddy window should be a control with
             // the class of EDIT.
             IntPtr hwndBuddy = HwndBuddy(_hwnd);
-            return hwndBuddy != IntPtr.Zero && Misc.ProxyGetClassName(hwndBuddy).IndexOf("EDIT", StringComparison.OrdinalIgnoreCase) != -1;
+            return hwndBuddy != IntPtr.Zero && Misc.ProxyGetClassName(hwndBuddy).Contains("EDIT");
         }
 
         private double Max

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsUpDown.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsUpDown.cs
@@ -373,7 +373,7 @@ namespace MS.Internal.AutomationProxies
             // If this is a Spinner UpDown Control, the buddy window should be a control with
             // the class of EDIT.
             IntPtr hwndBuddy = HwndBuddy(_hwnd);
-            return hwndBuddy != IntPtr.Zero && Misc.ProxyGetClassName(hwndBuddy).Contains("EDIT");
+            return hwndBuddy != IntPtr.Zero && Misc.ProxyGetClassName(hwndBuddy).Contains("EDIT", StringComparison.OrdinalIgnoreCase);
         }
 
         private double Max

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -419,7 +419,7 @@ namespace MS.Internal
                 else
                 {
                     // duplicate the formatting character
-                    sb.Append(s.Substring(index, formatIndex - index + 1));
+                    sb.Append(s.AsSpan(index, formatIndex - index + 1));
                     sb.Append(s[formatIndex]);
 
                     index = formatIndex + 1;
@@ -429,7 +429,7 @@ namespace MS.Internal
 
             if (index <= lengthMinus1)
             {
-                sb.Append(s.Substring(index));
+                sb.Append(s.AsSpan(index));
             }
 
             return sb.ToString();

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/ContainerUtilities.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/ContainerUtilities.cs
@@ -459,7 +459,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         {
             CheckStringAgainstNullAndEmpty(testString, testStringIdentifier);
 
-            if (testString.IndexOf(PathSeparator) != -1)
+            if (testString.Contains(PathSeparator))
                 throw new ArgumentException(
                     SR.Format(SR.NameCanNotHaveDelimiter,
                         testStringIdentifier,

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
@@ -60,7 +60,7 @@ namespace MS.Internal.IO.Packaging
         internal static bool IsPackUri(Uri uri)
         {
             return uri != null && 
-                string.Compare(uri.Scheme, System.IO.Packaging.PackUriHelper.UriSchemePack, StringComparison.OrdinalIgnoreCase) == 0;
+                string.Equals(uri.Scheme, System.IO.Packaging.PackUriHelper.UriSchemePack, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #10296 
Fixes #10282 
Fixes #10297 
Fixes #10298 
Fixes #10299 

## Description

This work is a part of our initiative to set code-style guidelines, align WPF and WinForms, and ensure PR standards with respect to styles. This in turn will help us in better maintainability and readability of the repo overall. The changes follow up from the PR #10080 and references to the issue #10017.

The current changes address the following Errors/Warnings in the src folder of WPF:

- **CA2249:** Consider using 'string.Contains' instead of 'string.IndexOf'
- **CA2251**: Use String.Equals over String.Compare
- **CA1847**: Use string.Contains(char) instead of string.Contains(string) with single characters
- **CA1845**: Use span-based 'string.Concat'
- **CA1846**: Prefer AsSpan over Substring

A good way to go about reviewing this is to go commit by commit which pans over individual errors/warnings and hence easing out the overall understanding.

## Customer Impact

None

## Regression

None

## Testing

Local Build Pass
The current set of changes looks fairly mechanical and probably don't need a Test Pass, but these set of PRs can be clubbed to do so at a later stage.

## Risk

Low

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10144)