### PR TITLE
Make system backdrop interfaces visible

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Appearance/WindowBackdropManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Appearance/WindowBackdropManager.cs
@@ -7,9 +7,9 @@ using HRESULT = Standard.HRESULT;
 // ReSharper disable once CheckNamespace
 namespace System.Windows.Appearance;
 
-internal static class WindowBackdropManager
+public static class WindowBackdropManager
 {
-    internal static bool IsSupported(WindowBackdropType backdropType)
+    public static bool IsSupported(WindowBackdropType backdropType)
     {
         return backdropType switch
         {
@@ -22,7 +22,7 @@ internal static class WindowBackdropManager
         };
     }
 
-    internal static bool SetBackdrop(Window window, WindowBackdropType backdropType)
+    public static bool SetBackdrop(Window window, WindowBackdropType backdropType)
     {
         if (window is null ||
                 !IsSupported(backdropType) ||
@@ -136,7 +136,7 @@ internal static class WindowBackdropManager
 
     #region Internal Properties
 
-    internal static bool IsBackdropEnabled => _isBackdropEnabled ??= Utility.IsWindows11_22H2OrNewer && 
+    public static bool IsBackdropEnabled => _isBackdropEnabled ??= Utility.IsWindows11_22H2OrNewer && 
                                                                         !FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop;
 
     private static bool? _isBackdropEnabled = null;


### PR DESCRIPTION
This commit changes the visibility for some functions, as this is crucial for WPF-based tabbed apps that aims to follow the Fluent Design guidelines.

Fixes [9496](https://github.com/dotnet/wpf/issues/9496)

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description
This commit changes the visibility for 2 methods, and a field in WindowBackdropManager.

## Customer Impact
Customers may change the backdrop without P/Invoking themselves. This is useful for tabbed apps, as
they can now switch over to Mica Alt without declaring any P/Invoke methods.

## Regression
On November 14th, .NET 9 released, with a brand new Fluent theme.

## Testing
Since WindowBackdropManager is known to be working, this fix doesn't need to be tested.

## Risk
I don't see any risks of exposing these APIs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10174)