### PR TITLE
[StyleCleanUp] Address IDE warnings Part 2

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -194,9 +194,6 @@ dotnet_diagnostic.IDE0005.severity = suggestion
 # IDE0017: Simplify object initialization
 dotnet_diagnostic.IDE0017.severity = suggestion
 
-# IDE0019: Use pattern matching to avoid as followed by a null check
-dotnet_diagnostic.IDE0019.severity = suggestion
-
 # IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
 dotnet_diagnostic.IDE0020.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -194,9 +194,6 @@ dotnet_diagnostic.IDE0005.severity = suggestion
 # IDE0017: Simplify object initialization
 dotnet_diagnostic.IDE0017.severity = suggestion
 
-# IDE0029: Use coalesce expression
-dotnet_diagnostic.IDE0029.severity = suggestion
-
 # IDE0030: Null check can be simplified
 dotnet_diagnostic.IDE0030.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -194,9 +194,6 @@ dotnet_diagnostic.IDE0005.severity = suggestion
 # IDE0017: Simplify object initialization
 dotnet_diagnostic.IDE0017.severity = suggestion
 
-# IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
-dotnet_diagnostic.IDE0020.severity = suggestion
-
 # IDE0029: Use coalesce expression
 dotnet_diagnostic.IDE0029.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemData/SystemDataExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemData/SystemDataExtension.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -190,9 +190,8 @@ namespace MS.Internal
                 {
                     column = table.Columns[columnName];
                 }
-                else if (arg is int)
+                else if (arg is int index)
                 {
-                    int index = (int)arg;
                     if (0 <= index && index < table.Columns.Count)
                     {
                         column = table.Columns[index];

--- a/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemXml/XmlNodeComparer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemXml/XmlNodeComparer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -28,7 +28,7 @@ namespace MS.Internal.Data
         {
             _sortParameters = sortParameters;
             _namespaceManager = namespaceManager;
-            _culture = (culture == null) ? CultureInfo.InvariantCulture : culture;
+            _culture = culture ?? CultureInfo.InvariantCulture;
         }
 
         int IComparer.Compare(object o1, object o2)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -1833,9 +1833,8 @@ namespace MS.Internal
                         desc.Arguments.CopyTo(args, 0);
                         CodeExpression[] expressions = new CodeExpression[args.Length];
 
-                        if (desc.MemberInfo is MethodInfo)
+                        if (desc.MemberInfo is MethodInfo mi)
                         {
-                            MethodInfo mi = (MethodInfo)desc.MemberInfo;
                             ParameterInfo[] parameters = mi.GetParameters();
 
                             for (int i = 0; i < args.Length; i++)
@@ -1851,9 +1850,8 @@ namespace MS.Internal
 
                             ce = cmie;
                         }
-                        else if (desc.MemberInfo is ConstructorInfo)  // instance ctor invoke
+                        else if (desc.MemberInfo is ConstructorInfo ci)
                         {
-                            ConstructorInfo ci = (ConstructorInfo)desc.MemberInfo;
                             ParameterInfo[] parameters = ci.GetParameters();
 
                             for (int i = 0; i < args.Length; i++)
@@ -1885,9 +1883,8 @@ namespace MS.Internal
         private Type GetEventHandlerType(MemberInfo memberInfo)
         {
             Type eventHandlerType = null;
-            if (memberInfo is EventInfo)
+            if (memberInfo is EventInfo ei)
             {
-                EventInfo ei = (EventInfo)memberInfo;
                 eventHandlerType = ei.EventHandlerType;
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -849,10 +849,9 @@ namespace MS.Internal
                     case XmlNodeType.CDATA:
                     case XmlNodeType.Text:
                     {
-                        IXmlLineInfo xmlLineInfo = xmlReader as IXmlLineInfo;
-                        int lineNumber = 0;
+                            int lineNumber = 0;
 
-                        if (null != xmlLineInfo)
+                            if (xmlReader is IXmlLineInfo xmlLineInfo)
                         {
                             lineNumber = xmlLineInfo.LineNumber;
                         }
@@ -1306,8 +1305,7 @@ namespace MS.Internal
             {
                 for (int i = 0; i < ReferenceAssemblyList.Count; i++)
                 {
-                    ReferenceAssembly refasm = ReferenceAssemblyList[i] as ReferenceAssembly;
-                    if (refasm != null && refasm.Path.Length > 0)
+                    if (ReferenceAssemblyList[i] is ReferenceAssembly refasm && refasm.Path.Length > 0)
                     {
                         paths.Add(refasm.Path);
                     }
@@ -1324,9 +1322,7 @@ namespace MS.Internal
             {
                 for (int i = 0; i < ReferenceAssemblyList.Count; i++)
                 {
-                    ReferenceAssembly refasm = ReferenceAssemblyList[i] as ReferenceAssembly;
-
-                    if (refasm != null && refasm.Path.Length > 0)
+                    if (ReferenceAssemblyList[i] is ReferenceAssembly refasm && refasm.Path.Length > 0)
                     {
                         _typeMapper.SetAssemblyPath(refasm.AssemblyName, refasm.Path);
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/CompilerWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/CompilerWrapper.cs
@@ -253,9 +253,7 @@ namespace MS.Internal
             {
                 for (int i = 0; i < _mc.ReferenceAssemblyList.Count; i++)
                 {
-                    ReferenceAssembly asmReference = _mc.ReferenceAssemblyList[i] as ReferenceAssembly;
-
-                    if (asmReference != null)
+                    if (_mc.ReferenceAssemblyList[i] is ReferenceAssembly asmReference)
                     {
                         if (string.Equals(asmReference.AssemblyName, assemblyName, StringComparison.OrdinalIgnoreCase))
                         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskFileService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskFileService.cs
@@ -162,8 +162,7 @@ namespace MS.Internal
             if (HostFileManager != null)
             {
                 object docData = HostFileManager.GetFileDocData(fileName);
-                IPersistFileCheckSum fileChecksummer = docData as IPersistFileCheckSum;
-                if (fileChecksummer != null)
+                if (docData is IPersistFileCheckSum fileChecksummer)
                 {
                     byte[] tempBytes = new byte[1024];
                     int actualSize;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -631,9 +631,7 @@ namespace Microsoft.Build.Tasks.Windows
 
             for (int i = 0; i < root.ChildNodes.Count; i++)
             {
-                XmlElement nodeGroup = root.ChildNodes[i] as XmlElement;
-
-                if (nodeGroup != null && string.Equals(nodeGroup.Name, groupName, StringComparison.OrdinalIgnoreCase))
+                if (root.ChildNodes[i] is XmlElement nodeGroup && string.Equals(nodeGroup.Name, groupName, StringComparison.OrdinalIgnoreCase))
                 {
                     //
                     // This is ItemGroup element.
@@ -644,9 +642,7 @@ namespace Microsoft.Build.Tasks.Windows
 
                         for (int j = 0; j < nodeGroup.ChildNodes.Count; j++)
                         {
-                            XmlElement nodeItem = nodeGroup.ChildNodes[j] as XmlElement;
-
-                            if (nodeItem != null && string.Equals(nodeItem.Name, sItemName, StringComparison.OrdinalIgnoreCase))
+                            if (nodeGroup.ChildNodes[j] is XmlElement nodeItem && string.Equals(nodeItem.Name, sItemName, StringComparison.OrdinalIgnoreCase))
                             {
                                 // This is the item that need to remove.
                                 // Add it into the temporary array list.
@@ -663,13 +659,11 @@ namespace Microsoft.Build.Tasks.Windows
                         {
                             foreach (object node in itemToRemove)
                             {
-                                XmlElement item = node as XmlElement;
-
                                 //
                                 // Remove this item from its parent node.
                                 // the parent node should be nodeGroup.
                                 //
-                                if (item != null)
+                                if (node is XmlElement item)
                                 {
                                     nodeGroup.RemoveChild(item);
                                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -1278,7 +1278,7 @@ namespace Microsoft.Build.Tasks.Windows
 
             public void SetLine(string line)
             {
-                Content = (line == null) ? string.Empty : line;
+                Content = line ?? string.Empty;
                 Index   = 0;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontFace/MatchingStyle.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontFace/MatchingStyle.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -247,10 +247,8 @@ namespace MS.Internal.FontFace
                     return false;
                 }
 
-                if(o is Vector)
+                if (o is Vector vector)
                 {
-                    Vector vector = (Vector)o;
-
                     return (this == vector);
                 }
                 else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextShapeableCharacters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextShapeableCharacters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -253,7 +253,7 @@ namespace System.Windows.Media.TextFormatting
             glyphRun.EmitBackground(drawingContext, _properties.BackgroundBrush);
 
             drawingContext.DrawGlyphRun(
-                foregroundBrush != null ? foregroundBrush : _properties.ForegroundBrush,
+                foregroundBrush ?? _properties.ForegroundBrush,
                 glyphRun
                 );
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -650,9 +650,9 @@ namespace System.Windows.Input
             // PreProcessedInputEventArgs and cast it to NotifyInputEventArgs
             // or ProcessInputEventArgs because a malicious user could upcast
             // the object and call inappropriate methods.
-            NotifyInputEventArgs notifyInputEventArgs = (_notifyInputEventArgs != null) ? _notifyInputEventArgs : new NotifyInputEventArgs();
-            ProcessInputEventArgs processInputEventArgs = (_processInputEventArgs != null) ? _processInputEventArgs : new ProcessInputEventArgs();
-            PreProcessInputEventArgs preProcessInputEventArgs = (_preProcessInputEventArgs != null) ? _preProcessInputEventArgs : new PreProcessInputEventArgs();
+            NotifyInputEventArgs notifyInputEventArgs = _notifyInputEventArgs ?? new NotifyInputEventArgs();
+            ProcessInputEventArgs processInputEventArgs = _processInputEventArgs ?? new ProcessInputEventArgs();
+            PreProcessInputEventArgs preProcessInputEventArgs = _preProcessInputEventArgs ?? new PreProcessInputEventArgs();
             _notifyInputEventArgs = null;
             _processInputEventArgs = null;
             _preProcessInputEventArgs = null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/QueryCursorEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/QueryCursorEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -44,7 +44,7 @@ namespace System.Windows.Input
         public Cursor Cursor
         {
             get {return _cursor;}
-            set {_cursor = ((value == null) ? Cursors.None : value);}
+            set {_cursor = (value ?? Cursors.None);}
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -683,10 +683,8 @@ namespace System.Windows.Media
         /// <returns>Whether or not the two colors are equal</returns>
         public override bool Equals(object o)
         {
-            if (o is Color)
+            if (o is Color color)
             {
-                Color color = (Color)o;
-
                 return (this == color);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/BrushValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/BrushValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -66,11 +66,10 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Brush)
+            if (value is Brush instance)
             {
-                Brush instance = (Brush) value;
                 // When invoked by the serialization engine we can convert to string only for some instances
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 if (!instance.CanSerializeToString())
                 {
                     // Let base throw an exception.
@@ -78,7 +77,7 @@ namespace System.Windows.Media.Converters
                 }
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/CacheModeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/CacheModeValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -66,11 +66,10 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is CacheMode)
+            if (value is CacheMode instance)
             {
-                CacheMode instance = (CacheMode) value;
                 // When invoked by the serialization engine we can convert to string only for some instances
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 if (!instance.CanSerializeToString())
                 {
                     // Let base throw an exception.
@@ -78,7 +77,7 @@ namespace System.Windows.Media.Converters
                 }
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/DoubleCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/DoubleCollectionValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is DoubleCollection)
+            if (value is DoubleCollection instance)
             {
-                DoubleCollection instance = (DoubleCollection) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/GeometryValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/GeometryValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -66,11 +66,10 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Geometry)
+            if (value is Geometry instance)
             {
-                Geometry instance = (Geometry) value;
                 // When invoked by the serialization engine we can convert to string only for some instances
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 if (!instance.CanSerializeToString())
                 {
                     // Let base throw an exception.
@@ -78,7 +77,7 @@ namespace System.Windows.Media.Converters
                 }
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/Int32CollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/Int32CollectionValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Int32Collection)
+            if (value is Int32Collection instance)
             {
-                Int32Collection instance = (Int32Collection) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PathFigureCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PathFigureCollectionValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -66,11 +66,10 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is PathFigureCollection)
+            if (value is PathFigureCollection instance)
             {
-                PathFigureCollection instance = (PathFigureCollection) value;
                 // When invoked by the serialization engine we can convert to string only for some instances
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 if (!instance.CanSerializeToString())
                 {
                     // Let base throw an exception.
@@ -78,7 +77,7 @@ namespace System.Windows.Media.Converters
                 }
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PointCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PointCollectionValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is PointCollection)
+            if (value is PointCollection instance)
             {
-                PointCollection instance = (PointCollection) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/TransformValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/TransformValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -66,11 +66,10 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Transform)
+            if (value is Transform instance)
             {
-                Transform instance = (Transform) value;
                 // When invoked by the serialization engine we can convert to string only for some instances
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 if (!instance.CanSerializeToString())
                 {
                     // Let base throw an exception.
@@ -78,7 +77,7 @@ namespace System.Windows.Media.Converters
                 }
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/VectorCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/VectorCollectionValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is VectorCollection)
+            if (value is VectorCollection instance)
             {
-                VectorCollection instance = (VectorCollection) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/DrawingDrawingContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/DrawingDrawingContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1026,8 +1026,7 @@ namespace System.Windows.Media
             // NOTE:Disabling this API for now
             
             _currentDrawingGroup.BitmapEffect = effect;
-            _currentDrawingGroup.BitmapEffectInput = (effectInput != null) ?
-                                                        effectInput : new BitmapEffectInput();
+            _currentDrawingGroup.BitmapEffectInput = effectInput ?? new BitmapEffectInput();
 }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamily.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamily.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -191,7 +191,7 @@ namespace System.Windows.Media
         public override string ToString()
         {
             string source = _familyIdentifier.Source;
-            return source != null ? source : string.Empty;
+            return source ?? string.Empty;
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSourceConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSourceConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -105,10 +105,8 @@ namespace System.Windows.Media
                         null
                         );
                 }
-                else if (value is byte[])
+                else if (value is byte[] bytes)
                 {
-                    byte[] bytes = (byte[])value;
-
                     if (bytes != null)
                     {
                         Stream memStream = null;
@@ -133,10 +131,8 @@ namespace System.Windows.Media
                             );
                     }
                 }
-                else if (value is Stream)
+                else if (value is Stream stream)
                 {
-                    Stream stream = (Stream)value;
-
                     return BitmapFrame.Create(
                         stream,
                         BitmapCreateOptions.None,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamGeometry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -396,9 +396,7 @@ namespace System.Windows.Media
                     data.hTransform = hTransform;
                     data.FillRule = FillRule;
 
-                    byte[] pathDataToMarshal = _data == null ?
-                        Geometry.GetEmptyPathGeometryData().SerializedData :
-                        _data;
+                    byte[] pathDataToMarshal = _data ?? GetEmptyPathGeometryData().SerializedData;
 
                     unsafe
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Matrix3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Matrix3DValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Matrix3D)
+            if (value is Matrix3D instance)
             {
-                Matrix3D instance = (Matrix3D) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DCollectionValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Point3DCollection)
+            if (value is Point3DCollection instance)
             {
-                Point3DCollection instance = (Point3DCollection) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Point3D)
+            if (value is Point3D instance)
             {
-                Point3D instance = (Point3D) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point4DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point4DValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Point4D)
+            if (value is Point4D instance)
             {
-                Point4D instance = (Point4D) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/QuaternionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/QuaternionValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Quaternion)
+            if (value is Quaternion instance)
             {
-                Quaternion instance = (Quaternion) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Rect3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Rect3DValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Rect3D)
+            if (value is Rect3D instance)
             {
-                Rect3D instance = (Rect3D) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Size3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Size3DValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Size3D)
+            if (value is Size3D instance)
             {
-                Size3D instance = (Size3D) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DCollectionValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Vector3DCollection)
+            if (value is Vector3DCollection instance)
             {
-                Vector3DCollection instance = (Vector3DCollection) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Vector3D)
+            if (value is Vector3D instance)
             {
-                Vector3D instance = (Vector3D) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Viewport2DVisual3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Viewport2DVisual3D.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -468,36 +468,32 @@ namespace System.Windows.Media.Media3D
             {
                 Material currMaterial = materialStack.Pop();
 
-                if (currMaterial is DiffuseMaterial)
+                if (currMaterial is DiffuseMaterial diffMaterial)
                 {
-                    DiffuseMaterial diffMaterial = (DiffuseMaterial)currMaterial;
                     if ((Boolean)diffMaterial.GetValue(Viewport2DVisual3D.IsVisualHostMaterialProperty))
                     {
                         diffMaterial.Brush = internalBrush;
                         numMaterialsSwapped++;
                     }
                 }
-                else if (currMaterial is EmissiveMaterial)
+                else if (currMaterial is EmissiveMaterial emmMaterial)
                 {
-                    EmissiveMaterial emmMaterial = (EmissiveMaterial)currMaterial;
                     if ((Boolean)emmMaterial.GetValue(Viewport2DVisual3D.IsVisualHostMaterialProperty))
                     {
                         emmMaterial.Brush = internalBrush;
                         numMaterialsSwapped++;
                     }
                 }
-                else if (currMaterial is SpecularMaterial)
+                else if (currMaterial is SpecularMaterial specMaterial)
                 {
-                    SpecularMaterial specMaterial = (SpecularMaterial)currMaterial;
                     if ((Boolean)specMaterial.GetValue(Viewport2DVisual3D.IsVisualHostMaterialProperty))
                     {
                         specMaterial.Brush = internalBrush;
                         numMaterialsSwapped++;
                     }
                 }
-                else if (currMaterial is MaterialGroup)
+                else if (currMaterial is MaterialGroup matGroup)
                 {
-                    MaterialGroup matGroup = (MaterialGroup)currMaterial;
 
                     // the IsVisualHostMaterialProperty should not be set on a MaterialGroup - verify that
                     if ((Boolean)matGroup.GetValue(Viewport2DVisual3D.IsVisualHostMaterialProperty))
@@ -507,10 +503,10 @@ namespace System.Windows.Media.Media3D
 
                     // iterate over the children and put them on the stack of materials to modify
                     MaterialCollection children = matGroup.Children;
-                    
+
                     if (children != null)
                     {
-                        for (int i=0, count = children.Count; i < count; i++)
+                        for (int i = 0, count = children.Count; i < count; i++)
                         {
                             Material m = children[i];
                             materialStack.Push(m);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Component/MarkedHighlightComponent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Component/MarkedHighlightComponent.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -54,7 +54,7 @@ namespace MS.Internal.Annotations.Component
         {
             ArgumentNullException.ThrowIfNull(type);
 
-            _DPHost = host == null ? this : host;
+            _DPHost = host ?? this;
             ClipToBounds = false;
 
             //create anchor highlight. The second parameter controls

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/ConnectionPointCookie.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/ConnectionPointCookie.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -23,10 +23,8 @@ namespace MS.Internal.Controls
         internal ConnectionPointCookie(object source, object sink, Type eventInterface)
         {
             Exception ex = null;
-            if (source is UnsafeNativeMethods.IConnectionPointContainer)
+            if (source is UnsafeNativeMethods.IConnectionPointContainer cpc)
             {
-                UnsafeNativeMethods.IConnectionPointContainer cpc = (UnsafeNativeMethods.IConnectionPointContainer)source;
-
                 try
                 {
                     Guid tmp = eventInterface.GUID;
@@ -37,11 +35,11 @@ namespace MS.Internal.Controls
                 }
                 catch (Exception e)
                 {
-                    if(CriticalExceptions.IsCriticalException(e))
+                    if (CriticalExceptions.IsCriticalException(e))
                     {
                         throw;
                     }
-                    
+
                     connectionPoint = null;
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ViewManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ViewManager.cs
@@ -554,7 +554,7 @@ namespace MS.Internal.Data
                 else
                 {
                     // collection is not a factory - create an appropriate view
-                    IList il = (ilsList != null) ? ilsList : collection as IList;
+                    IList il = ilsList ?? collection as IList;
                     if (il != null)
                     {
                         // create a view on an IList or IBindingList
@@ -582,7 +582,7 @@ namespace MS.Internal.Data
                     throw new ArgumentException(SR.Format(SR.CollectionView_WrongType, collectionViewType.Name));
 
                 // if collection is IListSource, get its list first (bug 1023903)
-                object arg = (ilsList != null) ? ilsList : collection;
+                object arg = ilsList ?? collection;
 
                 try
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ViewManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ViewManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -176,9 +176,8 @@ namespace MS.Internal.Data
 
         public override bool Equals(object o)
         {
-            if (o is WeakRefKey)
+            if (o is WeakRefKey ck)
             {
-                WeakRefKey ck = (WeakRefKey)o;
                 object c1 = Target;
                 object c2 = ck.Target;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/LocalizableResourceBuilder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/LocalizableResourceBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -565,7 +565,7 @@ namespace MS.Internal.Globalization
         {
             if (first == null || second == null)
             {
-                return (first == null) ? second : first;
+                return first ?? second;
             }
 
             // min of two readability enum. The less the more restrictive.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/SelectionEditor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/SelectionEditor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -165,7 +165,7 @@ namespace MS.Internal.Ink
                 // If the current captured device is Stylus, we should activate the LassoSelectionBehavior with
                 // the Stylus. Otherwise, use mouse.
                 EditingCoordinator.ActivateDynamicBehavior(EditingCoordinator.LassoSelectionBehavior,
-                    args.StylusDevice != null ? args.StylusDevice : args.Device);
+                    args.StylusDevice ?? args.Device);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FlowDocumentPage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FlowDocumentPage.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+ï»¿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -292,7 +292,7 @@ namespace MS.Internal.PtsHost
                     ie = _ptsPage.InputHitTest(point);
                 }
             }
-            return (ie != null) ? ie : _structuralCache.FormattingOwner as IInputElement;
+            return ie ?? _structuralCache.FormattingOwner as IInputElement;
         }
 
         /// <summary>
@@ -392,7 +392,7 @@ namespace MS.Internal.PtsHost
         }
 
         /// <summary>
-        /// Called when a UIElement-derived class which is hosted by a IContentHost changes it’s DesiredSize
+        /// Called when a UIElement-derived class which is hosted by a IContentHost changes itâ€™s DesiredSize
         /// </summary>
         /// <param name="child">
         /// Child element whose DesiredSize has changed
@@ -1212,7 +1212,7 @@ namespace MS.Internal.PtsHost
         }
 
         /// <summary>
-        /// Called when a UIElement-derived class which is hosted by a IContentHost changes it’s DesiredSize
+        /// Called when a UIElement-derived class which is hosted by a IContentHost changes itâ€™s DesiredSize
         /// </summary>
         /// <param name="child">
         /// Child element whose DesiredSize has changed

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
@@ -212,7 +212,7 @@ namespace MS.Internal.PtsHost
                 precedingText = new CharacterBufferRange(precedingTextString, 0, precedingTextString.Length);                
 
                 StaticTextPointer pointer = position.CreateStaticPointer();
-                DependencyObject element = (pointer.Parent != null) ? pointer.Parent : _paraClient.Paragraph.Element;
+                DependencyObject element = pointer.Parent ?? _paraClient.Paragraph.Element;
                 culture = DynamicPropertyReader.GetCultureInfo(element);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -408,9 +408,8 @@ namespace MS.Internal.PtsHost
                     foreach (TextSpan<TextRun> textSpan in runs)
                     {
                         TextRun run = (TextRun)textSpan.Value;
-                        if (run is InlineObjectRun)
+                        if (run is InlineObjectRun inlineObject)
                         {
-                            InlineObjectRun inlineObject = (InlineObjectRun)run;
                             FlowDirection flowDirection;
                             Rect rect = GetBoundsFromPosition(dcpRun, run.Length, out flowDirection);
                             Debug.Assert(DoubleUtil.GreaterThanOrClose(rect.Width, 0), "Negative inline object's width.");
@@ -422,7 +421,7 @@ namespace MS.Internal.PtsHost
                                 ContainerVisual parent = currentParent as ContainerVisual;
                                 Invariant.Assert(parent != null, "Parent should always derives from ContainerVisual.");
                                 parent.Children.Remove(inlineObject.UIElementIsland);
-                            }                                                        
+                            }
 
                             if (!line.HasCollapsed || ((rect.Left + inlineObject.UIElementIsland.Root.DesiredSize.Width) < line.Width))
                             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/OptimalTextSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/OptimalTextSource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -161,7 +161,7 @@ namespace MS.Internal.PtsHost
 
 
                 StaticTextPointer pointer = position.CreateStaticPointer();
-                DependencyObject element = (pointer.Parent != null) ? pointer.Parent : _paraClient.Paragraph.Element;
+                DependencyObject element = pointer.Parent ?? _paraClient.Paragraph.Element;
                 culture = DynamicPropertyReader.GetCultureInfo(element);                
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsHost.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1978,17 +1978,15 @@ namespace MS.Internal.PtsHost
 
                 for(int objectIndex = 0; objectIndex < attachedObjects.Count; objectIndex++)
                 {
-                    if(attachedObjects[objectIndex] is FigureObject)
+                    if (attachedObjects[objectIndex] is FigureObject figureObject)
                     {
-                        FigureObject figureObject = (FigureObject) attachedObjects[objectIndex];
-
                         rgnmpAttachedObject[objectIndex] = figureObject.Para.Handle;
                         rgdcpAnchor[objectIndex] = figureObject.Dcp;
                         rgidobj[objectIndex] = PTS.fsidobjFigure;
                     }
                     else
                     {
-                        FloaterObject floaterObject = (FloaterObject) attachedObjects[objectIndex];
+                        FloaterObject floaterObject = (FloaterObject)attachedObjects[objectIndex];
 
                         rgnmpAttachedObject[objectIndex] = floaterObject.Para.Handle;
                         rgdcpAnchor[objectIndex] = floaterObject.Dcp;
@@ -2095,17 +2093,15 @@ namespace MS.Internal.PtsHost
 
                 for(int objectIndex = 0; objectIndex < attachedObjects.Count; objectIndex++)
                 {
-                    if(attachedObjects[objectIndex] is FigureObject)
+                    if (attachedObjects[objectIndex] is FigureObject figureObject)
                     {
-                        FigureObject figureObject = (FigureObject) attachedObjects[objectIndex];
-
                         rgnmpAttachedObject[objectIndex] = figureObject.Para.Handle;
                         rgdcpAnchor[objectIndex] = figureObject.Dcp;
                         rgidobj[objectIndex] = PTS.fsidobjFigure;
                     }
                     else
                     {
-                        FloaterObject floaterObject = (FloaterObject) attachedObjects[objectIndex];
+                        FloaterObject floaterObject = (FloaterObject)attachedObjects[objectIndex];
 
                         rgnmpAttachedObject[objectIndex] = floaterObject.Para.Handle;
                         rgdcpAnchor[objectIndex] = floaterObject.Dcp;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/ComplexLine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/ComplexLine.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -101,7 +101,7 @@ namespace MS.Internal.Text
                 precedingText = new CharacterBufferRange(precedingTextString, 0, precedingTextString.Length);                         
 
                 StaticTextPointer pointer = position.CreateStaticPointer();                
-                DependencyObject element = (pointer.Parent != null) ? pointer.Parent : _owner;                
+                DependencyObject element = pointer.Parent ?? _owner;                
                 culture = DynamicPropertyReader.GetCultureInfo(element);                
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentGrid.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1707,9 +1707,8 @@ namespace MS.Internal.Documents
             //Ensure that the UserState passed with this event contains an
             //MakeVisibleData object. If not, we ignore it as this event
             //could have originated from someone else calling GetPageNumberAsync.
-            if (e.UserState is MakeVisibleData)
+            if (e.UserState is MakeVisibleData data)
             {
-                MakeVisibleData data = (MakeVisibleData)e.UserState;
                 MakeVisibleAsync(data, e.PageNumber);
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextContainerHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextContainerHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -700,13 +700,11 @@ namespace MS.Internal.Documents
         {
             Invariant.Assert(edge == ElementEdge.BeforeStart || edge == ElementEdge.AfterEnd, "Cannot retrieve CP from the content of embedded object.");
             int cp = -1;
-            if (embeddedObject is FrameworkElement)
+            if (embeddedObject is FrameworkElement fe)
             {
-                FrameworkElement fe = (FrameworkElement)embeddedObject;
                 //likely the embedded element is hosted by some TextElement, like InlineUIContainer or BlockUIContainer
-                if (fe.Parent is TextElement)
+                if (fe.Parent is TextElement uiContainer)
                 {
-                    TextElement uiContainer = (TextElement)fe.Parent;
                     cp = (edge == ElementEdge.BeforeStart) ? uiContainer.ContentStartOffset : uiContainer.ContentEndOffset;
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextDocumentView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextDocumentView.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -199,9 +199,8 @@ namespace MS.Internal.Documents
         private Rect CalculateViewportRect()
         {
             Rect visibleRect = Rect.Empty;
-            if (RenderScope is IScrollInfo)
+            if (RenderScope is IScrollInfo scrollInfo)
             {
-                IScrollInfo scrollInfo = (IScrollInfo)RenderScope;
                 if (scrollInfo.ViewportWidth != 0 && scrollInfo.ViewportHeight != 0)
                 {
                     visibleRect = new Rect(scrollInfo.HorizontalOffset, scrollInfo.VerticalOffset, scrollInfo.ViewportWidth, scrollInfo.ViewportHeight);
@@ -816,10 +815,8 @@ namespace MS.Internal.Documents
                     }
                 }
             }
-            else if (paragraph is SubpageParagraphResult)
+            else if (paragraph is SubpageParagraphResult subpageParagraphResult) // Subpage implies new coordinate system.
             {
-                // Subpage implies new coordinate system.
-                SubpageParagraphResult subpageParagraphResult = (SubpageParagraphResult)paragraph;
                 point.X -= subpageParagraphResult.ContentOffset.X;
                 point.Y -= subpageParagraphResult.ContentOffset.Y;
 
@@ -830,9 +827,8 @@ namespace MS.Internal.Documents
             {
                 ReadOnlyCollection<ColumnResult> columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements;
-                if (paragraph is FloaterParagraphResult)
+                if (paragraph is FloaterParagraphResult floaterParagraphResult)
                 {
-                    FloaterParagraphResult floaterParagraphResult = (FloaterParagraphResult)paragraph;
                     columns = floaterParagraphResult.Columns;
                     nestedFloatingElements = floaterParagraphResult.FloatingElements;
                     TransformToSubpage(ref point, floaterParagraphResult.ContentOffset);
@@ -1030,10 +1026,8 @@ namespace MS.Internal.Documents
                     cellInfo = ((TableParagraphResult)paragraph).GetCellInfoFromPoint(point);
                 }
             }
-            else if (paragraph is SubpageParagraphResult)
+            else if (paragraph is SubpageParagraphResult subpageParagraphResult) // Subpage implies new coordinate system.
             {
-                // Subpage implies new coordinate system.
-                SubpageParagraphResult subpageParagraphResult = (SubpageParagraphResult)paragraph;
                 point.X -= subpageParagraphResult.ContentOffset.X;
                 point.Y -= subpageParagraphResult.ContentOffset.Y;
 
@@ -1044,10 +1038,8 @@ namespace MS.Internal.Documents
                     cellInfo.Adjust(new Point(subpageParagraphResult.ContentOffset.X, subpageParagraphResult.ContentOffset.Y));
                 }
             }
-            else if (paragraph is FigureParagraphResult)
+            else if (paragraph is FigureParagraphResult figureParagraphResult) // Subpage implies new coordinate system.
             {
-                // Subpage implies new coordinate system.
-                FigureParagraphResult figureParagraphResult = (FigureParagraphResult)paragraph;
                 TransformToSubpage(ref point, figureParagraphResult.ContentOffset);
                 cellInfo = GetCellInfoFromPoint(figureParagraphResult.Columns, figureParagraphResult.FloatingElements, point, tableFilter);
                 if (cellInfo != null)
@@ -1055,10 +1047,8 @@ namespace MS.Internal.Documents
                     cellInfo.Adjust(new Point(figureParagraphResult.ContentOffset.X, figureParagraphResult.ContentOffset.Y));
                 }
             }
-            else if (paragraph is FloaterParagraphResult)
+            else if (paragraph is FloaterParagraphResult floaterParagraphResult) // Subpage implies new coordinate system.
             {
-                // Subpage implies new coordinate system.
-                FloaterParagraphResult floaterParagraphResult = (FloaterParagraphResult)paragraph;
                 TransformToSubpage(ref point, floaterParagraphResult.ContentOffset);
                 cellInfo = GetCellInfoFromPoint(floaterParagraphResult.Columns, floaterParagraphResult.FloatingElements, point, tableFilter);
                 if (cellInfo != null)
@@ -1191,10 +1181,8 @@ namespace MS.Internal.Documents
                     }
                 }
             }
-            else if (paragraph is SubpageParagraphResult)
+            else if (paragraph is SubpageParagraphResult subpageParagraphResult) // Subpage implies new coordinate system.
             {
-                // Subpage implies new coordinate system.
-                SubpageParagraphResult subpageParagraphResult = (SubpageParagraphResult)paragraph;
                 rect = GetRectangleFromTextPosition(subpageParagraphResult.Columns, subpageParagraphResult.FloatingElements, position);
                 if (rect != Rect.Empty)
                 {
@@ -1202,9 +1190,8 @@ namespace MS.Internal.Documents
                     rect.Y += subpageParagraphResult.ContentOffset.Y;
                 }
             }
-            else if (paragraph is FloaterParagraphResult)
+            else if (paragraph is FloaterParagraphResult floaterParagraphResult)
             {
-                FloaterParagraphResult floaterParagraphResult = (FloaterParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = floaterParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = floaterParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Columns collection is null.");
@@ -1216,9 +1203,8 @@ namespace MS.Internal.Documents
                     TransformFromSubpage(ref rect, floaterParagraphResult.ContentOffset);
                 }
             }
-            else if (paragraph is FigureParagraphResult)
+            else if (paragraph is FigureParagraphResult figureParagraphResult)
             {
-                FigureParagraphResult figureParagraphResult = (FigureParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = figureParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = figureParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Columns collection is null.");
@@ -1401,19 +1387,16 @@ namespace MS.Internal.Documents
                 Geometry paragraphGeometry = null;
                 Invariant.Assert(floatingElements[i] is FloaterParagraphResult ||
                                  floatingElements[i] is FigureParagraphResult);
-                if (floatingElements[i] is FloaterParagraphResult)
+                // Transform visible rect to subpage coordinates, and transform geometry from subpage coordinates
+                if (floatingElements[i] is FloaterParagraphResult floaterParagraphResult)
                 {
-                    // Transform visible rect to subpage coordinates, and transform geometry from subpage coordinates
-                    FloaterParagraphResult floaterParagraphResult = (FloaterParagraphResult)floatingElements[i];
                     TransformToSubpage(ref visibleRectThisPara, floaterParagraphResult.ContentOffset);
                     paragraphGeometry = floaterParagraphResult.GetTightBoundingGeometryFromTextPositions(startPosition, endPosition, visibleRectThisPara, out success);
                     // Geometry within the floater needs to be transformed from subpage content
                     TransformFromSubpage(paragraphGeometry, floaterParagraphResult.ContentOffset);
                 }
-                else if (floatingElements[i] is FigureParagraphResult)
+                else if (floatingElements[i] is FigureParagraphResult figureParagraphResult) // Transform visible rect to subpage coordinates, and transform geometry from subpage coordinates
                 {
-                    // Transform visible rect to subpage coordinates, and transform geometry from subpage coordinates
-                    FigureParagraphResult figureParagraphResult = (FigureParagraphResult)floatingElements[i];
                     TransformToSubpage(ref visibleRectThisPara, figureParagraphResult.ContentOffset);
                     paragraphGeometry = figureParagraphResult.GetTightBoundingGeometryFromTextPositions(startPosition, endPosition, visibleRectThisPara, out success);
                     // Geometry within the figure needs to be transformed from subpage content
@@ -1510,9 +1493,8 @@ namespace MS.Internal.Documents
                     isAtCaretUnitBoundary = IsAtCaretUnitBoundary(nestedParagraphs, _emptyParagraphCollection, position);
                 }
             }
-            else if (paragraph is SubpageParagraphResult)
+            else if (paragraph is SubpageParagraphResult subpageParagraphResult)
             {
-                SubpageParagraphResult subpageParagraphResult = (SubpageParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = subpageParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = subpageParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Column collection is null.");
@@ -1522,9 +1504,8 @@ namespace MS.Internal.Documents
                     isAtCaretUnitBoundary = IsAtCaretUnitBoundary(columns, nestedFloatingElements, position);
                 }
             }
-            else if (paragraph is FigureParagraphResult)
+            else if (paragraph is FigureParagraphResult figureParagraphResult)
             {
-                FigureParagraphResult figureParagraphResult = (FigureParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = figureParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = figureParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Column collection is null.");
@@ -1534,9 +1515,8 @@ namespace MS.Internal.Documents
                     isAtCaretUnitBoundary = IsAtCaretUnitBoundary(columns, nestedFloatingElements, position);
                 }
             }
-            else if (paragraph is FloaterParagraphResult)
+            else if (paragraph is FloaterParagraphResult floaterParagraphResult)
             {
-                FloaterParagraphResult floaterParagraphResult = (FloaterParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = floaterParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = floaterParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Column collection is null.");
@@ -1637,9 +1617,8 @@ namespace MS.Internal.Documents
                     nextCaretPosition = GetNextCaretUnitPosition(nestedParagraphs, _emptyParagraphCollection, position, direction);
                 }
             }
-            else if (paragraph is SubpageParagraphResult)
+            else if (paragraph is SubpageParagraphResult subpageParagraphResult)
             {
-                SubpageParagraphResult subpageParagraphResult = (SubpageParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = subpageParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = subpageParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Column collection is null.");
@@ -1649,9 +1628,8 @@ namespace MS.Internal.Documents
                     nextCaretPosition = GetNextCaretUnitPosition(columns, nestedFloatingElements, position, direction);
                 }
             }
-            else if (paragraph is FigureParagraphResult)
+            else if (paragraph is FigureParagraphResult figureParagraphResult)
             {
-                FigureParagraphResult figureParagraphResult = (FigureParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = figureParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = figureParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Column collection is null.");
@@ -1661,9 +1639,8 @@ namespace MS.Internal.Documents
                     nextCaretPosition = GetNextCaretUnitPosition(columns, nestedFloatingElements, position, direction);
                 }
             }
-            else if (paragraph is FloaterParagraphResult)
+            else if (paragraph is FloaterParagraphResult floaterParagraphResult)
             {
-                FloaterParagraphResult floaterParagraphResult = (FloaterParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = floaterParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = floaterParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Column collection is null.");
@@ -1760,9 +1737,8 @@ namespace MS.Internal.Documents
                     backspaceCaretPosition = GetBackspaceCaretUnitPosition(nestedParagraphs, _emptyParagraphCollection, position);
                 }
             }
-            else if (paragraph is SubpageParagraphResult)
+            else if (paragraph is SubpageParagraphResult subpageParagraphResult)
             {
-                SubpageParagraphResult subpageParagraphResult = (SubpageParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = subpageParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = subpageParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Column collection is null.");
@@ -1772,9 +1748,8 @@ namespace MS.Internal.Documents
                     backspaceCaretPosition = GetBackspaceCaretUnitPosition(columns, nestedFloatingElements, position);
                 }
             }
-            else if (paragraph is FigureParagraphResult)
+            else if (paragraph is FigureParagraphResult figureParagraphResult)
             {
-                FigureParagraphResult figureParagraphResult = (FigureParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = figureParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = figureParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Column collection is null.");
@@ -1784,9 +1759,8 @@ namespace MS.Internal.Documents
                     backspaceCaretPosition = GetBackspaceCaretUnitPosition(columns, nestedFloatingElements, position);
                 }
             }
-            else if (paragraph is FloaterParagraphResult)
+            else if (paragraph is FloaterParagraphResult floaterParagraphResult)
             {
-                FloaterParagraphResult floaterParagraphResult = (FloaterParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = floaterParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = floaterParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Column collection is null.");
@@ -2355,9 +2329,8 @@ namespace MS.Internal.Documents
                     lineRange = GetLineRangeFromPosition(nestedParagraphs, _emptyParagraphCollection, position);
                 }
             }
-            else if (paragraph is SubpageParagraphResult)
+            else if (paragraph is SubpageParagraphResult subpageParagraphResult)
             {
-                SubpageParagraphResult subpageParagraphResult = (SubpageParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = subpageParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = subpageParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Column collection is null.");
@@ -2367,9 +2340,8 @@ namespace MS.Internal.Documents
                     lineRange = GetLineRangeFromPosition(columns, nestedFloatingElements, position);
                 }
             }
-            else if (paragraph is FigureParagraphResult)
+            else if (paragraph is FigureParagraphResult figureParagraphResult)
             {
-                FigureParagraphResult figureParagraphResult = (FigureParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = figureParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = figureParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Column collection is null.");
@@ -2379,9 +2351,8 @@ namespace MS.Internal.Documents
                     lineRange = GetLineRangeFromPosition(columns, nestedFloatingElements, position);
                 }
             }
-            else if (paragraph is FloaterParagraphResult)
+            else if (paragraph is FloaterParagraphResult floaterParagraphResult)
             {
-                FloaterParagraphResult floaterParagraphResult = (FloaterParagraphResult)paragraph;
                 ReadOnlyCollection<ColumnResult> columns = floaterParagraphResult.Columns;
                 ReadOnlyCollection<ParagraphResult> nestedFloatingElements = floaterParagraphResult.FloatingElements;
                 Invariant.Assert(columns != null, "Column collection is null.");
@@ -2563,10 +2534,8 @@ namespace MS.Internal.Documents
                         }
                     }
                 }
-                else if (paragraphs[paragraphIndex] is TableParagraphResult)
+                else if (paragraphs[paragraphIndex] is TableParagraphResult tableResult) // c) TableParagraph - process nested paragraphs.
                 {
-                    // c) TableParagraph - process nested paragraphs.
-                    TableParagraphResult tableResult = (TableParagraphResult)paragraphs[paragraphIndex];
                     CellParaClient cpcStart = tableResult.GetCellParaClientFromPosition(position);
                     CellParaClient cpcCur = cpcStart;
                     Rect paragraphBox = paragraphs[paragraphIndex].LayoutBox;
@@ -2828,9 +2797,8 @@ namespace MS.Internal.Documents
                         break;
                     }
                 }
-                else if (paragraphs[paragraphIndex] is TableParagraphResult)
+                else if (paragraphs[paragraphIndex] is TableParagraphResult tableResult)
                 {
-                    TableParagraphResult tableResult = (TableParagraphResult)paragraphs[paragraphIndex];
                     Rect paragraphBox = paragraphs[paragraphIndex].LayoutBox;
                     CellParaClient cpcCur = null;
 
@@ -3133,9 +3101,8 @@ namespace MS.Internal.Documents
             for (int index = 0; index < paragraphs.Count; index++)
             {
                 ParagraphResult paragraph = paragraphs[index];
-                if (paragraph is TextParagraphResult)
+                if (paragraph is TextParagraphResult tpr)
                 {
-                    TextParagraphResult tpr = (TextParagraphResult)paragraph;
                     if (start.CompareTo(tpr.EndPosition) < 0 && end.CompareTo(tpr.StartPosition) > 0)
                     {
                         ITextPointer startRange = start.CompareTo(tpr.StartPosition) < 0 ? tpr.StartPosition : start;
@@ -3190,9 +3157,8 @@ namespace MS.Internal.Documents
                 {
                     success = true;
                     ITextPointer endThisPara = end.CompareTo(paragraph.EndPosition) < 0 ? end : paragraph.EndPosition;
-                    if (paragraph is FigureParagraphResult)
+                    if (paragraph is FigureParagraphResult figureParagraphResult)
                     {
-                        FigureParagraphResult figureParagraphResult = (FigureParagraphResult)paragraph;
                         ReadOnlyCollection<ColumnResult> columns = figureParagraphResult.Columns;
                         ReadOnlyCollection<ParagraphResult> nestedFloatingElements = figureParagraphResult.FloatingElements;
                         Invariant.Assert(columns != null, "Column collection is null.");
@@ -3202,9 +3168,8 @@ namespace MS.Internal.Documents
                             GetGlyphRuns(glyphRuns, start, endThisPara, columns, nestedFloatingElements);
                         }
                     }
-                    else if (paragraph is FloaterParagraphResult)
+                    else if (paragraph is FloaterParagraphResult floaterParagraphResult)
                     {
-                        FloaterParagraphResult floaterParagraphResult = (FloaterParagraphResult)paragraph;
                         ReadOnlyCollection<ColumnResult> columns = floaterParagraphResult.Columns;
                         ReadOnlyCollection<ParagraphResult> nestedFloatingElements = floaterParagraphResult.FloatingElements;
                         Invariant.Assert(columns != null, "Column collection is null.");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonItemDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonItemDialog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -121,7 +121,7 @@ namespace Microsoft.Win32
             get
             {
                 // Avoid returning a null string - return String.Empty instead.
-                return _defaultDirectory == null ? String.Empty : _defaultDirectory;
+                return _defaultDirectory ?? string.Empty;
             }
             set
             {
@@ -160,7 +160,7 @@ namespace Microsoft.Win32
             get
             {
                 // Avoid returning a null string - return String.Empty instead.
-                return _initialDirectory == null ? String.Empty : _initialDirectory;
+                return _initialDirectory ?? string.Empty;
             }
             set
             {
@@ -179,7 +179,7 @@ namespace Microsoft.Win32
             get
             {
                 // Avoid returning a null string - return String.Empty instead.
-                return _rootDirectory == null ? String.Empty : _rootDirectory;
+                return _rootDirectory ?? string.Empty;
             }
             set
             {
@@ -218,7 +218,7 @@ namespace Microsoft.Win32
             get
             {
                 // Avoid returning a null string - return String.Empty instead.
-                return _title == null ? String.Empty : _title;
+                return _title ?? string.Empty;
             }
             set
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -262,7 +262,7 @@ namespace Microsoft.Win32
             {
                 // For string properties, it's important to not return null, as an empty
                 // string tends to make more sense to beginning developers.
-                return _defaultExtension == null ? String.Empty : _defaultExtension;
+                return _defaultExtension ?? string.Empty;
             }
 
             set
@@ -307,7 +307,7 @@ namespace Microsoft.Win32
             {
                 // For string properties, it's important to not return null, as an empty
                 // string tends to make more sense to beginning developers.
-                return _filter == null ? String.Empty : _filter;
+                return _filter ?? string.Empty;
             }
 
             set

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/CalendarAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/CalendarAutomationPeer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -382,9 +382,8 @@ namespace System.Windows.Automation.Peers
                     if (childRow == row && childColumn == column)
                     {
                         object dataContext = (child as FrameworkElement).DataContext;
-                        if (dataContext is DateTime)
+                        if (dataContext is DateTime date)
                         {
-                            DateTime date = (DateTime)dataContext;
                             AutomationPeer peer = GetOrCreateDateTimeAutomationPeer(date, OwningCalendar.DisplayMode);
                             return ProviderFromPeer(peer);
                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/FrameworkContentElementAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/FrameworkContentElementAutomationPeer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -44,7 +44,7 @@ namespace System.Windows.Automation.Peers
                 }
             }
 
-            return result == null ? string.Empty : result;
+            return result ?? string.Empty;
         }
 
         ///

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemAutomationPeer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -677,7 +677,7 @@ namespace System.Windows.Automation.Peers
                 if (iwr != null)
                 {
                     object item = iwr.Target;
-                    return (item == null) ? DependencyProperty.UnsetValue : item;
+                    return item ?? DependencyProperty.UnsetValue;
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Calendar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Calendar.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -911,34 +911,32 @@ namespace System.Windows.Controls
 
         internal void OnCalendarButtonPressed(CalendarButton b, bool switchDisplayMode)
         {
-            if (b.DataContext is DateTime)
+            if (b.DataContext is DateTime d)
             {
-                DateTime d = (DateTime)b.DataContext;
-
                 DateTime? newDate = null;
                 CalendarMode newMode = CalendarMode.Month;
 
                 switch (this.DisplayMode)
                 {
                     case CalendarMode.Month:
-                    {
-                        Debug.Assert(false);
-                        break;
-                    }
+                        {
+                            Debug.Assert(false);
+                            break;
+                        }
 
                     case CalendarMode.Year:
-                    {
-                        newDate = DateTimeHelper.SetYearMonth(this.DisplayDate, d);
-                        newMode = CalendarMode.Month;
-                        break;
-                    }
+                        {
+                            newDate = DateTimeHelper.SetYearMonth(this.DisplayDate, d);
+                            newMode = CalendarMode.Month;
+                            break;
+                        }
 
                     case CalendarMode.Decade:
-                    {
-                        newDate = DateTimeHelper.SetYear(this.DisplayDate, d.Year);
-                        newMode = CalendarMode.Year;
-                        break;
-                    }
+                        {
+                            newDate = DateTimeHelper.SetYear(this.DisplayDate, d.Year);
+                            newMode = CalendarMode.Year;
+                            break;
+                        }
 
                     default:
                         Debug.Assert(false);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCellInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCellInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -122,7 +122,7 @@ namespace System.Windows.Controls
             }
             else
             {
-                return new DataGridCellInfo(owner, column, (item == null) ? DependencyProperty.UnsetValue : item);
+                return new DataGridCellInfo(owner, column, item ?? DependencyProperty.UnsetValue);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridLength.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -154,9 +154,8 @@ namespace System.Windows.Controls
         /// and unit type as oCompare.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is DataGridLength)
+            if (obj is DataGridLength l)
             {
-                DataGridLength l = (DataGridLength)obj;
                 return this == l;
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridRow.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridRow.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -713,9 +713,8 @@ namespace System.Windows.Controls
                 row.DataGridOwner,
                 DataGrid.RowDetailsVisibilityModeProperty);
 
-            if (visibility is DataGridRowDetailsVisibilityMode)
+            if (visibility is DataGridRowDetailsVisibilityMode visibilityMode)
             {
-                var visibilityMode = (DataGridRowDetailsVisibilityMode)visibility;
                 var hasDetailsTemplate = row.DetailsTemplate != null || row.DetailsTemplateSelector != null;
                 var isRealItem = row.Item != CollectionView.NewItemPlaceholder;
                 switch (visibilityMode)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DocumentViewer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DocumentViewer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -2327,9 +2327,8 @@ namespace System.Windows.Controls
             bool ok;
 
             // Ensure value is double
-            if (value is double)
+            if (value is double checkValue)
             {
-                double checkValue = (double)value;
 
                 // Check if double is within an assumed range
                 if ((double.IsNaN(checkValue)) ||

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/FlowDocumentReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/FlowDocumentReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1264,9 +1264,8 @@ namespace System.Windows.Controls
                 mode = (FlowDocumentReaderViewingMode)value;
                 success = true;
             }
-            else if (value is String)
+            else if (value is String str)
             {
-                String str = (String)value;
                 if (str == FlowDocumentReaderViewingMode.Page.ToString())
                 {
                     mode = FlowDocumentReaderViewingMode.Page;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordBox.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -944,9 +944,8 @@ namespace System.Windows.Controls
 
             // Add renderScope as a child of ContentHostTemplateName
             _renderScope = renderScope;
-            if (_passwordBoxContentHost is ScrollViewer)
+            if (_passwordBoxContentHost is ScrollViewer scrollViewer)
             {
-                ScrollViewer scrollViewer = (ScrollViewer)_passwordBoxContentHost;
                 if (scrollViewer.Content != null)
                 {
                     throw new NotSupportedException(SR.TextBoxScrollViewerMarkedAsTextBoxContentMustHaveNoContent);
@@ -956,9 +955,8 @@ namespace System.Windows.Controls
                     scrollViewer.Content = _renderScope;
                 }
             }
-            else if (_passwordBoxContentHost is Decorator)
+            else if (_passwordBoxContentHost is Decorator decorator)
             {
-                Decorator decorator = (Decorator)_passwordBoxContentHost;
                 if (decorator.Child != null)
                 {
                     throw new NotSupportedException(SR.TextBoxDecoratorMarkedAsTextBoxContentMustHaveNoContent);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/CalendarItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/CalendarItem.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1161,9 +1161,8 @@ namespace System.Windows.Controls.Primitives
                 for (int childIndex = COLS; childIndex < count; childIndex++)
                 {
                     CalendarDayButton childButton = _monthView.Children[childIndex] as CalendarDayButton;
-                    if (childButton.DataContext is DateTime)
+                    if (childButton.DataContext is DateTime date)
                     {
-                        DateTime date = (DateTime)childButton.DataContext;
                         childButton.SetValue(
                             CalendarDayButton.IsHighlightedPropertyKey,
                             (daysToHighlight != 0) && DateTimeHelper.InRange(date, hStart, hEnd));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/CustomPopupPlacement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/CustomPopupPlacement.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -81,9 +81,8 @@ namespace System.Windows.Controls.Primitives
         /// <returns>True if equivalent. False otherwise.</returns>
         public override bool Equals(object o)
         {
-            if (o is CustomPopupPlacement)
+            if (o is CustomPopupPlacement placement)
             {
-                CustomPopupPlacement placement = (CustomPopupPlacement)o;
                 return (placement._primaryAxis == _primaryAxis) && (placement._point == _point);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DocumentPageView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DocumentPageView.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -103,7 +103,7 @@ namespace System.Windows.Controls.Primitives
         /// </summary>
         public DocumentPage DocumentPage
         {
-            get { return (_documentPage == null) ? DocumentPage.Missing : _documentPage; }
+            get { return _documentPage ?? DocumentPage.Missing; }
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DocumentViewerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DocumentViewerBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1162,9 +1162,8 @@ namespace System.Windows.Controls.Primitives
                     if (child != null)
                     {
                         // Special case UIElements already connected to visual tree.
-                        if (args.TargetObject is UIElement)
+                        if (args.TargetObject is UIElement targetObject)
                         {
-                            UIElement targetObject = (UIElement)args.TargetObject;
                             if (VisualTreeHelper.IsAncestorOf(this, targetObject))
                             {
                                 targetRect = args.TargetRect;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/GridViewRowPresenterBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/GridViewRowPresenterBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -304,7 +304,7 @@ namespace System.Windows.Controls.Primitives
         {
             ItemsControl ic = ItemsControl.ItemsControlFromItemContainer(TemplatedParent);
 
-            return (ic != null) ? ic : (FrameworkElement)this;
+            return ic ?? (FrameworkElement)this;
         }
 
         // if and only if both conditions below are satisfied, row presenter visual is ready.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/HierarchicalVirtualizationConstraints.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/HierarchicalVirtualizationConstraints.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -101,9 +101,8 @@ namespace System.Windows.Controls
         /// and Viewport as oCompare.</returns>
         override public bool Equals(object oCompare)
         {
-            if (oCompare is HierarchicalVirtualizationConstraints)
+            if (oCompare is HierarchicalVirtualizationConstraints constraints)
             {
-                HierarchicalVirtualizationConstraints constraints = (HierarchicalVirtualizationConstraints)oCompare;
                 return (this == constraints);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/HierarchicalVirtualizationHeaderDesiredSizes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/HierarchicalVirtualizationHeaderDesiredSizes.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -84,9 +84,8 @@ namespace System.Windows.Controls
         /// and pixel sizes as oCompare.</returns>
         override public bool Equals(object oCompare)
         {
-            if (oCompare is HierarchicalVirtualizationHeaderDesiredSizes)
+            if (oCompare is HierarchicalVirtualizationHeaderDesiredSizes headerDesiredSizes)
             {
-                HierarchicalVirtualizationHeaderDesiredSizes headerDesiredSizes = (HierarchicalVirtualizationHeaderDesiredSizes)oCompare;
                 return (this == headerDesiredSizes);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/HierarchicalVirtualizationItemDesiredSizes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/HierarchicalVirtualizationItemDesiredSizes.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -175,9 +175,8 @@ namespace System.Windows.Controls
         /// and pixel sizes as oCompare.</returns>
         override public bool Equals(object oCompare)
         {
-            if (oCompare is HierarchicalVirtualizationItemDesiredSizes)
+            if (oCompare is HierarchicalVirtualizationItemDesiredSizes itemDesiredSizes)
             {
-                HierarchicalVirtualizationItemDesiredSizes itemDesiredSizes = (HierarchicalVirtualizationItemDesiredSizes)oCompare;
                 return (this == itemDesiredSizes);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/IItemContainerGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/IItemContainerGenerator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -158,10 +158,9 @@ namespace System.Windows.Controls.Primitives
         // This is required by FxCop.
         public override bool Equals(object o)
         {
-            if (o is GeneratorPosition)
+            if (o is GeneratorPosition that)
             {
-                GeneratorPosition that = (GeneratorPosition)o;
-                return  this._index == that._index &&
+                return this._index == that._index &&
                         this._offset == that._offset;
             }
             return false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/TextBoxBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/TextBoxBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1971,10 +1971,8 @@ namespace System.Windows.Controls.Primitives
 
             // Add renderScope as a child of ContentHostTemplateName
             _renderScope = renderScope;
-            if (_textBoxContentHost is ScrollViewer)
+            if (_textBoxContentHost is ScrollViewer scrollViewer)
             {
-                ScrollViewer scrollViewer = (ScrollViewer)_textBoxContentHost;
-
                 if (scrollViewer.Content != null)
                 {
                     _renderScope = null;
@@ -1987,9 +1985,8 @@ namespace System.Windows.Controls.Primitives
                     scrollViewer.Content = _renderScope; // this may replace old render scope in case of upgrade scenario in TextBox
                 }
             }
-            else if (_textBoxContentHost is Decorator)
+            else if (_textBoxContentHost is Decorator decorator)
             {
-                Decorator decorator = (Decorator)_textBoxContentHost;
                 if (decorator.Child != null)
                 {
                     _renderScope = null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/SelectedCellsChangedEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/SelectedCellsChangedEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -42,8 +42,8 @@ namespace System.Windows.Controls
 
         internal SelectedCellsChangedEventArgs(DataGrid owner, VirtualizedCellInfoCollection addedCells, VirtualizedCellInfoCollection removedCells)
         {
-            _addedCells = (addedCells != null) ? addedCells : VirtualizedCellInfoCollection.MakeEmptyCollection(owner);
-            _removedCells = (removedCells != null) ? removedCells : VirtualizedCellInfoCollection.MakeEmptyCollection(owner);
+            _addedCells = addedCells ?? VirtualizedCellInfoCollection.MakeEmptyCollection(owner);
+            _removedCells = removedCells ?? VirtualizedCellInfoCollection.MakeEmptyCollection(owner);
 
             Debug.Assert(_addedCells.IsReadOnly, "_addedCells should have ended up as read-only.");
             Debug.Assert(_removedCells.IsReadOnly, "_removedCells should have ended up as read-only.");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1717,7 +1717,7 @@ Debug.Assert(lineCount == LineCount);
             }
 
             // If nothing has been hit, assume that element itself has been hit.
-            return (ie != null) ? ie : this;
+            return ie ?? this;
         }
 
         /// <summary>
@@ -4090,7 +4090,7 @@ Debug.Assert(lineCount == LineCount);
 
             if (text._complexContent == null)
             {
-                text._contentCache = (newText != null) ? newText : String.Empty;
+                text._contentCache = newText ?? string.Empty;
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ValidationResult.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ValidationResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -114,7 +114,7 @@ namespace System.Windows.Controls
         /// <returns>hash code for the current ValidationResult</returns>
         public override int GetHashCode()
         {
-            return IsValid.GetHashCode() ^ ((ErrorContent == null) ? int.MinValue : ErrorContent).GetHashCode();
+            return IsValid.GetHashCode() ^ (ErrorContent ?? int.MinValue).GetHashCode();
         }
 
         private bool _isValid;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizationCacheLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizationCacheLength.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -122,9 +122,8 @@ namespace System.Windows.Controls
         /// and unit type as oCompare.</returns>
         override public bool Equals(object oCompare)
         {
-            if (oCompare is VirtualizationCacheLength)
+            if (oCompare is VirtualizationCacheLength l)
             {
-                VirtualizationCacheLength l = (VirtualizationCacheLength)oCompare;
                 return (this == l);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/CornerRadius.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/CornerRadius.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -69,9 +69,8 @@ namespace System.Windows
         /// <returns>True if object is a CornerRadius and all sides of it are equal to this CornerRadius'.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is CornerRadius)
+            if (obj is CornerRadius otherObj)
             {
-                CornerRadius otherObj = (CornerRadius)obj;
                 return (this == otherObj);
             }
             return (false);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ObjectDataProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ObjectDataProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -142,7 +142,7 @@ namespace System.Windows.Data
         {
             get
             {
-                 return (_instanceProvider != null) ? _instanceProvider : _objectInstance;
+                 return _instanceProvider ?? _objectInstance;
             }
             set
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlDataProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlDataProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -352,7 +352,7 @@ namespace System.Windows.Data
             Uri sourceUri = this.Source;
             if (sourceUri.IsAbsoluteUri == false)
             {
-                Uri baseUri = (_baseUri != null) ? _baseUri : BindUriHelper.BaseUri;
+                Uri baseUri = _baseUri ?? BindUriHelper.BaseUri;
                 sourceUri = BindUriHelper.GetResolvedUri(baseUri, sourceUri);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DependencyPropertyHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DependencyPropertyHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -118,11 +118,9 @@ namespace System.Windows
         /// </summary>
         public override bool Equals(object o)
         {
-            if (o is ValueSource)
+            if (o is ValueSource that)
             {
-                ValueSource that = (ValueSource)o;
-
-                return  this._baseValueSource == that._baseValueSource &&
+                return this._baseValueSource == that._baseValueSource &&
                         this._isExpression == that._isExpression &&
                         this._isAnimated == that._isAnimated &&
                         this._isCoerced == that._isCoerced;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentReference.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentReference.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -65,7 +65,7 @@ namespace System.Windows.Documents
         /// <returns>The document tree</returns>
         public FixedDocument GetDocument(bool forceReload)
         {
-            DocumentsTrace.FixedDocumentSequence.IDF.Trace($"DocumentReference.GetDocument ({(Source == null ? new Uri("", UriKind.RelativeOrAbsolute) : Source)}, {forceReload})");
+            DocumentsTrace.FixedDocumentSequence.IDF.Trace($"DocumentReference.GetDocument ({(Source ?? new Uri("", UriKind.RelativeOrAbsolute))}, {forceReload})");
              VerifyAccess();
 
             FixedDocument idp = null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequence.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequence.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -320,11 +320,10 @@ namespace System.Windows.Documents
             // Because of that we are expecting one of 2 types here.
             DynamicDocumentPaginator childPaginator = null;
             ContentPosition childContentPosition = null;
-            if (contentPosition is DocumentSequenceTextPointer)
+            if (contentPosition is DocumentSequenceTextPointer dsTextPointer)
             {
-                DocumentSequenceTextPointer dsTextPointer = (DocumentSequenceTextPointer)contentPosition;
 
-                #pragma warning suppress 6506 // dsTextPointer is obviously not null
+#pragma warning suppress 6506 // dsTextPointer is obviously not null
                 childPaginator = GetPaginator(dsTextPointer.ChildBlock.DocRef);
                 childContentPosition = dsTextPointer.ChildPointer as ContentPosition;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedDocument.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedDocument.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -498,7 +498,7 @@ namespace System.Windows.Documents
                 fixedTextPointer = new FixedTextPointer(true, LogicalDirection.Forward, flowPosition);
             }
 
-            return (fixedTextPointer != null) ? fixedTextPointer : ContentPosition.Missing;
+            return fixedTextPointer ?? ContentPosition.Missing;
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextBuilder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1507,9 +1507,8 @@ namespace System.Windows.Documents
                         _fixedNodes.Add(element.FixedNode);
                     }
                 }
-                else if (element is FixedSOMImage)
+                else if (element is FixedSOMImage image)
                 {
-                    FixedSOMImage image = (FixedSOMImage)element;
                     _FinishTextRun(true);
                     _SetHyperlink(navUri, image.FixedNode, shadowHyperlink);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextView.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -92,15 +92,13 @@ namespace System.Windows.Documents
                 {
                     pos = _CreateTextPointerFromGlyphs(g, point);
                 }
-                else if (e is Image)
+                else if (e is Image im)
                 {
-                    Image im = (Image)e;
                     FixedPosition fixedp = new FixedPosition(this.FixedPage.CreateFixedNode(this.PageIndex, im), 0);
                     pos = _CreateTextPointer(fixedp, LogicalDirection.Forward);
                 }
-                else if (e is Path)
+                else if (e is Path p)
                 {
-                    Path p = (Path)e;
                     if (p.Fill is ImageBrush)
                     {
                         FixedPosition fixedp = new FixedPosition(this.FixedPage.CreateFixedNode(this.PageIndex, p), 0);
@@ -196,17 +194,15 @@ namespace System.Windows.Documents
             }
 
             DependencyObject element = this.FixedPage.GetElement(fixedp.Node);
-            if (element is Glyphs)
+            if (element is Glyphs g)
             {
-                Glyphs g = (Glyphs)element;
                 designRect = _GetGlyphRunDesignRect(g, fixedp.Offset, fixedp.Offset);
                 // need to do transform
                 GeneralTransform tran = g.TransformToAncestor(this.FixedPage);
                 designRect = _GetTransformedCaretRect(tran, designRect.TopLeft, designRect.Height);
             }
-            else if (element is Image)
+            else if (element is Image image)
             {
-                Image image = (Image)element;
                 GeneralTransform tran = image.TransformToAncestor(this.FixedPage);
                 Point offset = new Point(0, 0);
                 if (fixedp.Offset > 0)
@@ -215,9 +211,8 @@ namespace System.Windows.Documents
                 }
                 designRect = _GetTransformedCaretRect(tran, offset, image.ActualHeight);
             }
-            else if (element is Path)
+            else if (element is Path path)
             {
-                Path path = (Path)element;
                 GeneralTransform tran = path.TransformToAncestor(this.FixedPage);
                 Rect bounds = path.Data.Bounds;
                 Point offset = bounds.TopLeft;
@@ -440,9 +435,8 @@ namespace System.Windows.Documents
             if (_GetFixedPosition(ftp, out fixedp))
             {
                 DependencyObject element = this.FixedPage.GetElement(fixedp.Node);
-                if (element is Glyphs)
+                if (element is Glyphs g)
                 {
-                    Glyphs g = (Glyphs)element;
                     int characterCount = (g.UnicodeString == null ? 0 : g.UnicodeString.Length);
                     if (fixedp.Offset == characterCount)
                     {   //end of line -- allow caret
@@ -511,9 +505,8 @@ namespace System.Windows.Documents
             if (_GetFixedPosition(ftp, out fixedp))
             {
                 DependencyObject element = this.FixedPage.GetElement(fixedp.Node);
-                if (element is Glyphs)
+                if (element is Glyphs g)
                 {
-                    Glyphs g = (Glyphs)element;
                     GlyphRun run = g.ToGlyphRun();
 
                     int characterCount = (run.Characters == null) ? 0 : run.Characters.Count;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FlowDocument.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FlowDocument.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -927,7 +927,7 @@ namespace System.Windows.Documents
                 textPointer = null;
             }
             flowContentPosition = textPointer as TextPointer;
-            return (flowContentPosition != null) ? flowContentPosition : ContentPosition.Missing;
+            return flowContentPosition ?? ContentPosition.Missing;
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/InlineCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/InlineCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -189,9 +189,8 @@ namespace System.Windows.Documents
             ArgumentNullException.ThrowIfNull(text);
 
             // Special case for TextBlock - to keep its simple content in simple state
-            if (this.Parent is TextBlock)
+            if (this.Parent is TextBlock textBlock)
             {
-                TextBlock textBlock = (TextBlock)this.Parent;
                 if (!textBlock.HasComplexContent)
                 {
                     textBlock.Text = textBlock.Text + text;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/PageContent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/PageContent.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -69,7 +69,7 @@ namespace System.Windows.Documents
         public FixedPage GetPageRoot(bool forceReload)
         {
 #if DEBUG
-            DocumentsTrace.FixedFormat.PageContent.Trace($"PageContent.GetPageRoot Source={(Source == null ? new Uri("", UriKind.RelativeOrAbsolute) : Source)}");
+            DocumentsTrace.FixedFormat.PageContent.Trace($"PageContent.GetPageRoot Source={(Source ?? new Uri("", UriKind.RelativeOrAbsolute))}");
 #endif
 
 //             VerifyAccess();
@@ -101,7 +101,7 @@ namespace System.Windows.Documents
         public void GetPageRootAsync(bool forceReload)
         {
 #if DEBUG
-            DocumentsTrace.FixedFormat.PageContent.Trace($"PageContent.GetPageRootAsync Source={(Source == null ? new Uri("", UriKind.RelativeOrAbsolute) : Source)}");
+            DocumentsTrace.FixedFormat.PageContent.Trace($"PageContent.GetPageRootAsync Source={(Source ?? new Uri("", UriKind.RelativeOrAbsolute))}");
 #endif
 
 //             VerifyAccess();
@@ -141,7 +141,7 @@ namespace System.Windows.Documents
         public void GetPageRootAsyncCancel()
         {
 #if DEBUG
-            DocumentsTrace.FixedFormat.PageContent.Trace($"PageContent.GetPageRootAsyncCancel Source={(Source == null ? new Uri("", UriKind.RelativeOrAbsolute) : Source)}");
+            DocumentsTrace.FixedFormat.PageContent.Trace($"PageContent.GetPageRootAsyncCancel Source={(Source ?? new Uri("", UriKind.RelativeOrAbsolute))}");
 #endif
 //             VerifyAccess();
             // Important: do not throw if no outstanding GetPageRootAsyncCall

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorSelection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorSelection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -311,7 +311,7 @@ namespace System.Windows.Documents
 
                         ITextPointer lineEndPosition = GetPositionAtLineEnd(originalMovingPosition);
                         ITextPointer nextPosition = lineEndPosition.GetNextInsertionPosition(LogicalDirection.Forward);
-                        This.Selection.SetCaretToPosition(nextPosition != null ? nextPosition : lineEndPosition,
+                        This.Selection.SetCaretToPosition(nextPosition ?? lineEndPosition,
                             originalMovingPosition.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
                     }
                     else if (IsPaginated(This.TextView))
@@ -401,7 +401,7 @@ namespace System.Windows.Documents
 
                         ITextPointer lineStartPosition = GetPositionAtLineStart(originalMovingPosition);
                         ITextPointer previousPosition = lineStartPosition.GetNextInsertionPosition(LogicalDirection.Backward);
-                        This.Selection.SetCaretToPosition(previousPosition != null ? previousPosition : lineStartPosition,
+                        This.Selection.SetCaretToPosition(previousPosition ?? lineStartPosition,
                             originalMovingPosition.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
                     }
                     else if (IsPaginated(This.TextView))
@@ -1070,7 +1070,7 @@ namespace System.Windows.Documents
                                 ITextPointer nextPosition = lineEndPosition.GetNextInsertionPosition(LogicalDirection.Forward);
 
                                 // Extend selection and bring new position into view if needed (for paginated viewers)
-                                ExtendSelectionAndBringIntoView(nextPosition != null ? nextPosition : lineEndPosition, This);
+                                ExtendSelectionAndBringIntoView(nextPosition ?? lineEndPosition, This);
                             }
                             else if (IsPaginated(This.TextView))
                             {
@@ -1260,7 +1260,7 @@ namespace System.Windows.Documents
                                 ITextPointer previousPosition = lineStartPosition.GetNextInsertionPosition(LogicalDirection.Backward);
 
                                 // Extend selection and bring new position into view if needed (for paginated viewers)
-                                ExtendSelectionAndBringIntoView(previousPosition != null ? previousPosition : lineStartPosition, This);
+                                ExtendSelectionAndBringIntoView(previousPosition ?? lineStartPosition, This);
                             }
                             else if (IsPaginated(This.TextView))
                             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeBase.cs
@@ -1345,7 +1345,7 @@ namespace System.Windows.Documents
                 // which can create paragraphs etc.
                 if (textData.Length > 0)
                 {
-                    ITextPointer insertPosition = (explicitInsertPosition == null) ? thisRange.Start : explicitInsertPosition;
+                    ITextPointer insertPosition = explicitInsertPosition ?? thisRange.Start;
 
                     // Ensure last paragraph existence and prepare ends for the new selection
                     bool pastedFragmentEndsWithNewLine = textData.EndsWith("\n", StringComparison.Ordinal);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1739,9 +1739,8 @@ namespace System.Windows.Documents
                 else
                 {
                     // Handle Floater/Figure boundaries: non-empty ranges never cross them
-                    if (start is TextPointer)
+                    if (start is TextPointer adjustedStart)
                     {
-                        TextPointer adjustedStart = (TextPointer)start;
                         TextPointer adjustedEnd = (TextPointer)end;
                         NormalizeAnchoredBlockBoundaries(ref adjustedStart, ref adjustedEnd);
                         start = adjustedStart;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSchema.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSchema.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -591,28 +591,24 @@ namespace System.Windows.Documents
             // Comparing null with empty collections
             if (value1 == null)
             {
-                if (value2 is TextDecorationCollection)
+                if (value2 is TextDecorationCollection decorations2)
                 {
-                    TextDecorationCollection decorations2 = (TextDecorationCollection)value2;
                     return decorations2.Count == 0;
                 }
-                else if (value2 is TextEffectCollection)
+                else if (value2 is TextEffectCollection effects2)
                 {
-                    TextEffectCollection effects2 = (TextEffectCollection)value2;
                     return effects2.Count == 0;
                 }
                 return false;
             }
             else if (value2 == null)
             {
-                if (value1 is TextDecorationCollection)
+                if (value1 is TextDecorationCollection decorations1)
                 {
-                    TextDecorationCollection decorations1 = (TextDecorationCollection)value1;
                     return decorations1.Count == 0;
                 }
-                else if (value1 is TextEffectCollection)
+                else if (value1 is TextEffectCollection effects1)
                 {
-                    TextEffectCollection effects1 = (TextEffectCollection)value1;
                     return effects1.Count == 0;
                 }
                 return false;
@@ -632,9 +628,8 @@ namespace System.Windows.Documents
                 TextDecorationCollection decorations2 = (TextDecorationCollection)value2;
                 return decorations1.ValueEquals(decorations2);
             }
-            else if (value1 is FontFamily)
+            else if (value1 is FontFamily fontFamily1)
             {
-                FontFamily fontFamily1 = (FontFamily)value1;
                 FontFamily fontFamily2 = (FontFamily)value2;
                 return fontFamily1.Equals(fontFamily2);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ZoomPercentageConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ZoomPercentageConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -145,64 +145,62 @@ namespace System.Windows.Documents
                 isValidArg = true;
             }
             // If value is a string, then parse
-            else if (value is string)
-            {
-                try
+            else if (value is string zoomString) // Remove whitespace on either end of the string.
                 {
-                    // Remove whitespace on either end of the string.
-                    string zoomString = (string)value;
-                    if ((culture != null) && !String.IsNullOrEmpty(zoomString))
+                    try
                     {
-                        zoomString = ((string)value).Trim();
-
-                        // If this is not a neutral culture attempt to remove the percent symbol.
-                        if ((!culture.IsNeutralCulture) && (zoomString.Length > 0) && (culture.NumberFormat != null))
+                        if ((culture != null) && !String.IsNullOrEmpty(zoomString))
                         {
-                            // This will strip the percent sign (if it exists) depending on the culture information.
-                            switch (culture.NumberFormat.PercentPositivePattern)
-                            {
-                                case 0: // n %
-                                case 1: // n%
-                                    // Remove the last character if it is a percent sign
-                                    if (zoomString.Length - 1 == zoomString.LastIndexOf(
-                                                                    culture.NumberFormat.PercentSymbol,
-                                                                    StringComparison.CurrentCultureIgnoreCase))
-                                    {
-                                        zoomString = zoomString.Substring(0, zoomString.Length - 1);
-                                    }
-                                    break;
-                                case 2: // %n
-                                    // Remove the first character if it is a percent sign.
-                                    if (0 == zoomString.IndexOf(
-                                                culture.NumberFormat.PercentSymbol,
-                                                StringComparison.CurrentCultureIgnoreCase))
-                                    {
-                                        zoomString = zoomString.Substring(1);
-                                    }
-                                    break;
-                            }
-                        }
+                            zoomString = ((string)value).Trim();
 
-                        // If this conversion throws then the string wasn't a valid zoom value.
-                        zoomValue = System.Convert.ToDouble(zoomString, culture);
-                        isValidArg = true;
+                            // If this is not a neutral culture attempt to remove the percent symbol.
+                            if ((!culture.IsNeutralCulture) && (zoomString.Length > 0) && (culture.NumberFormat != null))
+                            {
+                                // This will strip the percent sign (if it exists) depending on the culture information.
+                                switch (culture.NumberFormat.PercentPositivePattern)
+                                {
+                                    case 0: // n %
+                                    case 1: // n%
+                                            // Remove the last character if it is a percent sign
+                                        if (zoomString.Length - 1 == zoomString.LastIndexOf(
+                                                                        culture.NumberFormat.PercentSymbol,
+                                                                        StringComparison.CurrentCultureIgnoreCase))
+                                        {
+                                            zoomString = zoomString.Substring(0, zoomString.Length - 1);
+                                        }
+                                        break;
+                                    case 2: // %n
+                                            // Remove the first character if it is a percent sign.
+                                        if (0 == zoomString.IndexOf(
+                                                    culture.NumberFormat.PercentSymbol,
+                                                    StringComparison.CurrentCultureIgnoreCase))
+                                        {
+                                            zoomString = zoomString.Substring(1);
+                                        }
+                                        break;
+                                }
+                            }
+
+                            // If this conversion throws then the string wasn't a valid zoom value.
+                            zoomValue = System.Convert.ToDouble(zoomString, culture);
+                            isValidArg = true;
+                        }
                     }
-                }
-// Allow empty catch statements.
+                    // Allow empty catch statements.
 #pragma warning disable 56502
 
-                // Catch only the expected parse exceptions
-                catch (ArgumentOutOfRangeException) { }
-                catch (ArgumentNullException) { }
-                catch (FormatException) { }
-                catch (OverflowException) { }
+                    // Catch only the expected parse exceptions
+                    catch (ArgumentOutOfRangeException) { }
+                    catch (ArgumentNullException) { }
+                    catch (FormatException) { }
+                    catch (OverflowException) { }
 
-// Disallow empty catch statements.
+                    // Disallow empty catch statements.
 #pragma warning restore 56502
-            }
+                }
 
-            // Argument wasn't a valid percent, set error value.
-            if (!isValidArg)
+                // Argument wasn't a valid percent, set error value.
+                if (!isValidArg)
             {
                 return DependencyProperty.UnsetValue;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -182,9 +182,8 @@ namespace System.Windows
         /// and unit type as oCompare.</returns>
         override public bool Equals(object oCompare)
         {
-            if(oCompare is FigureLength)
+            if (oCompare is FigureLength l)
             {
-                FigureLength l = (FigureLength)oCompare;
                 return (this == l);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1767,7 +1767,7 @@ namespace System.Windows
 
                 DependencyObject parent = LogicalTreeHelper.GetParent(d);
 
-                d = (parent != null) ? parent : Helper.FindMentor(d.InheritanceContext);
+                d = parent ?? Helper.FindMentor(d.InheritanceContext);
             }
 
             scopeOwner = null;
@@ -2501,7 +2501,7 @@ namespace System.Windows
             if (Parent == null)
             {
                 // Invalidate relevant properties for this subtree
-                DependencyObject parent = (newParent != null) ? newParent : oldParent;
+                DependencyObject parent = newParent ?? oldParent;
                 TreeWalkHelper.InvalidateOnTreeChange(this, null, parent, (newParent != null));
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkContentElement.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -336,7 +336,7 @@ namespace System.Windows
             ///////////////////
 
             // Invalidate relevant properties for this subtree
-            DependencyObject parent = (newParent != null) ? newParent : oldParent;
+            DependencyObject parent = newParent ?? oldParent;
             TreeWalkHelper.InvalidateOnTreeChange(/* fe = */ null, /* fce = */ this, parent, (newParent != null));
 
             // If no one has called BeginInit then mark the element initialized and fire Initialized event

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkElement.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -333,7 +333,7 @@ namespace System.Windows
             ///////////////////
 
             // Invalidate relevant properties for this subtree
-            DependencyObject parent = (newParent != null) ? newParent : oldParent;
+            DependencyObject parent = newParent ?? oldParent;
             TreeWalkHelper.InvalidateOnTreeChange(/* fe = */ this, /* fce = */ null, parent, (newParent != null));
 
             // If no one has called BeginInit then mark the element initialized and fire Initialized event

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/GridLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/GridLength.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -151,9 +151,8 @@ namespace System.Windows
         /// and unit type as oCompare.</returns>
         override public bool Equals(object oCompare)
         {
-            if(oCompare is GridLength)
+            if (oCompare is GridLength l)
             {
-                GridLength l = (GridLength)oCompare;
                 return (this == l);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/KeyboardNavigation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/KeyboardNavigation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1072,7 +1072,7 @@ namespace System.Windows.Input
                 if (!traversed && firstElement != nextTab)
                 {
                     // Navigate to next element in the tree
-                    traversed = Navigate(nextTab, request, modifierKeys, firstElement == null ? nextTab : firstElement);
+                    traversed = Navigate(nextTab, request, modifierKeys, firstElement ?? nextTab);
                 }
 
                 return traversed;
@@ -3093,7 +3093,7 @@ namespace System.Windows.Input
                     }
                 }
             }
-            return result != null ? result : partialResult;
+            return result ?? partialResult;
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -1123,14 +1123,13 @@ namespace System.Windows.Markup
         internal void EnsureAssemblyRecord(Assembly asm)
         {
             string fullName = asm.FullName;
-            BamlAssemblyInfoRecord record = ObjectHashTable[fullName] as BamlAssemblyInfoRecord;
 
             // If we don't have an assembly record for this assembly yet it is most likely
             // because it is an assembly that is part of the default namespace and was not defined
             // using a mapping PI.  In that case, add an assembly record to the object cache and
             // populate it with the required data.  Note that it DOES NOT have a valid AssemblyId
             // and this is not written out the the baml stream.
-            if (record == null)
+            if (ObjectHashTable[fullName] is not BamlAssemblyInfoRecord record)
             {
                 record = new BamlAssemblyInfoRecord();
                 record.AssemblyFullName = fullName;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -1949,6 +1949,6 @@ namespace System.Windows.Markup
         ///     Return string representation of this key
         /// </summary>
         public override string ToString() =>
-            $"TypeInfoKey: Assembly={((DeclaringAssembly != null) ? DeclaringAssembly : "null")} Type={((TypeFullName != null) ? TypeFullName : "null")}";
+            $"TypeInfoKey: Assembly={(DeclaringAssembly ?? "null")} Type={(TypeFullName ?? "null")}";
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -1845,10 +1845,8 @@ namespace System.Windows.Markup
         /// </summary>
         public override bool Equals(object o)
         {
-            if (o is AssemblyInfoKey)
+            if (o is AssemblyInfoKey key)
             {
-                AssemblyInfoKey key = (AssemblyInfoKey)o;
-
                 return ((key.AssemblyFullName != null) ?
                                       key.AssemblyFullName.Equals(this.AssemblyFullName) :
                                       (this.AssemblyFullName == null));
@@ -1907,10 +1905,8 @@ namespace System.Windows.Markup
         /// </summary>
         public override bool Equals(object o)
         {
-            if (o is TypeInfoKey)
+            if (o is TypeInfoKey key)
             {
-                TypeInfoKey key = (TypeInfoKey)o;
-
                 return ((key.DeclaringAssembly != null) ?
                                       key.DeclaringAssembly.Equals(this.DeclaringAssembly) :
                                       (this.DeclaringAssembly == null)) &&

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -816,7 +816,7 @@ namespace System.Windows.Markup
             info.ClrNamespace = string.Empty;
             info.AssemblyName = string.Empty;
             info.Prefix = "xmlns";
-            info.LocalName = bamlRecord.Prefix == null ? string.Empty : bamlRecord.Prefix;
+            info.LocalName = bamlRecord.Prefix ?? string.Empty;
             info.Name = string.IsNullOrEmpty(bamlRecord.Prefix) ?
                                           "xmlns" :
                                           $"xmlns:{bamlRecord.Prefix}";
@@ -1039,7 +1039,7 @@ namespace System.Windows.Markup
             {
                 Type declaringType = null;
                 _propertyDP = _bamlRecordReader.GetCustomDependencyPropertyValue(bamlRecord, out declaringType);
-                declaringType = declaringType == null ? _propertyDP.OwnerType : declaringType;
+                declaringType = declaringType ?? _propertyDP.OwnerType;
                 info.Value = $"{declaringType.Name}.{_propertyDP.Name}";
 
                 string xmlns = _parserContext.XamlTypeMapper.GetXmlNamespace(declaringType.Namespace,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -3810,9 +3810,8 @@ namespace System.Windows.Markup
 
             // Check if we have a Nullable type.  If so and the object being set is
             // not a Nullable or an expression, then attempt a conversion.
-            if (memberInfo is PropertyInfo)
+            if (memberInfo is PropertyInfo propertyInfo)
             {
-                PropertyInfo propertyInfo = (PropertyInfo)memberInfo;
                 value = OptionallyMakeNullable(propertyInfo.PropertyType, value, propertyInfo.Name);
 
                 propertyInfo.SetValue(parentObject, value, BindingFlags.Default, null, null

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordWriter.cs
@@ -535,8 +535,7 @@ namespace System.Windows.Markup
                     for (int i = 0; i < record.RecordList.Count; i++)
                     {
                         ValueDeferRecord valueDeferRecord = (ValueDeferRecord)record.RecordList[i];
-                        IBamlDictionaryKey dictionaryKey = valueDeferRecord.Record as IBamlDictionaryKey;
-                        if (dictionaryKey != null)
+                        if (valueDeferRecord.Record is IBamlDictionaryKey dictionaryKey)
                         {
                             return dictionaryKey;
                         }
@@ -567,11 +566,10 @@ namespace System.Windows.Markup
                 // attribute is *NOT* a MarkupExtension.  A MarkupExtension would cause
                 // WriteKeyElementStart being called.
                 KeyDeferRecord keyRecord = (KeyDeferRecord)(_deferKeys[_deferKeys.Count-1]);
-                BamlDefAttributeKeyStringRecord defKeyRecord = keyRecord.Record as BamlDefAttributeKeyStringRecord;
-                if (defKeyRecord == null)
+                if (keyRecord.Record is not BamlDefAttributeKeyStringRecord defKeyRecord)
                 {
                     defKeyRecord =
-                        (BamlDefAttributeKeyStringRecord) BamlRecordManager.GetWriteRecord(BamlRecordType.DefAttributeKeyString);
+                        (BamlDefAttributeKeyStringRecord)BamlRecordManager.GetWriteRecord(BamlRecordType.DefAttributeKeyString);
                     TransferOldSharedData(keyRecord.Record as IBamlDictionaryKey, defKeyRecord as IBamlDictionaryKey);
                     keyRecord.Record = defKeyRecord;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecords.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecords.cs
@@ -4710,8 +4710,7 @@ namespace System.Windows.Markup
             else
             {
                 // Cache a additional MemberInfo for the given attribute
-                object[] arr = PropertyMember as object[];
-                if (arr == null)
+                if (PropertyMember is not object[] arr)
                 {
                     arr = new object[3];
                     arr[0] = PropertyMember;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/ParserContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/ParserContext.cs
@@ -279,7 +279,7 @@ namespace System.Windows.Markup
             set
             {
                 EndRepeat();
-                _xmlLang = (null == value ? String.Empty : value);
+                _xmlLang = (value ?? string.Empty);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/ElementMarkupObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/ElementMarkupObject.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -342,7 +342,7 @@ namespace System.Windows.Markup.Primitives
         {
             // The instance stored in _shouldSerializeCacheLock is used as a sentinal for null
             // The avoids having to perform two lookups in the Hashtable to detect a cached null value.
-            object value = methodInfo == null ? _shouldSerializeCacheLock : methodInfo;
+            object value = methodInfo ?? _shouldSerializeCacheLock;
             lock (_shouldSerializeCacheLock)
             {
                 _shouldSerializeCache[key] = value;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/TemplateXamlParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/TemplateXamlParser.cs
@@ -745,25 +745,23 @@ namespace System.Windows.Markup
 
             if (xamlElementStartNode.SerializerType != null && _styleModeStack.Depth > 0)
             {
-                XamlSerializer serializer = XamlTypeMapper.CreateInstance(xamlElementStartNode.SerializerType)
-                                                          as XamlSerializer;
-                 if (serializer == null)
-                 {
-                     ThrowException(nameof(SR.ParserNoSerializer),
-                                   xamlElementStartNode.TypeFullName,
-                                   xamlElementStartNode.LineNumber,
-                                   xamlElementStartNode.LinePosition);
-                 }
-                 else
-                 {
-                     // Depending on whether this is the compile case or the parse xaml
-                     // case, we want to convert the xaml into baml or objects.
+                if (XamlTypeMapper.CreateInstance(xamlElementStartNode.SerializerType) is not XamlSerializer serializer)
+                {
+                    ThrowException(nameof(SR.ParserNoSerializer),
+                                  xamlElementStartNode.TypeFullName,
+                                  xamlElementStartNode.LineNumber,
+                                  xamlElementStartNode.LinePosition);
+                }
+                else
+                {
+                    // Depending on whether this is the compile case or the parse xaml
+                    // case, we want to convert the xaml into baml or objects.
 
-                     #if PBTCOMPILER
-                         serializer.ConvertXamlToBaml(TokenReader,
-                                       BamlRecordWriter == null ? ParserContext : BamlRecordWriter.ParserContext,
-                                       xamlElementStartNode, BamlRecordWriter);
-                     #else
+#if PBTCOMPILER
+                    serializer.ConvertXamlToBaml(TokenReader,
+                                  BamlRecordWriter == null ? ParserContext : BamlRecordWriter.ParserContext,
+                                  xamlElementStartNode, BamlRecordWriter);
+#else
 
                          // If we're in the content of the template, we'll convert to baml.  Then TemplateBamlRecordReader
                          // gets the option of instantiating it or keeping it in baml.  For example, if this is a nested
@@ -803,9 +801,9 @@ namespace System.Windows.Markup
                                                TreeBuilder.RecordReader);
                          }
 
-                     #endif
+#endif
 
-                 }
+                }
 
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/TemplateXamlParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/TemplateXamlParser.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -918,6 +918,7 @@ namespace System.Windows.Markup
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0029:Use coalesce expression", Justification = "Incorrect resolution by formatter")]
         private Type TargetType
         {
             get

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlParser.cs
@@ -221,9 +221,8 @@ namespace System.Windows.Markup
                     int linePosition = 0;
                     string newMessage = null;
 
-                    if (e is XmlException)
+                    if (e is XmlException xmlEx)
                     {
-                        XmlException xmlEx = (XmlException)e;
                         lineNumber = xmlEx.LineNumber;
                         linePosition = xmlEx.LinePosition;
                         newMessage = xmlEx.Message;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -515,9 +515,8 @@ namespace System.Windows.Markup
                 System.Xaml.XamlException xe = (System.Xaml.XamlException)e;
                 return new XamlParseException(xe.Message, xe.LineNumber, xe.LinePosition, baseUri, baseException);
             }
-            else if (e is XmlException)
+            else if (e is XmlException xe)
             {
-                XmlException xe = (XmlException)e;
                 return new XamlParseException(xe.Message, xe.LineNumber, xe.LinePosition, baseUri, baseException);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
@@ -498,7 +498,7 @@ namespace System.Windows.Markup
 
         internal static XamlParseException WrapException(Exception e, IXamlLineInfo lineInfo, Uri baseUri)
         {
-            Exception baseException = (e.InnerException == null) ? e : e.InnerException;
+            Exception baseException = e.InnerException ?? e;
             if (baseException is System.Windows.Markup.XamlParseException)
             {
                 var xe = ((System.Windows.Markup.XamlParseException)baseException);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -1467,8 +1467,7 @@ namespace System.Windows.Markup
             {
                 get
                 {
-                    DictionaryContextData dcd = _contextData as DictionaryContextData;
-                    if (dcd == null)
+                    if (_contextData is not DictionaryContextData dcd)
                     {
                         return _contextData as Type;
                     }
@@ -3125,8 +3124,7 @@ namespace System.Windows.Markup
                     ThrowException(nameof(SR.ParserNoDictionaryName));
                 }
 
-                DictionaryContextData dictionaryData = ParentContext.ContextData as DictionaryContextData;
-                if (dictionaryData != null)
+                if (ParentContext.ContextData is DictionaryContextData dictionaryData)
                 {
                     object key;
                     // Note that not all keys can be resolved at compile time.  For those that fail,
@@ -3952,13 +3950,12 @@ namespace System.Windows.Markup
             // BamlRecordReader has secondary protection against nested property
             //  records, but the error message less friendly to users. ("'Property'
             //  record unexpected in BAML stream.")
-            ElementContextStackData parentTag = ElementContextStack.ParentContext as ElementContextStackData;
-            if( parentTag != null )
+            if (ElementContextStack.ParentContext is ElementContextStackData parentTag)
             {
-                if ( parentTag.ContextType == ElementContextType.PropertyComplex ||
+                if (parentTag.ContextType == ElementContextType.PropertyComplex ||
                      parentTag.ContextType == ElementContextType.PropertyArray ||
                      parentTag.ContextType == ElementContextType.PropertyIList ||
-                     parentTag.ContextType == ElementContextType.PropertyIDictionary )
+                     parentTag.ContextType == ElementContextType.PropertyIDictionary)
                 {
                     ThrowException(nameof(SR.ParserNestedComplexProp), complexPropName);
                 }
@@ -5263,21 +5260,18 @@ namespace System.Windows.Markup
         {
             set
             {
-
                 Debug.Assert(null != XmlReader, "XmlReader is not yet set");
                 //check if it's a XmlCompatibilityReader first
-                XmlCompatibilityReader xmlCompatReader = XmlReader as XmlCompatibilityReader;
-                if (null != xmlCompatReader)
+                if (XmlReader is XmlCompatibilityReader xmlCompatReader)
                 {
                     xmlCompatReader.Normalization = true;
                 }
                 else
                 {
                     //now check for XmlTextReader
-                    XmlTextReader xmlTextReader = XmlReader as XmlTextReader;
 
                     // review, what if not the XmlTextReader.
-                    if (null != xmlTextReader)
+                    if (XmlReader is XmlTextReader xmlTextReader)
                     {
                         xmlTextReader.Normalization = true;
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -2908,7 +2908,7 @@ namespace System.Windows.Markup
                             case AttributeContext.Unknown:
                                 WriteUnknownAttribute(attribNamespaceURI, attribLocalName,
                                                       attribValue, depth, parentTypeNamespace,
-                                                      unknownTagName == null ? parentType.Name : unknownTagName,
+                                                      unknownTagName ?? parentType.Name,
                                                       dynamicObject, resolvedProperties);
                                 break;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -3197,9 +3197,8 @@ namespace System.Windows.Markup
                     propertyCanWrite = !((DependencyProperty)dynamicObject).ReadOnly;
                 }
 #endif
-                else if (dynamicObject is MethodInfo)
+                else if (dynamicObject is MethodInfo methodInfo)
                 {
-                    MethodInfo methodInfo = (MethodInfo)dynamicObject;
                     if (methodInfo.GetParameters().Length == 1)
                     {
                         methodInfo = methodInfo.DeclaringType.GetMethod(

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
@@ -3891,20 +3891,16 @@ namespace System.Windows.Markup
             _linePosition = 0;
             _isProtectedAttributeAllowed = false;
 
-            NamespaceMapEntry[] defaultNsMaps = _namespaceMapHashList[XamlReaderHelper.DefaultNamespaceURI] as NamespaceMapEntry[];
-            NamespaceMapEntry[] definitionNsMaps = _namespaceMapHashList[XamlReaderHelper.DefinitionNamespaceURI] as NamespaceMapEntry[];
-            NamespaceMapEntry[] definitionMetroNsMaps = _namespaceMapHashList[XamlReaderHelper.DefinitionMetroNamespaceURI] as NamespaceMapEntry[];
-
             _namespaceMapHashList.Clear();
-            if (null != defaultNsMaps)
+            if (_namespaceMapHashList[XamlReaderHelper.DefaultNamespaceURI] is NamespaceMapEntry[] defaultNsMaps)
             {
                 _namespaceMapHashList.Add(XamlReaderHelper.DefaultNamespaceURI, defaultNsMaps);
             }
-            if (null != definitionNsMaps)
+            if (_namespaceMapHashList[XamlReaderHelper.DefinitionNamespaceURI] is NamespaceMapEntry[] definitionNsMaps)
             {
                 _namespaceMapHashList.Add(XamlReaderHelper.DefinitionNamespaceURI, definitionNsMaps);
             }
-            if (null != definitionMetroNsMaps)
+            if (_namespaceMapHashList[XamlReaderHelper.DefinitionMetroNamespaceURI] is NamespaceMapEntry[] definitionMetroNsMaps)
             {
                 _namespaceMapHashList.Add(XamlReaderHelper.DefinitionMetroNamespaceURI, definitionMetroNsMaps);
             }
@@ -4012,8 +4008,7 @@ namespace System.Windows.Markup
                     "GetPropertyAndType must always be called before SetPropertyAndType");
 
                 // add the type taking a lock
-                PropertyAndType pAndT = _dpLookupHashtable[dpName] as PropertyAndType;
-                if (pAndT == null)
+                if (_dpLookupHashtable[dpName] is not PropertyAndType pAndT)
                 {
                     _dpLookupHashtable[dpName] = new PropertyAndType(null, dpInfo, false, true, ownerType, isInternal);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsDictionary.cs
@@ -255,9 +255,8 @@ namespace System.Windows.Markup
         /// <param name="index">The zero-based index in array at which copying begins</param>
         public void CopyTo(Array array, int index)
         {
-            IDictionary dict = GetNamespacesInScope(NamespaceScope.All) as IDictionary;
-            if (dict != null)
-                dict.CopyTo(array,index);
+            if (GetNamespacesInScope(NamespaceScope.All) is IDictionary dict)
+                dict.CopyTo(array, index);
         }
 
 #endregion ICollectionMethods

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -386,7 +386,7 @@ namespace System.Windows.Markup
         public string DefaultNamespace()
         {
              string defaultNs = LookupNamespace(string.Empty);
-             return (defaultNs == null) ? string.Empty : defaultNs;
+             return defaultNs ?? string.Empty;
          }
 #endif
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MultiTrigger.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MultiTrigger.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -103,7 +103,7 @@ namespace System.Windows
                     _conditions[i].Property,
                     LogicalOp.Equals,
                     _conditions[i].Value,
-                    (_conditions[i].SourceName != null) ? _conditions[i].SourceName : StyleHelper.SelfName);
+_conditions[i].SourceName ?? StyleHelper.SelfName);
             }
 
             // Set conditions array for all property triggers

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StaticResourceExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StaticResourceExtension.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -253,9 +253,8 @@ namespace System.Windows
                         return resourceDictionary;
                     }
                 }
-                if (ambientValue.Value is Style)
+                if (ambientValue.Value is Style style)
                 {
-                    var style = (Style)ambientValue.Value;
                     var resourceDictionary = style.FindResourceDictionary(ResourceKey);
                     if (resourceDictionary != null)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -782,28 +782,26 @@ namespace System.Windows
                         {
                             StyleHelper.AddPropertyTriggerWithAction( trigger, ((Trigger)trigger).Property, ref this.PropertyTriggersWithActions );
                         }
-                        else if( trigger is MultiTrigger )
+                        else if (trigger is MultiTrigger multiTrigger)
                         {
-                            MultiTrigger multiTrigger = (MultiTrigger)trigger;
-                            for( int k = 0; k < multiTrigger.Conditions.Count; k++ )
+                            for (int k = 0; k < multiTrigger.Conditions.Count; k++)
                             {
                                 Condition triggerCondition = multiTrigger.Conditions[k];
 
-                                StyleHelper.AddPropertyTriggerWithAction( trigger, triggerCondition.Property, ref this.PropertyTriggersWithActions );
+                                StyleHelper.AddPropertyTriggerWithAction(trigger, triggerCondition.Property, ref this.PropertyTriggersWithActions);
                             }
                         }
-                        else if( trigger is DataTrigger )
+                        else if (trigger is DataTrigger)
                         {
-                            StyleHelper.AddDataTriggerWithAction( trigger, ((DataTrigger)trigger).Binding, ref this.DataTriggersWithActions );
+                            StyleHelper.AddDataTriggerWithAction(trigger, ((DataTrigger)trigger).Binding, ref this.DataTriggersWithActions);
                         }
-                        else if( trigger is MultiDataTrigger )
+                        else if (trigger is MultiDataTrigger multiDataTrigger)
                         {
-                            MultiDataTrigger multiDataTrigger = (MultiDataTrigger)trigger;
-                            for( int k = 0; k < multiDataTrigger.Conditions.Count; k++ )
+                            for (int k = 0; k < multiDataTrigger.Conditions.Count; k++)
                             {
                                 Condition dataCondition = multiDataTrigger.Conditions[k];
 
-                                StyleHelper.AddDataTriggerWithAction( trigger, dataCondition.Binding, ref this.DataTriggersWithActions );
+                                StyleHelper.AddDataTriggerWithAction(trigger, dataCondition.Binding, ref this.DataTriggersWithActions);
                             }
                         }
                         else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -5763,35 +5763,33 @@ namespace System.Windows
         //  Trading off an object boxing cost in exchange for avoiding reflection cost.
         public override bool Equals( object value )
         {
-            if( value is ChildValueLookup )
+            if (value is ChildValueLookup other)
             {
-                ChildValueLookup other = (ChildValueLookup)value;
-
-                if( LookupType      == other.LookupType &&
-                    Property        == other.Property &&
-                    Value           == other.Value )
+                if (LookupType == other.LookupType &&
+                    Property == other.Property &&
+                    Value == other.Value)
                 {
-                    if( Conditions == null &&
-                        other.Conditions == null )
+                    if (Conditions == null &&
+                        other.Conditions == null)
                     {
                         // Both condition arrays are null
                         return true;
                     }
 
-                    if( Conditions == null ||
-                        other.Conditions == null )
+                    if (Conditions == null ||
+                        other.Conditions == null)
                     {
                         // One condition array is null, but not other
                         return false;
                     }
 
                     // Both condition array non-null, see if they're the same length..
-                    if( Conditions.Length == other.Conditions.Length )
+                    if (Conditions.Length == other.Conditions.Length)
                     {
                         // Same length.  Walk the list and compare.
-                        for( int i = 0; i < Conditions.Length; i++ )
+                        for (int i = 0; i < Conditions.Length; i++)
                         {
-                            if( !Conditions[i].TypeSpecificEquals(other.Conditions[i]) )
+                            if (!Conditions[i].TypeSpecificEquals(other.Conditions[i]))
                             {
                                 return false;
                             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Thickness.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Thickness.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -70,9 +70,8 @@ namespace System.Windows
         /// <returns>True if object is a Thickness and all sides of it are equal to this Thickness'.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Thickness)
+            if (obj is Thickness otherObj)
             {
-                Thickness otherObj = (Thickness)obj;
                 return (this == otherObj);
             }
             return (false);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Trigger.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Trigger.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -213,7 +213,7 @@ namespace System.Windows
                     _property,
                     LogicalOp.Equals,
                     _value,
-                    (_sourceName != null) ? _sourceName : StyleHelper.SelfName) };
+_sourceName ?? StyleHelper.SelfName) };
 
             // Set Condition for all property triggers
             for (int i = 0; i < PropertyValues.Count; i++)

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/BrushProxy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/BrushProxy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -3323,9 +3323,8 @@ namespace Microsoft.Internal.AlphaFlattener
             }
 
             // SolidColorBrush * GradientBrush
-            if (brushB.Brush is GradientBrush)
+            if (brushB.Brush is GradientBrush gradientBrush)
             {
-                GradientBrush gradientBrush = (GradientBrush)brushB.Brush;
                 return brushB.BlendGradient(colorA, reverse, gradientBrush.ColorInterpolationMode);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/PrimitiveList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/PrimitiveList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -54,13 +54,11 @@ namespace Microsoft.Internal.AlphaFlattener
             {
                 s = ((Double)obj).ToString("F1", CultureInfo.InvariantCulture);
             }
-            else if (obj is Rect)
+            else if (obj is Rect r)
             {
-                Rect r = (Rect) obj;
-
-                return " [" + LeftPad(r.Left,   6) + ' '
-                            + LeftPad(r.Top,    6) + ' '
-                            + LeftPad(r.Width,  6) + ' '
+                return " [" + LeftPad(r.Left, 6) + ' '
+                            + LeftPad(r.Top, 6) + ' '
+                            + LeftPad(r.Width, 6) + ' '
                             + LeftPad(r.Height, 6) + "]";
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/MetroSerializationManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/MetroSerializationManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -882,8 +882,8 @@ namespace System.Windows.Xps.Serialization
                                                       out designerSerializationFlagsAttr) == true)
                               {
                                   TypeCacheItem typeCacheItem = GetTypeCacheItem(propertyType);
-                                  serializerTypeForProperty = serializerTypeForProperty == null ? typeCacheItem.SerializerType : serializerTypeForProperty;
-                                  typeConverterForProperty  = typeConverterForProperty == null ? typeCacheItem.TypeConverter : typeConverterForProperty;
+                                  serializerTypeForProperty = serializerTypeForProperty ?? typeCacheItem.SerializerType;
+                                  typeConverterForProperty  = typeConverterForProperty ?? typeCacheItem.TypeConverter;
 
                                   TypeDependencyPropertyCache
                                   dependencyPropertyCache = new TypeDependencyPropertyCache(memberInfo,

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachSerializationUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachSerializationUtils.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -884,9 +884,8 @@ namespace System.Windows.Xps.Serialization
 
         private void SerializeLinkTargetForElement(IInputElement element, IContentHost contentHost, Visual root)
         {
-            if (element is FrameworkElement)
+            if (element is FrameworkElement fe)
             {
-                FrameworkElement fe = (FrameworkElement)element;
                 string id = fe.Name;
                 if (!String.IsNullOrEmpty(id))
                 {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Invariant.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Invariant.cs
@@ -227,7 +227,6 @@ namespace MS.Internal
                 if (key != null)
                 {
                     object dbgJITDebugLaunchSettingValue = key.GetValue("DbgJITDebugLaunchSetting");
-                    string dbgManagedDebuggerValue = key.GetValue("DbgManagedDebugger") as string;
 
                     //
                     // Only count the enable if there's a JIT debugger to launch.
@@ -235,7 +234,7 @@ namespace MS.Internal
                     enabled = (dbgJITDebugLaunchSettingValue is int && ((int)dbgJITDebugLaunchSettingValue & 2) != 0);
                     if (enabled)
                     {
-                        enabled = dbgManagedDebuggerValue != null && dbgManagedDebuggerValue.Length > 0;
+                        enabled = key.GetValue("DbgManagedDebugger") is string dbgManagedDebuggerValue && dbgManagedDebuggerValue.Length > 0;
                     }
                 }
                 return enabled;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -68,7 +68,7 @@ namespace System.Xaml
         {
             AssemblyName name = new AssemblyName(assembly.FullName);
             string partialName = name.Name;
-            return (partialName != null) ? partialName : string.Empty;
+            return partialName ?? string.Empty;
         }
 #endif
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
@@ -198,8 +198,7 @@ namespace System.Xaml
             {
                 foreach (object key in _assemblies.Keys)
                 {
-                    WeakReference weakRef = key as WeakReference;
-                    if (weakRef == null)
+                    if (key is not WeakReference weakRef)
                     {
                         continue;
                     }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/TraceProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/TraceProvider.cs
@@ -269,8 +269,7 @@ namespace MS.Utility
         {
             dataDescriptor->Reserved = 0;
 
-            string sRet = data as string;
-            if (sRet != null)
+            if (data is string sRet)
             {
                 dataDescriptor->Size = (uint)((sRet.Length + 1) * 2);
                 return sRet;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
@@ -398,9 +398,7 @@ namespace MS.Win32
             param.retVal = IntPtr.Zero;
             if (_bond == Bond.Attached)
             {
-                HwndWrapperHook hook= _hook.Target as HwndWrapperHook;
-
-                if (hook != null)
+                if (_hook.Target is HwndWrapperHook hook)
                 {
                     // make the call
                     param.retVal = hook(param.hwnd, param.msg, param.wParam, param.lParam, ref param.handled);

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
@@ -72,9 +72,7 @@ namespace MS.Win32
 
             public override bool Equals( object obj )
             {
-                XFORM xform = obj as XFORM;
-
-                if( xform == null )
+                if (obj is not XFORM xform)
                 {
                     return false;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -200,8 +200,7 @@ namespace System.Xaml
             if (item == null)
                 return null;
 
-            ICustomTypeProvider ictp = item as ICustomTypeProvider;
-            if (ictp == null)
+            if (item is not ICustomTypeProvider ictp)
                 return item.GetType();
             else
                 return ictp.GetCustomType();

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -229,7 +229,7 @@ namespace System.Xaml
         {
             IList<CustomAttributeData> list = CustomAttributeData.GetCustomAttributes(mi);
             string attrValue = GetCustomAttributeData(list, attrType, out typeValue, true, false);
-            return attrValue == null ? string.Empty : attrValue;
+            return attrValue ?? string.Empty;
         }
 
 #if PBTCOMPILER

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/RuntimeIdentifierPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/RuntimeIdentifierPropertyAttribute.cs
@@ -65,14 +65,12 @@ namespace System.Windows.Markup
 #if !PBTCOMPILER
         internal static bool NameValidationCallback(object candidateName)
         {
-            string name = candidateName as string;
-
-            if( name != null )
+            if (candidateName is string name)
             {
                 // Non-null string, ask the XAML validation code for blessing.
                 return IsValidIdentifierName(name);
             }
-            else if( candidateName == null )
+            else if (candidateName == null)
             {
                 // Null string is allowed
                 return true;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/TypeConverterHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/TypeConverterHelper.cs
@@ -49,9 +49,8 @@ namespace System.Windows.Markup
             {
                 MethodInfo methodInfo;
 #if !PBTCOMPILER
-                DependencyProperty dp = dpOrPiOrMi as DependencyProperty;
 
-                if (dp != null)
+                if (dpOrPiOrMi is DependencyProperty dp)
                 {
                     // While parsing styles or templates, we end up getting a DependencyProperty,
                     // even for non-attached cases. In this case, we try fetching the CLR

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
@@ -704,10 +704,8 @@ namespace System.Windows.Markup
         {
             set
             {
-                XmlTextReader xmlTextReader = Reader as XmlTextReader;
-
                 // review, what if not the XmlTextReader.
-                if (null != xmlTextReader)
+                if (Reader is XmlTextReader xmlTextReader)
                 {
                     xmlTextReader.Normalization = value;
                 }
@@ -722,8 +720,7 @@ namespace System.Windows.Markup
         {
             get
             {
-                XmlTextReader textReader = Reader as XmlTextReader;
-                if (textReader == null)
+                if (Reader is not XmlTextReader textReader)
                 {
                     return new System.Text.UTF8Encoding(true, true);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/KeyTipAdorner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/KeyTipAdorner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -34,7 +34,7 @@ namespace Microsoft.Windows.Controls
             RibbonGroup ownerRibbonGroup)
             : base(adornedElement)
         {
-            PlacementTarget = (placementTarget == null ? adornedElement : placementTarget);
+            PlacementTarget = (placementTarget ?? adornedElement);
             HorizontalPlacement = horizontalPlacement;
             VerticalPlacement = verticalPlacement;
             HorizontalOffset = horizontalOffset;

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/KeyTipService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/KeyTipService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1380,7 +1380,7 @@ namespace Microsoft.Windows.Controls
                     if (activatingEventArgs.KeyTipVisibility == Visibility.Visible)
                     {
                         // Create the keytip and add it as the adorner.
-                        UIElement adornedElement = RibbonHelper.GetContainingUIElement(activatingEventArgs.PlacementTarget == null ? element : activatingEventArgs.PlacementTarget);
+                        UIElement adornedElement = RibbonHelper.GetContainingUIElement(activatingEventArgs.PlacementTarget ?? element);
                         if (adornedElement != null && adornedElement.IsVisible)
                         {
                             bool isScrollAdornerLayer = false;

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControlLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControlLength.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -95,9 +95,8 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public override bool Equals(object obj)
         {
-            if (obj is RibbonControlLength)
+            if (obj is RibbonControlLength length)
             {
-                RibbonControlLength length = (RibbonControlLength)obj;
                 return (this == length);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/InertiaProcessor2D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/InertiaProcessor2D.cs
@@ -328,22 +328,19 @@ namespace System.Windows.Input.Manipulations
         {
             ArgumentNullException.ThrowIfNull(parameters);
 
-            InertiaTranslationBehavior2D translationParameters = parameters as InertiaTranslationBehavior2D;
-            if (translationParameters != null)
+            if (parameters is InertiaTranslationBehavior2D translationParameters)
             {
                 TranslationBehavior = translationParameters;
                 return;
             }
 
-            InertiaRotationBehavior2D rotationParameters = parameters as InertiaRotationBehavior2D;
-            if (rotationParameters != null)
+            if (parameters is InertiaRotationBehavior2D rotationParameters)
             {
                 RotationBehavior = rotationParameters;
                 return;
             }
 
-            InertiaExpansionBehavior2D expansionParameters = parameters as InertiaExpansionBehavior2D;
-            if (expansionParameters != null)
+            if (parameters is InertiaExpansionBehavior2D expansionParameters)
             {
                 ExpansionBehavior = expansionParameters;
                 return;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/Reference.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/Reference.cs
@@ -26,8 +26,7 @@ namespace System.Windows.Markup
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
             ArgumentNullException.ThrowIfNull(serviceProvider);
-            IXamlNameResolver nameResolver = serviceProvider.GetService(typeof(IXamlNameResolver)) as IXamlNameResolver;
-            if (nameResolver == null)
+            if (serviceProvider.GetService(typeof(IXamlNameResolver)) is not IXamlNameResolver nameResolver)
             {
                 throw new InvalidOperationException(SR.MissingNameResolver);
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/StaticExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/StaticExtension.cs
@@ -80,8 +80,7 @@ namespace System.Windows.Markup
 
                 ArgumentNullException.ThrowIfNull(serviceProvider);
 
-                IXamlTypeResolver xamlTypeResolver = serviceProvider.GetService(typeof(IXamlTypeResolver)) as IXamlTypeResolver;
-                if (xamlTypeResolver == null)
+                if (serviceProvider.GetService(typeof(IXamlTypeResolver)) is not IXamlTypeResolver xamlTypeResolver)
                 {
                     throw new ArgumentException(SR.Format(SR.MarkupExtensionNoContext, GetType().Name, nameof(IXamlTypeResolver)));
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/TypeExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/TypeExtension.cs
@@ -67,8 +67,7 @@ namespace System.Windows.Markup
             // Get the IXamlTypeResolver from the service provider
             ArgumentNullException.ThrowIfNull(serviceProvider);
 
-            IXamlTypeResolver xamlTypeResolver = serviceProvider.GetService(typeof(IXamlTypeResolver)) as IXamlTypeResolver;
-            if( xamlTypeResolver == null)
+            if (serviceProvider.GetService(typeof(IXamlTypeResolver)) is not IXamlTypeResolver xamlTypeResolver)
             {
                 throw new InvalidOperationException(SR.Format(SR.MarkupExtensionNoContext, GetType().Name, nameof(IXamlTypeResolver)));
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachablePropertyServices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachablePropertyServices.cs
@@ -20,8 +20,7 @@ namespace System.Xaml
                 return 0;
             }
 
-            IAttachedPropertyStore ap = instance as IAttachedPropertyStore;
-            if (ap != null)
+            if (instance is IAttachedPropertyStore ap)
             {
                 return ap.PropertyCount;
             }
@@ -36,8 +35,7 @@ namespace System.Xaml
                 return;
             }
 
-            IAttachedPropertyStore ap = instance as IAttachedPropertyStore;
-            if (ap != null)
+            if (instance is IAttachedPropertyStore ap)
             {
                 ap.CopyPropertiesTo(array, index);
             }
@@ -54,8 +52,7 @@ namespace System.Xaml
                 return false;
             }
 
-            IAttachedPropertyStore ap = instance as IAttachedPropertyStore;
-            if (ap != null)
+            if (instance is IAttachedPropertyStore ap)
             {
                 return ap.RemoveProperty(name);
             }
@@ -72,8 +69,7 @@ namespace System.Xaml
 
             ArgumentNullException.ThrowIfNull(name);
 
-            IAttachedPropertyStore ap = instance as IAttachedPropertyStore;
-            if (ap != null)
+            if (instance is IAttachedPropertyStore ap)
             {
                 ap.SetProperty(name, value);
                 return;
@@ -96,8 +92,7 @@ namespace System.Xaml
                 return false;
             }
 
-            IAttachedPropertyStore ap = instance as IAttachedPropertyStore;
-            if (ap != null)
+            if (instance is IAttachedPropertyStore ap)
             {
                 object obj;
                 bool result = ap.TryGetProperty(name, out obj);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ContextServices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ContextServices.cs
@@ -17,8 +17,7 @@ namespace MS.Internal.Xaml.Context
             // If the XamlMember implements IProvideValueTarget, ask it for the TargetProperty first
             Debug.Assert(xamlContext.ParentProperty != null);
 
-            IProvideValueTarget ipvt = xamlContext.ParentProperty as IProvideValueTarget;
-            if (ipvt != null)
+            if (xamlContext.ParentProperty is IProvideValueTarget ipvt)
             {
                 return ipvt.TargetProperty;
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
@@ -372,13 +372,11 @@ namespace MS.Internal.Xaml.Context
                                 }
                                 else
                                 {   // The Ambient Property is either Fully build or not set.
-
                                     // FIRST: Ask the object (via IQueryAmbient interface) if it has a value for this property.
                                     // This is usefull to prevent needless creation of empty lazy properties.
-                                    var ambientCtrl = inst as XAML3.IQueryAmbient;
 
                                     // If there is no ambientControl or if ambientControl says YES, then get the property value.
-                                    if (ambientCtrl == null || ambientCtrl.IsAmbientPropertyAvailable(prop.Name))
+                                    if (inst is not XAML3.IQueryAmbient ambientCtrl || ambientCtrl.IsAmbientPropertyAvailable(prop.Name))
                                     {
                                         returnAmbientValue = true;
                                         value = _runtime.GetValue(inst, prop);
@@ -874,8 +872,7 @@ namespace MS.Internal.Xaml.Context
 
             if (nameScopeDictionary == null)
             {
-                XAML3.INameScope nameScope = inst as XAML3.INameScope;
-                if (nameScope != null)
+                if (inst is XAML3.INameScope nameScope)
                 {
                     nameScopeDictionary = new NameScopeDictionary(nameScope);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterFrame.cs
@@ -137,8 +137,7 @@ namespace MS.Internal.Xaml.Context
             {
                 // We use a special KeyHolder in some x:Reference scenarios.
                 // We need to unwrap this when returning.
-                FixupTargetKeyHolder ftkh = _key as FixupTargetKeyHolder;
-                if (ftkh != null)
+                if (_key is FixupTargetKeyHolder ftkh)
                 {
                     return ftkh.Key;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/EventConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/EventConverter.cs
@@ -48,15 +48,13 @@ namespace System.Xaml
                 return;
             }
 
-            IRootObjectProvider? rootObjectService = context.GetService(typeof(IRootObjectProvider)) as IRootObjectProvider;
-            if (rootObjectService == null)
+            if (context.GetService(typeof(IRootObjectProvider)) is not IRootObjectProvider rootObjectService)
             {
                 return;
             }
             rootObject = rootObjectService.RootObject;
 
-            IDestinationTypeProvider? targetService = context.GetService(typeof(IDestinationTypeProvider)) as IDestinationTypeProvider;
-            if (targetService == null)
+            if (context.GetService(typeof(IDestinationTypeProvider)) is not IDestinationTypeProvider targetService)
             {
                 return;
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
@@ -258,9 +258,8 @@ namespace System.Xaml
             {
                 return false;
             }
-            if (data is InternalNodeType)
+            if (data is InternalNodeType internalNodeType)
             {
-                InternalNodeType internalNodeType = (InternalNodeType)data;
                 if (internalNodeType == InternalNodeType.EndOfStream)
                 {
                     return true;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -1979,9 +1979,8 @@ namespace System.Xaml
                                                 ctx.ParentType));
                     }
                     ctx.ParentIsPropertyValueSet = true;
-                    if (value is NameFixupToken)
+                    if (value is NameFixupToken token)
                     {
-                        var token = (NameFixupToken)value;
                         if (parentProperty.IsDirective)
                         {
                             // Only the key directive may be assigned a reference.

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -752,8 +752,7 @@ namespace System.Xaml
                 bool shouldSetValue = true;
                 if (value != null)
                 {
-                    XAML3.MarkupExtension me = value as XAML3.MarkupExtension;
-                    if (me != null)
+                    if (value is XAML3.MarkupExtension me)
                     {
                         _context.CurrentInstance = me;
                         XamlType valueXamlType = GetXamlType(value.GetType());
@@ -1123,8 +1122,7 @@ namespace System.Xaml
                 object[] args = ctx.CurrentCtorArgs;
                 for (int i = 0; i < args.Length; i++)
                 {
-                    XAML3.MarkupExtension me = args[i] as XAML3.MarkupExtension;
-                    if (me != null)
+                    if (args[i] is XAML3.MarkupExtension me)
                     {
                         args[i] = Logic_PushAndPopAProvideValueStackFrame(ctx, XamlLanguage.PositionalParameters, me, false);
                     }
@@ -1300,8 +1298,7 @@ namespace System.Xaml
             XamlType propertyType = property.Type;
 
             object value = ctx.CurrentInstance;
-            XamlReader deferredContent = value as XamlReader;
-            if (deferredContent != null)
+            if (value is XamlReader deferredContent)
             {
                 // property.DeferringLoader looks at the property AND the type of the property.
                 XamlValueConverter<XamlDeferringLoader> deferringLoader = property.DeferringLoader;
@@ -1522,8 +1519,7 @@ namespace System.Xaml
                     // so don't call ProvideValue() now on directives here.
                     // (x:Key and x:Name need their own "saved spot" outside of PreconstructionPropertyValues)
 
-                    XAML3.MarkupExtension me = value as XAML3.MarkupExtension;
-                    if (me != null && !prop.IsDirective)
+                    if (value is XAML3.MarkupExtension me && !prop.IsDirective)
                     {
                         Logic_PushAndPopAProvideValueStackFrame(ctx, prop, me, true);
                     }
@@ -1761,8 +1757,7 @@ namespace System.Xaml
                 {
                     // If Value is a Markup Extention then check the collection item type
                     // if it can hold the ME then don't call ProvideValue().
-                    XAML3.MarkupExtension me = value as XAML3.MarkupExtension;
-                    if(me != null && !Logic_WillParentCollectionAdd(ctx, value.GetType(), true))
+                    if (value is XAML3.MarkupExtension me && !Logic_WillParentCollectionAdd(ctx, value.GetType(), true))
                     {
                         // We don't need to call Logic_ProvideValue() with the extra handler
                         // interfaces, because this is collection not a scalar property.
@@ -2110,8 +2105,7 @@ namespace System.Xaml
                                 XAML3.INameScope nameScope, XAML3.INameScope parentNameScope, bool isRoot)
         {
             XAML3.INameScope underlyingNameScope = nameScope;
-            NameScopeDictionary nameScopeDict = nameScope as NameScopeDictionary;
-            if (nameScopeDict != null)
+            if (nameScope is NameScopeDictionary nameScopeDict)
             {
                 underlyingNameScope = nameScopeDict.UnderlyingNameScope;
             }
@@ -2167,8 +2161,7 @@ namespace System.Xaml
             {
                 throw ctx.WithLineInfo(new XamlObjectWriterException(SR.Format(SR.DirectiveNotAtRoot, XamlLanguage.Class)));
             }
-            string className = value as string;
-            if (className == null)
+            if (value is not string className)
             {
                 throw ctx.WithLineInfo(new XamlObjectWriterException(SR.Format(SR.DirectiveMustBeString, XamlLanguage.Class)));
             }
@@ -2513,8 +2506,7 @@ namespace System.Xaml
                 _lastInstance = owc.CurrentInstance;
             }
 
-            NameFixupToken newToken = owc.CurrentInstance as NameFixupToken;
-            if (newToken != null)
+            if (owc.CurrentInstance is NameFixupToken newToken)
             {
                 // Line Info should be the same as the original token, not wherever we happen to be currently.
                 // Also several properties on Target (IsOnTheStack, EndInstanceLineInfo, and potentially others)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReader.cs
@@ -192,9 +192,8 @@ namespace System.Xaml
             {
                 _mergedSettings.XmlLang = myXmlReader.XmlLang;
             }
-            IXmlNamespaceResolver myXmlReaderNS = myXmlReader as IXmlNamespaceResolver;
             Dictionary<string, string> xmlnsDictionary = null;
-            if (myXmlReaderNS != null)
+            if (myXmlReader is IXmlNamespaceResolver myXmlReaderNS)
             {
                 IDictionary<string, string> rootNamespaces = myXmlReaderNS.GetNamespacesInScope(XmlNamespaceScope.Local);
                 if (rootNamespaces != null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/ClrObjectRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/ClrObjectRuntime.cs
@@ -117,8 +117,7 @@ namespace MS.Internal.Xaml.Runtime
             {
                 // We go down this path even if there are no args, because we might match a params array
                 MemberInfo[] members = type.GetMember(methodName, MemberTypes.Method, flags);
-                MethodBase[] methods = members as MethodBase[];
-                if (methods == null)
+                if (members is not MethodBase[] methods)
                 {
                     methods = new MethodBase[members.Length];
                     Array.Copy(members, methods, members.Length);
@@ -360,8 +359,7 @@ namespace MS.Internal.Xaml.Runtime
                 // - an IDictionaryEnumerator,
                 // - an IEnumerator<KeyValuePair<K,V>>, or
                 // - an IEnumerator that returns DictionaryEntrys
-                IDictionaryEnumerator dictionaryEnumerator = enumerator as IDictionaryEnumerator;
-                if (dictionaryEnumerator != null)
+                if (enumerator is IDictionaryEnumerator dictionaryEnumerator)
                 {
                     return DictionaryEntriesFromIDictionaryEnumerator(dictionaryEnumerator);
                 }
@@ -438,8 +436,7 @@ namespace MS.Internal.Xaml.Runtime
         {
             try
             {
-                XAML3.IComponentConnector connector = root as XAML3.IComponentConnector;
-                if(connector != null)
+                if (root is XAML3.IComponentConnector connector)
                 {
                     connector.Connect(connectionId, instance);
                 }
@@ -458,10 +455,9 @@ namespace MS.Internal.Xaml.Runtime
         {
             try
             {
-                ISupportInitialize supportInit = obj as ISupportInitialize;
-                if(supportInit != null)
+                if (obj is ISupportInitialize supportInit)
                 {
-                    if(begin)
+                    if (begin)
                     {
                         supportInit.BeginInit();
                     }
@@ -502,8 +498,7 @@ namespace MS.Internal.Xaml.Runtime
         {
             try
             {
-                XAML3.IUriContext uriContext = obj as XAML3.IUriContext;
-                if(uriContext != null)
+                if (obj is XAML3.IUriContext uriContext)
                 {
                     uriContext.BaseUri = baseUri;
                 }
@@ -523,14 +518,12 @@ namespace MS.Internal.Xaml.Runtime
         public override void SetXmlInstance(object inst, XamlMember property, XAML3.XData xData)
         {
             object propInstance = GetValue(inst, property, true);
-            IXmlSerializable iXmlSerial = propInstance as IXmlSerializable;
-            if(iXmlSerial == null)
+            if (propInstance is not IXmlSerializable iXmlSerial)
             {
                 throw CreateException((SR.Format(SR.XmlDataNull, property.Name)));
             }
 
-            XmlReader reader = xData.XmlReader as XmlReader;
-            if(reader == null)
+            if (xData.XmlReader is not XmlReader reader)
             {
                 throw new XamlInternalException(SR.Format(SR.XmlValueNotReader, property.Name));
             }
@@ -569,8 +562,7 @@ namespace MS.Internal.Xaml.Runtime
             catch (Exception e)
             {
                 // Reset the reader in case our caller catches and retries
-                IXamlIndexingReader indexingReader = deferredContent as IXamlIndexingReader;
-                if(indexingReader != null && indexingReader.CurrentIndex >= 0)
+                if (deferredContent is IXamlIndexingReader indexingReader && indexingReader.CurrentIndex >= 0)
                 {
                     indexingReader.CurrentIndex = -1;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/DynamicMethodRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/DynamicMethodRuntime.cs
@@ -158,8 +158,7 @@ namespace MS.Internal.Xaml.Runtime
         {
             if (ts == BuiltInValueConverter.Event)
             {
-                string valueString = value as string;
-                if (valueString != null)
+                if (value is string valueString)
                 {
                     object rootObject;
                     Type delegateType;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeReflector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeReflector.cs
@@ -399,8 +399,7 @@ namespace System.Xaml.Schema
             // We only check this once, at the root of the doc, and only in ObjectWriter.
             // So it's fine to use live reflection here.
             object obj = GetCustomAttribute(typeof(XAML3.NameScopePropertyAttribute), xamlType.UnderlyingType);
-            XAML3.NameScopePropertyAttribute nspAttr = obj as XAML3.NameScopePropertyAttribute;
-            if (nspAttr != null)
+            if (obj is XAML3.NameScopePropertyAttribute nspAttr)
             {
                 Type ownerType = nspAttr.Type;
                 string propertyName = nspAttr.Name;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
@@ -62,8 +62,7 @@ namespace System.Xaml.Schema
         public virtual void AddToCollection(object instance, object item)
         {
             ArgumentNullException.ThrowIfNull(instance);
-            IList list = instance as IList;
-            if (list != null)
+            if (instance is IList list)
             {
                 list.Add(item);
                 return;
@@ -94,8 +93,7 @@ namespace System.Xaml.Schema
         public virtual void AddToDictionary(object instance, object key, object item)
         {
             ArgumentNullException.ThrowIfNull(instance);
-            IDictionary dictionary = instance as IDictionary;
-            if (dictionary != null)
+            if (instance is IDictionary dictionary)
             {
                 dictionary.Add(key, item);
                 return;
@@ -209,8 +207,7 @@ namespace System.Xaml.Schema
         public virtual IEnumerator GetItems(object instance)
         {
             ArgumentNullException.ThrowIfNull(instance);
-            IEnumerable enumerable = instance as IEnumerable;
-            if (enumerable != null)
+            if (instance is IEnumerable enumerable)
             {
                 return enumerable.GetEnumerator();
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeTypeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeTypeConverter.cs
@@ -18,9 +18,7 @@ namespace System.Xaml.Schema
 
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            string typeName = value as string;
-
-            if (context != null && typeName != null)
+            if (context != null && value is string typeName)
             {
                 XamlType result = ConvertStringToXamlType(context, typeName);
                 if (result != null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlValueConverter.cs
@@ -106,8 +106,7 @@ namespace System.Xaml.Schema
 
         public override bool Equals(object obj)
         {
-            XamlValueConverter<TConverterBase> other = obj as XamlValueConverter<TConverterBase>;
-            if (other is null)
+            if (obj is not XamlValueConverter<TConverterBase> other)
             {
                 return false;
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlException.cs
@@ -22,8 +22,7 @@ namespace System.Xaml
         public XamlException(string message, Exception innerException)
             : base(message, innerException)
         {
-            XamlException xex = innerException as XamlException;
-            if (xex != null)
+            if (innerException is XamlException xex)
             {
                 LineNumber = xex.LineNumber;
                 LinePosition = xex.LinePosition;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
@@ -172,9 +172,7 @@ namespace System.Xaml
 
         public override void WriteValue(object value)
         {
-            string s = value as string;
-
-            if (s == null)
+            if (value is not string s)
             {
                 throw new ArgumentException(SR.XamlMarkupExtensionWriterCannotWriteNonstringValue);
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
@@ -100,8 +100,7 @@ namespace System.Xaml
             MarkupInfo node = nodes.Pop();
             currentXamlNode = node.XamlNode;
 
-            ObjectMarkupInfo objectNode = node as ObjectMarkupInfo;
-            currentInstance = objectNode != null ? objectNode.Object : null;
+            currentInstance = node is ObjectMarkupInfo objectNode ? objectNode.Object : null;
 
             var subNodes = node.Decompose();
 
@@ -277,8 +276,7 @@ namespace System.Xaml
                         return false;
                     }
 
-                    ObjectMarkupInfo r = children[0] as ObjectMarkupInfo;
-                    return (r != null && r.IsAttributableMarkupExtension);
+                    return (children[0] is ObjectMarkupInfo r && r.IsAttributableMarkupExtension);
                 }
             }
 
@@ -306,8 +304,7 @@ namespace System.Xaml
                     //Empty collections and atoms are attributable
                     if (Children.Count == 0 || Children[0] is ValueMarkupInfo) { return true; }
 
-                    ObjectMarkupInfo r = Children[0] as ObjectMarkupInfo;
-                    if (r == null)
+                    if (Children[0] is not ObjectMarkupInfo r)
                     {
                         throw new InvalidOperationException(SR.ExpectedObjectMarkupInfo);
                     }
@@ -669,20 +666,17 @@ namespace System.Xaml
                 {
                     if (memberInfo.Children.Count == 1)
                     {
-                        var objectInfo = memberInfo.Children[0] as ObjectMarkupInfo;
-                        if (objectInfo != null && objectInfo.Properties.Count == 1 && memberType == objectInfo.XamlNode.XamlType)
+                        if (memberInfo.Children[0] is ObjectMarkupInfo objectInfo && objectInfo.Properties.Count == 1 && memberType == objectInfo.XamlNode.XamlType)
                         {
 
                             if (objectInfo.Properties[0].XamlNode.Member == XamlLanguage.Items)
                             {
-                                var itemsMemberInfo = objectInfo.Properties[0] as MemberMarkupInfo;
-                                if(itemsMemberInfo != null && itemsMemberInfo.Children.Count > 0)
+                                if (objectInfo.Properties[0] is MemberMarkupInfo itemsMemberInfo && itemsMemberInfo.Children.Count > 0)
                                 {
                                     //Check if the first element of the collection/dictionary is a ME and replace the SO with GO only if it is not an ME.
                                     //This is to handle cases where the first element is, say, null. If we remove the SO, then there is no way to
                                     //know if the collection is null or the first element is null.
-                                    var itemInfo = itemsMemberInfo.Children[0] as ObjectMarkupInfo;
-                                    if(itemInfo == null || itemInfo.XamlNode.XamlType == null || !itemInfo.XamlNode.XamlType.IsMarkupExtension)
+                                    if (itemsMemberInfo.Children[0] is not ObjectMarkupInfo itemInfo || itemInfo.XamlNode.XamlType == null || !itemInfo.XamlNode.XamlType.IsMarkupExtension)
                                     {
                                         // change the member to GetObject
                                         objectInfo.XamlNode = new XamlNode(XamlNodeType.GetObject);
@@ -1917,8 +1911,7 @@ namespace System.Xaml
                 //    throw new XamlObjectReaderException(SR.XamlSerializerCannotHaveXDataAtRoot(valueType.Name));
                 //}
 
-                var valueAsArray = value as Array;
-                if (valueAsArray != null)
+                if (value is Array valueAsArray)
                 {
                     return ForArray(valueAsArray, context);
                 }
@@ -3020,8 +3013,7 @@ namespace System.Xaml
 
                 public override bool Equals(object obj)
                 {
-                    Entry other = obj as Entry;
-                    return other != null && other.Key.Equals(Key);
+                    return obj is Entry other && other.Key.Equals(Key);
                 }
 
                 public override int GetHashCode()

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
@@ -1221,14 +1221,12 @@ namespace System.Xaml
                     // default ctor
                     methodParams = Array.Empty<ParameterInfo>();
                 }
-                else if (memberInfo is ConstructorInfo)
+                else if (memberInfo is ConstructorInfo ctor)
                 {
-                    var ctor = (ConstructorInfo)memberInfo;
                     methodParams = ctor.GetParameters();
                 }
-                else if (memberInfo is MethodInfo)
+                else if (memberInfo is MethodInfo mi)
                 {
-                    var mi = (MethodInfo)memberInfo;
                     methodParams = mi.GetParameters();
 
                     var methodName = memberInfo.Name;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -781,8 +781,7 @@ namespace System.Xaml
         private static void CleanupCollectedAssemblies(object schemaContextWeakRef)
         {
             WeakReference weakRef = (WeakReference)schemaContextWeakRef;
-            XamlSchemaContext schemaContext = weakRef.Target as XamlSchemaContext;
-            if (schemaContext != null)
+            if (weakRef.Target is XamlSchemaContext schemaContext)
             {
                 schemaContext.CleanupCollectedAssemblies();
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
@@ -626,8 +626,7 @@ namespace System.Xaml
                 return null;
             }
             IEnumerable<ConstructorInfo> ctors = GetConstructors();
-            ConstructorInfo[] ctorArray = ctors as ConstructorInfo[];
-            if (ctorArray == null)
+            if (ctors is not ConstructorInfo[] ctorArray)
             {
                 ctorArray = new List<ConstructorInfo>(ctors).ToArray();
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
@@ -211,8 +211,7 @@ namespace System.Xaml
             }
             else
             {
-                string s = value as string;
-                if (s == null)
+                if (value is not string s)
                 {
                     throw new ArgumentException(SR.XamlXmlWriterCannotWriteNonstringValue, nameof(value));
                 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ProxyManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ProxyManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -174,15 +174,14 @@ namespace MS.Internal.Automation
                         {
                             proxyDescriptions[count++] = (ClientSideProviderDescription)o;
                         }
-                        else if (o is ClientSideProviderFactoryCallback)
+                        else if (o is ClientSideProviderFactoryCallback pfc)
                         {
-                            ClientSideProviderFactoryCallback pfc = (ClientSideProviderFactoryCallback)o;
                             proxyDescriptions[count++] = new ClientSideProviderDescription(pfc, null);
 
                         }
                         else
                         {
-                            foreach( Object o1 in (ArrayList) o )
+                            foreach (Object o1 in (ArrayList)o)
                             {
                                 proxyDescriptions[count++] = (ClientSideProviderDescription)o1;
                             }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ItemContainerPattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ItemContainerPattern.cs
@@ -154,14 +154,12 @@ namespace System.Windows.Automation
                 // If this is a control type, use the ID, not the CLR object
                 value = ((ControlType)value).Id;
             }
-            else if (value is Rect)
+            else if (value is Rect rc)
             {
-                Rect rc = (Rect)value;
                 value = new double[] { rc.Left, rc.Top, rc.Width, rc.Height };
             }
-            else if (value is Point)
+            else if (value is Point pt)
             {
-                Point pt = (Point)value;
                 value = new double[] { pt.X, pt.Y };
             }
             else if (value is CultureInfo)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/PropertyCondition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/PropertyCondition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -157,24 +157,21 @@ namespace System.Windows.Automation
                 // If this is a control type, use the ID, not the CLR object
                 val = ((ControlType)val).Id;
             }
-            else if (val is Rect)
+            else if (val is Rect rc)
             {
-                Rect rc = (Rect)val;
                 val = new double[] { rc.Left, rc.Top, rc.Width, rc.Height };
             }
-            else if (val is Point)
+            else if (val is Point pt)
             {
-                Point pt = (Point)val;
                 val = new double[] { pt.X, pt.Y };
             }
             else if (val is CultureInfo)
             {
                 val = ((CultureInfo)val).LCID;
             }
-            else if (val is AutomationHeadingLevel)
+            else if (val is AutomationHeadingLevel automationHeadingLevel)
             {
-                AutomationHeadingLevel automationHeadingLevel = (AutomationHeadingLevel)(val);
-                switch(automationHeadingLevel)
+                switch (automationHeadingLevel)
                 {
                     case AutomationHeadingLevel.None:
                         val = HeadingLevel.None;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Accessible.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Accessible.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -574,9 +574,8 @@ namespace MS.Internal.AutomationProxies
                 {
                     return Accessible.Wrap(accChild);
                 }
-                else if (child is int)
+                else if (child is int idChild)
                 {
-                    int idChild = (int)child;
                     return Accessible.Wrap(accParent.IAccessible, idChild);
                 }
             }
@@ -640,11 +639,10 @@ namespace MS.Internal.AutomationProxies
                 children = new Accessible[1];
                 children[0] = AccessibleFromObject(obj, _acc);
             }
-            else if (obj is object [])
+            else if (obj is object[] objs)
             {
-                object [] objs = (object [])obj;
                 children = new Accessible[objs.Length];
-                for (int i=0;i<objs.Length;i++)
+                for (int i = 0; i < objs.Length; i++)
                 {
                     children[i] = AccessibleFromObject(objs[i], _acc);
                 }
@@ -768,10 +766,8 @@ namespace MS.Internal.AutomationProxies
                 // point is not on this object or one of its children
                 rval = null;
             }
-            else if (scan is int)
+            else if (scan is int idChild) // point is on child or self. If self then return 'this'
             {
-                // point is on child or self. If self then return 'this'
-                int idChild = (int)scan;
                 if (idChild == NativeMethods.CHILD_SELF)
                 {
                     rval = this;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Accessible.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Accessible.cs
@@ -517,7 +517,7 @@ namespace MS.Internal.AutomationProxies
                     // Need to convert nulls into an empty string, so need to just test for a null.
                     // Therefore we can not use IsNullOrEmpty() here, suppress the warning.
 #pragma warning suppress 6507
-                    return value != null ? value : "";
+                    return value ?? "";
                 }
                 catch (Exception e)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsStatusBar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsStatusBar.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -236,7 +236,7 @@ namespace MS.Internal.AutomationProxies
                 if (Misc.PtInRect(ref rc, x, y))
                 {
                     ProxySimple grip = StatusBarGrip.Create(_hwnd, this, -1);
-                    return (ProxySimple)(grip != null ? grip : this);
+                    return (ProxySimple)(grip ?? this);
                 }
             }
             return this;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -533,8 +533,7 @@ namespace MS.Internal
             object[] argstrs = new object[args.Length];
             for (int i = 0; i < args.Length; ++i)
             {
-                string s = args[i] as string;
-                argstrs[i] = (s != null) ? s : AvTrace.ToStringHelper(args[i]);
+                argstrs[i] = (args[i] is string s) ? s : AvTrace.ToStringHelper(args[i]);
             }
             _sb.AppendFormat( CultureInfo.InvariantCulture, message, argstrs );
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/APCustomTypeDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/APCustomTypeDescriptor.cs
@@ -73,8 +73,7 @@ namespace MS.Internal.ComponentModel
             {
                 foreach (Attribute attr in attributes) 
                 {
-                    PropertyFilterAttribute filterAttr = attr as PropertyFilterAttribute;
-                    if (filterAttr != null) 
+                    if (attr is PropertyFilterAttribute filterAttr)
                     {
                         filter = filterAttr.Filter;
                         break;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DPCustomTypeDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DPCustomTypeDescriptor.cs
@@ -56,11 +56,10 @@ namespace MS.Internal.ComponentModel
         {
             if (_instance != null) 
             {
-                RuntimeNamePropertyAttribute nameAttr = GetAttributes()[typeof(RuntimeNamePropertyAttribute)] as RuntimeNamePropertyAttribute;
-                if (nameAttr != null && nameAttr.Name != null) 
+                if (GetAttributes()[typeof(RuntimeNamePropertyAttribute)] is RuntimeNamePropertyAttribute nameAttr && nameAttr.Name != null)
                 {
                     PropertyDescriptor nameProp = GetProperties()[nameAttr.Name];
-                    if (nameProp != null) 
+                    if (nameProp != null)
                     {
                         return nameProp.GetValue(_instance) as string;
                     }
@@ -97,8 +96,7 @@ namespace MS.Internal.ComponentModel
             {
                 foreach (Attribute attr in attributes) 
                 {
-                    PropertyFilterAttribute filterAttr = attr as PropertyFilterAttribute;
-                    if (filterAttr != null) 
+                    if (attr is PropertyFilterAttribute filterAttr)
                     {
                         filter = filterAttr.Filter;
                         break;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyObjectPropertyDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyObjectPropertyDescriptor.cs
@@ -400,7 +400,7 @@ namespace MS.Internal.ComponentModel
                 method = reflectionType.GetMethod(methodName, f, _dpBinder, DpType, null);
 
                 lock(_getMethodCache) {
-                    _getMethodCache[dp] = (method == null ? _nullMethodSentinel : method);
+                    _getMethodCache[dp] = (method ?? _nullMethodSentinel);
                 }
             }
 
@@ -572,7 +572,7 @@ namespace MS.Internal.ComponentModel
                 method = reflectionType.GetMethod(methodName, f, _dpBinder, paramTypes, null);
 
                 lock(_setMethodCache) {
-                    _setMethodCache[dp] = (method == null ? _nullMethodSentinel : method);
+                    _setMethodCache[dp] = (method ?? _nullMethodSentinel);
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyObjectPropertyDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyObjectPropertyDescriptor.cs
@@ -481,28 +481,28 @@ namespace MS.Internal.ComponentModel
 
                 foreach(Attribute attr in attrArray) 
                 {
-                    AttributeProviderAttribute pa = attr as AttributeProviderAttribute;
-                    if (pa != null) 
+                    if (attr is AttributeProviderAttribute pa)
                     {
                         Type providerType = Type.GetType(pa.TypeName);
-                        if (providerType != null) 
+                        if (providerType != null)
                         {
                             Attribute[] paAttrs = null;
-                            if (!string.IsNullOrEmpty(pa.PropertyName)) 
+                            if (!string.IsNullOrEmpty(pa.PropertyName))
                             {
                                 MemberInfo[] milist = providerType.GetMember(pa.PropertyName);
-                                if (milist.Length > 0 && milist[0] != null) 
+                                if (milist.Length > 0 && milist[0] != null)
                                 {
                                     paAttrs = (Attribute[])milist[0].GetCustomAttributes(typeof(Attribute), true);
                                 }
                             }
-                            else {
+                            else
+                            {
                                 paAttrs = (Attribute[])providerType.GetCustomAttributes(typeof(Attribute), true);
                             }
 
                             if (paAttrs != null)
                             {
-                                if (addAttrs == null) 
+                                if (addAttrs == null)
                                 {
                                     addAttrs = paAttrs;
                                 }
@@ -512,7 +512,7 @@ namespace MS.Internal.ComponentModel
                                     addAttrs.CopyTo(newArray, 0);
                                     paAttrs.CopyTo(newArray, addAttrs.Length);
                                     addAttrs = newArray;
-}
+                                }
                             }
                         }
                     }
@@ -664,18 +664,16 @@ namespace MS.Internal.ComponentModel
             foreach (Attribute a in baseAttributes) 
             {
                 Attribute attrToAdd = a;
-                DefaultValueAttribute defAttr = a as DefaultValueAttribute;
 
-                if (defAttr != null) 
+                if (a is DefaultValueAttribute defAttr)
                 {
                     // DP metadata always overrides CLR metadata for
                     // default value.
                     attrToAdd = null;
                 }
-                else 
+                else
                 {
-                    ReadOnlyAttribute roAttr = a as ReadOnlyAttribute;
-                    if (roAttr != null)
+                    if (a is ReadOnlyAttribute roAttr)
                     {
                         // DP metata is the merge of CLR metadata for
                         // read only

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyObjectProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyObjectProvider.cs
@@ -96,13 +96,11 @@ namespace MS.Internal.ComponentModel
         /// </summary>
         public override IDictionary GetCache(object instance) 
         {
-            DependencyObject d = instance as DependencyObject;
-
             // This should never happen because we are bound only
             // to dependency object types.  However, in case it
             // does, simply invoke the base and get out.
 
-            if (d == null) 
+            if (instance is not DependencyObject d)
             {
                 return base.GetCache(instance);
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyPropertyAttribute.cs
@@ -48,11 +48,9 @@ namespace MS.Internal.ComponentModel
         /// </summary>
         public override bool Equals(object value) 
         {
-            DependencyPropertyAttribute da = value as DependencyPropertyAttribute;
-
-            if (da != null && 
-                object.ReferenceEquals(da._dp, _dp) && 
-                da._isAttached == _isAttached) 
+            if (value is DependencyPropertyAttribute da &&
+                object.ReferenceEquals(da._dp, _dp) &&
+                da._isAttached == _isAttached)
             {
                 return true;
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/FreezableDefaultValueFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/FreezableDefaultValueFactory.cs
@@ -52,14 +52,13 @@ namespace MS.Internal
                 "It is the caller responsibility to ensure that owner and property are non-null.");
             
             Freezable result = _defaultValuePrototype;
-            Freezable ownerFreezable = owner as Freezable;
-            
+
             // If the owner is frozen, just return the frozen prototype.
-            if (ownerFreezable != null && ownerFreezable.IsFrozen)
+            if (owner is Freezable ownerFreezable && ownerFreezable.IsFrozen)
             {
                 return result;
             }
-            
+
             result = _defaultValuePrototype.Clone();
 
             // Wire up a FreezableDefaultPromoter to observe the default value we

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
@@ -754,8 +754,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             ref bool stop
             )
         {
-            LoadUseLicenseForUserParams lulfup = param as LoadUseLicenseForUserParams;
-            if (lulfup == null)
+            if (param is not LoadUseLicenseForUserParams lulfup)
             {
                 throw new ArgumentException(SR.CallbackParameterInvalid, "param");
             }
@@ -809,8 +808,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             ref bool stop
             )
         {
-            ContentUser userToDelete = param as ContentUser;
-            if (userToDelete == null)
+            if (param is not ContentUser userToDelete)
             {
                 throw new ArgumentException(SR.CallbackParameterInvalid, "param");
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlDigitalSignatureProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlDigitalSignatureProcessor.cs
@@ -524,8 +524,7 @@ namespace MS.Internal.IO.Packaging
             // we should attempt to dispose it if it offers IDisposable.
             if (algorithm == null && o != null)
             {
-                IDisposable disposable = o as IDisposable;
-                if (disposable != null)
+                if (o is IDisposable disposable)
                     disposable.Dispose();
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/ClientSession.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/ClientSession.cs
@@ -917,8 +917,7 @@ namespace MS.Internal.Security.RightsManagement
             else
             {
                 object keyValue = key.GetValue(null); // this should get the default value
-                string stringValue = keyValue as string;
-                if (stringValue != null)
+                if (keyValue is string stringValue)
                 {
                     return new Uri(stringValue);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Threading/ExceptionWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Threading/ExceptionWrapper.cs
@@ -65,15 +65,13 @@ namespace System.Windows.Threading
             // expensive DynamicInvoke call.
             if(numArgsEx == 0)
             {
-                Action action = callback as Action;
-                if (action != null)
+                if (callback is Action action)
                 {
                     action();
                 }
                 else
                 {
-                    Dispatcher.ShutdownCallback shutdownCallback = callback as Dispatcher.ShutdownCallback;
-                    if(shutdownCallback != null)
+                    if (callback is Dispatcher.ShutdownCallback shutdownCallback)
                     {
                         shutdownCallback();
                     }
@@ -86,21 +84,19 @@ namespace System.Windows.Threading
             }
             else if(numArgsEx == 1)
             {
-                DispatcherOperationCallback dispatcherOperationCallback = callback as DispatcherOperationCallback;
-                if(dispatcherOperationCallback != null)
+                if (callback is DispatcherOperationCallback dispatcherOperationCallback)
                 {
                     result = dispatcherOperationCallback(singleArg);
                 }
                 else
                 {
-                    SendOrPostCallback sendOrPostCallback = callback as SendOrPostCallback;
-                    if(sendOrPostCallback != null)
+                    if (callback is SendOrPostCallback sendOrPostCallback)
                     {
                         sendOrPostCallback(singleArg);
                     }
                     else
                     {
-                        if(numArgs == -1)
+                        if (numArgs == -1)
                         {
                             // Explicitly pass an object[] to DynamicInvoke so that
                             // it will not try to wrap the arg in another object[].

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/TraceLevelStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/TraceLevelStore.cs
@@ -105,8 +105,7 @@ namespace MS.Internal
             public override int GetHashCode()
             {
 #if DEBUG
-                WeakReference wr = _element as WeakReference;
-                object element = (wr != null) ? wr.Target : _element;
+                object element = (_element is WeakReference wr) ? wr.Target : _element;
                 if (element != null)
                 {
                     int hashcode = element.GetHashCode();

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakEventTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakEventTable.cs
@@ -516,8 +516,7 @@ namespace MS.Internal
             public override int GetHashCode()
             {
 #if DEBUG
-                WeakReference wr = _source as WeakReference;
-                object source = (wr != null) ? wr.Target : _source;
+                object source = (_source is WeakReference wr) ? wr.Target : _source;
                 if (source != null)
                 {
                     int hashcode = unchecked(_manager.GetHashCode() + RuntimeHelpers.GetHashCode(source));

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakEventTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakEventTable.cs
@@ -584,9 +584,8 @@ namespace MS.Internal
 
             public override bool Equals(object o)
             {
-                if (o is EventNameKey)
+                if (o is EventNameKey that)
                 {
-                    EventNameKey that = (EventNameKey)o;
                     return (this._eventSourceType == that._eventSourceType && this._eventName == that._eventName);
                 }
                 else

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakReferenceKey.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakReferenceKey.cs
@@ -27,11 +27,10 @@ namespace MS.Internal.Utility
             if (o == this)
                 return true;
 
-            WeakReferenceKey<T> key = o as WeakReferenceKey<T>;
-            if (key != null)
+            if (o is WeakReferenceKey<T> key)
             {
                 T item = this.Item;
-                
+
                 if (item == null)
                     return false;   // a stale key matches nothing (except itself)
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Collections/ObjectModel/WeakReadOnlyCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Collections/ObjectModel/WeakReadOnlyCollection.cs
@@ -121,11 +121,12 @@ namespace System.Collections.ObjectModel
         object ICollection.SyncRoot {
             get {
                 if( _syncRoot == null) {
-                    ICollection c = list as ICollection;
-                    if( c != null) {
+                    if (list is ICollection c)
+                    {
                         _syncRoot = c.SyncRoot;
                     }
-                    else {
+                    else
+                    {
                         System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new Object(), null);
                     }
                 }
@@ -157,11 +158,12 @@ namespace System.Collections.ObjectModel
             }
 
             IList<T> dlist = CreateDereferencedList();
-            T[] items = array as T[];
-            if (items != null) {
+            if (array is T[] items)
+            {
                 dlist.CopyTo(items, index);
             }
-            else {
+            else
+            {
                 //
                 // Catch the obvious case assignment will fail.
                 // We can found all possible problems by doing the check though.
@@ -170,7 +172,8 @@ namespace System.Collections.ObjectModel
                 //
                 Type targetType = array.GetType().GetElementType();
                 Type sourceType = typeof(T);
-                if(!(targetType.IsAssignableFrom(sourceType) || sourceType.IsAssignableFrom(targetType))) {
+                if (!(targetType.IsAssignableFrom(sourceType) || sourceType.IsAssignableFrom(targetType)))
+                {
                     //ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
                     throw new ArgumentException(SR.Argument_InvalidArrayType);
                 }
@@ -179,19 +182,22 @@ namespace System.Collections.ObjectModel
                 // We can't cast array of value type to object[], so we don't support
                 // widening of primitive types here.
                 //
-                object[] objects = array as object[];
-                if( objects == null) {
+                if (array is not object[] objects)
+                {
                     //ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
                     throw new ArgumentException(SR.Argument_InvalidArrayType);
                 }
 
                 int count = dlist.Count;
-                try {
-                    for (int i = 0; i < count; i++) {
+                try
+                {
+                    for (int i = 0; i < count; i++)
+                    {
                         objects[index++] = dlist[i];
                     }
                 }
-                catch(ArrayTypeMismatchException) {
+                catch (ArrayTypeMismatchException)
+                {
                     //ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
                     throw new ArgumentException(SR.Argument_InvalidArrayType);
                 }
@@ -287,8 +293,7 @@ namespace System.Collections.ObjectModel
 
             public T Current {
                 get {
-                    WeakReference wr = ie.Current as WeakReference;
-                    if (wr != null)
+                    if (ie.Current is WeakReference wr)
                         return (T)wr.Target;
                     else
                         return default(T);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/DependencyPropertyDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/DependencyPropertyDescriptor.cs
@@ -84,17 +84,15 @@ namespace System.ComponentModel
             DependencyProperty dp = null;
             bool isAttached = false;
 
-            DependencyObjectPropertyDescriptor idpd = property as DependencyObjectPropertyDescriptor;
-            if (idpd != null) 
+            if (property is DependencyObjectPropertyDescriptor idpd)
             {
                 dp = idpd.DependencyProperty;
                 isAttached = idpd.IsAttached;
             }
-            else 
+            else
             {
-                #pragma warning suppress 6506 // Property is obviously not null.
-                DependencyPropertyAttribute dpa = property.Attributes[typeof(DependencyPropertyAttribute)] as DependencyPropertyAttribute;
-                if (dpa != null)
+#pragma warning suppress 6506 // Property is obviously not null.
+                if (property.Attributes[typeof(DependencyPropertyAttribute)] is DependencyPropertyAttribute dpa)
                 {
                     dp = dpa.DependencyProperty;
                     isAttached = dpa.IsAttached;
@@ -308,8 +306,7 @@ namespace System.ComponentModel
         /// </summary>
         public override bool Equals(object obj) 
         {
-            DependencyPropertyDescriptor dp = obj as DependencyPropertyDescriptor;
-            if (dp != null && dp._dp == _dp && dp._componentType == _componentType)
+            if (obj is DependencyPropertyDescriptor dp && dp._dp == _dp && dp._componentType == _componentType)
             {
                 return true;
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyFilterAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyFilterAttribute.cs
@@ -47,8 +47,7 @@ namespace System.ComponentModel
         /// </summary>
         public override bool Equals(object value) 
         {
-            PropertyFilterAttribute a = value as PropertyFilterAttribute;
-            if (a != null && a._filter.Equals(_filter)) 
+            if (value is PropertyFilterAttribute a && a._filter.Equals(_filter))
             {
                 return true;
             }
@@ -72,8 +71,8 @@ namespace System.ComponentModel
         /// </summary>
         public override bool Match(object value) 
         {
-            PropertyFilterAttribute a = value as PropertyFilterAttribute;
-            if (a == null) return false;
+            if (value is not PropertyFilterAttribute a)
+                return false;
             return ((_filter & a._filter) == _filter);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/DataSpaceManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/DataSpaceManager.cs
@@ -862,17 +862,15 @@ namespace System.IO.Packaging
     /// </returns>
     internal IDataTransform GetTransformFromName(string transformLabel)
     {
-        TransformInstance transformInstance = _transformDefinitions[transformLabel] as TransformInstance;
+            if (_transformDefinitions[transformLabel] is not TransformInstance transformInstance)
+            {
+                //
+                // There is no transform instance with the specified name.
+                //
+                return null;
+            }
 
-        if (transformInstance == null)
-        {
-            //
-            // There is no transform instance with the specified name.
-            //
-            return null;
-        }
-
-        IDataTransform transformObject = transformInstance.transformReference;
+            IDataTransform transformObject = transformInstance.transformReference;
         if (transformObject == null)
         {
             //

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageInfo.cs
@@ -803,59 +803,57 @@ public class StorageInfo
 
         // Invalidate enumerators
         InvalidateEnumerators();
-        
-        // Remove the now-meaningless name, which also signifies disposed status.
-        if( deadElementWalking is StorageInfoCore )
-        {
-            StorageInfoCore deadStorageInfoCore = (StorageInfoCore)deadElementWalking;
 
-            // Erase this storage's existence
-            deadStorageInfoCore.storageName = null;
-            if( null != deadStorageInfoCore.safeIStorage )
+            // Remove the now-meaningless name, which also signifies disposed status.
+            if (deadElementWalking is StorageInfoCore deadStorageInfoCore)
             {
-                ((IDisposable) deadStorageInfoCore.safeIStorage).Dispose();
-                deadStorageInfoCore.safeIStorage = null;
-            }
-        }
-        else if( deadElementWalking is StreamInfoCore )
-        {
-            StreamInfoCore deadStreamInfoCore = (StreamInfoCore)deadElementWalking;
 
-            // Erase this stream's existence
-            deadStreamInfoCore.streamName = null;
-
-            try
-            {
-                if (null != deadStreamInfoCore.exposedStream)
+                // Erase this storage's existence
+                deadStorageInfoCore.storageName = null;
+                if (null != deadStorageInfoCore.safeIStorage)
                 {
-                    ((Stream)(deadStreamInfoCore.exposedStream)).Close();
+                    ((IDisposable)deadStorageInfoCore.safeIStorage).Dispose();
+                    deadStorageInfoCore.safeIStorage = null;
                 }
             }
-            catch(Exception e)
+            else if (deadElementWalking is StreamInfoCore deadStreamInfoCore)
             {
-                if(CriticalExceptions.IsCriticalException(e))
+
+                // Erase this stream's existence
+                deadStreamInfoCore.streamName = null;
+
+                try
                 {
-                    // PreSharp Warning 56500
-                    throw;
+                    if (null != deadStreamInfoCore.exposedStream)
+                    {
+                        ((Stream)(deadStreamInfoCore.exposedStream)).Close();
+                    }
                 }
-                else
+                catch (Exception e)
                 {
-                    // We don't care if there are any issues - 
-                    //  the user wanted this stream gone anyway.
+                    if (CriticalExceptions.IsCriticalException(e))
+                    {
+                        // PreSharp Warning 56500
+                        throw;
+                    }
+                    else
+                    {
+                        // We don't care if there are any issues - 
+                        //  the user wanted this stream gone anyway.
+                    }
+                }
+
+                deadStreamInfoCore.exposedStream = null;
+
+                if (null != deadStreamInfoCore.safeIStream)
+                {
+                    ((IDisposable)deadStreamInfoCore.safeIStream).Dispose();
+                    deadStreamInfoCore.safeIStream = null;
                 }
             }
 
-            deadStreamInfoCore.exposedStream = null;
-            
-            if( null != deadStreamInfoCore.safeIStream ) 
-            {
-                ((IDisposable) deadStreamInfoCore.safeIStream).Dispose();
-                deadStreamInfoCore.safeIStream = null;
-            }
-        }
-        
-        // Remove reference for destroyed element
-        core.elementInfoCores.Remove(elementNameInternal);
+            // Remove reference for destroyed element
+            core.elementInfoCores.Remove(elementNameInternal);
     }
     /// <summary>
     /// Looks for a storage element with the given name, retrieves its
@@ -1210,33 +1208,31 @@ public class StorageInfo
                 {
                     RecursiveStorageInfoCoreRelease( (StorageInfoCore)o );
                 }
-                else if( o is StreamInfoCore )
-                {
-                    StreamInfoCore streamRelease = (StreamInfoCore)o;
-
-                    try
+                else if (o is StreamInfoCore streamRelease)
                     {
-                        if (null != streamRelease.exposedStream)
+                        try
                         {
-                            ((Stream)(streamRelease.exposedStream)).Close();
+                            if (null != streamRelease.exposedStream)
+                            {
+                                ((Stream)(streamRelease.exposedStream)).Close();
+                            }
+                            streamRelease.exposedStream = null;
                         }
-                        streamRelease.exposedStream = null;
-                    }
-                    finally
-                    {
-                        // We need this release and null-out to happen even if we
-                        //  ran into problems with the clean-up code above.
-                        if( null != streamRelease.safeIStream)
+                        finally
                         {
-                            ((IDisposable) streamRelease.safeIStream).Dispose();
-                            streamRelease.safeIStream = null;
-                        }
+                            // We need this release and null-out to happen even if we
+                            //  ran into problems with the clean-up code above.
+                            if (null != streamRelease.safeIStream)
+                            {
+                                ((IDisposable)streamRelease.safeIStream).Dispose();
+                                streamRelease.safeIStream = null;
+                            }
 
-                        // Null name in core signifies the core object is disposed
-                        ((StreamInfoCore)o).streamName = null;
+                            // Null name in core signifies the core object is disposed
+                            ((StreamInfoCore)o).streamName = null;
+                        }
                     }
                 }
-            }
 
             // All child objects freed, clear out the enumerators
             InvalidateEnumerators( startCore );

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StreamInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StreamInfo.cs
@@ -804,8 +804,7 @@ namespace System.IO.Packaging
 
                 foreach (IDataTransform dataTransform in transforms)
                 {
-                    string id = dataTransform.TransformIdentifier as string;
-                    if (id != null)
+                    if (dataTransform.TransformIdentifier is string id)
                     {
                         if (string.Equals(id, RightsManagementEncryptionTransform.ClassTransformIdentifier, StringComparison.OrdinalIgnoreCase)
                             &&

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/EncryptedPackage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/EncryptedPackage.cs
@@ -491,8 +491,7 @@ namespace System.IO.Packaging
             }
             catch (IOException ex)
             {
-                COMException comException = ex.InnerException as COMException;
-                if (comException != null && comException.ErrorCode == STG_E_FILEALREADYEXISTS)
+                if (ex.InnerException is COMException comException && comException.ErrorCode == STG_E_FILEALREADYEXISTS)
                     return false;
 
                 throw;  // Any other kind of IOException is a real error.
@@ -548,8 +547,7 @@ namespace System.IO.Packaging
             }
             catch (IOException ex)
             {
-                COMException comException = ex.InnerException as COMException;
-                if (comException != null && comException.ErrorCode == STG_E_FILEALREADYEXISTS)
+                if (ex.InnerException is COMException comException && comException.ErrorCode == STG_E_FILEALREADYEXISTS)
                     return false;
 
                 throw;  // Any other kind of IOException is a real error.
@@ -905,8 +903,7 @@ namespace System.IO.Packaging
 
             foreach (IDataTransform dataTransform in transforms)
             {
-                string id = dataTransform.TransformIdentifier as string;
-                if (id != null &&
+                if (dataTransform.TransformIdentifier is string id &&
                     string.Equals(id, RightsManagementEncryptionTransform.ClassTransformIdentifier, StringComparison.OrdinalIgnoreCase))
                 {
                     // Do not allow more than one RM Transform

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignature.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignature.cs
@@ -296,8 +296,7 @@ namespace System.IO.Packaging
             }
 
             // convert to Ex variant that has more functionality
-            X509Certificate2 certificate = signingCertificate as X509Certificate2;
-            if (certificate == null)
+            if (signingCertificate is not X509Certificate2 certificate)
                 certificate = new X509Certificate2(signingCertificate.Handle);
 
             // verify

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
@@ -480,8 +480,7 @@ namespace System.IO.Packaging
             bool embedCertificateInSignaturePart = (_certificateEmbeddingOption == CertificateEmbeddingOption.InSignaturePart);
 
             // convert cert to version2 - more functionality
-            X509Certificate2 exSigner = certificate as X509Certificate2;
-            if (exSigner == null)
+            if (certificate is not X509Certificate2 exSigner)
                 exSigner = new X509Certificate2(certificate.Handle);
 
             //PRESHARP: Parameter to this public method must be validated:  A null-dereference can occur here.
@@ -1004,8 +1003,7 @@ namespace System.IO.Packaging
                 return true;            // null means empty
 
             // see if it's really a collection as this is more efficient than enumerating
-            System.Collections.ICollection collection = enumerable as System.Collections.ICollection;
-            if (collection != null)
+            if (enumerable is System.Collections.ICollection collection)
             {
                 return (collection.Count == 0);
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AttachedPropertyBrowsableForTypeAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AttachedPropertyBrowsableForTypeAttribute.cs
@@ -78,8 +78,8 @@ namespace System.Windows
         /// </summary>
         public override bool Equals(object obj) 
         {
-            AttachedPropertyBrowsableForTypeAttribute other = obj as AttachedPropertyBrowsableForTypeAttribute;
-            if (other == null) return false;
+            if (obj is not AttachedPropertyBrowsableForTypeAttribute other)
+                return false;
             return _targetType == other._targetType;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AttachedPropertyBrowsableWhenAttributePresentAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AttachedPropertyBrowsableWhenAttributePresentAttribute.cs
@@ -64,8 +64,8 @@ namespace System.Windows
         /// </summary>
         public override bool Equals(object obj) 
         {
-            AttachedPropertyBrowsableWhenAttributePresentAttribute other = obj as AttachedPropertyBrowsableWhenAttributePresentAttribute;
-            if (other == null) return false;
+            if (obj is not AttachedPropertyBrowsableWhenAttributePresentAttribute other)
+                return false;
             return _attributeType == other._attributeType;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/Int32RectValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/Int32RectValueSerializer.cs
@@ -63,12 +63,11 @@ namespace System.Windows.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Int32Rect)
+            if (value is Int32Rect instance)
             {
-                Int32Rect instance = (Int32Rect) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/PointValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/PointValueSerializer.cs
@@ -63,12 +63,11 @@ namespace System.Windows.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Point)
+            if (value is Point instance)
             {
-                Point instance = (Point) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/RectValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/RectValueSerializer.cs
@@ -63,12 +63,11 @@ namespace System.Windows.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Rect)
+            if (value is Rect instance)
             {
-                Rect instance = (Rect) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/SizeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/SizeValueSerializer.cs
@@ -63,12 +63,11 @@ namespace System.Windows.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Size)
+            if (value is Size instance)
             {
-                Size instance = (Size) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/VectorValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/VectorValueSerializer.cs
@@ -63,12 +63,11 @@ namespace System.Windows.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Vector)
+            if (value is Vector instance)
             {
-                Vector instance = (Vector) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
@@ -824,8 +824,7 @@ namespace System.Windows
         //
         internal bool ProvideSelfAsInheritanceContext( object value, DependencyProperty dp )
         {
-            DependencyObject doValue = value as DependencyObject;
-            if (doValue != null)
+            if (value is DependencyObject doValue)
             {
                 return ProvideSelfAsInheritanceContext(doValue, dp);
             }
@@ -869,8 +868,7 @@ namespace System.Windows
         //
         internal bool RemoveSelfAsInheritanceContext( object value, DependencyProperty dp )
         {
-            DependencyObject doValue = value as DependencyObject;
-            if (doValue != null)
+            if (value is DependencyObject doValue)
             {
                 return RemoveSelfAsInheritanceContext(doValue, dp);
             }
@@ -1138,8 +1136,7 @@ namespace System.Windows
 
             // if the target is a Freezable, call FireChanged to kick off
             // notifications to the Freezable's parent chain.
-            Freezable freezable = this as Freezable;
-            if (freezable != null)
+            if (this is Freezable freezable)
             {
                 freezable.FireChanged();
             }
@@ -2160,8 +2157,7 @@ namespace System.Windows
                 // localValue may still not be a DeferredReference, e.g.
                 // if it is an expression whose value is a DeferredReference.
                 // So a little more work is needed before converting the value.
-                DeferredReference dr = value as DeferredReference;
-                if (dr != null)
+                if (value is DeferredReference dr)
                 {
                     value = dr.GetValue(entry.BaseValueSourceInternal);
                 }
@@ -2626,8 +2622,7 @@ namespace System.Windows
                         object localValue = ReadLocalValueEntry(new EntryIndex(i), dp, true /* allowDeferredReferences */);
                         if (localValue != DependencyProperty.UnsetValue)
                         {
-                            DependencyObject inheritanceChild = localValue as DependencyObject;
-                            if (inheritanceChild!= null && inheritanceChild.InheritanceContext == this)
+                            if (localValue is DependencyObject inheritanceChild && inheritanceChild.InheritanceContext == this)
                             {
                                 inheritanceChild.OnInheritanceContextChanged(args);
                             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
@@ -406,18 +406,16 @@ namespace System.Windows
                 // deriving from DispatcherObject are allowed - it is up to the user to
                 // make any custom types free-threaded.
 
-                DispatcherObject dispatcherObject = defaultValue as DispatcherObject;
 
-                if (dispatcherObject != null && dispatcherObject.Dispatcher != null)
+                if (defaultValue is DispatcherObject dispatcherObject && dispatcherObject.Dispatcher != null)
                 {
                     // Try to make the DispatcherObject free-threaded if it's an
                     // ISealable.
 
-                    ISealable valueAsISealable = dispatcherObject as ISealable;
 
-                    if (valueAsISealable != null && valueAsISealable.CanSeal)
+                    if (dispatcherObject is ISealable valueAsISealable && valueAsISealable.CanSeal)
                     {
-                        Invariant.Assert (!valueAsISealable.IsSealed,
+                        Invariant.Assert(!valueAsISealable.IsSealed,
                                "A Sealed ISealable must not have dispatcher affinity");
 
                         valueAsISealable.Seal();

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyPropertyValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyPropertyValueSerializer.cs
@@ -22,8 +22,7 @@ namespace System.Windows
 
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            DependencyProperty property = value as DependencyProperty;
-            if (property != null)
+            if (value is DependencyProperty property)
             {
                 ValueSerializer typeSerializer = ValueSerializer.GetSerializerFor(typeof(Type), context);
                 if (typeSerializer != null)
@@ -37,8 +36,7 @@ namespace System.Windows
 
         public override IEnumerable<Type> TypeReferences(object value, IValueSerializerContext context)
         {
-            DependencyProperty property = value as DependencyProperty;
-            if (property != null)
+            if (value is DependencyProperty property)
             {
                 return new Type[] { property.OwnerType };
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/EffectiveValueEntry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/EffectiveValueEntry.cs
@@ -629,8 +629,7 @@ namespace System.Windows
         {
             get
             {
-                BaseValueWeakReference wr = _baseValue as BaseValueWeakReference;
-                return (wr != null) ? wr.Target : _baseValue;
+                return (_baseValue is BaseValueWeakReference wr) ? wr.Target : _baseValue;
             }
             set { _baseValue = value; }
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Freezable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Freezable.cs
@@ -951,9 +951,8 @@ namespace System.Windows
                     Debug.Assert(!(sourceValue is Expression && sourceValue is Freezable),
                         "This logic assumes Expressions and Freezables don't co-derive");
 
-                    Freezable valueAsFreezable = sourceValue as Freezable;
 
-                    if (valueAsFreezable != null)
+                    if (sourceValue is Freezable valueAsFreezable)
                     {
                         Freezable valueAsFreezableClone;
 
@@ -1931,8 +1930,7 @@ namespace System.Windows
 
                 Invariant.Assert(!cloneAsFreezable.HasHandlers, "CloneCore should not have handlers attached on construction.");
 
-                IList originalAsIList = original as IList;
-                if (originalAsIList != null)
+                if (original is IList originalAsIList)
                 {
                     // we've already checked that original and clone are the same type
                     IList cloneAsIList = clone as IList;
@@ -1942,8 +1940,7 @@ namespace System.Windows
                     for (int i = 0; i < cloneAsIList.Count; i++)
                     {
                         Freezable originalItemAsFreezable = originalAsIList[i] as Freezable;
-                        Freezable cloneItemAsFreezable = cloneAsIList[i] as Freezable;
-                        if (isDeepClone && cloneItemAsFreezable != null && cloneItemAsFreezable != null)
+                        if (isDeepClone && cloneAsIList[i] is Freezable cloneItemAsFreezable && cloneItemAsFreezable != null)
                         {
                             Invariant.Assert(originalItemAsFreezable != cloneItemAsFreezable, "CloneCore didn't clone the elements in the list correctly.");
                         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Int32RectConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Int32RectConverter.cs
@@ -77,9 +77,8 @@ namespace System.Windows
                 throw GetConvertFromException(value);
             }
 
-            String source = value as string;
 
-            if (source != null)
+            if (value is string source)
             {
                 return Int32Rect.Parse(source);
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/PointConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/PointConverter.cs
@@ -77,9 +77,8 @@ namespace System.Windows
                 throw GetConvertFromException(value);
             }
 
-            String source = value as string;
 
-            if (source != null)
+            if (value is string source)
             {
                 return Point.Parse(source);
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/RectConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/RectConverter.cs
@@ -77,9 +77,8 @@ namespace System.Windows
                 throw GetConvertFromException(value);
             }
 
-            String source = value as string;
 
-            if (source != null)
+            if (value is string source)
             {
                 return Rect.Parse(source);
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/SizeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/SizeConverter.cs
@@ -77,9 +77,8 @@ namespace System.Windows
                 throw GetConvertFromException(value);
             }
 
-            String source = value as string;
 
-            if (source != null)
+            if (value is string source)
             {
                 return Size.Parse(source);
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/VectorConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/VectorConverter.cs
@@ -77,9 +77,8 @@ namespace System.Windows
                 throw GetConvertFromException(value);
             }
 
-            String source = value as string;
 
-            if (source != null)
+            if (value is string source)
             {
                 return Vector.Parse(source);
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/LocalValueEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/LocalValueEnumerator.cs
@@ -31,10 +31,8 @@ namespace System.Windows
         /// </summary>
         public override bool Equals(object obj)
         {
-            if(obj is LocalValueEnumerator)
+            if (obj is LocalValueEnumerator other)
             {
-                LocalValueEnumerator other = (LocalValueEnumerator) obj;
-
                 return (_count == other._count &&
                         _index == other._index &&
                         _snapshot == other._snapshot);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Converters/Generated/MatrixValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Converters/Generated/MatrixValueSerializer.cs
@@ -63,12 +63,11 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Matrix)
+            if (value is Matrix instance)
             {
-                Matrix instance = (Matrix) value;
 
 
-                #pragma warning suppress 6506 // instance is obviously not null
+#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Generated/MatrixConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Generated/MatrixConverter.cs
@@ -77,9 +77,8 @@ namespace System.Windows.Media
                 throw GetConvertFromException(value);
             }
 
-            String source = value as string;
 
-            if (source != null)
+            if (value is string source)
             {
                 return Matrix.Parse(source);
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/NameScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/NameScope.cs
@@ -124,8 +124,7 @@ namespace System.Windows
             INameScope nameScope = obj as INameScope;
             if (nameScope == null)
             {
-                DependencyObject objAsDO = obj as DependencyObject;
-                if (objAsDO != null)
+                if (obj is DependencyObject objAsDO)
                 {
                     nameScope = GetNameScope(objAsDO);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/PropertyMetadata.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/PropertyMetadata.cs
@@ -76,8 +76,7 @@ namespace System.Windows
         {
             get
             {
-                DefaultValueFactory defaultFactory = _defaultValue as DefaultValueFactory;
-                if (defaultFactory == null)
+                if (_defaultValue is not DefaultValueFactory defaultFactory)
                 {
                     return _defaultValue;
                 }
@@ -134,8 +133,7 @@ namespace System.Windows
 
             // If we are not using a DefaultValueFactory (common case)
             // just return _defaultValue
-            DefaultValueFactory defaultFactory = _defaultValue as DefaultValueFactory;
-            if (defaultFactory == null)
+            if (_defaultValue is not DefaultValueFactory defaultFactory)
             {
                 return _defaultValue;
             }
@@ -296,9 +294,7 @@ namespace System.Windows
         /// <param name="value">The cached default</param>
         private static void DefaultValueCacheRemovalCallback(ArrayList list, int key, object value)
         {
-            Freezable cachedDefault = value as Freezable;
-
-            if (cachedDefault != null)
+            if (value is Freezable cachedDefault)
             {
                 // Freeze fires the Changed event so we need to clear off the handlers before
                 // calling it.  Otherwise the promoter would run and attempt to set the
@@ -319,9 +315,7 @@ namespace System.Windows
         /// <param name="value">The cached default</param>
         private static void DefaultValueCachePromotionCallback(ArrayList list, int key, object value)
         {
-            Freezable cachedDefault = value as Freezable;
-
-            if (cachedDefault != null)
+            if (value is Freezable cachedDefault)
             {
                 // The only way to promote a cached default is to fire its Changed event.
                 cachedDefault.FireChanged();
@@ -464,9 +458,7 @@ namespace System.Windows
 
                 if (value != null)
                 {
-                    Freezable valueAsFreezable = value as Freezable;
-
-                    if (valueAsFreezable != null)
+                    if (value is Freezable valueAsFreezable)
                     {
                         if (!valueAsFreezable.Freeze(isChecking))
                         {
@@ -485,9 +477,7 @@ namespace System.Windows
                     }
                     else  // not a Freezable
                     {
-                        DispatcherObject valueAsDispatcherObject = value as DispatcherObject;
-
-                        if (valueAsDispatcherObject != null)
+                        if (value is DispatcherObject valueAsDispatcherObject)
                         {
                             if (valueAsDispatcherObject.Dispatcher == null)
                             {
@@ -510,7 +500,7 @@ namespace System.Windows
                                         d,
                                         dp,
                                         dp.OwnerType,
-                                        valueAsDispatcherObject );
+                                        valueAsDispatcherObject);
                                 }
 
                                 return false;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
@@ -105,13 +105,12 @@ namespace System.Windows.Threading
                         // being updated if we encounter a dead weak reference.
                         for(int i = 0; i < _dispatchers.Count; i++)
                         {
-                            Dispatcher d = _dispatchers[i].Target as Dispatcher;
-                            if(d != null)
+                            if (_dispatchers[i].Target is Dispatcher d)
                             {
                                 // Note: we compare the thread objects themselves to protect
                                 // against threads reusing old thread IDs.
                                 Thread dispatcherThread = d.Thread;
-                                if(dispatcherThread == thread)
+                                if (dispatcherThread == thread)
                                 {
                                     dispatcher = d;
 
@@ -1694,8 +1693,7 @@ namespace System.Windows.Threading
             {
                 if (!_hasRequestProcessingFailed)
                     return _reservedPtsCache;
-                Tuple<Object, List<String>> tuple = _reservedPtsCache as Tuple<Object, List<String>>;
-                if (tuple == null)
+                if (_reservedPtsCache is not Tuple<Object, List<String>> tuple)
                     return _reservedPtsCache;
                 else
                     return tuple.Item1;
@@ -1707,8 +1705,7 @@ namespace System.Windows.Threading
                     _reservedPtsCache = value;
                 else
                 {
-                    Tuple<Object, List<String>> tuple = _reservedPtsCache as Tuple<Object, List<String>>;
-                    List<String> list = (tuple != null) ? tuple.Item2 : new List<String>();
+                    List<String> list = (_reservedPtsCache is Tuple<Object, List<String>> tuple) ? tuple.Item2 : new List<String>();
                     _reservedPtsCache = new Tuple<Object, List<String>>(value, list);
                 }
             }
@@ -2488,8 +2485,7 @@ namespace System.Windows.Threading
             }
 
             // add a new entry to the failure log
-            Tuple<Object, List<String>> tuple = _reservedPtsCache as Tuple<Object, List<String>>;
-            if (tuple != null)
+            if (_reservedPtsCache is Tuple<Object, List<String>> tuple)
             {
                 List<String> list = tuple.Item2;
                 list.Add(String.Format(System.Globalization.CultureInfo.InvariantCulture,
@@ -2500,7 +2496,7 @@ namespace System.Windows.Threading
                 if (list.Count > 1000)
                 {
                     // keep the earliest and latest failures
-                    list.RemoveRange(100, list.Count-200);
+                    list.RemoveRange(100, list.Count - 200);
                     // acknowledge the gap
                     list.Insert(100, "... entries removed to conserve memory ...");
                 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManager.cs
@@ -641,8 +641,7 @@ namespace System.Windows
                 {
                     // 1% case - the target listens multiple times
                     // we store the delegates in a list
-                    List<Delegate> list = value as List<Delegate>;
-                    if (list == null)
+                    if (value is not List<Delegate> list)
                     {
                         // lazily allocate the list, and add the old handler
                         Delegate oldHandler = value as Delegate;
@@ -681,8 +680,7 @@ namespace System.Windows
                 // remove the handler from the CWT
                 if (_cwt.TryGetValue(target, out value))
                 {
-                    List<Delegate> list = value as List<Delegate>;
-                    if (list == null)
+                    if (value is not List<Delegate> list)
                     {
                         // 99% case - the target is removing its single handler
                         _cwt.Remove(target);
@@ -780,8 +778,7 @@ namespace System.Windows
                     else
                     {
                         // legacy (4.0)
-                        IWeakEventListener iwel = target as IWeakEventListener;
-                        if (iwel != null)
+                        if (target is IWeakEventListener iwel)
                         {
                             bool handled = iwel.ReceiveWeakEvent(managerType, sender, args);
 
@@ -834,9 +831,7 @@ namespace System.Windows
 
             protected void CopyTo(ListenerList newList)
             {
-                IWeakEventListener iwel;
-
-                for (int k=0, n=Count; k<n; ++k)
+                for (int k = 0, n = Count; k < n; ++k)
                 {
                     Listener listener = GetListener(k);
                     if (listener.Target != null)
@@ -849,7 +844,7 @@ namespace System.Windows
                                 newList.AddHandler(handler);
                             }
                         }
-                        else if ((iwel = listener.Target as IWeakEventListener) != null)
+                        else if (listener.Target is IWeakEventListener iwel)
                         {
                             newList.Add(iwel);
                         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManager.cs
@@ -258,7 +258,7 @@ namespace System.Windows
 
         private void AddListener(object source, IWeakEventListener listener, Delegate handler)
         {
-            object sourceKey = (source != null) ? source : StaticSource;
+            object sourceKey = source ?? StaticSource;
 
             using (Table.WriteLock)
             {
@@ -297,7 +297,7 @@ namespace System.Windows
 
         private void RemoveListener(object source, object target, Delegate handler)
         {
-            object sourceKey = (source != null) ? source : StaticSource;
+            object sourceKey = source ?? StaticSource;
 
             using (Table.WriteLock)
             {
@@ -338,7 +338,7 @@ namespace System.Windows
         protected void DeliverEvent(object sender, EventArgs args)
         {
             ListenerList list;
-            object sourceKey = (sender != null) ? sender : StaticSource;
+            object sourceKey = sender ?? StaticSource;
 
             // get the list of listeners
             using (Table.ReadLock)


### PR DESCRIPTION
## Description
This work is a part of our initiative to set code-style guidelines, align WPF and WinForms, and ensure PR standards with respect to styles. This in turn will help us in better maintainability and readability of the repo overall. The changes follow up from the PR #10080 and references to the issue #10017.

The current changes addresses the following Errors/Warnings in the src folder of WPF:
- **IDE0019:** Use pattern matching to avoid as followed by a null check
- **IDE0020:** Use pattern matching to avoid is check followed by a cast (with variable)
- **IDE0029:** Use coalesce expression

A good way to go about reviewing this is to go commit by commit which pans over individual errors/warnings, and hence easing out the overall understanding. 

## Customer Impact
_None_

## Regression
_None_

## Testing
Local Build Pass
Will be taken in the next test pass