### PR TITLE
[Cleanup] Use named arguments in WindowsBase

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
@@ -326,7 +326,7 @@ namespace MS.Internal.IO.Packaging
             #region Internal Constructors
 
             internal ValidatedPartUri(string partUriString)
-                : this(partUriString, false /*isNormalized*/, true /*computeIsRelationship*/, false /*dummy value as we will compute it later*/)
+                : this(partUriString, isNormalized: false, computeIsRelationship: true, false /*dummy value as we will compute it later*/)
             {               
             }
                        
@@ -335,7 +335,7 @@ namespace MS.Internal.IO.Packaging
             //This will optimize the code and we will not have to parse the Uri to find out
             //if it is a relationship part uri
             internal ValidatedPartUri(string partUriString, bool isRelationshipUri)
-                : this(partUriString, false /*isNormalized*/, false /*computeIsRelationship*/, isRelationshipUri)
+                : this(partUriString, isNormalized: false, computeIsRelationship: false, isRelationshipUri)
             {                
             }
 
@@ -539,8 +539,8 @@ namespace MS.Internal.IO.Packaging
                     return this;
                 else
                     return new ValidatedPartUri(_normalizedPartUriString, 
-                                                true /*isNormalized*/, 
-                                                false /*computeIsRelationship*/, 
+                                                isNormalized: true, 
+                                                computeIsRelationship: false, 
                                                 IsRelationshipPartUri);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
@@ -575,9 +575,9 @@ namespace MS.Internal.IO.Packaging
             //need to use the private constructor to initialize this particular partUri as we need this in the 
             //IsRelationshipPartUri, that is called from the constructor.
             private static readonly Uri   _containerRelationshipNormalizedPartUri = new ValidatedPartUri("/_RELS/.RELS", 
-                                                                                                         true /*isnormalized*/, 
-                                                                                                         false /*computeIsRelationship*/,
-                                                                                                         true /*IsRelationship*/);
+                                                                                                         isNormalized: true,
+                                                                                                         computeIsRelationship: false,
+                                                                                                         isRelationshipPartUri: true);
 
             private static ReadOnlySpan<char> ForwardSlashSeparator => ['/'];
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/SparseMemoryStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/SparseMemoryStream.cs
@@ -306,8 +306,8 @@ namespace MS.Internal.IO.Packaging
                     {
                         _isolatedStorageStream.Seek(0, SeekOrigin.Begin);
                         PackagingUtilities.CopyStream(_isolatedStorageStream, stream,
-                                                Int64.MaxValue/*bytes to copy*/,
-                                                0x80000 /*512K buffer size */);
+                                                bytesToCopy: Int64.MaxValue,
+                                                bufferSize: 0x80000 /* 512K */);
                     }
                  }
                 else
@@ -657,8 +657,8 @@ namespace MS.Internal.IO.Packaging
                             _isolatedStorageStream.Seek(0, SeekOrigin.Begin);
                             newMemStreamBlock.Stream.Seek(0, SeekOrigin.Begin);
                             PackagingUtilities.CopyStream(_isolatedStorageStream, newMemStreamBlock.Stream,
-                                                    Int64.MaxValue/*bytes to copy*/,
-                                                    0x80000 /*512K buffer size */);
+                                                    bytesToCopy: Int64.MaxValue,
+                                                    bufferSize: 0x80000 /* 512K */);
                         }
 
                         Debug.Assert(newMemStreamBlock.Stream.Length > 0);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlDigitalSignatureProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlDigitalSignatureProcessor.cs
@@ -94,7 +94,7 @@ namespace MS.Internal.IO.Packaging
 
             // Validate the Reference tags in the SignedInfo as per the 
             // restrictions imposed by the OPC spec
-            ValidateReferences(xmlSig.SignedInfo.References, true /*allowPackageSpecificReference*/);
+            ValidateReferences(xmlSig.SignedInfo.References, allowPackageSpecificReferences: true);
 
             // verify "standard" XmlSignature portions
             result = xmlSig.CheckSignature(signer, true);
@@ -498,8 +498,8 @@ namespace MS.Internal.IO.Packaging
 
                 // generate a valid Relationship tag according to the Opc schema
                 InternalRelationshipCollection.WriteRelationshipsAsXml(writer, relationships,
-                        true,  /* systematically write target mode */
-                        false  /* not in streaming production */
+                        alwaysWriteTargetModeAttribute: true,
+                        inStreamingProduction: false
                         );
 
                 // end of Relationships tag
@@ -901,7 +901,7 @@ namespace MS.Internal.IO.Packaging
             {
                 // Validate the Reference tags in the SignedInfo as per the 
                 // restrictions imposed by the OPC spec
-                ValidateReferences(objectReferences, false /*allowPackageSpecificReference*/);
+                ValidateReferences(objectReferences, allowPackageSpecificReferences: false);
 
                 foreach (Reference reference in objectReferences)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyChangedEventManager.cs
@@ -381,7 +381,7 @@ namespace System.ComponentModel
                 if (dict == null)
                 {
                     // no entry in the hashtable - add a new one
-                    dict = new HybridDictionary(true /* case insensitive */);
+                    dict = new HybridDictionary(caseInsensitive: true);
 
                     this[source] = dict;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/DataSpaceManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/DataSpaceManager.cs
@@ -39,9 +39,9 @@ namespace System.IO.Packaging
     private static readonly string DataSpaceVersionIdentifier = "Microsoft.Container.DataSpaces";
 
     // Version Writer - 1.0, Reader - 1.0, Updater - 1.0
-    private static readonly VersionPair DataSpaceCurrentWriterVersion  = new VersionPair(1 /*major*/, 0 /*minor*/);
-    private static readonly VersionPair DataSpaceCurrentReaderVersion  = new VersionPair(1 /*major*/, 0 /*minor*/);
-    private static readonly VersionPair DataSpaceCurrentUpdaterVersion = new VersionPair(1 /*major*/, 0 /*minor*/);
+    private static readonly VersionPair DataSpaceCurrentWriterVersion  = new VersionPair(major: 1, minor: 0);
+    private static readonly VersionPair DataSpaceCurrentReaderVersion  = new VersionPair(major: 1, minor: 0);
+    private static readonly VersionPair DataSpaceCurrentUpdaterVersion = new VersionPair(major: 1, minor: 0);
 
     // The version information we read from the file
     private FormatVersion _fileFormatVersion;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/DataSpaceManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/DataSpaceManager.cs
@@ -807,7 +807,7 @@ namespace System.IO.Packaging
                 targetInstance.transformPrimaryStream =
                     new DirtyStateTrackingStream (new MemoryStream
                             (Array.Empty<byte>(), 
-                            false /* Not writable */));
+                            writable: false));
             }
             else
             {
@@ -1353,7 +1353,7 @@ namespace System.IO.Packaging
                                 //  NOTE: Building MemoryStream directly on top of
                                 //  instanceData byte array because we want it to be
                                 //  NOT resizable and NOT writable.                    
-                                instanceDataStream = new MemoryStream(instanceData, false /* Not writable */);
+                                instanceDataStream = new MemoryStream(instanceData, writable: false);
                             }
                             else
                             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/EncryptedPackage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/EncryptedPackage.cs
@@ -1126,8 +1126,8 @@ namespace System.IO.Packaging
                 //copy the stream
 
                 PackagingUtilities.CopyStream(packageStream, _packageStream,
-                                                Int64.MaxValue, /*bytes to copy*/
-                                                4096 /*buffer size */);
+                                                bytesToCopy: Int64.MaxValue,
+                                                bufferSize: 4096);
                 _package = Package.Open(_packageStream, FileMode.Open, this.FileOpenAccess);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
@@ -1089,7 +1089,7 @@ namespace System.Windows
                     entryIndex,
                     dp,
                     metadata,
-                    new EffectiveValueEntry() /* oldEntry */,
+                    oldEntry: new EffectiveValueEntry(),
                     ref newEntry,
                     coerceWithDeferredReference: false,
                     coerceWithCurrentValue: false,
@@ -1186,7 +1186,7 @@ namespace System.Windows
                     LookupEntry(dp.GlobalIndex),
                     dp,
                     dp.GetMetadata(DependencyObjectType),
-                    new EffectiveValueEntry() /* oldEntry */,
+                    oldEntry: new EffectiveValueEntry(),
                     ref newEntry,
                     coerceWithDeferredReference: false,
                     coerceWithCurrentValue: false,
@@ -3049,7 +3049,7 @@ namespace System.Windows
 
             if (iHi <= 0)
             {
-                return new EntryIndex(0, false /* Found */);
+                return new EntryIndex(0, found: false);
             }
 
             // Do a binary search to find the value
@@ -3091,7 +3091,7 @@ namespace System.Windows
             }
             while (iLo < iHi);
 
-            return new EntryIndex(iLo, false /* Found */);
+            return new EntryIndex(iLo, found: false);
         }
 
         // insert the given entry at the given index

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
@@ -388,7 +388,7 @@ namespace System.Windows
                 }
                 else
                 {
-                    entry.SetCoercedValue(value, null, true /* skipBaseValueChecks */, entry.IsCoercedWithCurrentValue);
+                    entry.SetCoercedValue(value, null, skipBaseValueChecks: true, entry.IsCoercedWithCurrentValue);
                 }
 
                 _effectiveValues[entryIndex.Index] = entry;
@@ -414,7 +414,7 @@ namespace System.Windows
             PropertyMetadata metadata = SetupPropertyChange(dp);
 
             // Do standard property set
-            SetValueCommon(dp, value, metadata, false /* coerceWithDeferredReference */, false /* coerceWithCurrentValue */, OperationType.Unknown, false /* isInternal */);
+            SetValueCommon(dp, value, metadata, coerceWithDeferredReference: false, coerceWithCurrentValue: false, OperationType.Unknown, isInternal: false);
         }
 
         /// <summary>
@@ -440,7 +440,7 @@ namespace System.Windows
             PropertyMetadata metadata = SetupPropertyChange(dp);
 
             // Do standard property set
-            SetValueCommon(dp, value, metadata, false /* coerceWithDeferredReference */, true /* coerceWithCurrentValue */, OperationType.Unknown, false /* isInternal */);
+            SetValueCommon(dp, value, metadata, coerceWithDeferredReference: false, coerceWithCurrentValue: true, OperationType.Unknown, isInternal: false);
         }
 
         /// <summary>
@@ -482,7 +482,7 @@ namespace System.Windows
             PropertyMetadata metadata = SetupPropertyChange(dp);
 
             // Do standard property set
-            SetValueCommon(dp, value, metadata, false /* coerceWithDeferredReference */, false /* coerceWithCurrentValue */, OperationType.Unknown, true /* isInternal */);
+            SetValueCommon(dp, value, metadata, coerceWithDeferredReference: false, coerceWithCurrentValue: false, OperationType.Unknown, isInternal: true);
         }
 
         /// <summary>
@@ -502,7 +502,7 @@ namespace System.Windows
             PropertyMetadata metadata = SetupPropertyChange(dp);
 
             // Do standard property set
-            SetValueCommon(dp, value, metadata, false /* coerceWithDeferredReference */, true /* coerceWithCurrentValue */, OperationType.Unknown, true /* isInternal */);
+            SetValueCommon(dp, value, metadata, coerceWithDeferredReference: false, coerceWithCurrentValue: true, OperationType.Unknown, isInternal: true);
         }
 
         /// <summary>
@@ -514,7 +514,7 @@ namespace System.Windows
             PropertyMetadata metadata = SetupPropertyChange(dp);
 
             // Do standard property set
-            SetValueCommon(dp, deferredReference, metadata, true /* coerceWithDeferredReference */, false /* coerceWithCurrentValue */, OperationType.Unknown, false /* isInternal */);
+            SetValueCommon(dp, deferredReference, metadata, coerceWithDeferredReference: true, coerceWithCurrentValue: false, OperationType.Unknown, isInternal: false);
         }
 
         /// <summary>
@@ -526,7 +526,7 @@ namespace System.Windows
             PropertyMetadata metadata = SetupPropertyChange(dp);
 
             // Do standard property set
-            SetValueCommon(dp, deferredReference, metadata, true /* coerceWithDeferredReference */, true /* coerceWithCurrentValue */, OperationType.Unknown, false /* isInternal */);
+            SetValueCommon(dp, deferredReference, metadata, coerceWithDeferredReference: true, coerceWithCurrentValue: true, OperationType.Unknown, isInternal: false);
         }
 
         /// <summary>
@@ -538,7 +538,7 @@ namespace System.Windows
             PropertyMetadata metadata = SetupPropertyChange(dp);
 
             // Do standard property set
-            SetValueCommon(dp, value, metadata, false /* coerceWithDeferredReference */, false /* coerceWithCurrentValue */, OperationType.ChangeMutableDefaultValue, false /* isInternal */);
+            SetValueCommon(dp, value, metadata, coerceWithDeferredReference: false, coerceWithCurrentValue: false, OperationType.ChangeMutableDefaultValue, isInternal: false);
         }
 
         /// <summary>
@@ -568,7 +568,7 @@ namespace System.Windows
             PropertyMetadata metadata = SetupPropertyChange(key, out dp);
 
             // Do standard property set
-            SetValueCommon(dp, value, metadata, false /* coerceWithDeferredReference */, false /* coerceWithCurrentValue */, OperationType.Unknown, false /* isInternal */);
+            SetValueCommon(dp, value, metadata, coerceWithDeferredReference: false, coerceWithCurrentValue: false, OperationType.Unknown, isInternal: false);
         }
 
         /// <summary>
@@ -998,8 +998,8 @@ namespace System.Windows
                     metadata,
                     oldEntry,
                     ref newEntry,
-                    false /* coerceWithDeferredReference */,
-                    false /* coerceWithCurrentValue */,
+                    coerceWithDeferredReference: false,
+                    coerceWithCurrentValue: false,
                     OperationType.Unknown);
         }
 
@@ -1091,8 +1091,8 @@ namespace System.Windows
                     metadata,
                     new EffectiveValueEntry() /* oldEntry */,
                     ref newEntry,
-                    false /* coerceWithDeferredReference */,
-                    false /* coerceWithCurrentValue */,
+                    coerceWithDeferredReference: false,
+                    coerceWithCurrentValue: false,
                     OperationType.Unknown);
         }
 
@@ -1188,8 +1188,8 @@ namespace System.Windows
                     dp.GetMetadata(DependencyObjectType),
                     new EffectiveValueEntry() /* oldEntry */,
                     ref newEntry,
-                    false /* coerceWithDeferredReference */,
-                    false /* coerceWithCurrentValue */,
+                    coerceWithDeferredReference: false,
+                    coerceWithCurrentValue: false,
                     OperationType.Unknown);
         }
 
@@ -1389,10 +1389,10 @@ namespace System.Windows
                     ref oldValue,
                     baseValue,
                     controlValue,
-                    null /*coerceValueCallback */,
+                    coerceValueCallback: null,
                     coerceWithDeferredReference,
                     coerceWithCurrentValue,
-                    false /*skipBaseValueChecks*/);
+                    skipBaseValueChecks: false);
 
                 // Make sure that the call out did not cause a change to entryIndex
                 entryIndex = CheckEntryIndex(entryIndex, targetIndex);
@@ -1414,11 +1414,11 @@ namespace System.Windows
                     ref oldEntry,
                     ref oldValue,
                     baseValue,
-                    null /* controlValue */,
+                    controlValue: null,
                     metadata.CoerceValueCallback,
                     coerceWithDeferredReference,
-                    false /* coerceWithCurrentValue */,
-                    false /*skipBaseValueChecks*/);
+                    coerceWithCurrentValue: false,
+                    skipBaseValueChecks: false);
 
                 // Make sure that the call out did not cause a change to entryIndex
                 entryIndex = CheckEntryIndex(entryIndex, targetIndex);
@@ -1448,11 +1448,11 @@ namespace System.Windows
                     ref oldEntry,
                     ref oldValue,
                     newEntry.GetFlattenedEntry(RequestFlags.FullyResolved).Value,
-                    null /*controlValue*/,
+                    controlValue: null,
                     dp.DesignerCoerceValueCallback,
-                    false /*coerceWithDeferredReference*/,
-                    false /*coerceWithCurrentValue*/,
-                    true /*skipBaseValueChecks*/);
+                    coerceWithDeferredReference: false,
+                    coerceWithCurrentValue: false,
+                    skipBaseValueChecks: true);
 
                 // Make sure that the call out did not cause a change to entryIndex
                 entryIndex = CheckEntryIndex(entryIndex, targetIndex);
@@ -2134,7 +2134,7 @@ namespace System.Windows
             EntryIndex entryIndex = LookupEntry(dp.GlobalIndex);
 
             // Call Forwarded
-            return ReadLocalValueEntry(entryIndex, dp, false /* allowDeferredReferences */);
+            return ReadLocalValueEntry(entryIndex, dp, allowDeferredReferences: false);
         }
 
         /// <summary>
@@ -2197,7 +2197,7 @@ namespace System.Windows
                 DependencyProperty dp = DependencyProperty.RegisteredPropertyList.List[_effectiveValues[i].PropertyIndex];
                 if (dp != null)
                 {
-                    object localValue = ReadLocalValueEntry(new EntryIndex(i), dp, false /* allowDeferredReferences */);
+                    object localValue = ReadLocalValueEntry(new EntryIndex(i), dp, allowDeferredReferences: false);
                     if (localValue != DependencyProperty.UnsetValue)
                     {
                         snapshot[count++] = new LocalValueEntry(dp, localValue);
@@ -2623,7 +2623,7 @@ namespace System.Windows
                     DependencyProperty dp = DependencyProperty.RegisteredPropertyList.List[_effectiveValues[i].PropertyIndex];
                     if (dp != null)
                     {
-                        object localValue = ReadLocalValueEntry(new EntryIndex(i), dp, true /* allowDeferredReferences */);
+                        object localValue = ReadLocalValueEntry(new EntryIndex(i), dp, allowDeferredReferences: true);
                         if (localValue != DependencyProperty.UnsetValue)
                         {
                             DependencyObject inheritanceChild = localValue as DependencyObject;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
@@ -367,7 +367,7 @@ namespace System.Windows
             }
 
             ValidateDefaultValueCommon(defaultMetadata.DefaultValue, propertyType,
-                propertyName, validateValueCallback, /*checkThreadAffinity = */ true);
+                propertyName, validateValueCallback, checkThreadAffinity: true);
         }
 
         // Validate the given default value, used by PropertyMetadata.GetDefaultValue()

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Freezable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Freezable.cs
@@ -68,7 +68,7 @@ namespace System.Windows
             Freezable clone = CreateInstance();
 
             clone.CloneCore(this);
-            Debug_VerifyCloneCommon(/* original = */ this, /* clone = */ clone, /* isDeepClone = */ true);
+            Debug_VerifyCloneCommon(original: this, clone: clone, isDeepClone: true);
 
             return clone;
         }
@@ -93,7 +93,7 @@ namespace System.Windows
             // Freezable implementers who override CloneCurrentValueCore must ensure that
             // on creation the copy is not frozen.  Debug_VerifyCloneCommon checks for this,
             // among other things.
-            Debug_VerifyCloneCommon(/* original = */ this, /* clone = */ clone, /* isDeepClone = */ true);
+            Debug_VerifyCloneCommon(original: this, clone: clone, isDeepClone: true);
 
             return clone;
         }
@@ -115,7 +115,7 @@ namespace System.Windows
             Freezable clone = CreateInstance();
 
             clone.GetAsFrozenCore(this);
-            Debug_VerifyCloneCommon(/* original = */ this, /* clone = */ clone, /* isDeepClone = */ false);
+            Debug_VerifyCloneCommon(original: this, clone: clone, isDeepClone: false);
 
             clone.Freeze();
 
@@ -140,7 +140,7 @@ namespace System.Windows
             Freezable clone = CreateInstance();
 
             clone.GetCurrentValueAsFrozenCore(this);
-            Debug_VerifyCloneCommon(/* original = */ this, /* clone = */ clone, /* isDeepClone = */ false);
+            Debug_VerifyCloneCommon(original: this, clone: clone, isDeepClone: false);
 
             clone.Freeze();
 
@@ -154,7 +154,7 @@ namespace System.Windows
         {
             get
             {
-                return IsFrozenInternal || FreezeCore(/* isChecking = */ true);
+                return IsFrozenInternal || FreezeCore(isChecking: true);
             }
         }
 
@@ -173,7 +173,7 @@ namespace System.Windows
                 throw new InvalidOperationException(SR.Freezable_CantFreeze);
             }
 
-            Freeze(/* isChecking = */ false);
+            Freeze(isChecking: false);
         }
 
         #endregion
@@ -348,8 +348,8 @@ namespace System.Windows
         protected virtual void CloneCore(Freezable sourceFreezable)
         {
             CloneCoreCommon(sourceFreezable,
-                /* useCurrentValue = */ false,
-                /* cloneFrozenValues = */ true);
+                useCurrentValue: false,
+                cloneFrozenValues: true);
         }
 
         /// <summary>
@@ -370,8 +370,8 @@ namespace System.Windows
         protected virtual void CloneCurrentValueCore(Freezable sourceFreezable)
         {
             CloneCoreCommon(sourceFreezable,
-                /* useCurrentValue = */ true,
-                /* cloneFrozenValues = */ true);
+                useCurrentValue: true,
+                cloneFrozenValues: true);
         }
 
         /// <summary>
@@ -396,8 +396,8 @@ namespace System.Windows
         protected virtual void GetAsFrozenCore(Freezable sourceFreezable)
         {
             CloneCoreCommon(sourceFreezable,
-                /* useCurrentValue = */ false,
-                /* cloneFrozenValues = */ false);
+                useCurrentValue: false,
+                cloneFrozenValues: false);
         }
 
         /// <summary>
@@ -421,8 +421,8 @@ namespace System.Windows
         protected virtual void GetCurrentValueAsFrozenCore(Freezable sourceFreezable)
         {
             CloneCoreCommon(sourceFreezable,
-                /* useCurrentValue = */ true,
-                /* cloneFrozenValues = */ false);
+                useCurrentValue: true,
+                cloneFrozenValues: false);
         }
 
         /// <summary>
@@ -926,7 +926,7 @@ namespace System.Windows
                         // If the local value has modifiers, ReadLocalValue will return the base
                         // value, which is what we want.  A modified default will return UnsetValue,
                         // which will be ignored at the call to SetValue
-                        sourceValue = sourceFreezable.ReadLocalValueEntry(entryIndex, dp, true /* allowDeferredReferences */);
+                        sourceValue = sourceFreezable.ReadLocalValueEntry(entryIndex, dp, allowDeferredReferences: true);
 
                         // For the useCurrentValue = false case we ignore any UnsetValues.
                         if (sourceValue == DependencyProperty.UnsetValue)
@@ -979,7 +979,7 @@ namespace System.Windows
                             }
 
                             sourceValue = valueAsFreezableClone;
-                            Debug_VerifyCloneCommon(valueAsFreezable, valueAsFreezableClone, /*isDeepClone=*/ true);
+                            Debug_VerifyCloneCommon(valueAsFreezable, valueAsFreezableClone, isDeepClone: true);
                         }
                         else // skip cloning frozen values
                         {
@@ -1001,7 +1001,7 @@ namespace System.Windows
                                 }
 
                                 sourceValue = valueAsFreezableClone;
-                                Debug_VerifyCloneCommon(valueAsFreezable, valueAsFreezableClone, /*isDeepClone=*/ false);
+                                Debug_VerifyCloneCommon(valueAsFreezable, valueAsFreezableClone, isDeepClone: false);
                             }
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Markup/Primitives/MarkupObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Markup/Primitives/MarkupObject.cs
@@ -42,7 +42,7 @@ namespace System.Windows.Markup.Primitives
         /// If the MarkupItem is in a dictionary, one of the properties of the item will have an IsKey set to true. 
         /// This is the value for the dictionary key.
         /// </summary>
-        public virtual IEnumerable<MarkupProperty> Properties { get { return GetProperties(true /*mapToConstructorArgs*/); } }
+        public virtual IEnumerable<MarkupProperty> Properties { get { return GetProperties(mapToConstructorArgs: true); } }
         internal abstract IEnumerable<MarkupProperty> GetProperties(bool mapToConstructorArgs);
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Matrix.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Matrix.cs
@@ -755,7 +755,7 @@ namespace System.Windows.Media
         /// <param name='angle'>The angle to rotate specified in radians</param>
         internal static Matrix CreateRotationRadians(double angle)
         {
-            return CreateRotationRadians(angle, /* centerX = */ 0, /* centerY = */ 0);
+            return CreateRotationRadians(angle, centerX: 0, centerY: 0);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
@@ -109,7 +109,7 @@ namespace System.Windows
 
             EntryIndex entryIndex = instance.LookupEntry(_globalIndex);
 
-            instance.UnsetEffectiveValue(entryIndex, null /* dp */, null /* metadata */);
+            instance.UnsetEffectiveValue(entryIndex, dp: null, metadata: null);
         }
 
         internal int GlobalIndex


### PR DESCRIPTION
Contributes to dotnet/wpf#10018

## Description
I replaced comments specifying an argument name with named arguments, which were introduced in C# 7. This improves readability and maintainability.

My changes are in 2 commits the first commit is automated changes using regexes and the second commit is manual changes where the comment is outdated or formatted differently than the parameter name.

**Note: The compiled IL is identical.**

## Customer Impact
None.

## Regression
No.

## Testing
Local build + validated IL.

## Risk
Low to none.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10215)