### PR TITLE
Remove obsolete PreSharp warning suppressions

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,8 +9,6 @@
 //   binary stream (Baml) and\or code (IL) in an assembly.
 //
 //---------------------------------------------------------------------------
-
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Xml;
@@ -489,7 +487,6 @@ namespace MS.Internal
             }
             // All exceptions including NullRef & SEH need to be caught by the markupcompiler
             // since it is an app and not a component.
-            #pragma warning suppress 6500
             catch (Exception e)
             {
                 OnError(e);
@@ -543,7 +540,6 @@ namespace MS.Internal
             }
             // All exceptions including NullRef & SEH need to be caught by the markupcompiler
             // since it is an app and not a component.
-#pragma warning suppress 6500
             catch (Exception e)
             {
                 OnError(e);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/PathInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/PathInternal.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -12,8 +12,6 @@
 //   current platform (StringComparison.OrdinalIgnoreCase for Windows.)
 //
 //---------------------------------------------------------------------------
-
-#pragma warning disable 1634, 1691
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/FileClassifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/FileClassifier.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -21,10 +21,6 @@ using Microsoft.Build.Utilities;
 
 using MS.Utility;
 using MS.Internal.Tasks;
-
-// Since we disable PreSharp warnings in this file, PreSharp warning is unknown to C# compiler.
-// We first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace Microsoft.Build.Tasks.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/FileClassifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/FileClassifier.cs
@@ -98,7 +98,6 @@ namespace Microsoft.Build.Tasks.Windows
             }
             catch (Exception e)
             {
-                // PreSharp Complaint 6500 - do not handle null-ref or SEH exceptions.
                 if (e is NullReferenceException || e is SEHException)
                 {
                     throw;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/FileClassifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/FileClassifier.cs
@@ -121,14 +121,11 @@ namespace Microsoft.Build.Tasks.Windows
 
                 return false;
             }
-#pragma warning disable 6500
             catch // Non-CLS compliant errors
             {
                 Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
                 return false;
             }
-#pragma warning restore 6500
-
 
             return ret;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -28,10 +28,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 using MS.Utility;
-
-// Since we disable PreSharp warnings in this file, PreSharp warning is unknown to C# compiler.
-// We first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace Microsoft.Build.Tasks.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -22,10 +22,6 @@ using Microsoft.Build.Utilities;
 using MS.Utility;
 using MS.Internal;
 using MS.Internal.Tasks;
-
-// Since we disable PreSharp warnings in this file, PreSharp warning is unknown to C# compiler.
-// We first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace Microsoft.Build.Tasks.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
@@ -175,7 +175,6 @@ namespace Microsoft.Build.Tasks.Windows
                 }
 
             }
-#pragma warning disable 6500
             catch (Exception e)
             {
                 string message;
@@ -198,7 +197,6 @@ namespace Microsoft.Build.Tasks.Windows
                 Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
                 _nErrors++;
             }
-#pragma warning restore 6500
 
             if (_nErrors > 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass2.cs
@@ -129,7 +129,6 @@ namespace Microsoft.Build.Tasks.Windows
                     Log.LogMessageFromResources(MessageImportance.Low, nameof(SR.CompilationDone));
                 }
             }
-#pragma warning disable 6500
             catch (Exception e)
             {
                 string message;
@@ -154,7 +153,6 @@ namespace Microsoft.Build.Tasks.Windows
 
                 _nErrors++;
             }
-#pragma warning restore 6500
 
             if (_nErrors > 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass2.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -22,10 +22,6 @@ using Microsoft.Build.Utilities;
 using MS.Utility;
 using MS.Internal;
 using MS.Internal.Tasks;
-
-// Since we disable PreSharp warnings in this file, PreSharp warning is unknown to C# compiler.
-// We first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace Microsoft.Build.Tasks.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MergeLocalizationDirectives.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MergeLocalizationDirectives.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,7 +7,6 @@
 // Description: The task that merges all the localization directives files
 //
 //---------------------------------------------------------------------------
-
 
 using System;
 using System.IO;
@@ -20,10 +19,6 @@ using Microsoft.Build.Utilities;
 using MS.Internal.Globalization;
 using MS.Internal.Tasks;
 using MS.Utility;                   // For SR
-
-// Since we disable PreSharp warnings in this file, we first need to disable warnings
-// about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace Microsoft.Build.Tasks.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MergeLocalizationDirectives.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MergeLocalizationDirectives.cs
@@ -97,13 +97,11 @@ namespace Microsoft.Build.Tasks.Windows
                         return false;
                     }
                 }
-#pragma warning disable 6500
                 catch // Non-CLS compliant errors
                 {
                     Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
                     return false;
                 }
-#pragma warning restore 6500
             }
 
             return true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MergeLocalizationDirectives.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MergeLocalizationDirectives.cs
@@ -86,7 +86,6 @@ namespace Microsoft.Build.Tasks.Windows
                 }
                 catch (Exception e)
                 {
-                    // PreSharp Complaint 6500 - do not handle null-ref or SEH exceptions.
                     if (e is NullReferenceException || e is SEHException)
                     {
                         throw;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
@@ -217,13 +217,11 @@ namespace Microsoft.Build.Tasks.Windows
                     return false;
                 }
             }
-#pragma warning disable 6500
             catch   // Non-cls compliant errors
             {
                 Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
                 return false;
             }
-#pragma warning restore 6500
 
             return true;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
@@ -197,7 +197,6 @@ namespace Microsoft.Build.Tasks.Windows
             }
             catch (Exception e)
             {
-                // PreSharp Complaint 6500 - do not handle null-ref or SEH exceptions.
                 if (e is NullReferenceException || e is SEHException)
                 {
                     throw;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
@@ -21,10 +21,6 @@ using MS.Utility;
 using MS.Internal;
 using MS.Internal.Tasks;
 
-// Since we disable PreSharp warnings in this file, PreSharp warning is unknown to C# compiler.
-// We first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 namespace Microsoft.Build.Tasks.Windows
 {
     public sealed class ResourcesGenerator : Task

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -116,13 +116,11 @@ namespace Microsoft.Build.Tasks.Windows
                     allFilesOk = false;
                 }
             }
-#pragma warning disable 6500
             catch // Non-CLS compliant errors
             {
                 Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
                 allFilesOk = false;
             }
-#pragma warning restore 6500
 
             return allFilesOk;
         }
@@ -405,13 +403,11 @@ namespace Microsoft.Build.Tasks.Windows
                     return false;
                 }
             }
-#pragma warning disable 6500
             catch   // Non-cls compliant errors
             {
                 Log.LogErrorWithCodeFromResources(nameof(SR.IntermediateDirectoryError), _backupPath);
                 return false;
             }
-#pragma warning restore 6500
         }
 
 
@@ -859,8 +855,6 @@ namespace Microsoft.Build.Tasks.Windows
             {
                 string suffix = uid.Substring(separatorIndex + 1);
 
-                // Disable Presharp warning 6502 : catch block shouldn't have empty body
-                #pragma warning disable 6502
                 try {
                     index  = Int64.Parse(suffix, TypeConverterHelper.InvariantEnglishUS);
                     prefix = uid.Substring(0, separatorIndex);
@@ -873,7 +867,6 @@ namespace Microsoft.Build.Tasks.Windows
                 {
                     // not acceptable uid
                 }
-                #pragma warning restore 6502
             }
         }
 
@@ -895,8 +888,6 @@ namespace Microsoft.Build.Tasks.Windows
             Int64 ext = 1;
             string prefix = UidNamespaceAbbreviation.ToString(TypeConverterHelper.InvariantEnglishUS);
 
-            // Disable Presharp warning 6502 : catch block shouldn't have empty body
-            #pragma warning disable 6502
             try
             {
                 // find a prefix that is not used in the Xaml
@@ -911,7 +902,6 @@ namespace Microsoft.Build.Tasks.Windows
             catch (OverflowException)
             {
             }
-            #pragma warning restore 6502
 
             // if overflows, (extreamly imposible), we will return a guid as the prefix
             return Guid.NewGuid().ToString();
@@ -1004,12 +994,10 @@ namespace Microsoft.Build.Tasks.Windows
 
                 return false;
             }
-#pragma warning disable 6500
             catch
             {
                 return false;
             }
-#pragma warning restore 6500
         }
 
         // writing to the target stream removing uids
@@ -1038,7 +1026,6 @@ namespace Microsoft.Build.Tasks.Windows
             }
             catch (Exception e)
             {
-                // PreSharp Complaint 6500 - do not handle null-ref or SEH exceptions.
                 if (e is NullReferenceException || e is SEHException)
                 {
                     throw;
@@ -1046,12 +1033,10 @@ namespace Microsoft.Build.Tasks.Windows
 
                 return false;
             }
-#pragma warning disable 6500
             catch
             {
                 return false;
             }
-#pragma warning restore 6500
         }
 
         private void WriteTillSourcePosition(int lineNumber, int linePosition)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,7 +10,6 @@
 //     on all XAML elements in XAML files.
 //
 //---------------------------------------------------------------------------
-
 
 using System;
 using System.Xml;
@@ -28,9 +27,6 @@ using Microsoft.Build.Utilities;
 
 using MS.Utility;                   // For SR
 using MS.Internal.Tasks;
-
-// Since we disable PreSharp warnings in this file, we first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace Microsoft.Build.Tasks.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -93,7 +93,6 @@ namespace Microsoft.Build.Tasks.Windows
             }
             catch (Exception e)
             {
-                // PreSharp Complaint 6500 - do not handle null-ref or SEH exceptions.
                 if (e is NullReferenceException || e is SEHException)
                 {
                     throw;
@@ -392,7 +391,6 @@ namespace Microsoft.Build.Tasks.Windows
             }
             catch (Exception e)
             {
-                // PreSharp Complaint 6500 - do not handle null-ref or SEH exceptions.
                 if (e is NullReferenceException || e is SEHException)
                 {
                     throw;
@@ -986,7 +984,6 @@ namespace Microsoft.Build.Tasks.Windows
             }
             catch (Exception e)
             {
-                // PreSharp Complaint 6500 - do not handle null-ref or SEH exceptions.
                 if (e is NullReferenceException || e is SEHException)
                 {
                     throw;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UpdateManifestForBrowserApplication.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UpdateManifestForBrowserApplication.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -16,11 +16,6 @@ using System.Xml;
 
 using MS.Utility;
 using MS.Internal.Tasks;
-
-// Since we disable PreSharp warnings in this file, PreSharp warning is unknown to C# compiler.
-// We first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 
 namespace Microsoft.Build.Tasks.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UpdateManifestForBrowserApplication.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UpdateManifestForBrowserApplication.cs
@@ -131,7 +131,6 @@ namespace Microsoft.Build.Tasks.Windows
             }
             catch (Exception e)
             {
-                // PreSharp Complaint 6500 - do not handle null-ref or SEH exceptions.
                 if (e is NullReferenceException || e is SEHException)
                 {
                     throw;
@@ -142,14 +141,11 @@ namespace Microsoft.Build.Tasks.Windows
                     successful = false;
                 }
             }
-#pragma warning disable 6500
             catch   // Non-cls compliant errors
             {
                 Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
                 successful = false;
             }
-#pragma warning restore 6500
-
 
             return successful;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FamilyCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FamilyCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -19,9 +19,6 @@ using System.Windows.Media;
 using MS.Win32;
 using MS.Internal.FontFace;
 using MS.Internal.Shaping;
-
-// Since we disable PreSharp warnings in this file, we first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal.FontCache
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontCacheUtil.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontCacheUtil.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -19,9 +19,6 @@ using MS.Win32;
 using MS.Internal.PresentationCore;
 
 using Microsoft.Win32.SafeHandles;
-
-// Since we disable PreSharp warnings in this file, we first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal.FontCache
 {
@@ -817,12 +814,6 @@ namespace MS.Internal.FontCache
             {
                 unsafe
                 {
-                    // Disable PREsharp warning about not calling Marshal.GetLastWin32Error,
-                    // because we already check the handle for invalid value and
-                    // we are not particularly interested in specific Win32 error.
-
-#pragma warning disable 6523
-
                     long size;
 
                     using (SafeFileHandle fileHandle = UnsafeNativeMethods.CreateFile(
@@ -863,8 +854,6 @@ namespace MS.Internal.FontCache
                     _viewHandle = UnsafeNativeMethods.MapViewOfFileEx(_mappingHandle, UnsafeNativeMethods.FILE_MAP_READ, 0, 0, IntPtr.Zero, IntPtr.Zero);
                     if (_viewHandle.IsInvalid)
                         throw new IOException(SR.Format(SR.IOExceptionWithFileName, fileName));
-
-#pragma warning restore 6523
 
                     Initialize((byte*)_viewHandle.Memory, size, size, FileAccess.Read);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontFace/FontDriver.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontFace/FontDriver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,10 +6,6 @@ using System.IO;
 using System.Runtime.InteropServices;
 using MS.Internal.PresentationCore;
 using MS.Internal.FontCache;
-
-// Since we disable PreSharp warnings in this file, we first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 
 namespace MS.Internal.FontFace
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/GestureRecognizer/NativeRecognizer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/GestureRecognizer/NativeRecognizer.cs
@@ -14,8 +14,6 @@ using System.Windows.Media;
 using System.Windows.Ink;
 using System.Windows.Input;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace MS.Internal.Ink.GestureRecognition
 {
     /// <summary>
@@ -634,7 +632,6 @@ namespace MS.Internal.Ink.GestureRecognition
                 {
                     if (pRecoAlternates[i] != IntPtr.Zero)
                     {
-                        #pragma warning suppress 6031, 56031 // Return value ignored on purpose.
                         MS.Win32.Recognizer.UnsafeNativeMethods.DestroyAlternate(pRecoAlternates[i]);
                         pRecoAlternates[i] = IntPtr.Zero;
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/CustomAttributeSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/CustomAttributeSerializer.cs
@@ -78,7 +78,6 @@ namespace MS.Internal.Ink.InkSerializedFormat
             // Presharp gives a warning when local IDisposable variables are not closed
             // in this case, we can't call Dispose since it will also close the underlying stream
             // which still needs to be written to
-#pragma warning disable 6518
             BinaryWriter bw = new BinaryWriter(stream);
 
             // if this guid used the legacy internal attribute persistence APIs,
@@ -294,8 +293,6 @@ namespace MS.Internal.Ink.InkSerializedFormat
                     throw new InvalidOperationException(SR.InvalidEpInIsf);
                 }
             }
-#pragma warning restore 6518
-#pragma warning restore 1634, 1691
         }
 #if OLD_ISF
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/CustomAttributeSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/CustomAttributeSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -78,7 +78,6 @@ namespace MS.Internal.Ink.InkSerializedFormat
             // Presharp gives a warning when local IDisposable variables are not closed
             // in this case, we can't call Dispose since it will also close the underlying stream
             // which still needs to be written to
-#pragma warning disable 1634, 1691
 #pragma warning disable 6518
             BinaryWriter bw = new BinaryWriter(stream);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/InkSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/InkSerializer.cs
@@ -1312,8 +1312,6 @@ namespace MS.Internal.Ink.InkSerializedFormat
             }
 
             return cbRead;
-#pragma warning restore 6518
-#pragma warning restore 1634, 1691
         }
 
         /// <summary>
@@ -2069,8 +2067,6 @@ namespace MS.Internal.Ink.InkSerializedFormat
                     bw.Write(strkIds[i]);
                     cbWrote += Native.SizeOfInt;
                 }
-#pragma warning restore 6518
-#pragma warning restore 1634, 1691
             }
 
             return cbWrote;
@@ -2425,8 +2421,6 @@ namespace MS.Internal.Ink.InkSerializedFormat
                         cbData += Native.SizeOfFloat;
                     }
                 }
-#pragma warning restore 6518
-#pragma warning restore 1634, 1691
             }
 
             return cbData;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/InkSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/InkSerializer.cs
@@ -1251,12 +1251,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
             if (0 == cbSize)
                 return 0;
 
-            // samgeo - Presharp issue
-            // Presharp gives a warning when local IDisposable variables are not closed
-            // in this case, we can't call Dispose since it will also close the underlying stream
-            // which still needs to be read from
-#pragma warning disable 1634, 1691
-#pragma warning disable 6518
+            // TODO: Use leaveOpen ctor
             BinaryReader bw = new BinaryReader(strm);
 
             if (KnownTagCache.KnownTagIndex.TransformRotate == tag)
@@ -2066,13 +2061,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                 strm.WriteByte(bCompAlgo);
                 cbWrote++;
 
-                // Now write all the ids in the stream
-                // samgeo - Presharp issue
-                // Presharp gives a warning when local IDisposable variables are not closed
-                // in this case, we can't call Dispose since it will also close the underlying stream
-                // which still needs to be written to
-#pragma warning disable 1634, 1691
-#pragma warning disable 6518
+                // TODO: Use leaveOpen ctor
                 BinaryWriter bw = new BinaryWriter(strm);
 
                 for (int i = 0; i < strkIds.Length; i++)
@@ -2418,12 +2407,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
             }
             else
             {
-                // samgeo - Presharp issue
-                // Presharp gives a warning when local IDisposable variables are not closed
-                // in this case, we can't call Dispose since it will also close the underlying stream
-                // which still needs to be written to
-#pragma warning disable 1634, 1691
-#pragma warning disable 6518
+                // TODO: Use leaveOpen ctor
                 BinaryWriter bw = new BinaryWriter(strm);
 
                 for (int i = 0; i < xform.Size; i++)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/LineServicesCallbacks.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/LineServicesCallbacks.cs
@@ -10,20 +10,9 @@ using System.Windows.Media.TextFormatting;
 
 using MS.Internal.Text.TextInterface;
 
-// Disabling 1634 and 1691: 
-// In order to avoid generating warnings about unknown message numbers and 
-// unknown pragmas when compiling C# source code with the C# compiler, 
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
-
-// Disabling 6500: 
-// Suppressing PRESHARP:Warning 6500 Fatal exceptions (NULLReferenceException, SEHException) 
-// potentially ignored by this catch.
 // LineServices callbacks are designed to catch all exceptions such than an error code can be 
 // returned to Line Services engine. An exception is eventually re-thrown to the user after line
 // services engine finishes cleaning up and returns the control to line layout code.
-//
-#pragma warning disable 6500
 
 namespace MS.Internal.TextFormatting
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/WpfWebRequestHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/WpfWebRequestHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -19,12 +19,6 @@ using System.Windows.Navigation;
 using System.IO.Packaging;
 using MS.Internal.AppModel;
 using MS.Internal.PresentationCore;
-
-//From Presharp documentation:
-//In order to avoid generating warnings about unknown message numbers and
-//unknown pragmas when compiling your C# source code with the actual C# compiler,
-//you need to disable warnings 1634 and 1691. 
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/WpfWebRequestHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/WpfWebRequestHelper.cs
@@ -263,7 +263,6 @@ namespace MS.Internal
                     }
                 }
             }
-#pragma warning disable 6502
             catch (NotImplementedException)
             {
                 // this is a valid result and indicates that the subclass chose not to implement this property
@@ -272,7 +271,6 @@ namespace MS.Internal
             {
                 // this is a valid result and indicates that the subclass chose not to implement this property
             }
-#pragma warning restore 6502
         }
 
         // DevDiv2 29007 - IE9 - pack://siteoforigin:,,,/ Uris fail for standalone applications

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/IO/Packaging/PackWebResponse.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/IO/Packaging/PackWebResponse.cs
@@ -441,9 +441,8 @@ namespace System.IO.Packaging
         /// <remarks>assumes caller has locked the syncObject and that we are not disposed</remarks>
         private void AbortResponse()
         {
-// Disable the PreSharp warning about empty catch blocks - we need this one because sub-classes of WebResponse may or may
-// not implement Abort() and we want to silently ignore this if they don't.
-#pragma warning disable 56502
+            // We need this one because sub-classes of WebResponse may or may
+            // not implement Abort() and we want to silently ignore this if they don't.
             // Close was called - abort the response if necessary
             try
             {
@@ -458,7 +457,6 @@ namespace System.IO.Packaging
             {
                 // Ignore - innerRequest class chose to implement BeginGetResponse but not Abort.  This is allowed.
             }
-#pragma warning restore 56502
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/IO/Packaging/PackWebResponse.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/IO/Packaging/PackWebResponse.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -19,8 +19,6 @@ using MS.Internal.PresentationCore;     // for ExceptionStringTable
 using MS.Internal.IO.Packaging;              // for ResponseStream
 using MS.Utility;
 using MS.Internal;
-
-#pragma warning disable 1634, 1691      // disable warning about unknown Presharp warnings
 
 namespace System.IO.Packaging
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/GenericRootAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/GenericRootAutomationPeer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,10 +6,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.ComponentModel;
 using MS.Win32;
-
-// Used to support the warnings disabled below
-#pragma warning disable 1634, 1691
-
 
 namespace System.Windows.Automation.Peers
 {
@@ -51,11 +47,7 @@ namespace System.Windows.Automation.Peers
 
                         name = sb.ToString();
                     }
-// Allow empty catch statements.
-#pragma warning disable 56502
                     catch(Win32Exception) {}
-// Disallow empty catch statements.
-#pragma warning restore 56502
                     
                     if (name == null)
                         name = string.Empty;
@@ -79,11 +71,7 @@ namespace System.Windows.Automation.Peers
                     //This method elevates via SuppressUnmanadegCodeSecurity and throws Win32Exception on GetLastError
                     SafeNativeMethods.GetWindowRect(new HandleRef(null, hwnd), ref rc); 
                 }
-// Allow empty catch statements.
-#pragma warning disable 56502
                 catch(Win32Exception) {}
-// Disallow empty catch statements.
-#pragma warning restore 56502
 
                 bounds = new Rect(rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Duration.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Duration.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Allow suppression of certain presharp messages
-#pragma warning disable 1634, 1691
-
 using System.ComponentModel;
 
 namespace System.Windows
@@ -402,7 +399,6 @@ namespace System.Windows
                 }
                 else
                 {
-#pragma warning suppress 56503 // Suppress presharp warning: Follows a pattern similar to Nullable.
                     throw new InvalidOperationException(SR.Format(SR.Timing_NotTimeSpan, this));
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/ContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/ContentElement.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -16,8 +16,6 @@ using MS.Utility;
 using System.ComponentModel;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/ContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/ContentElement.cs
@@ -70,17 +70,13 @@ namespace System.Windows
 
             if (!AnimationStorage.IsPropertyAnimatable(this, dp))
             {
-        #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                 throw new ArgumentException(SR.Format(SR.Animation_DependencyPropertyIsNotAnimatable, dp.Name, this.GetType()), "dp");
-        #pragma warning restore 56506
             }
 
             if (clock != null
                 && !AnimationStorage.IsAnimationValid(dp, clock.Timeline))
             {
-        #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                 throw new ArgumentException(SR.Format(SR.Animation_AnimationTimelineTypeMismatch, clock.Timeline.GetType(), dp.Name, dp.PropertyType), "clock");
-        #pragma warning restore 56506
             }
 
             if (!HandoffBehaviorEnum.IsDefined(handoffBehavior))
@@ -139,9 +135,7 @@ namespace System.Windows
 
             if (!AnimationStorage.IsPropertyAnimatable(this, dp))
             {
-        #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                 throw new ArgumentException(SR.Format(SR.Animation_DependencyPropertyIsNotAnimatable, dp.Name, this.GetType()), "dp");
-        #pragma warning restore 56506
             }
 
             if (   animation != null

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -16,8 +16,6 @@ using MS.Utility;
 using System.ComponentModel;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement.cs
@@ -70,17 +70,13 @@ namespace System.Windows
 
             if (!AnimationStorage.IsPropertyAnimatable(this, dp))
             {
-        #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                 throw new ArgumentException(SR.Format(SR.Animation_DependencyPropertyIsNotAnimatable, dp.Name, this.GetType()), "dp");
-        #pragma warning restore 56506
             }
 
             if (clock != null
                 && !AnimationStorage.IsAnimationValid(dp, clock.Timeline))
             {
-        #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                 throw new ArgumentException(SR.Format(SR.Animation_AnimationTimelineTypeMismatch, clock.Timeline.GetType(), dp.Name, dp.PropertyType), "clock");
-        #pragma warning restore 56506
             }
 
             if (!HandoffBehaviorEnum.IsDefined(handoffBehavior))
@@ -139,9 +135,7 @@ namespace System.Windows
 
             if (!AnimationStorage.IsPropertyAnimatable(this, dp))
             {
-        #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                 throw new ArgumentException(SR.Format(SR.Animation_DependencyPropertyIsNotAnimatable, dp.Name, this.GetType()), "dp");
-        #pragma warning restore 56506
             }
 
             if (   animation != null

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement3D.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,8 +14,6 @@ using MS.Internal.PresentationCore;
 using MS.Utility;
 using System.ComponentModel;
 using System.Windows.Input;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollection.cs
@@ -235,14 +235,10 @@ namespace System.Windows.Ink
             // Apply the transform to each strokes
             foreach ( Stroke stroke in this )
             {
-                // samgeo - Presharp issue
                 // Presharp gives a warning when get methods might deref a null.  It's complaining
                 // here that 'stroke'' could be null, but StrokeCollection never allows nulls to be added
                 // so this is not possible
-#pragma warning disable 1634, 1691
-#pragma warning suppress 6506
                 stroke.Transform(transformMatrix, applyToStylusTip);
-#pragma warning restore 1634, 1691
             }
         }
 
@@ -254,14 +250,10 @@ namespace System.Windows.Ink
             StrokeCollection clone = new StrokeCollection();
             foreach ( Stroke s in this )
             {
-                // samgeo - Presharp issue
                 // Presharp gives a warning when get methods might deref a null.  It's complaining
                 // here that s could be null, but StrokeCollection never allows nulls to be added
                 // so this is not possible
-#pragma warning disable 1634, 1691
-#pragma warning suppress 6506
                 clone.Add(s.Clone());
-#pragma warning restore 1634, 1691
             }
 
             //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollection2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollection2.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -28,14 +28,10 @@ namespace System.Windows.Ink
             Rect bounds = Rect.Empty;
             foreach (Stroke stroke in this)
             {
-                // samgeo - Presharp issue
                 // Presharp gives a warning when get methods might deref a null.  It's complaining
                 // here that 'stroke'' could be null, but StrokeCollection never allows nulls to be added
                 // so this is not possible
-#pragma warning disable 1634, 1691
-#pragma warning suppress 6506
                 bounds.Union(stroke.GetBounds());
-#pragma warning restore 1634, 1691
             }
             return bounds;
         }
@@ -167,17 +163,13 @@ namespace System.Windows.Ink
             StrokeCollection hits = new StrokeCollection();
             foreach (Stroke stroke in this)
             {
-                // samgeo - Presharp issue
                 // Presharp gives a warning when get methods might deref a null.  It's complaining
                 // here that 'stroke'' could be null, but StrokeCollection never allows nulls to be added
                 // so this is not possible
-#pragma warning disable 1634, 1691
-#pragma warning suppress 6506
                 if (true == stroke.HitTest(bounds, percentageWithinBounds))
                 {
                     hits.Add(stroke);
                 }
-#pragma warning restore 1634, 1691
             }
             return hits;
         }
@@ -209,18 +201,14 @@ namespace System.Windows.Ink
             StrokeCollection hits = new StrokeCollection();
             foreach (Stroke stroke in this)
             {
-                // samgeo - Presharp issue
                 // Presharp gives a warning when get methods might deref a null.  It's complaining
                 // here that 'stroke'' could be null, but StrokeCollection never allows nulls to be added
                 // so this is not possible
-#pragma warning disable 1634, 1691
-#pragma warning suppress 6506
                 if (erasingBounds.IntersectsWith(stroke.GetBounds()) &&
                     erasingStroke.HitTest(StrokeNodeIterator.GetIterator(stroke, stroke.DrawingAttributes)))
                 {
                     hits.Add(stroke);
                 }
-#pragma warning restore 1634, 1691
             }
 
             return hits;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollectionConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -71,11 +71,7 @@ namespace System.Windows
         {
             //we only support converting to / from a string
             string text = value as string;
-            // brianew - presharp issue
-            //   diabling the warning for not using IsNullOrEmpty on the string since
-            //   are using the two operations for differnt results.
-#pragma warning disable 1634, 1691
-#pragma warning disable 6507
+
             if (text != null)
             {
                 //always return an ink object
@@ -94,8 +90,6 @@ namespace System.Windows
                     return new StrokeCollection();
                 }
             }
-#pragma warning restore 6507
-#pragma warning restore 1634, 1691
             return base.ConvertFrom(context, culture, value);
         }
 
@@ -135,18 +129,13 @@ namespace System.Windows
                     //get a ref to the StrokeCollection objects constructor that takes a byte[]
                     ConstructorInfo ci = typeof(StrokeCollection).GetConstructor(new Type[] { typeof(Stream) });
 
-                    // samgeo - Presharp issue
                     // Presharp gives a warning when local IDisposable variables are not closed
                     // in this case, we can't call Dispose since it will also close the underlying stream
                     // which strokecollection needs open to read in the constructor
-#pragma warning disable 1634, 1691
-#pragma warning disable 6518
                     MemoryStream stream = new MemoryStream();
                     strokes.Save(stream, true/*compress*/);
                     stream.Position = 0;
                     return new InstanceDescriptor(ci, new object[] { stream });
-#pragma warning restore 6518
-#pragma warning restore 1634, 1691
                 }
             }
             return base.ConvertTo(context, culture, value, destinationType);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/InputBindingCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/InputBindingCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -156,12 +156,6 @@ namespace System.Windows.Input
         {
             get
             {
-                // disable PreSharp warning about throwing exceptions in getter;
-                // this is allowed in an indexed property.  (First disable C#
-                // warning about unknown warning numbers.)
-                #pragma warning disable 1634, 1691
-                #pragma warning disable 6503
-
                 if (_innerBindingList != null)
                 {
                     return _innerBindingList[index];
@@ -170,9 +164,6 @@ namespace System.Windows.Input
                 {
                     throw new ArgumentOutOfRangeException("index");
                 }
-
-                #pragma warning restore 6503
-                #pragma warning restore 1634, 1691
             }
             set
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -12,8 +12,6 @@
 
 using System.ComponentModel;    // for TypeConverter
 using System.Windows.Markup;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Input
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureValueSerializer.cs
@@ -43,11 +43,9 @@ namespace System.Windows.Input
         {
             KeyGesture keyGesture = value as KeyGesture;
 
-            #pragma warning disable 6506
             return (keyGesture != null) 
                 && ModifierKeysConverter.IsDefinedModifierKeys(keyGesture.Modifiers)
                 && KeyGestureConverter.IsDefinedKey(keyGesture.Key);
-            #pragma warning restore 6506
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputProcessorProfilesLoader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputProcessorProfilesLoader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,9 +9,6 @@
 //              Services Framework.
 //
 //
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System.Threading;
 using MS.Win32;
@@ -59,8 +56,6 @@ namespace System.Windows.Input
 
             Debug.Assert(Thread.CurrentThread.GetApartmentState() == ApartmentState.STA, "Load called on MTA thread!");
 
-
-#pragma warning suppress 6523
             if (UnsafeNativeMethods.TF_CreateInputProcessorProfiles(out obj) == NativeMethods.S_OK)
             {
                 return obj;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
@@ -6,8 +6,6 @@ using System.Windows.Threading;
 using MS.Internal;
 using System.Windows.Automation.Peers;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Input
 {
     /// <summary>
@@ -120,7 +118,6 @@ namespace System.Windows.Input
             {
                 if(!InputElement.IsValid(element))
                 {
-                    #pragma warning suppress 6506 // element is obviously not null
                     throw new InvalidOperationException(SR.Format(SR.Invalid_IInputElement, element.GetType()));
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
@@ -10,8 +10,6 @@ using MS.Internal;
 using MS.Win32;
 using System.Runtime.InteropServices;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 // There's a choice of where to send MouseWheel events - to the element under
 // the mouse (like IE does) or to the element with keyboard focus (like Win32
 // does).  The latter choice lets you move the mouse away from the area you're
@@ -309,7 +307,6 @@ namespace System.Windows.Input
             {
                 UIElement e = element as UIElement;
 
-                #pragma warning suppress 6506 // e is obviously not null
                 if(e.IsVisible && e.IsEnabled)
                 {
                     success = true;
@@ -319,7 +316,6 @@ namespace System.Windows.Input
             {
                 ContentElement ce = element as ContentElement;
 
-                #pragma warning suppress 6506 // ce is obviosuly not null
                 if(ce.IsEnabled) // There is no IsVisible property for ContentElement
                 {
                     success = true;
@@ -329,7 +325,6 @@ namespace System.Windows.Input
             {
                 UIElement3D e = element as UIElement3D;
 
-                #pragma warning suppress 6506 // e is obviously not null
                 if(e.IsVisible && e.IsEnabled)
                 {
                     success = true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPointDescription.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPointDescription.cs
@@ -291,7 +291,7 @@ namespace System.Windows.Input
                 throw new ArgumentNullException("stylusPointDescription");
             }
 
-            #pragma warning disable 6506 // if a StylusPointDescription is not null, then _stylusPointPropertyInfos is not null.
+            // if a StylusPointDescription is not null, then _stylusPointPropertyInfos is not null.
             //
             // ignore X, Y, Pressure - they are guaranteed to be the first3 members
             //
@@ -316,7 +316,6 @@ namespace System.Windows.Input
                     return false;
                 }
             }
-            #pragma warning restore 6506
 
             return true;
         }
@@ -333,7 +332,7 @@ namespace System.Windows.Input
             ArgumentNullException.ThrowIfNull(stylusPointDescriptionPreserveInfo);
 
 
-#pragma warning disable 6506 // if a StylusPointDescription is not null, then _stylusPointPropertyInfos is not null.
+            // if a StylusPointDescription is not null, then _stylusPointPropertyInfos is not null.
             //
             // ignore X, Y, Pressure - they are guaranteed to be the first3 members
             //
@@ -366,7 +365,6 @@ namespace System.Windows.Input
                     }
                 }
             }
-            #pragma warning restore 6506
             
             return new StylusPointDescription(commonProperties);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPointDescription.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPointDescription.cs
@@ -1,10 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.ObjectModel;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Input
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
@@ -13,8 +13,6 @@ using MS.Internal;
 using MS.Internal.Interop;
 using System.ComponentModel;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Interop
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
@@ -2515,13 +2515,12 @@ namespace System.Windows.Interop
                         {
                             Disposed(this, EventArgs.Empty);
                         }
-#pragma warning disable 56500
                         // We can't tolerate an exception thrown by third-party code to
                         // abort our Dispose half-way through.  So we just eat it.
                         catch
                         {
                         }
-#pragma warning restore 56500
+
                         Disposed = null;
                     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -1457,7 +1457,6 @@ namespace System.Windows.Interop
 
                 return AutomationInteropProvider.ReturnRawElementProvider(handle, wparam, lparam, el);
             }
-#pragma warning disable 56500
             catch (Exception e)
             {
                 if(CriticalExceptions.IsCriticalException(e))
@@ -1467,7 +1466,6 @@ namespace System.Windows.Interop
 
                 return new IntPtr(Marshal.GetHRForException(e));
             }
-#pragma warning restore 56500
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -20,8 +20,6 @@ using HRESULT = MS.Internal.HRESULT;
 using NativeMethodsSetLastError = MS.Internal.WindowsBase.NativeMethodsSetLastError;
 using PROCESS_DPI_AWARENESS = MS.Win32.NativeMethods.PROCESS_DPI_AWARENESS;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Interop
 {
     // This is the internal, more expressive, enum used by the InvalidateRenderMode method.
@@ -293,7 +291,7 @@ namespace System.Windows.Interop
                 //
                 if(exceptionThrown)
                 {
-                    #pragma warning suppress 6031 // Return value ignored on purpose.
+                    // Return value ignored on purpose.
                     VisualTarget_DetachFromHwnd(hwnd);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Animatable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Animatable.cs
@@ -1,11 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-//
-
-// Allow suppression of certain presharp messages
-#pragma warning disable 1634, 1691
 
 using MS.Internal;
 using MS.Utility;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Clock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Clock.cs
@@ -3968,8 +3968,6 @@ namespace System.Windows.Media.Animation
             /// </summary>
             ~SubtreeFinalizer()
             {
-#pragma warning disable 1634, 1691
-#pragma warning suppress 6525
                 _timeManager.ScheduleClockCleanup();
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Animatable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Animatable.cs
@@ -63,17 +63,13 @@ namespace System.Windows.Media.Animation
 
             if (!AnimationStorage.IsPropertyAnimatable(this, dp))
             {
-        #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                 throw new ArgumentException(SR.Format(SR.Animation_DependencyPropertyIsNotAnimatable, dp.Name, this.GetType()), "dp");
-        #pragma warning restore 56506
             }
 
             if (clock != null
                 && !AnimationStorage.IsAnimationValid(dp, clock.Timeline))
             {
-        #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                 throw new ArgumentException(SR.Format(SR.Animation_AnimationTimelineTypeMismatch, clock.Timeline.GetType(), dp.Name, dp.PropertyType), "clock");
-        #pragma warning restore 56506
             }
 
             if (!HandoffBehaviorEnum.IsDefined(handoffBehavior))
@@ -132,9 +128,7 @@ namespace System.Windows.Media.Animation
 
             if (!AnimationStorage.IsPropertyAnimatable(this, dp))
             {
-        #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                 throw new ArgumentException(SR.Format(SR.Animation_DependencyPropertyIsNotAnimatable, dp.Name, this.GetType()), "dp");
-        #pragma warning restore 56506
             }
 
             if (   animation != null

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Animatable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Animatable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //     wpf\src\Graphics\codegen\mcg\generators\AnimatableTemplate.cs
 //
 // Please see MilCodeGen.html for more information.
-
-// Allow suppression of certain presharp messages
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/BooleanAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/BooleanAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ByteAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ByteAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/CharAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/CharAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ColorAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ColorAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/DecimalAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/DecimalAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/DoubleAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/DoubleAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Int16AnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Int16AnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Int32AnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Int32AnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Int64AnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Int64AnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/MatrixAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/MatrixAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ObjectAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ObjectAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -80,10 +77,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Point3DAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Point3DAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 using System.Windows.Media.Media3D;
 
@@ -136,10 +133,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/PointAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/PointAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/QuaternionAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/QuaternionAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 using System.Windows.Media.Media3D;
 
@@ -136,10 +133,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/RectAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/RectAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Rotation3DAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Rotation3DAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 using System.Windows.Media.Media3D;
 
@@ -133,10 +130,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/SingleAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/SingleAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/SizeAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/SizeAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/StringAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/StringAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -131,10 +128,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Vector3DAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Vector3DAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 using System.Windows.Media.Media3D;
 
@@ -136,10 +133,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/VectorAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/VectorAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -134,10 +131,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/KeySpline.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/KeySpline.cs
@@ -1,9 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-// Allow suppression of certain presharp messages
-#pragma warning disable 1634, 1691
 
 using System.ComponentModel;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/KeySplineConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/KeySplineConverter.cs
@@ -1,9 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-// Allow suppression of certain presharp messages
-#pragma warning disable 1634, 1691
 
 using MS.Internal;
 using System.ComponentModel;
@@ -115,7 +112,6 @@ namespace System.Windows
                 }
                 else if (destinationType == typeof(string))
                 {
-#pragma warning disable 56506 // Suppress presharp warning: Parameter 'cultureInfo.TextInfo' to this public method must be validated:  A null-dereference can occur here.
                     return String.Format(
                         cultureInfo,
                         "{0}{4}{1}{4}{2}{4}{3}",
@@ -124,7 +120,6 @@ namespace System.Windows
                         keySpline.ControlPoint2.X,
                         keySpline.ControlPoint2.Y,
                         cultureInfo != null ? cultureInfo.TextInfo.ListSeparator : CultureInfo.InvariantCulture.TextInfo.ListSeparator);
-#pragma warning restore 56506
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/KeyTime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/KeyTime.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Allow suppression of certain presharp messages
-#pragma warning disable 1634, 1691
-
 using System.ComponentModel;
 
 namespace System.Windows.Media.Animation
@@ -247,7 +244,6 @@ namespace System.Windows.Media.Animation
                 }
                 else
                 {
-#pragma warning suppress 56503 // Suppress presharp warning: Follows a pattern similar to Nullable.
                     throw new InvalidOperationException();
                 }
             }
@@ -269,7 +265,6 @@ namespace System.Windows.Media.Animation
                 }
                 else
                 {
-#pragma warning suppress 56503 // Suppress presharp warning: Follows a pattern similar to Nullable.
                     throw new InvalidOperationException();
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Allow suppression of certain presharp messages
-#pragma warning disable 1634, 1691
-
 using System.ComponentModel;
 using System.Text;
 
@@ -126,7 +123,6 @@ namespace System.Windows.Media.Animation
             {
                 if (_type != RepeatBehaviorType.IterationCount)
                 {
-#pragma warning suppress 56503 // Suppress presharp warning: Follows a pattern similar to Nullable.
                     throw new InvalidOperationException(SR.Format(SR.Timing_RepeatBehaviorNotIterationCount, this));
                 }
 
@@ -145,7 +141,6 @@ namespace System.Windows.Media.Animation
             {
                 if (_type != RepeatBehaviorType.RepeatDuration)
                 {
-#pragma warning suppress 56503 // Suppress presharp warning: Follows a pattern similar to Nullable.
                     throw new InvalidOperationException(SR.Format(SR.Timing_RepeatBehaviorNotRepeatDuration, this));
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimelineClockCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimelineClockCollection.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Animation
 {
@@ -96,7 +94,7 @@ namespace System.Windows.Media.Animation
 
             foreach (Clock t in this)
             {
-                #pragma warning suppress 6506 // the enumerator will not contain nulls
+                // the enumerator will not contain nulls
                 if (t.Equals(item))
                     return true;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimelineClockCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimelineClockCollection.cs
@@ -231,9 +231,7 @@ namespace System.Windows.Media.Animation
             else
             {
                 // Both are non-null.
-#pragma warning disable 56506 // Suppress presharp warning: Parameter 'objA' to this public method must be validated:  A null-dereference can occur here.
                 return objA._owner == objB._owner;
-#pragma warning restore 56506
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetrics.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetrics.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,8 +6,6 @@ using System.Globalization;
 using StringBuilder = System.Text.StringBuilder;
 using CompositeFontParser = MS.Internal.FontFace.CompositeFontParser;
 using Constants = MS.Internal.TextFormatting.Constants;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetrics.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetrics.cs
@@ -273,9 +273,6 @@ namespace System.Windows.Media
         {
             CharacterMetrics other = obj as CharacterMetrics;
 
-            // Suppress PRESharp warning that other can be null; apparently PRESharp
-            // doesn't understand short circuit evaluation of operator &&.
-            #pragma warning disable 6506
             return other != null &&
                 other._blackBoxWidth == _blackBoxWidth &&
                 other._blackBoxHeight == _blackBoxHeight &&
@@ -283,7 +280,6 @@ namespace System.Windows.Media
                 other._rightSideBearing == _rightSideBearing &&
                 other._topSideBearing == _topSideBearing &&
                 other._bottomSideBearing == _bottomSideBearing;
-            #pragma warning restore 6506
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetricsDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetricsDictionary.cs
@@ -1,11 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using SC = System.Collections;
-
-// Allow suppression of presharp warnings
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media
 {
@@ -108,9 +105,6 @@ namespace System.Windows.Media
         [CLSCompliant(false)]
         public bool Contains(KeyValuePair<int, CharacterMetrics> item)
         {
-            // Suppress PRESharp warning that item.Value can be null; apparently PRESharp
-            // doesn't understand short circuit evaluation of operator &&.
-#pragma warning suppress 56506
             return item.Value != null && item.Value.Equals(GetValue(item.Key));
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
@@ -7,8 +7,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using MS.Internal;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media
 {
     /// <summary>
@@ -409,12 +407,8 @@ namespace System.Windows.Media
             }
             else if (color1.context == color2.context)
             {
-                Color c1 = new Color
-                {
-                    context = color1.context
-                };
+                Color c1 = new Color { context = color1.context };
 
-#pragma warning suppress 6506 // c1.context is obviously not null - both color1.context AND color2.context are not null
                 c1.nativeColorValue = new float[c1.context.NumChannels];
                 for (int i = 0; i < c1.nativeColorValue.Length; i++)
                 {
@@ -530,12 +524,8 @@ namespace System.Windows.Media
             }
             else if (color1.context == color2.context)
             {
-                Color c1 = new Color
-                {
-                    context = color1.context
-                };
+                Color c1 = new Color { context = color1.context };
 
-#pragma warning suppress 6506 // c1.context is obviously not null - both color1.context AND color2.context are not null
                 c1.nativeColorValue = new float[c1.context.NumChannels];
                 for (int i = 0; i < c1.nativeColorValue.Length; i++)
                 {
@@ -644,7 +634,6 @@ namespace System.Windows.Media
             {
                 c1.context = color.context;
 
-                #pragma warning suppress 6506 // c1.context is obviously not null
                 c1.ComputeNativeValues(c1.context.NumChannels);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorContext.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#pragma warning disable 1634, 1691 // Allow suppression of certain presharp messages
 
 using MS.Internal;
 using MS.Win32;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorContext.cs
@@ -432,7 +432,6 @@ namespace System.Windows.Media
             }
             else if (obj1 != null && obj2 != null)
             {
-                #pragma warning disable 6506
                 return (
                     (context1._profileHeader.phSize == context2._profileHeader.phSize) &&
                     (context1._profileHeader.phCMMType == context2._profileHeader.phCMMType) &&
@@ -456,7 +455,6 @@ namespace System.Windows.Media
                     (context1._profileHeader.phIlluminant_2 == context2._profileHeader.phIlluminant_2) &&
                     (context1._profileHeader.phCreator == context2._profileHeader.phCreator)
                     );
-                #pragma warning restore 6506
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/BrushValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/BrushValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Converters
 {
     /// <summary>
@@ -42,7 +40,6 @@ namespace System.Windows.Media.Converters
 
             Brush instance  = (Brush) value;
 
-            #pragma warning suppress 6506 // instance is obviously not null
             return instance.CanSerializeToString();
 }
 
@@ -69,15 +66,12 @@ namespace System.Windows.Media.Converters
             if (value is Brush instance)
             {
                 // When invoked by the serialization engine we can convert to string only for some instances
-#pragma warning suppress 6506 // instance is obviously not null
                 if (!instance.CanSerializeToString())
                 {
                     // Let base throw an exception.
                     return base.ConvertToString(value, context);
                 }
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/CacheModeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/CacheModeValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Converters
 {
     /// <summary>
@@ -42,7 +40,6 @@ namespace System.Windows.Media.Converters
 
             CacheMode instance  = (CacheMode) value;
 
-            #pragma warning suppress 6506 // instance is obviously not null
             return instance.CanSerializeToString();
 }
 
@@ -69,15 +66,12 @@ namespace System.Windows.Media.Converters
             if (value is CacheMode instance)
             {
                 // When invoked by the serialization engine we can convert to string only for some instances
-#pragma warning suppress 6506 // instance is obviously not null
                 if (!instance.CanSerializeToString())
                 {
                     // Let base throw an exception.
                     return base.ConvertToString(value, context);
                 }
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/DoubleCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/DoubleCollectionValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Converters
             if (value is DoubleCollection instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/GeometryValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/GeometryValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Converters
 {
     /// <summary>
@@ -42,7 +40,6 @@ namespace System.Windows.Media.Converters
 
             Geometry instance  = (Geometry) value;
 
-            #pragma warning suppress 6506 // instance is obviously not null
             return instance.CanSerializeToString();
 }
 
@@ -69,15 +66,12 @@ namespace System.Windows.Media.Converters
             if (value is Geometry instance)
             {
                 // When invoked by the serialization engine we can convert to string only for some instances
-#pragma warning suppress 6506 // instance is obviously not null
                 if (!instance.CanSerializeToString())
                 {
                     // Let base throw an exception.
                     return base.ConvertToString(value, context);
                 }
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/Int32CollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/Int32CollectionValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Converters
             if (value is Int32Collection instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PathFigureCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PathFigureCollectionValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Converters
 {
     /// <summary>
@@ -42,7 +40,6 @@ namespace System.Windows.Media.Converters
 
             PathFigureCollection instance  = (PathFigureCollection) value;
 
-            #pragma warning suppress 6506 // instance is obviously not null
             return instance.CanSerializeToString();
 }
 
@@ -69,15 +66,12 @@ namespace System.Windows.Media.Converters
             if (value is PathFigureCollection instance)
             {
                 // When invoked by the serialization engine we can convert to string only for some instances
-#pragma warning suppress 6506 // instance is obviously not null
                 if (!instance.CanSerializeToString())
                 {
                     // Let base throw an exception.
                     return base.ConvertToString(value, context);
                 }
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PointCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PointCollectionValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Converters
             if (value is PointCollection instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/TransformValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/TransformValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Converters
 {
     /// <summary>
@@ -42,7 +40,6 @@ namespace System.Windows.Media.Converters
 
             Transform instance  = (Transform) value;
 
-            #pragma warning suppress 6506 // instance is obviously not null
             return instance.CanSerializeToString();
 }
 
@@ -69,15 +66,12 @@ namespace System.Windows.Media.Converters
             if (value is Transform instance)
             {
                 // When invoked by the serialization engine we can convert to string only for some instances
-#pragma warning suppress 6506 // instance is obviously not null
                 if (!instance.CanSerializeToString())
                 {
                     // Let base throw an exception.
                     return base.ConvertToString(value, context);
                 }
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/VectorCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/VectorCollectionValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Converters
             if (value is VectorCollection instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EventProxy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EventProxy.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-#pragma warning disable 1634, 1691 // Allow suppression of certain presharp messages
-
 using MS.Internal;
 using MS.Win32;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EventProxy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EventProxy.cs
@@ -74,7 +74,6 @@ namespace System.Windows.Media
 
         public int RaiseEvent(byte[] buffer, uint cb)
         {
-#pragma warning disable 6500
             try
             {
                 ObjectDisposedException.ThrowIf(target == null, typeof(EventProxyWrapper));
@@ -94,7 +93,6 @@ namespace System.Windows.Media
             {
                 return Marshal.GetHRForException(e);
             }
-#pragma warning restore 6500
 
             return NativeMethods.S_OK;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingManager.cs
@@ -1,9 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-// Allow suppression of presharp warnings
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media
 {
@@ -46,9 +43,6 @@ namespace System.Windows.Media
         {
             ArgumentNullException.ThrowIfNull(glyphRun);
 
-            // Suppress PRESharp parameter validation warning about glyphRun.GlyphTypeface because
-            // GlyphRun.GlyphTypeface property cannot be null.
-#pragma warning suppress 56506
             Uri glyphTypeface = glyphRun.GlyphTypeface.FontUri;
 
             Dictionary<ushort, bool> glyphSet;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamily.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamily.cs
@@ -10,9 +10,6 @@ using MS.Internal.FontCache;
 using MS.Internal.FontFace;
 using MS.Internal.Shaping;
 
-// Since we disable PreSharp warnings in this file, we first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 namespace System.Windows.Media
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamily.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamily.cs
@@ -518,8 +518,6 @@ namespace System.Windows.Media
                 return fontFamily;
             }
             // The method returns null in case of malformed/non-existent fonts and we fall back to the next font.
-            // Therefore, we can disable PreSharp warning about empty catch bodies.
-#pragma warning disable 6502
             catch (FileFormatException)
             {
                 // malformed font file
@@ -545,7 +543,7 @@ namespace System.Windows.Media
             {
                 // canonical name points to a malformed Uri
             }
-#pragma warning restore 6502
+
             // we want to fall back to the default fallback font instead of crashing
             return null;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamilyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamilyConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,9 +6,6 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Windows.Navigation;
 using System.Windows.Markup;
-
-// Allow suppression of presharp warnings
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media
 {
@@ -46,9 +43,6 @@ namespace System.Windows.Media
                     // only if it's a named font family.
                     FontFamily fontFamily = context.Instance as FontFamily;
 
-                    // Suppress PRESharp warning that fontFamily can be null; apparently PRESharp
-                    // doesn't understand short circuit evaluation of operator &&.
-#pragma warning suppress 56506
                     return fontFamily != null && fontFamily.Source != null && fontFamily.Source.Length != 0;
                 }
                 else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamilyValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamilyValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,9 +11,6 @@
 //
 
 using System.Windows.Markup;
-
-// Allow suppression of presharp warnings
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media
 {
@@ -49,9 +46,6 @@ namespace System.Windows.Media
         {
             FontFamily fontFamily = value as FontFamily;
 
-            // Suppress PRESharp warning that fontFamily can be null; apparently PRESharp
-            // doesn't understand short circuit evaluation of operator &&.
-#pragma warning suppress 56506
             return fontFamily != null && fontFamily.Source != null && fontFamily.Source.Length != 0;           
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
@@ -324,7 +324,6 @@ namespace System.Windows.Media
                 SpanRider formatRider = new SpanRider(_formatRuns, _latestPosition, i);
                 i = Math.Min(limit, i + formatRider.Length);
 
-#pragma warning disable 6506
                 // Presharp warns that runProps is not validated, but it can never be null 
                 // because the rider is already checked to be in range
                 GenericTextRunProperties runProps = formatRider.CurrentElement as GenericTextRunProperties;
@@ -346,7 +345,7 @@ namespace System.Windows.Media
                     runProps.CultureInfo,
                     runProps.NumberSubstitution
                     );
-#pragma warning restore 6506
+
                 _latestPosition = _formatRuns.SetValue(formatRider.CurrentPosition, i - formatRider.CurrentPosition, newProps, formatRider.SpanPosition);
             }
         }
@@ -398,7 +397,6 @@ namespace System.Windows.Media
                 SpanRider formatRider = new SpanRider(_formatRuns, _latestPosition, i);
                 i = Math.Min(limit, i + formatRider.Length);
 
-#pragma warning disable 6506
                 // Presharp warns that runProps is not validated, but it can never be null 
                 // because the rider is already checked to be in range
                 GenericTextRunProperties runProps = formatRider.CurrentElement as GenericTextRunProperties;
@@ -421,7 +419,7 @@ namespace System.Windows.Media
                     runProps.CultureInfo,
                     runProps.NumberSubstitution
                     );
-#pragma warning restore 6506
+
                 _latestPosition = _formatRuns.SetValue(formatRider.CurrentPosition, i - formatRider.CurrentPosition, newProps, formatRider.SpanPosition);
                 InvalidateMetrics();
             }
@@ -453,7 +451,6 @@ namespace System.Windows.Media
                 SpanRider formatRider = new SpanRider(_formatRuns, _latestPosition, i);
                 i = Math.Min(limit, i + formatRider.Length);
 
-#pragma warning disable 6506
                 // Presharp warns that runProps is not validated, but it can never be null 
                 // because the rider is already checked to be in range
                 GenericTextRunProperties runProps = formatRider.CurrentElement as GenericTextRunProperties;
@@ -476,7 +473,7 @@ namespace System.Windows.Media
                     runProps.NumberSubstitution
                     );
                 _latestPosition = _formatRuns.SetValue(formatRider.CurrentPosition, i - formatRider.CurrentPosition, newProps, formatRider.SpanPosition);
-#pragma warning restore 6506
+
                 InvalidateMetrics();
             }
         }
@@ -506,7 +503,6 @@ namespace System.Windows.Media
                 SpanRider formatRider = new SpanRider(_formatRuns, _latestPosition, i);
                 i = Math.Min(limit, i + formatRider.Length);
 
-#pragma warning disable 6506 
                 // Presharp warns that runProps is not validated, but it can never be null 
                 // because the rider is already checked to be in range
                 GenericTextRunProperties runProps = formatRider.CurrentElement as GenericTextRunProperties;
@@ -528,7 +524,7 @@ namespace System.Windows.Media
                     culture,
                     runProps.NumberSubstitution
                     );
-#pragma warning restore 6506
+
                 _latestPosition = _formatRuns.SetValue(formatRider.CurrentPosition, i - formatRider.CurrentPosition, newProps, formatRider.SpanPosition);
                 InvalidateMetrics();
             }
@@ -565,7 +561,6 @@ namespace System.Windows.Media
                 SpanRider formatRider = new SpanRider(_formatRuns, _latestPosition, i);
                 i = Math.Min(limit, i + formatRider.Length);
 
-#pragma warning disable 6506
                 // Presharp warns that runProps is not validated, but it can never be null 
                 // because the rider is already checked to be in range
                 GenericTextRunProperties runProps = formatRider.CurrentElement as GenericTextRunProperties;
@@ -595,7 +590,7 @@ namespace System.Windows.Media
                     runProps.CultureInfo,
                     numberSubstitution
                     );
-#pragma warning restore 6506
+
                 _latestPosition = _formatRuns.SetValue(formatRider.CurrentPosition, i - formatRider.CurrentPosition, newProps, formatRider.SpanPosition);
                 InvalidateMetrics();
             }
@@ -624,7 +619,6 @@ namespace System.Windows.Media
                 SpanRider formatRider = new SpanRider(_formatRuns, _latestPosition, i);
                 i = Math.Min(limit, i + formatRider.Length);
 
-#pragma warning disable 6506 
                 // Presharp warns that runProps is not validated, but it can never be null 
                 // because the rider is already checked to be in range
                 GenericTextRunProperties runProps = formatRider.CurrentElement as GenericTextRunProperties;
@@ -647,7 +641,6 @@ namespace System.Windows.Media
                     runProps.CultureInfo,
                     runProps.NumberSubstitution
                     );
-#pragma warning restore 6506 
                 _latestPosition = _formatRuns.SetValue(formatRider.CurrentPosition, i - formatRider.CurrentPosition, newProps, formatRider.SpanPosition);
                 InvalidateMetrics();
             }
@@ -676,7 +669,6 @@ namespace System.Windows.Media
                 SpanRider formatRider = new SpanRider(_formatRuns, _latestPosition, i);
                 i = Math.Min(limit, i + formatRider.Length);
 
-#pragma warning disable 6506 
                 // Presharp warns that runProps is not validated, but it can never be null 
                 // because the rider is already checked to be in range
                 GenericTextRunProperties runProps = formatRider.CurrentElement as GenericTextRunProperties;
@@ -699,7 +691,6 @@ namespace System.Windows.Media
                     runProps.CultureInfo,
                     runProps.NumberSubstitution
                     );
-#pragma warning restore 6506 
                 
                 _latestPosition = _formatRuns.SetValue(formatRider.CurrentPosition, i - formatRider.CurrentPosition, newProps, formatRider.SpanPosition);
                 InvalidateMetrics(); // invalidate cached metrics
@@ -729,7 +720,6 @@ namespace System.Windows.Media
                 SpanRider formatRider = new SpanRider(_formatRuns, _latestPosition, i);
                 i = Math.Min(limit, i + formatRider.Length);
 
-#pragma warning disable 6506 
                 // Presharp warns that runProps is not validated, but it can never be null 
                 // because the rider is already checked to be in range
                 GenericTextRunProperties runProps = formatRider.CurrentElement as GenericTextRunProperties;
@@ -753,7 +743,6 @@ namespace System.Windows.Media
                     runProps.NumberSubstitution
                     );
                 _latestPosition = _formatRuns.SetValue(formatRider.CurrentPosition, i - formatRider.CurrentPosition, newProps, formatRider.SpanPosition);
-#pragma warning restore 6506 
                 
                 InvalidateMetrics();
             }
@@ -782,7 +771,6 @@ namespace System.Windows.Media
                 SpanRider formatRider = new SpanRider(_formatRuns, _latestPosition, i);
                 i = Math.Min(limit, i + formatRider.Length);
 
-#pragma warning disable 6506 
                 // Presharp warns that runProps is not validated, but it can never be null 
                 // because the rider is already checked to be in range
                 GenericTextRunProperties runProps = formatRider.CurrentElement as GenericTextRunProperties;
@@ -804,7 +792,6 @@ namespace System.Windows.Media
                     runProps.CultureInfo,
                     runProps.NumberSubstitution
                     );
-#pragma warning restore 6506 
                 
                 _latestPosition = _formatRuns.SetValue(formatRider.CurrentPosition, i - formatRider.CurrentPosition, newProps, formatRider.SpanPosition);
                 InvalidateMetrics();
@@ -834,7 +821,6 @@ namespace System.Windows.Media
                 SpanRider formatRider = new SpanRider(_formatRuns, _latestPosition, i);
                 i = Math.Min(limit, i + formatRider.Length);
 
-#pragma warning disable 6506 
                 // Presharp warns that runProps is not validated, but it can never be null 
                 // because the rider is already checked to be in range
                 GenericTextRunProperties runProps = formatRider.CurrentElement as GenericTextRunProperties;
@@ -856,7 +842,6 @@ namespace System.Windows.Media
                     runProps.CultureInfo,
                     runProps.NumberSubstitution
                     );
-#pragma warning restore 6506 
                 
                 _latestPosition = _formatRuns.SetValue(formatRider.CurrentPosition, i - formatRider.CurrentPosition, newProps, formatRider.SpanPosition);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
@@ -9,9 +9,6 @@ using System.Windows.Media.TextFormatting;
 using MS.Internal;
 using MS.Internal.TextFormatting;
 
-#pragma warning disable 1634, 1691
-//Allow suppression of Presharp warnings
-
 namespace System.Windows.Media
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BrushConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BrushConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,8 +7,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media
 {
@@ -57,7 +55,6 @@ namespace System.Windows.Media
 
                     Brush value = (Brush)context.Instance;
 
-                    #pragma warning suppress 6506 // value is obviously not null
                     return value.CanSerializeToString();
                 }
 
@@ -122,7 +119,6 @@ namespace System.Windows.Media
                     // When invoked by the serialization engine we can convert to string only for some instances
                     if (context != null && context.Instance != null)
                     {
-                        #pragma warning suppress 6506 // instance is obviously not null
                         if (!instance.CanSerializeToString())
                         {
                             throw new NotSupportedException(SR.Converter_ConvertToNotSupported);
@@ -130,8 +126,6 @@ namespace System.Windows.Media
                     }
 
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/CacheModeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/CacheModeConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,8 +7,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media
 {
@@ -57,7 +55,6 @@ namespace System.Windows.Media
 
                     CacheMode value = (CacheMode)context.Instance;
 
-                    #pragma warning suppress 6506 // value is obviously not null
                     return value.CanSerializeToString();
                 }
 
@@ -122,7 +119,6 @@ namespace System.Windows.Media
                     // When invoked by the serialization engine we can convert to string only for some instances
                     if (context != null && context.Instance != null)
                     {
-                        #pragma warning suppress 6506 // instance is obviously not null
                         if (!instance.CanSerializeToString())
                         {
                             throw new NotSupportedException(SR.Converter_ConvertToNotSupported);
@@ -130,8 +126,6 @@ namespace System.Windows.Media
                     }
 
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DoubleCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DoubleCollectionConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,8 +7,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media
 {
@@ -57,7 +55,6 @@ namespace System.Windows.Media
 
                     Geometry value = (Geometry)context.Instance;
 
-                    #pragma warning suppress 6506 // value is obviously not null
                     return value.CanSerializeToString();
                 }
 
@@ -122,7 +119,6 @@ namespace System.Windows.Media
                     // When invoked by the serialization engine we can convert to string only for some instances
                     if (context != null && context.Instance != null)
                     {
-                        #pragma warning suppress 6506 // instance is obviously not null
                         if (!instance.CanSerializeToString())
                         {
                             throw new NotSupportedException(SR.Converter_ConvertToNotSupported);
@@ -130,8 +126,6 @@ namespace System.Windows.Media
                     }
 
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Int32CollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Int32CollectionConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigureCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigureCollectionConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,8 +7,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media
 {
@@ -57,7 +55,6 @@ namespace System.Windows.Media
 
                     PathFigureCollection value = (PathFigureCollection)context.Instance;
 
-                    #pragma warning suppress 6506 // value is obviously not null
                     return value.CanSerializeToString();
                 }
 
@@ -122,7 +119,6 @@ namespace System.Windows.Media
                     // When invoked by the serialization engine we can convert to string only for some instances
                     if (context != null && context.Instance != null)
                     {
-                        #pragma warning suppress 6506 // instance is obviously not null
                         if (!instance.CanSerializeToString())
                         {
                             throw new NotSupportedException(SR.Converter_ConvertToNotSupported);
@@ -130,8 +126,6 @@ namespace System.Windows.Media
                     }
 
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PointCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PointCollectionConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,8 +7,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media
 {
@@ -57,7 +55,6 @@ namespace System.Windows.Media
 
                     Transform value = (Transform)context.Instance;
 
-                    #pragma warning suppress 6506 // value is obviously not null
                     return value.CanSerializeToString();
                 }
 
@@ -122,7 +119,6 @@ namespace System.Windows.Media
                     // When invoked by the serialization engine we can convert to string only for some instances
                     if (context != null && context.Instance != null)
                     {
-                        #pragma warning suppress 6506 // instance is obviously not null
                         if (!instance.CanSerializeToString())
                         {
                             throw new NotSupportedException(SR.Converter_ConvertToNotSupported);
@@ -130,8 +126,6 @@ namespace System.Windows.Media
                     }
 
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VectorCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VectorCollectionConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
@@ -14,9 +14,6 @@
 //
 //
 
-// Enable presharp pragma warning suppress directives.
-#pragma warning disable 1634, 1691
-
 using System.Collections;
 using System.ComponentModel;
 using System.Windows.Media.Converters;
@@ -128,10 +125,6 @@ namespace System.Windows.Media
             XmlLanguage language
             )
         {
-            // Suppress PRESharp warning that glyphIndices and advanceWidths are not validated and can be null.
-            // They can indeed be null, but that's perfectly OK. An explicit null check in the constructor is
-            // not required.
-#pragma warning suppress 56506
             Initialize(
                 glyphTypeface,
                 bidiLevel,
@@ -223,10 +216,6 @@ namespace System.Windows.Media
             XmlLanguage             language
             )
         {
-            // Suppress PRESharp warning that glyphIndices and advanceWidths are not validated and can be null.
-            // They can indeed be null, but that's perfectly OK. An explicit null check in the constructor is
-            // not required.
-#pragma warning suppress 56506
             Initialize(
                 glyphTypeface,
                 bidiLevel,
@@ -284,10 +273,6 @@ namespace System.Windows.Media
         {
             GlyphRun glyphRun = new GlyphRun(pixelsPerDip);
 
-            // Suppress PRESharp warning that glyphIndices and advanceWidths are not validated and can be null.
-            // They can indeed be null, but that's perfectly OK. An explicit null check in the constructor is
-            // not required.
-#pragma warning suppress 56506
             glyphRun.Initialize(
                 glyphTypeface,
                 bidiLevel,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSourceConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSourceConverter.cs
@@ -10,8 +10,6 @@ using System.Runtime.InteropServices;
 using System.Windows.Markup;
 using System.Windows.Media.Imaging;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media
 {
     #region ImageSourceConverter
@@ -58,10 +56,8 @@ namespace System.Windows.Media
                         throw new ArgumentException(SR.Format(SR.General_Expected_Type, "ImageSource"), "context");
                     }
 
-                    #pragma warning suppress 6506 // context is obviously not null
                     ImageSource value = (ImageSource)context.Instance;
 
-                    #pragma warning suppress 6506 // value is obviously not null
                     return value.CanSerializeToString();
                 }
 
@@ -197,12 +193,10 @@ namespace System.Windows.Media
                     // When invoked by the serialization engine we can convert to string only for some instances
                     if (context != null && context.Instance != null)
                     {
-                        #pragma warning disable 6506
                         if (!instance.CanSerializeToString())
                         {
                             throw new NotSupportedException(SR.Converter_ConvertToNotSupported);
                         }
-                        #pragma warning restore 6506
                     }
 
                     // Delegate to the formatting/culture-aware ConvertToString method.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSourceValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSourceValueSerializer.cs
@@ -33,9 +33,7 @@ namespace System.Windows.Media
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             ImageSource imageSource = value as ImageSource;
-            #pragma warning disable 6506
             return imageSource != null && imageSource.CanSerializeToString();
-            #pragma warning restore 6506
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSourceValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSourceValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,7 +8,6 @@
 //  Contents:  Value serializer for ImageSource instances
 //
 //
-#pragma warning disable 1634, 1691 // Allow suppression of certain presharp messages
 
 using System.Windows.Markup;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
@@ -1171,12 +1171,9 @@ namespace System.Windows.Media.Imaging
             catch
             {
                 bitmapStream.Close();
-                #pragma warning disable 6500
 
                 decoderHandle = null;
                 throw;
-
-                #pragma warning restore 6500
             }
             finally
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#pragma warning disable 1634, 1691 // Allow suppression of certain presharp messages
 
 using System.IO;
 using System.IO.Packaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
@@ -1069,12 +1069,10 @@ namespace System.Windows.Media.Imaging
                     }
                     else
                     {
-                        #pragma warning disable 6518
                         // We don't have an absolute URI, so we don't necessarily know
                         // if it is a file, but we'll have to assume it is and try to
                         // create a stream from the original string.
                         bitmapStream = new System.IO.FileStream(uri.OriginalString, FileMode.Open, FileAccess.Read, FileShare.Read);
-                        #pragma warning restore 6518
                     }
 
                     uriStream = bitmapStream;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDownload.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDownload.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable 1634, 1691 // Allow suppression of certain presharp messages
-
 using System.IO;
 using System.Collections;
 using System.ComponentModel;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDownload.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDownload.cs
@@ -201,8 +201,6 @@ namespace System.Windows.Media.Imaging
                 {
                     QueueEntry entry = (QueueEntry)workQueue.Dequeue();
 
-                    #pragma warning disable 6500
-
                     // Catch all exceptions and marshal them to the correct thread
                     try
                     {
@@ -227,8 +225,6 @@ namespace System.Windows.Media.Imaging
                         //
                         entry = null;
                     }
-
-                    #pragma warning restore 6500
                 }
             }
         }
@@ -238,8 +234,6 @@ namespace System.Windows.Media.Imaging
         private static void ResponseCallback(IAsyncResult result)
         {
             QueueEntry entry = (QueueEntry)result.AsyncState;
-
-            #pragma warning disable 6500
 
             // Catch all exceptions and marshal them to the correct thread
             try
@@ -254,12 +248,10 @@ namespace System.Windows.Media.Imaging
                 // Signal
                 _waitEvent.Set();
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 MarshalException(entry, e);
             }
-
-            #pragma warning restore 6500
         }
 
         ///
@@ -270,18 +262,14 @@ namespace System.Windows.Media.Imaging
             QueueEntry entry = (QueueEntry)result.AsyncState;
             int bytesRead = 0;
 
-            #pragma warning disable 6500
-
             try
             {
                 bytesRead = entry.inputStream.EndRead(result);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 MarshalException(entry, e);
             }
-
-            #pragma warning restore 6500
 
             if (bytesRead == 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapEncoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapEncoder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,8 +7,6 @@ using MS.Internal;
 using System.Windows.Threading;
 using System.Runtime.InteropServices;
 using MS.Win32.PresentationCore;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Imaging
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapFrameDecode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapFrameDecode.cs
@@ -1,15 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-//
-//
 
 using System.Collections.ObjectModel;
 using MS.Internal;
 using MS.Win32.PresentationCore;
-
-#pragma warning disable 1634, 1691 // Allow suppression of certain presharp messages
 
 namespace System.Windows.Media.Imaging
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapMetadata.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapMetadata.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-//
-
 using System.Collections;
 using System.Collections.ObjectModel;
 using MS.Internal;
@@ -12,9 +9,6 @@ using MS.Win32.PresentationCore;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
-using MS.Internal.PresentationCore;                        // SecurityHelper
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Imaging
 {
@@ -174,7 +168,7 @@ namespace System.Windows.Media.Imaging
                             {
                                 if (pIMetadataWriter != IntPtr.Zero)
                                 {
-                                    #pragma warning suppress 6031 // Return value ignored on purpose.
+                                    // Return value ignored on purpose.
                                     UnsafeNativeMethods.MILUnknown.Release(pIMetadataWriter);
                                 }
                             }
@@ -315,7 +309,7 @@ namespace System.Windows.Media.Imaging
                                 }
                                 if (pIMetadataWriter != IntPtr.Zero)
                                 {
-                                    #pragma warning suppress 6031 // Return value ignored on purpose.
+                                    // Return value ignored on purpose.
                                     UnsafeNativeMethods.MILUnknown.Release(pIMetadataWriter);
                                 }
                             }
@@ -712,12 +706,12 @@ namespace System.Windows.Media.Imaging
                 {
                     if (blockWriter != IntPtr.Zero)
                     {
-                        #pragma warning suppress 6031 // Return value ignored on purpose.
+                        // Return value ignored on purpose.
                         UnsafeNativeMethods.MILUnknown.Release(blockWriter);
                     }
                     if (queryWriter != IntPtr.Zero)
                     {
-                        #pragma warning suppress 6031 // Return value ignored on purpose.
+                        // Return value ignored on purpose.
                         UnsafeNativeMethods.MILUnknown.Release(queryWriter);
                     }
                 }
@@ -761,12 +755,12 @@ namespace System.Windows.Media.Imaging
                 {
                     if (blockWriter != IntPtr.Zero)
                     {
-                        #pragma warning suppress 6031 // Return value ignored on purpose.
+                        // Return value ignored on purpose.
                         UnsafeNativeMethods.MILUnknown.Release(blockWriter);
                     }
                     if (queryWriter != IntPtr.Zero)
                     {
-                        #pragma warning suppress 6031 // Return value ignored on purpose.
+                        // Return value ignored on purpose.
                         UnsafeNativeMethods.MILUnknown.Release(queryWriter);
                     }
                 }
@@ -818,7 +812,7 @@ namespace System.Windows.Media.Imaging
             {
                 if (queryWriter != IntPtr.Zero)
                 {
-                    #pragma warning suppress 6031 // Return value ignored on purpose.
+                    // Return value ignored on purpose.
                     UnsafeNativeMethods.MILUnknown.Release(queryWriter);
                 }
             }
@@ -1045,10 +1039,8 @@ namespace System.Windows.Media.Imaging
                     BitmapMetadata metadata = value as BitmapMetadata;
                     Invariant.Assert(metadata != null);
 
-                    #pragma warning suppress 6506 // Invariant.Assert(metadata != null);
                     metadata.VerifyAccess();
 
-                    #pragma warning suppress 6506 // Invariant.Assert(metadata != null);
                     lock (metadata._syncObject)
                     {
                         lock (_syncObject)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapMetadataEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapMetadataEnumerator.cs
@@ -1,9 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-// Allow suppression of certain presharp messages
-#pragma warning disable 1634, 1691
 
 using System.Collections;
 using System.Runtime.InteropServices;
@@ -127,13 +124,11 @@ namespace System.Windows.Media.Imaging
                 {
                     if (!_fStarted)
                     {
-#pragma warning suppress 56503 // Suppress presharp warning: Follows a pattern similar to Nullable.
-                    throw new InvalidOperationException(SR.Enumerator_NotStarted);
+                        throw new InvalidOperationException(SR.Enumerator_NotStarted);
                     }
                     else
                     {
-#pragma warning suppress 56503 // Suppress presharp warning: Follows a pattern similar to Nullable.
-                    throw new InvalidOperationException(SR.Enumerator_ReachedEnd);
+                        throw new InvalidOperationException(SR.Enumerator_ReachedEnd);
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/LateBoundBitmapDecoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/LateBoundBitmapDecoder.cs
@@ -1,10 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-//
-//
-#pragma warning disable 1634, 1691 // Allow suppression of certain presharp messages
 
 using System.IO;
 using System.Collections.ObjectModel;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/LateBoundBitmapDecoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/LateBoundBitmapDecoder.cs
@@ -302,11 +302,7 @@ namespace System.Windows.Media.Imaging
                 }
                 catch(Exception e)
                 {
-                    #pragma warning disable 6500
-
                     return ExceptionCallback(e);
-
-                    #pragma warning restore 6500
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/PropVariant.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/PropVariant.cs
@@ -1,16 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-//
-//
 
 using MS.Internal;
 using MS.Win32.PresentationCore;
 using System.Runtime.InteropServices;
-using MS.Internal.PresentationCore;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 //
 // This class wraps a PROPVARIANT type for interop with the unmanaged metadata APIs.  Only
@@ -456,7 +450,7 @@ namespace System.Windows.Media.Imaging
 
                         for (uint i=0; i<ca.cElems; i++)
                         {
-                            #pragma warning suppress 6031 // Return value ignored on purpose.
+                            // Return value ignored on purpose.
                             UnsafeNativeMethods.MILUnknown.Release(Marshal.ReadIntPtr(punkPtr, (int) (i*sizeIntPtr)));
                         }
                     }
@@ -486,7 +480,7 @@ namespace System.Windows.Media.Imaging
             }
             else if (vt == VarEnum.VT_UNKNOWN)
             {
-                #pragma warning suppress 6031 // Return value ignored on purpose.
+                // Return value ignored on purpose.
                 UnsafeNativeMethods.MILUnknown.Release(punkVal);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaPlayer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaPlayer.cs
@@ -1,14 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
-
-// Disable the warnings that C# emmits when it finds pragmas it does not recognize, this is to
-// get rid of false positive PreSharp warning
-#pragma warning disable 1634, 1691
-
 
 namespace System.Windows.Media
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaPlayerState.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaPlayerState.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@ using System.Windows.Threading;
 using System.Windows.Navigation;
 
 using UnsafeNativeMethods = MS.Win32.PresentationCore.UnsafeNativeMethods;
-
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaPlayerState.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaPlayerState.cs
@@ -999,11 +999,7 @@ namespace System.Windows.Media
             bool                    notifyUceDirectly
             )
         {
-//
-// This is an interrop call, but, it does not set a last error being a COM call. So, suppress the
-// presharp warning about losing last error.
-//
-#pragma warning disable 6523
+            // This is an interrop call, but, it does not set a last error being a COM call. 
 
             //
             // AddRef to ensure the media player stays alive during transport, even if the
@@ -1023,8 +1019,6 @@ namespace System.Windows.Media
                 _nativeMedia,
                 notifyUceDirectly
                 );
-
-#pragma warning restore 6523
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/PixelFormat.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/PixelFormat.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#pragma warning disable 1634, 1691 // Allow suppression of certain presharp messages
 
 using System.ComponentModel;
 using MS.Internal;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamAsIStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamAsIStream.cs
@@ -155,8 +155,6 @@ namespace System.Windows.Media
         {
             stream = IntPtr.Zero;
 
-            #pragma warning disable 6500
-
             try
             {
                 Verify();
@@ -168,15 +166,11 @@ namespace System.Windows.Media
                 return SecurityHelper.GetHRForException(e);
             }
 
-            #pragma warning restore 6500
-
             return NativeMethods.E_NOTIMPL;
         }
 
         public int Commit(uint grfCommitFlags)
         {
-            #pragma warning disable 6500
-
             try
             {
                 Verify();
@@ -191,8 +185,6 @@ namespace System.Windows.Media
                 return SecurityHelper.GetHRForException(e);
             }
 
-            #pragma warning restore 6500
-
             return NativeMethods.S_OK;
         }
 
@@ -206,8 +198,6 @@ namespace System.Windows.Media
 
             cbWritten = 0;
             cbRead = 0;
-
-            #pragma warning disable 6500
 
             try
             {
@@ -252,15 +242,11 @@ namespace System.Windows.Media
                 return SecurityHelper.GetHRForException(e);
             }
 
-            #pragma warning restore 6500
-
             return hr;
         }
 
         public int LockRegion(long libOffset, long cb, uint dwLockType)
         {
-            #pragma warning disable 6500
-
             try
             {
                 Verify();
@@ -272,16 +258,12 @@ namespace System.Windows.Media
                 return SecurityHelper.GetHRForException(e);
             }
 
-            #pragma warning restore 6500
-
             return NativeMethods.E_NOTIMPL;
         }
 
         public int Read(Span<byte> buffer, out uint cbRead)
         {
             cbRead = 0;
-
-            #pragma warning disable 6500
 
             try
             {
@@ -297,15 +279,11 @@ namespace System.Windows.Media
                 return SecurityHelper.GetHRForException(e);
             }
 
-            #pragma warning restore 6500
-
             return NativeMethods.S_OK;
         }
 
         public int Revert()
         {
-            #pragma warning disable 6500
-
             try
             {
                 Verify();
@@ -317,15 +295,11 @@ namespace System.Windows.Media
                 return SecurityHelper.GetHRForException(e);
             }
 
-            #pragma warning restore 6500
-
             return NativeMethods.E_NOTIMPL;
         }
 
         public unsafe int Seek(long offset, uint origin, long * plibNewPostion)
         {
-            #pragma warning disable 6500
-
             try
             {
                 Verify();
@@ -393,15 +367,11 @@ namespace System.Windows.Media
                 return SecurityHelper.GetHRForException(e);
             }
 
-            #pragma warning restore 6500
-
             return NativeMethods.S_OK;
         }
 
         public int SetSize(long value)
         {
-            #pragma warning disable 6500
-
             try
             {
                 Verify();
@@ -415,8 +385,6 @@ namespace System.Windows.Media
                 return SecurityHelper.GetHRForException(e);
             }
 
-            #pragma warning restore 6500
-
             return NativeMethods.S_OK;
         }
 
@@ -424,8 +392,6 @@ namespace System.Windows.Media
         {
             System.Runtime.InteropServices.ComTypes.STATSTG statstgOut = new System.Runtime.InteropServices.ComTypes.STATSTG();
             statstg = statstgOut;
-
-            #pragma warning disable 6500
 
             try
             {
@@ -444,15 +410,11 @@ namespace System.Windows.Media
                 return SecurityHelper.GetHRForException(e);
             }
 
-            #pragma warning restore 6500
-
             return NativeMethods.S_OK;
         }
 
         public int UnlockRegion(long libOffset, long cb, uint dwLockType)
         {
-            #pragma warning disable 6500
-
             try
             {
                 Verify();
@@ -464,16 +426,12 @@ namespace System.Windows.Media
                 return SecurityHelper.GetHRForException(e);
             }
 
-            #pragma warning restore 6500
-
             return NativeMethods.E_NOTIMPL;
         }
 
         public int Write(byte[] buffer, uint cb, out uint cbWritten)
         {
             cbWritten = 0;
-
-            #pragma warning disable 6500
 
             try
             {
@@ -492,16 +450,12 @@ namespace System.Windows.Media
                 return SecurityHelper.GetHRForException(e);
             }
 
-            #pragma warning restore 6500
-
             return NativeMethods.S_OK;
         }
 
         public int CanWrite(out bool canWrite)
         {
             canWrite = false;
-
-            #pragma warning disable 6500
 
             try
             {
@@ -516,16 +470,12 @@ namespace System.Windows.Media
                 return SecurityHelper.GetHRForException(e);
             }
 
-            #pragma warning restore 6500
-
             return NativeMethods.S_OK;
         }
 
         public int CanSeek(out bool canSeek)
         {
             canSeek = false;
-
-            #pragma warning disable 6500
 
             try
             {
@@ -539,8 +489,6 @@ namespace System.Windows.Media
                 _lastException = e;
                 return SecurityHelper.GetHRForException(e);
             }
-
-            #pragma warning restore 6500
 
             return NativeMethods.S_OK;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamAsIStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamAsIStream.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable 1634, 1691 // Allow suppression of certain presharp messages
-
 using MS.Internal;
 using MS.Win32;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/UnsafeNativeMethodsMilCoreApi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/UnsafeNativeMethodsMilCoreApi.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -16,8 +16,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace MS.Win32.PresentationCore
 {
@@ -518,7 +516,7 @@ namespace MS.Win32.PresentationCore
             {
                 if (ptr != IntPtr.Zero)
                 {
-                    #pragma warning suppress 6031 // Return value ignored on purpose.
+                    // Return value ignored on purpose.
                     UnsafeNativeMethods.MILUnknown.Release(ptr);
                     ptr = IntPtr.Zero;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualCollection.cs
@@ -311,17 +311,12 @@ namespace System.Windows.Media
             get
             {
                 // We should likely skip the context checks here for performance reasons.
-                //     MediaSystem.VerifyContext(_owner); The guy who gets the Visual won't be able to access the context
-                //     the Visual anyway if he is in the wrong context.
+                // The guy who gets the Visual won't be able to access the Visual anyway if he is in the wrong context.
+                // MediaSystem.VerifyContext(_owner);
 
-                // Disable PREsharp warning about throwing exceptions in property
-                // get methods
-
-#pragma warning disable 6503
                 ArgumentOutOfRangeException.ThrowIfNegative(index);
                 ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _size);
                 return _items[index];
-#pragma warning restore 6503
             }
             set
             {
@@ -960,11 +955,6 @@ namespace System.Windows.Media
             {
                 get
                 {
-                    // Disable PREsharp warning about throwing exceptions in property
-                    // get methods
-
-#pragma warning disable 6503
-
                     if (_index < 0)
                     {
                         if (_index == -1)
@@ -979,9 +969,8 @@ namespace System.Windows.Media
                             throw new InvalidOperationException(SR.Enumerator_ReachedEnd);
                         }
                     }
-                    return _currentElement;
 
-#pragma warning restore 6503
+                    return _currentElement;
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,11 +15,6 @@ using MS.Internal;
 //  - Performance: RemoveRange moves and nulls entry. It is better to null out
 //    after we moved all the items.
 //------------------------------------------------------------------------------
-
-
-// Since we disable PreSharp warnings in this file, we first need to disable
-// warnings about unknown message numbers and unknown pragmas:
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/NumberSubstitution.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/NumberSubstitution.cs
@@ -1,13 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
 using System.ComponentModel;
 using MS.Internal.FontCache;
-
-// Allow suppression of presharp warnings
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/NumberSubstitution.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/NumberSubstitution.cs
@@ -245,14 +245,10 @@ namespace System.Windows.Media
         {
             NumberSubstitution sub = obj as NumberSubstitution;
 
-            // Suppress PRESharp warning that sub can be null; apparently PRESharp
-            // doesn't understand short circuit evaluation of operator &&.
-            #pragma warning disable 6506
             return sub != null &&
                 _source == sub._source &&
                 _substitution == sub._substitution &&
                 (_cultureOverride == null ? (sub._cultureOverride == null) : (_cultureOverride.Equals(sub._cultureOverride)));
-            #pragma warning restore 6506
         }
 
         private NumberCultureSource _source;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Matrix3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Matrix3DValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Media3D.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Media3D.Converters
             if (value is Matrix3D instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DCollectionValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Media3D.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Media3D.Converters
             if (value is Point3DCollection instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Media3D.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Media3D.Converters
             if (value is Point3D instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point4DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point4DValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Media3D.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Media3D.Converters
             if (value is Point4D instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/QuaternionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/QuaternionValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Media3D.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Media3D.Converters
             if (value is Quaternion instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Rect3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Rect3DValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Media3D.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Media3D.Converters
             if (value is Rect3D instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Size3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Size3DValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Media3D.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Media3D.Converters
             if (value is Size3D instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DCollectionValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Media3D.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Media3D.Converters
             if (value is Vector3DCollection instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DValueSerializer.cs
@@ -11,8 +11,6 @@
 
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Media.Media3D.Converters
 {
     /// <summary>
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Media3D.Converters
             if (value is Vector3D instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Matrix3DConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Matrix3DConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Media3D
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media.Media3D
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3DCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3DCollectionConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Media3D
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media.Media3D
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3DConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3DConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Media3D
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media.Media3D
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point4DConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point4DConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Media3D
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media.Media3D
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/QuaternionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/QuaternionConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Media3D
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media.Media3D
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Rect3DConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Rect3DConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Media3D
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media.Media3D
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Size3DConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Size3DConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Media3D
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media.Media3D
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3DCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3DCollectionConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Media3D
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media.Media3D
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3DConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3DConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Media3D
 {
@@ -110,8 +108,6 @@ namespace System.Windows.Media.Media3D
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Visual3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Visual3D.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //     wpf\src\Graphics\codegen\mcg\generators\AnimatableTemplate.cs
 //
 // Please see MilCodeGen.html for more information.
-
-// Allow suppression of certain presharp messages
-#pragma warning disable 1634, 1691
 
 using System.Windows.Media.Animation;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Visual3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Visual3D.cs
@@ -65,17 +65,13 @@ namespace System.Windows.Media.Media3D
 
             if (!AnimationStorage.IsPropertyAnimatable(this, dp))
             {
-        #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                 throw new ArgumentException(SR.Format(SR.Animation_DependencyPropertyIsNotAnimatable, dp.Name, this.GetType()), "dp");
-        #pragma warning restore 56506
             }
 
             if (clock != null
                 && !AnimationStorage.IsAnimationValid(dp, clock.Timeline))
             {
-        #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                 throw new ArgumentException(SR.Format(SR.Animation_AnimationTimelineTypeMismatch, clock.Timeline.GetType(), dp.Name, dp.PropertyType), "clock");
-        #pragma warning restore 56506
             }
 
             if (!HandoffBehaviorEnum.IsDefined(handoffBehavior))
@@ -134,9 +130,7 @@ namespace System.Windows.Media.Media3D
 
             if (!AnimationStorage.IsPropertyAnimatable(this, dp))
             {
-        #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                 throw new ArgumentException(SR.Format(SR.Animation_DependencyPropertyIsNotAnimatable, dp.Name, this.GetType()), "dp");
-        #pragma warning restore 56506
             }
 
             if (   animation != null

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Visual3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Visual3DCollection.cs
@@ -198,9 +198,7 @@ namespace System.Windows.Media.Media3D
                 return -1;
             }
 
-#pragma warning disable 56506 // Suppress presharp warning: Parameter 'value' to this public method must be validated:  A null-dereference can occur here.
             return value.ParentIndex;
-#pragma warning restore 56506
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Visual3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Visual3DCollection.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 using MS.Utility;
 using MS.Internal;
@@ -668,8 +666,6 @@ namespace System.Windows.Media.Media3D
             /// </summary>
             public Visual3D Current
             {
-#pragma warning disable 1634, 1691
-#pragma warning disable 6503
                 get
                 {
                     if ((_index < 0) || (_index >= _list.Count))
@@ -679,8 +675,6 @@ namespace System.Windows.Media.Media3D
 
                     return _list[_index];
                 }
-#pragma warning restore 6503
-#pragma warning restore 1634, 1691
             }
 
             #endregion Public Methods

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-//
-//
-
 using System.Globalization;
 using System.Text;
 using System.Windows.Markup;
@@ -18,10 +14,6 @@ using MS.Internal.IO.Packaging;
 using MS.Internal.PresentationCore;
 
 using PackUriHelper = System.IO.Packaging.PackUriHelper;
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling your C# source code with the actual C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Navigation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -50,10 +50,6 @@ namespace System.Windows
         /// </summary>
         Collapsed
     }
-
-    // PreSharp uses message numbers that the C# compiler doesn't know about.
-    // Disable the C# complaints, per the PreSharp documentation.
-#pragma warning disable 1634, 1691
 
     /// <summary>
     /// UIElement is the base class for frameworks building on the Windows Presentation Core.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
@@ -1135,17 +1135,13 @@ namespace System.Windows
                 HandleRef desktopWnd = new HandleRef(null, IntPtr.Zero);
 
                 // Win32Exception will get the Win32 error code so we don't have to
-#pragma warning disable 6523
                 IntPtr dc = UnsafeNativeMethods.GetDC(desktopWnd);
 
                 // Detecting error case from unmanaged call, required by PREsharp to throw a Win32Exception
-#pragma warning disable 6503
                 if (dc == IntPtr.Zero)
                 {
                     throw new Win32Exception();
                 }
-#pragma warning restore 6503
-#pragma warning restore 6523
 
                 try
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -23,12 +23,8 @@ using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
 //
 // See spec at http://avalon/uis/Data%20Transfer%20clipboard%20dragdrop/Avalon%20Data%20Transfer%20Object.htm
 
-
 namespace System.Windows
 {
-    // PreSharp uses message numbers that the C# compiler doesn't know about.
-    // Disable the C# complaints, per the PreSharp documentation.
-#pragma warning disable 1634, 1691
 
     #region DataObject Class
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -1840,10 +1840,6 @@ namespace System.Windows
 
                 currentPtr = (IntPtr)((long)currentPtr + baseStructSize);
 
-                // Win32 CopyMemory return void, so we should disable PreSharp 6523 that
-                // expects the Win32 exception with the last error.
-#pragma warning disable 6523
-
                 // Write out the strings...
                 for (int i = 0; i < files.Length; i++)
                 {
@@ -1860,8 +1856,6 @@ namespace System.Windows
                     // Increase the current pointer by 2 since it is a unicode.
                     currentPtr = (IntPtr)((long)currentPtr + 2);
                 }
-
-#pragma warning restore 6523
 
                 // Terminate the string and add 2bytes since it is a unicode.
                 unsafe
@@ -1908,13 +1902,7 @@ namespace System.Windows
                 {
                     chars = str.ToCharArray(0, str.Length);
 
-                    // Win32 CopyMemory return void, so we should disable PreSharp 6523 that
-                    // expects the Win32 exception with the last error.
-#pragma warning disable 6523
-
                     UnsafeNativeMethods.CopyMemoryW(ptr, chars, chars.Length * 2);
-
-#pragma warning restore 6523
 
                     // Terminate the string becasue of GlobalReAlloc GMEM_ZEROINIT will zero
                     // out only the bytes it adds to the memory object. It doesn't initialize
@@ -1964,13 +1952,7 @@ namespace System.Windows
 
                 try
                 {
-                    // Win32 CopyMemory return void, so we should disable PreSharp 6523 that
-                    // expects the Win32 exception with the last error.
-#pragma warning disable 6523
-
                     UnsafeNativeMethods.CopyMemory(ptr, strBytes, pinvokeSize);
-
-#pragma warning restore 6523
 
                     Marshal.Copy(new byte[] { 0 }, 0, (IntPtr)((long)ptr + pinvokeSize), 1);
                 }
@@ -2018,14 +2000,8 @@ namespace System.Windows
 
             try
             {
-                // Win32 CopyMemory return void, so we should disable PreSharp 6523 that
-                // expects the Win32 exception with the last error.
-#pragma warning disable 6523
-
                 // Copy UTF8 encoding bytes to the memory.
                 UnsafeNativeMethods.CopyMemory(pointerUtf8, utf8Bytes, utf8ByteCount);
-
-#pragma warning restore 6523
 
                 // Copy the null into the last of memory.
                 Marshal.Copy(new byte[] { 0 }, 0, (IntPtr)((long)pointerUtf8 + utf8ByteCount), 1);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/DataIdProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/DataIdProcessor.cs
@@ -1,17 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#pragma warning disable 1634, 1691
-//
-//
-// Description:
-//     DataIdProcessor walks the tree and loads annotations based on unique ids
-//     identified by the DataIdProperty.  It loads annotations when it
-//     reaches a leaf in the tree or when it runs into a node with the
-//     FetchAnnotationsAsBatch property set to true.
-//     Spec: Anchoring Namespace Spec.doc
-//
 
 using System.ComponentModel;
 using System.Windows;
@@ -265,7 +254,6 @@ namespace MS.Internal.Annotations.Anchoring
         ///     logical tree node.  Attach this property to the element with a
         ///     unique value.
         /// </summary>
-#pragma warning suppress 7009
         public static readonly DependencyProperty DataIdProperty =
                 DependencyProperty.RegisterAttached(
                         "DataId",
@@ -310,7 +298,6 @@ namespace MS.Internal.Annotations.Anchoring
         ///     processor should load all annotations for the subtree rooted
         ///     a the element as a batch.
         /// </summary>
-#pragma warning suppress 7009
         public static readonly DependencyProperty FetchAnnotationsAsBatchProperty = DependencyProperty.RegisterAttached(
                 "FetchAnnotationsAsBatch",
                 typeof(bool),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
@@ -2,17 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable 1634, 1691
-//
-//
-// Description:
-//     The main entry-point to the Anchoring namespace.  LocatorManager is the
-//     controller for the Anchoring algorithms.  Most of the work is delegated
-//     to processors.  LocatorManager maintains a registry of processors.
-//     Spec: Anchoring Namespace Spec.doc
-//
-//
-
 using System.Collections;
 using System.ComponentModel;
 using System.Windows;
@@ -445,7 +434,6 @@ namespace MS.Internal.Annotations.Anchoring
         ///     processed, you should set this property and call LoadAnnotations/
         ///     UnloadAnnotations on the service.
         /// </summary>
-#pragma warning suppress 7009
         public static readonly DependencyProperty SubTreeProcessorIdProperty = DependencyProperty.RegisterAttached(
                 "SubTreeProcessorId",
                 typeof(string),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/PathNode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/PathNode.cs
@@ -1,16 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#pragma warning disable 1634, 1691
-//
-//
-// Description:
-//     PathNode represents a node in a path (a subset of the element tree).
-//     PathNodes can have other PathNodes as children.  Each refers to a
-//     single element in the element tree.
-//     Spec: Anchoring Namespace Spec.doc
-//
 
 using System.Collections;
 using System.Windows;
@@ -196,7 +186,6 @@ namespace MS.Internal.Annotations.Anchoring
         /// For instance, the root of a PageViewer's content tree would point
         /// to the DocumentPaginator that is holding on to the tree.
         /// </summary>
-#pragma warning suppress 7009
         internal static readonly DependencyProperty HiddenParentProperty = DependencyProperty.RegisterAttached("HiddenParent", typeof(DependencyObject), typeof(PathNode));
 
         #endregion Internal Properties

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/Journaling.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/Journaling.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,11 +11,6 @@ using System.Windows;
 using System.Windows.Markup;
 
 using System.Windows.Navigation;
-
-//In order to avoid generating warnings about unknown message numbers and 
-//unknown pragmas when compiling your C# source code with the actual C# compiler, 
-//you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal.AppModel
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourcePart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourcePart.cs
@@ -1,24 +1,12 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-//
-//
-// Description:
-// ResourcePart is an implementation of the abstract PackagePart class. It contains an override for GetStreamCore.
-//
 
 using System.IO.Packaging;
 using System.Windows;
 using System.IO;
 
 using MS.Internal.Resources;
-
-//In order to avoid generating warnings about unknown message numbers and 
-//unknown pragmas when compiling your C# source code with the actual C# compiler, 
-//you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
-
 
 namespace MS.Internal.AppModel
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourcePart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourcePart.cs
@@ -134,7 +134,6 @@ namespace MS.Internal.AppModel
                         }
                     }
                 }
-#pragma warning disable 6502 // PRESharp - Catch statements should not have empty bodies
                 catch (System.Resources.MissingManifestResourceException)
                 {
                     // When the main assembly doesn't contain any resource (all the resources must come from satellite assembly)
@@ -144,8 +143,6 @@ namespace MS.Internal.AppModel
                     // If the main assembly does contain resource, but the resource with above _name does't exist, the above GetStream( )
                     // just returns null without exception.
                 }
-#pragma warning restore 6502
-
             }
 
             // Do not attempt to load the original file name here.  If the .baml does not exist or if this resource not

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/ConnectionPointCookie.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/ConnectionPointCookie.cs
@@ -85,10 +85,6 @@ namespace MS.Internal.Controls
             }
         }
 
-#pragma warning disable 6500
-
-// The 6500 warning is actually handled in below code, but the PreSharp explicitly checks the presence of NullReferenceException and SEHException, and still treat below code as violation of presharp rule, so suppress it here.
-
         /// <summary>
         /// Disconnect the current connection point.  If the object is not connected,
         /// this method will do nothing.
@@ -131,8 +127,6 @@ namespace MS.Internal.Controls
                 }
             }
         }
-
-#pragma warning restore 6500
 
         ~ConnectionPointCookie()
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/ConnectionPointCookie.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/ConnectionPointCookie.cs
@@ -6,10 +6,6 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using MS.Win32;
 
-// Since we disable PreSharp warnings in this file, PreSharp warning is unknown to C# compiler.
-// We first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 namespace MS.Internal.Controls
 {
     internal class ConnectionPointCookie

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/EmptyEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/EmptyEnumerator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -46,9 +46,6 @@ namespace MS.Internal.Controls
         /// <returns>false</returns>
         public bool MoveNext() { return false; }
 
-
-#pragma warning disable 1634, 1691  // about to use PreSharp message numbers - unknown to C#
-
         /// <summary>
         /// Returns null.
         /// </summary>
@@ -56,14 +53,9 @@ namespace MS.Internal.Controls
         {
             get
             {
-#pragma warning disable 6503 // "Property get methods should not throw exceptions."
-
                 throw new InvalidOperationException();
-
-#pragma warning restore 6503
             }
         }
-#pragma warning restore 1634, 1691
 
         private static IEnumerator _instance;
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/ModelTreeEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/ModelTreeEnumerator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -74,13 +74,8 @@ namespace MS.Internal.Controls
                 {
                     return _content;
                 }
-
-#pragma warning disable 1634 // about to use PreSharp message numbers - unknown to C#
-                // Fall through -- can't enumerate (before beginning or after end)
-#pragma warning suppress 6503   
+                // Exception is part of the IEnumerator.Current contract when moving beyond begin/end
                 throw new InvalidOperationException(SR.EnumeratorInvalidOperation);
-                // above exception is part of the IEnumerator.Current contract when moving beyond begin/end
-#pragma warning restore 1634
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/WebBrowserEvent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/WebBrowserEvent.cs
@@ -108,9 +108,6 @@ namespace MS.Internal.Controls
                     cancelRequested = e.Cancel;
                 }
             }
-            // We disable this to suppress FXCop warning since in this case we really want to catch all exceptions
-            // please refer to comment below
-#pragma warning disable 6502
             catch
             {
                 // This is an interesting pattern of putting a try catch block around this that catches everything,
@@ -120,7 +117,6 @@ namespace MS.Internal.Controls
                 // There fore I catch all exceptions and cancel navigation 
                 cancelRequested = true;
             }
-#pragma warning restore 6502
             finally
             {
                 // Clean the WebBrowser control state if navigation cancelled.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/WebBrowserEvent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/WebBrowserEvent.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -16,11 +16,6 @@ using System.Windows.Controls;
 using MS.Win32;
 using MS.Internal.AppModel;
 using MS.Internal.Interop;
-
-//In order to avoid generating warnings about unknown message numbers and
-//unknown pragmas when compiling your C# source code with the actual C# compiler,
-//you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal.Controls
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CompositeCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CompositeCollectionView.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -17,8 +17,6 @@ using System.Windows.Data;
 using System.Windows.Controls;
 using MS.Internal.Utility;
 using MS.Internal.Hashing.PresentationFramework;    // HashHelper
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace MS.Internal.Data
 {
@@ -1560,12 +1558,12 @@ namespace MS.Internal.Data
                     // InvalidOperationException: The enumerator is positioned before the first element of the collection or after the last element.
                     if (_index < 0)
                     {
-#pragma warning suppress 6503 // ICollectionView.CurrentItem is documented to throw this exception
+                        // ICollectionView.CurrentItem is documented to throw this exception
                         throw new InvalidOperationException(SR.EnumeratorNotStarted);
                     }
                     if (_done)
                     {
-#pragma warning suppress 6503 // ICollectionView.CurrentItem is documented to throw this exception
+                        // ICollectionView.CurrentItem is documented to throw this exception
                         throw new InvalidOperationException(SR.EnumeratorReachedEnd);
                     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DefaultAsyncDataDispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DefaultAsyncDataDispatcher.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -58,14 +58,9 @@ namespace MS.Internal.Data
         {
             AsyncDataRequest request = (AsyncDataRequest)o;
 
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-#pragma warning disable 1634, 1691
-
             // PreSharp complains about catching NullReference (and other) exceptions.
             // In this case, these are precisely the ones we want to catch the most,
             // so that a failure on a worker thread doesn't affect the main thread.
-#pragma warning disable 56500
 
             // run the request - this may take a while
             try
@@ -87,9 +82,6 @@ namespace MS.Internal.Data
             {
                 request.Fail(new InvalidOperationException(SR.Format(SR.NonCLSException, "processing an async data request")));
             }
-
-#pragma warning restore 56500
-#pragma warning restore 1634, 1691
 
             // remove the request from the list
             lock (_list.SyncRoot)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/IndexedEnumerable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/IndexedEnumerable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -91,7 +91,7 @@ namespace MS.Internal.Data
                     return _cachedIndex;
             }
 
-            // If item != cached item, that doesn�t mean that the enumerator
+            // If item != cached item, that doesn’t mean that the enumerator
             // is `blown, it just means we have to go find the item represented by item.
             index = -1;
             // only ask for fresh enumerator if current enumerator already was moved before
@@ -205,7 +205,6 @@ namespace MS.Internal.Data
         {
             get
             {
-#pragma warning disable 1634 // about to use PreSharp message numbers - unknown to C#
                 // try if source collection has a indexer
                 object value;
                 if (GetNativeItemAt(index, out value))
@@ -245,13 +244,11 @@ namespace MS.Internal.Data
                 // moved beyond the end of the enumerator?
                 if (moveBy != 0)
                 {
-#pragma warning suppress 6503   // "Property get methods should not throw exceptions."
                     throw new ArgumentOutOfRangeException("index"); // validating the index argument
                 }
 
                 CacheCurrentItem(index, _enumerator.Current);
                 return _cachedItem;
-#pragma warning restore 1634
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PropertyPathWorker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PropertyPathWorker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -533,13 +533,6 @@ namespace MS.Internal.Data
         {
             bool result = false;
 
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-#pragma warning disable 1634, 1691
-
-            // PreSharp complains about catching NullReference (and other) exceptions.
-            // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-#pragma warning disable 56500
             try
             {
                 result = (pi != null) && pi.GetIndexParameters().Length > 0;
@@ -550,9 +543,6 @@ namespace MS.Internal.Data
                 if (CriticalExceptions.IsCriticalApplicationException(ex))
                     throw;
             }
-
-#pragma warning restore 56500
-#pragma warning restore 1634, 1691
 
             return result;
         }
@@ -1372,14 +1362,6 @@ namespace MS.Internal.Data
                         return false;
                 }
 
-                // PreSharp uses message numbers that the C# compiler doesn't know about.
-                // Disable the C# complaints, per the PreSharp documentation.
-#pragma warning disable 1634, 1691
-
-                // PreSharp complains about catching NullReference (and other) exceptions.
-                // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-#pragma warning disable 56500
-
                 try
                 {
                     object arg = null;
@@ -1436,9 +1418,6 @@ namespace MS.Internal.Data
                 {
                     return false;
                 }
-
-#pragma warning restore 56500
-#pragma warning restore 1634, 1691
             }
 
             // common case is IList - one arg of type Int32.  Wrap the arg so
@@ -1535,14 +1514,6 @@ namespace MS.Internal.Data
                     }
                 }
 
-                // PreSharp uses message numbers that the C# compiler doesn't know about.
-                // Disable the C# complaints, per the PreSharp documentation.
-#pragma warning disable 1634, 1691
-
-                // PreSharp complains about catching NullReference (and other) exceptions.
-                // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-#pragma warning disable 56500
-
                 try
                 {
                     o = GetValue(item, k);
@@ -1571,9 +1542,6 @@ namespace MS.Internal.Data
                     if (_host != null)
                         _host.ReportGetValueError(k, item, new ArgumentOutOfRangeException("index"));
                 }
-
-#pragma warning restore 56500
-#pragma warning restore 1634, 1691
 
                 return o;
             }
@@ -1643,14 +1611,6 @@ namespace MS.Internal.Data
             // the (arbitrary) exception they throw, and just use the result of
             // CanWrite.
 
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-#pragma warning disable 1634, 1691
-
-            // PreSharp complains about catching NullReference (and other) exceptions.
-            // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-#pragma warning disable 56500
-
             // CanWrite says whether we're even allowed to call SetValue
             // (there's no try-block here - if a custom property doesn't even
             // implement CanWrite, we just fail).
@@ -1686,9 +1646,6 @@ namespace MS.Internal.Data
             // if we get here, the property has CanWrite=true, and a non-public
             // setter. Returning true causes the caller to throw.
             return true;
-
-#pragma warning restore 56500
-#pragma warning restore 1634, 1691
         }
 
         // see whether DBNull is a valid value for update, and cache the answer

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/BamlTreeMap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/BamlTreeMap.cs
@@ -13,13 +13,6 @@ using System.Windows;
 
 using MS.Utility;
 
-
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
-
 namespace MS.Internal.Globalization
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/LocalizationComments.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/LocalizationComments.cs
@@ -17,12 +17,6 @@ using System.Windows;
 
 using MS.Utility;
 
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
-
 namespace MS.Internal.Globalization
 {
     /// <remarks>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/ISFClipboardData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/ISFClipboardData.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -61,20 +61,15 @@ namespace MS.Internal.Ink
         // Copies the internal strokes to the IDataObject
         protected override void DoCopy(IDataObject dataObject)
         {
-            // samgeo - Presharp issue
             // Presharp gives a warning when local IDisposable variables are not closed
             // in this case, we can't call Dispose since it will also close the underlying stream
             // which needs to be open for consumers to read
-#pragma warning disable 1634, 1691
-#pragma warning disable 6518
 
             // Save the data in the data object.
             MemoryStream stream = new MemoryStream();
             Strokes.Save(stream);
             stream.Position = 0;
             dataObject.SetData(StrokeCollection.InkSerializedFormat, stream);
-#pragma warning restore 6518
-#pragma warning restore 1634, 1691
         }
 
         // Retrieves the stroks from the IDataObject

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/ContainerParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/ContainerParagraph.cs
@@ -428,14 +428,12 @@ namespace MS.Internal.PtsHost
         internal override void CreateParaclient(
             out IntPtr paraClientHandle)        // OUT: opaque to PTS paragraph client
         {
-#pragma warning disable 6518
-            // Disable PRESharp warning 6518. ContainerParaClient is an UnmamangedHandle, that adds itself
+            // ContainerParaClient is an UnmamangedHandle, that adds itself
             // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and 
             // calls DestroyParaclient to get rid of it. DestroyParaclient will call Dispose() on the object
             // and remove it from HandleMapper.
             ContainerParaClient paraClient =  new ContainerParaClient(this);
             paraClientHandle = paraClient.Handle;
-#pragma warning restore 6518
         }
 
         //-------------------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/ContainerParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/ContainerParagraph.cs
@@ -2,19 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-//
-// Description: ContainerParagraph represents continuous piece of backing 
-//              storage and consists of other paragraphs. Collection of 
-//              these paragraphs is stored  as double-linked list of 
-//              Paragraph objects. 
-//              A container paragraph is associated with a block element 
-//              and can be hosted by a section or another container paragraph.
-//
-
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown 
-// message numbers and unknown pragmas for PRESharp contol
-
 using System.Windows;
 using System.Windows.Documents;
 using MS.Internal.Documents;
@@ -1332,6 +1319,3 @@ namespace MS.Internal.PtsHost
         private bool _firstParaValidInUpdateMode;
     }
 }
-
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FigureHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FigureHelper.cs
@@ -1,14 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-
-//
-// Description: Helpers for figure formatting
-//
-
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown 
-// message numbers and unknown pragmas for PRESharp contol
 
 using System.Windows;
 using System.Windows.Media;
@@ -257,6 +249,3 @@ namespace MS.Internal.PtsHost
         }
     }
 }
-
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FigureParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FigureParagraph.cs
@@ -10,9 +10,6 @@
 //              Figures now are finite only.
 //
 
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown 
-// message numbers and unknown pragmas for PRESharp contol
-
 using System.Windows;
 using System.Windows.Documents;
 using MS.Internal.Text;
@@ -706,6 +703,3 @@ namespace MS.Internal.PtsHost
         #endregion Private Fields
     }
 }
-
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FigureParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FigureParagraph.cs
@@ -83,14 +83,12 @@ namespace MS.Internal.PtsHost
         internal override void CreateParaclient(
             out IntPtr paraClientHandle)        // OUT: opaque to PTS paragraph client
         {
-#pragma warning disable 6518
-            // Disable PRESharp warning 6518. FigureParaClient is an UnmamangedHandle, that adds itself
+            // FigureParaClient is an UnmamangedHandle, that adds itself
             // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and 
             // calls DestroyParaclient to get rid of it. DestroyParaclient will call Dispose() on the object
             // and remove it from HandleMapper.
             FigureParaClient paraClient =  new FigureParaClient(this);
             paraClientHandle = paraClient.Handle;
-#pragma warning restore 6518
 
             // Create the main text segment
             if (_mainTextSegment == null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FloaterBaseParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FloaterBaseParagraph.cs
@@ -1,13 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-// 
-// Description: FloaterBaseParagraph class provides a wrapper for floater 
-//              and UIElement objects.
-//
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown
-// message numbers and unknown pragmas for PRESharp contol
 
 using System.Windows.Documents;
 
@@ -210,5 +203,3 @@ namespace MS.Internal.PtsHost
         #endregion PTS callbacks
     }
 }
-
-#pragma warning enable 1634, 1691

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FloaterParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FloaterParagraph.cs
@@ -2,13 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// 
-// Description: FloaterParagraph class provides a wrapper floater objects.
-//
-
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown 
-// message numbers and unknown pragmas for PRESharp contol
-
 using System.Windows;
 using System.Windows.Documents;
 using MS.Internal.Text;
@@ -936,6 +929,4 @@ namespace MS.Internal.PtsHost
         #endregion Private Fields
     }
 }
-
-#pragma warning enable 1634, 1691
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FloaterParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FloaterParagraph.cs
@@ -78,14 +78,12 @@ namespace MS.Internal.PtsHost
         internal override void CreateParaclient(
             out IntPtr paraClientHandle)        // OUT: opaque to PTS paragraph client
         {
-#pragma warning disable 6518
-            // Disable PRESharp warning 6518. FloaterParaClient is an UnmamangedHandle, that adds itself
+            // FloaterParaClient is an UnmamangedHandle, that adds itself
             // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and 
             // calls DestroyParaclient to get rid of it. DestroyParaclient will call Dispose() on the object
             // and remove it from HandleMapper.
             FloaterParaClient paraClient =  new FloaterParaClient(this);
             paraClientHandle = paraClient.Handle;
-#pragma warning restore 6518
 
             // Create the main text segment
             if (_mainTextSegment == null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
@@ -2,14 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-//
-// Description: Text line formatter.
-//
-
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown
-// message numbers and unknown pragmas for PRESharp contol
-
 using System.Globalization;
 using System.Windows;
 using System.Windows.Documents;
@@ -1325,6 +1317,3 @@ namespace MS.Internal.PtsHost
         #endregion FormattingContext Class
     }
 }
-
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/LineBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/LineBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,7 +7,6 @@
 // Description: Text line formatter.
 //
 
-
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Media.TextFormatting;
@@ -15,9 +14,6 @@ using MS.Internal.Text;
 using MS.Internal.Documents;
 
 using MS.Internal.PtsHost.UnsafeNativeMethods;
-
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown
-// message numbers and unknown pragmas for PRESharp contol
 
 namespace MS.Internal.PtsHost
 {
@@ -387,6 +383,3 @@ namespace MS.Internal.PtsHost
         #endregion Protected Fields
     }
 }
-
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/ListParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/ListParagraph.cs
@@ -1,13 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-//
-// Description: ListParagraph represents collection of list items.
-//
-
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown 
-// message numbers and unknown pragmas for PRESharp contol
 
 using System.Windows;
 using System.Windows.Documents;
@@ -42,14 +35,12 @@ namespace MS.Internal.PtsHost
         internal override void CreateParaclient(
             out IntPtr paraClientHandle)         
         {
-#pragma warning disable 6518
-            // Disable PRESharp warning 6518. ListParaClient is an UnmamangedHandle, that adds itself
+            // ListParaClient is an UnmamangedHandle, that adds itself
             // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and 
             // calls DestroyParaclient to get rid of it. DestroyParaclient will call Dispose() on the object
             // and remove it from HandleMapper.
             ListParaClient paraClient =  new ListParaClient(this);
             paraClientHandle = paraClient.Handle;
-#pragma warning restore 6518
         }
 
         /// <summary>
@@ -146,6 +137,3 @@ namespace MS.Internal.PtsHost
         }
     }
 }
-
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/OptimalTextSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/OptimalTextSource.cs
@@ -2,14 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-//
-// Description: Text line formatter.
-//
-
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown
-// message numbers and unknown pragmas for PRESharp contol
-
 using System.Globalization;
 using System.Windows;
 using System.Windows.Documents;
@@ -251,6 +243,3 @@ namespace MS.Internal.PtsHost
         private int _cpPara;
     }
 }
-
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsHost.cs
@@ -1519,25 +1519,21 @@ namespace MS.Internal.PtsHost
                 {
                     TextBreakpoint textBreakpoint = textBreakpoints[breakIndex];
 
-#pragma warning disable 56518
-                    // Disable PRESharp warning 56518. LineBreakpoint is an UnmamangedHandle, that adds itself
+                    // LineBreakpoint is an UnmamangedHandle, that adds itself
                     // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and 
                     // calls Destroyline to get rid of it. Destroyline will call Dispose() on the object
                     // and remove it from HandleMapper.
                     LineBreakpoint lineBreakpoint = new LineBreakpoint(optimalBreakSession, textBreakpoint);
-#pragma warning restore 56518
 
                     TextLineBreak textLineBreakOut = textBreakpoint.GetTextLineBreak();
 
                     if(textLineBreakOut != null)
                     {
-#pragma warning disable 56518
-                // Disable PRESharp warning 6518. Line is an UnmamangedHandle, that adds itself
+                //Line is an UnmamangedHandle, that adds itself
                 // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and
                 // calls DestroyLineBreakRecord to get rid of it. DestroyLineBreakRecord will call Dispose() on the object
                 // and remove it from HandleMapper.
                         LineBreakRecord lineBreakRecord = new LineBreakRecord(optimalBreakSession.PtsContext, textLineBreakOut);
-#pragma warning disable 56518
 
                         rgfslinevariant[breakIndex].pfsbreakreclineclient = lineBreakRecord.Handle;
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsHost.cs
@@ -14,15 +14,6 @@
 *
 **************************************************************************/
 
-
-//
-// Description: Provides PTS callbacks implementation / forwarding. 
-//
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown 
-// message numbers and unknown pragmas for PRESharp contol
-
-#pragma warning disable 6500        // Specifically disable warning about unhandled null reference and SEH exceptions.
-
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Media.TextFormatting;
@@ -4190,7 +4181,3 @@ namespace MS.Internal.PtsHost
         #endregion PTS callbacks
     }
 }
-
-#pragma warning enable 6500
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/SubpageParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/SubpageParagraph.cs
@@ -1,14 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-
-//
-// Description: SubpageParagraph represents a PTS subpage.
-//
-
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown 
-// message numbers and unknown pragmas for PRESharp contol
 
 using System.Windows;
 using System.Windows.Documents;
@@ -706,6 +698,3 @@ namespace MS.Internal.PtsHost
         #endregion Private Fields
     }
 }
-
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/SubpageParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/SubpageParagraph.cs
@@ -83,14 +83,12 @@ namespace MS.Internal.PtsHost
         {
             SubpageParaClient paraClient;
 
-#pragma warning disable 6518
-            // Disable PRESharp warning 6518. SubpageParaClient is an UnmamangedHandle, that adds itself
+            // SubpageParaClient is an UnmamangedHandle, that adds itself
             // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and 
             // calls DestroyParaclient to get rid of it. DestroyParaclient will call Dispose() on the object
             // and remove it from HandleMapper.
             paraClient =  new SubpageParaClient(this);
             paraClientHandle = paraClient.Handle;
-#pragma warning restore 6518
         }
 
         //-------------------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TableParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TableParagraph.cs
@@ -2,13 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 //
 // Description: Implementation of the PTS paragraph corresponding to table.
 //
-
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown 
-// message numbers and unknown pragmas for PRESharp contol
 
 using System.Windows;
 using System.Windows.Documents;
@@ -597,6 +593,3 @@ namespace MS.Internal.PtsHost
         #endregion Private Structures Classes 
     }
 }
-
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TableParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TableParagraph.cs
@@ -126,14 +126,12 @@ namespace MS.Internal.PtsHost
         internal override void CreateParaclient(
             out IntPtr pfsparaclient)           // OUT: opaque to PTS paragraph client
         {
-#pragma warning disable 6518
-            // Disable PRESharp warning 6518. TableParaClient is an UnmamangedHandle, that adds itself
+            // TableParaClient is an UnmamangedHandle, that adds itself
             // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and 
             // calls DestroyParaclient to get rid of it. DestroyParaclient will call Dispose() on the object
             // and remove it from HandleMapper.
             TableParaClient paraClient = new TableParaClient(this);
             pfsparaclient = paraClient.Handle;
-#pragma warning restore 6518
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParagraph.cs
@@ -965,8 +965,7 @@ namespace MS.Internal.PtsHost
                 }
                 else
                 {
-#pragma warning disable 6518
-                    // Disable PRESharp warning 6518. FigureParagraph is passed to attached objects
+                    // FigureParagraph is passed to attached objects
                     // which will do following:
                     // a) store this object in TextParagraph._floaters collection. Later when
                     //    TextParagraph is disposed, all objects in _floaters collection will be
@@ -976,8 +975,6 @@ namespace MS.Internal.PtsHost
                     // c) call Dipose() on this object during layout pass following removal of floater.
 
                     FloaterParagraph floaterPara = new FloaterParagraph(textElement, StructuralCache);
-
-#pragma warning restore 6518
 
                     if (StructuralCache.CurrentFormatContext.IncrementalUpdate)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParagraph.cs
@@ -2,15 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-//
-// Description: TextParagraph is a Paragraph representing continuous sequence
-//              of lines.
-//
-
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown
-// message numbers and unknown pragmas for PRESharp contol
-
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Media.TextFormatting;
@@ -1788,6 +1779,3 @@ namespace MS.Internal.PtsHost
         #endregion Private Fields
     }
 }
-
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParagraph.cs
@@ -114,14 +114,12 @@ namespace MS.Internal.PtsHost
         internal override void CreateParaclient(
             out IntPtr paraClientHandle)         
         {
-#pragma warning disable 6518
-            // Disable PRESharp warning 6518. TextParaClient is an UnmamangedHandle, that adds itself
+            // TextParaClient is an UnmamangedHandle, that adds itself
             // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and
             // calls DestroyParaclient to get rid of it. DestroyParaclient will call Dispose() on the object
             // and remove it from HandleMapper.
             TextParaClient paraClient = new TextParaClient(this);
             paraClientHandle = paraClient.Handle;
-#pragma warning restore 6518
         }
 
         /// <summary>
@@ -516,13 +514,11 @@ namespace MS.Internal.PtsHost
             StructuralCache.CurrentFormatContext.OnFormatLine();
 
             // Create and format line
-#pragma warning disable 6518
-            // Disable PRESharp warning 6518. Line is an UnmamangedHandle, that adds itself
+            // Line is an UnmamangedHandle, that adds itself
             // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and
             // calls DestroyLine to get rid of it. DestroyLine will call Dispose() on the object
             // and remove it from HandleMapper.
             Line line = new Line(StructuralCache.TextFormatterHost, paraClient, ParagraphStartCharacterPosition);
-#pragma warning restore 6518
 
             Line.FormattingContext ctx = new Line.FormattingContext(true, fClearOnLeft, fClearOnRight, _textRunCache)
             {
@@ -538,13 +534,11 @@ namespace MS.Internal.PtsHost
 
             if(textLineBreak != null)
             {
-#pragma warning disable 56518
-                // Disable PRESharp warning 6518. Line is an UnmamangedHandle, that adds itself
+                // Line is an UnmamangedHandle, that adds itself
                 // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and
                 // calls DestroyLineBreakRecord to get rid of it. DestroyLineBreakRecord will call Dispose() on the object
                 // and remove it from HandleMapper.
                 LineBreakRecord lineBreakRecord = new LineBreakRecord(PtsContext, textLineBreak);
-#pragma warning disable 56518
 
                 ppbrlineOut = lineBreakRecord.Handle;
             }
@@ -704,13 +698,12 @@ namespace MS.Internal.PtsHost
             StructuralCache.CurrentFormatContext.OnFormatLine();
 
             // Create and format line
-#pragma warning disable 6518
-            // Disable PRESharp warning 6518. Line is an UnmamangedHandle, that adds itself
+            // Line is an UnmamangedHandle, that adds itself
             // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and
             // calls DestroyLine to get rid of it. DestroyLine will call Dispose() on the object
             // and remove it from HandleMapper.
             Line line = new Line(StructuralCache.TextFormatterHost, paraClient, ParagraphStartCharacterPosition);
-#pragma warning restore 6518
+
             Line.FormattingContext ctx = new Line.FormattingContext(true, fClearOnLeft, fClearOnRight, _textRunCache);
             FormatLineCore(line, pbrlineIn, ctx, dcp, durLine, durTrack, fTreatAsFirstInPara, dcp);
 
@@ -722,13 +715,11 @@ namespace MS.Internal.PtsHost
 
             if(textLineBreak != null)
             {
-#pragma warning disable 56518
-                // Disable PRESharp warning 6518. Line is an UnmamangedHandle, that adds itself
+                // Line is an UnmamangedHandle, that adds itself
                 // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and
                 // calls DestroyLineBreakRecord to get rid of it. DestroyLineBreakRecord will call Dispose() on the object
                 // and remove it from HandleMapper.
                 LineBreakRecord lineBreakRecord = new LineBreakRecord(PtsContext, textLineBreak);
-#pragma warning restore 56518
 
                 ppbrlineOut = lineBreakRecord.Handle;
             }
@@ -954,8 +945,7 @@ namespace MS.Internal.PtsHost
 
                 if(textElement is Figure && StructuralCache.CurrentFormatContext.FinitePage)
                 {
-#pragma warning disable 6518
-                    // Disable PRESharp warning 6518. FigureParagraph is passed to attached objects
+                    // FigureParagraph is passed to attached objects
                     // which will do following:
                     // a) store this object in TextParagraph._floaters collection. Later when
                     //    TextParagraph is disposed, all objects in _floaters collection will be
@@ -965,8 +955,6 @@ namespace MS.Internal.PtsHost
                     // c) call Dipose() on this object during layout pass following removal of floater.
 
                     FigureParagraph figurePara = new FigureParagraph(textElement, StructuralCache);
-
-#pragma warning restore 6518
 
                     if (StructuralCache.CurrentFormatContext.IncrementalUpdate)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/UIElementParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/UIElementParagraph.cs
@@ -2,13 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-// 
-// Description: UIElementParagraph class provides a wrapper for UIElements.
-//
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown
-// message numbers and unknown pragmas for PRESharp contol
-
 using System.Windows;                           // UIElement
 using System.Windows.Documents;                 // BlockUIContainer
 using MS.Internal.Text;                         // TextDpi
@@ -586,6 +579,3 @@ namespace MS.Internal.PtsHost
         #endregion Private Fields
     }
 }
-
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/UIElementParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/UIElementParagraph.cs
@@ -87,14 +87,12 @@ namespace MS.Internal.PtsHost
         internal override void CreateParaclient(
             out IntPtr paraClientHandle)        // OUT: opaque to PTS paragraph client
         {
-#pragma warning disable 6518
-            // Disable PRESharp warning 6518. FloaterParaClient is an UnmamangedHandle, that adds itself
+            // FloaterParaClient is an UnmamangedHandle, that adds itself
             // to HandleMapper that holds a reference to it. PTS manages lifetime of this object, and 
             // calls DestroyParaclient to get rid of it. DestroyParaclient will call Dispose() on the object
             // and remove it from HandleMapper.
             UIElementParaClient paraClient = new UIElementParaClient(this);
             paraClientHandle = paraClient.Handle;
-#pragma warning restore 6518
         }
 
         //-------------------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Utility/BindUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Utility/BindUriHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,12 +13,6 @@
 using System.Windows;
 using System.Windows.Navigation;
 using MS.Internal.AppModel;
-
-// In order to avoid generating warnings about unknown message numbers and 
-// unknown pragmas when compiling your C# source code with the actual C# compiler, 
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
-
 
 namespace MS.Internal.Utility
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/HostedElements.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/HostedElements.cs
@@ -1,15 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-// Enumerator class for returning descendants of TextBlock and FlowDocumentPage
-//
-
 using System.Collections;
 using System.Collections.ObjectModel;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Documents
 {
@@ -160,19 +154,18 @@ namespace System.Windows.Documents
         {
             get
             {
-                // Disable PRESharp warning 6503: "Property get methods should not throw exceptions".
                 // HostedElements must throw exception if Current property is incorrectly accessed
                 if (_textSegments == null)
                 {
                     // Collection was modified 
-#pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                    // IEnumerator.Current is documented to throw this exception
                     throw new InvalidOperationException(SR.EnumeratorCollectionDisposed);
                 }
 
                 if (_currentPosition == null)
                 {
                     // Enumerator not started. Call MoveNext to see if we can move ahead
-#pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                    // IEnumerator.Current is documented to throw this exception
                     throw new InvalidOperationException(SR.EnumeratorNotStarted);
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/AnnotationHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/AnnotationHelper.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#pragma warning disable 1634, 1691
 
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/AnnotationService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/AnnotationService.cs
@@ -1,8 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable 1634, 1691
 //
 // Description:
 //      AnnotationService provides DynamicProperties and API for configuring
@@ -531,7 +530,6 @@ namespace System.Windows.Annotations
         /// out of box annotation component.  If the DP is set to AnnotationComponentChooser.None, no annotation components will be choosen
         /// for this subtree, in essence disabling the mechanism for the subtree.
         /// </summary>
-#pragma warning suppress 7009
         internal static readonly DependencyProperty ChooserProperty = DependencyProperty.RegisterAttached("Chooser", typeof(AnnotationComponentChooser), typeof(AnnotationService), new FrameworkPropertyMetadata(new AnnotationComponentChooser(), FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.OverridesInheritanceBehavior));
 
         /// <summary>
@@ -555,7 +553,6 @@ namespace System.Windows.Annotations
         ///     processed, you should set this property and call LoadAnnotations/
         ///     UnloadAnnotations on the service.
         /// </summary>
-#pragma warning suppress 7009
         internal static readonly DependencyProperty SubTreeProcessorIdProperty = LocatorManager.SubTreeProcessorIdProperty.AddOwner(typeof(AnnotationService));
 
         /// <summary>
@@ -594,7 +591,6 @@ namespace System.Windows.Annotations
         ///     logical tree node.  Attach this property to the element with a
         ///     unique value.
         /// </summary>
-#pragma warning suppress 7009
         internal static readonly DependencyProperty DataIdProperty = DataIdProcessor.DataIdProperty.AddOwner(typeof(AnnotationService));
 
         /// <summary>
@@ -693,7 +689,6 @@ namespace System.Windows.Annotations
         ///     in order to make direct calls such as CreateAnnotation.  Kept internal because
         ///     PathNode uses it to short-circuit the path building when there is a service set.
         /// </summary>
-#pragma warning suppress 7009
         internal static readonly DependencyProperty ServiceProperty = DependencyProperty.RegisterAttached("Service", typeof(AnnotationService), typeof(AnnotationService), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.OverridesInheritanceBehavior));
 
         #endregion Internal Fields
@@ -1730,7 +1725,6 @@ namespace System.Windows.Annotations
         ///     Private DynamicProperty used to attach lists of AttachedAnnotations to
         ///     Elements in the tree.
         /// </summary>
-#pragma warning suppress 7009
         private static readonly DependencyProperty AttachedAnnotationsProperty = DependencyProperty.RegisterAttached("AttachedAnnotations", typeof(IList<IAttachedAnnotation>), typeof(AnnotationService));
 
         // The root of the subtree for which this AnnotationService is managing annotations.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/LocatorPartList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/LocatorPartList.cs
@@ -1,17 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#pragma warning disable 1634, 1691
-//
-// Description:
-//     ContentLocatorBase contains an ordered set of ContentLocatorParts which each identify
-//     a piece of content within a certain context. Resolving one part
-//     provides the context to resolve the next part.  Locators are used 
-//     to refer to external data in a structured way.
-//
-//     Spec: Simplifying Store Cache Model.doc
-//
 
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -20,8 +9,6 @@ using System.Xml.Schema;
 using System.Xml.Serialization;
 using MS.Internal;
 using MS.Internal.Annotations;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Annotations
 {
@@ -81,7 +68,6 @@ namespace System.Windows.Annotations
             Invariant.Assert(locator.Parts != null, "Locator has null Parts property.");
 
             // If this locator is shorter than matchList, then this can't contain matchList.            
-            #pragma warning suppress 6506 // Invariant.Assert(locator.Parts != null)
             if (this.Parts.Count < locator.Parts.Count)
             {
                 return false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -15,12 +15,6 @@
 //              to define global properties and maintain state across multiple pages of markup.
 //
 
-
-//In order to avoid generating warnings about unknown message numbers and unknown pragmas
-//when compiling your C# source code with the actual C# compiler, you need to disable
-//warnings 1634 and 1691. (From PreSharp Documentation)
-#pragma warning disable 1634, 1691
-
 using System.Collections;
 using System.Collections.Specialized;
 using System.ComponentModel;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/WindowAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/WindowAutomationPeer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,10 +6,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.ComponentModel;
 using MS.Win32;
-
-// Used to support the warnings disabled below
-#pragma warning disable 1634, 1691
-
 
 namespace System.Windows.Automation.Peers
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/WindowAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/WindowAutomationPeer.cs
@@ -72,11 +72,7 @@ namespace System.Windows.Automation.Peers
                 if(windowHandle != IntPtr.Zero) //it is Zero on a window that was just closed
                 {
                     try { SafeNativeMethods.GetWindowRect(new HandleRef(null, windowHandle), ref rc); }
-// Allow empty catch statements.
-#pragma warning disable 56502
                     catch(Win32Exception) {}
-// Disallow empty catch statements.
-#pragma warning restore 56502
                 }        
                 bounds = new Rect(rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/CheckBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/CheckBox.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,7 +10,7 @@ using MS.Internal.KnownBoxes;
 using MS.Internal.Telemetry.PresentationFramework;
 
 // Disable CS3001: Warning as Error: not CLS-compliant
-#pragma warning disable 3001
+#pragma warning disable CS3001
 
 namespace System.Windows.Controls
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ColumnDefinition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ColumnDefinition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -28,8 +28,6 @@ using BuildInfo = MS.Internal.PresentationFramework.BuildInfo;
 
 //
 //---------------------------------------------------------------------------
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Controls
 {
@@ -798,12 +796,12 @@ namespace System.Windows.Controls
                     {
                         if (_index == -1)
                         {
-                            #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                            // IEnumerator.Current is documented to throw this exception
                             throw new InvalidOperationException(SR.EnumeratorNotStarted);
                         }
                         else
                         {
-                            #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                            // IEnumerator.Current is documented to throw this exception
                             throw new InvalidOperationException(SR.EnumeratorReachedEnd);
                         }
                     }
@@ -824,12 +822,12 @@ namespace System.Windows.Controls
                     {
                         if (_index == -1)
                         {
-                            #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                            // IEnumerator.Current is documented to throw this exception
                             throw new InvalidOperationException(SR.EnumeratorNotStarted);
                         }
                         else
                         {
-                            #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                            // IEnumerator.Current is documented to throw this exception
                             throw new InvalidOperationException(SR.EnumeratorReachedEnd);
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataErrorValidationRule.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataErrorValidationRule.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -72,14 +72,6 @@ namespace System.Windows.Controls
                     // We do this in a paranoid way, even though indexers with
                     // string-valued arguments are not supposed to throw exceptions.
 
-                    // PreSharp uses message numbers that the C# compiler doesn't know about.
-                    // Disable the C# complaints, per the PreSharp documentation.
-                    #pragma warning disable 1634, 1691
-
-                    // PreSharp complains about catching NullReference (and other) exceptions.
-                    // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-                    #pragma warning disable 56500
-
                     string error;
                     try
                     {
@@ -103,8 +95,6 @@ namespace System.Windows.Controls
                                             bindingExpr);
                         }
                     }
-                    #pragma warning restore 56500
-                    #pragma warning restore 1634, 1691
 
                     if (!String.IsNullOrEmpty(error))
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
@@ -23,8 +23,6 @@ using System.Threading;
 using System.Windows.Media;
 using System.Windows.Markup;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Controls
 {
     /// <summary>
@@ -3922,12 +3920,12 @@ namespace System.Windows.Controls
                 {
                     if (_currentEnumerator == -1)
                     {
-                        #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                        // IEnumerator.Current is documented to throw this exception
                         throw new InvalidOperationException(SR.EnumeratorNotStarted);
                     }
                     if (_currentEnumerator >= 3)
                     {
-                        #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                        // IEnumerator.Current is documented to throw this exception
                         throw new InvalidOperationException(SR.EnumeratorReachedEnd);
                     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -736,7 +736,6 @@ namespace System.Windows.Controls
             }
         }
 
-#pragma warning disable 1634, 1691  // about to use PreSharp message numbers - unknown to C#
         /// <summary>
         ///     Returns an object to be used in thread synchronization.
         /// </summary>
@@ -752,14 +751,12 @@ namespace System.Windows.Controls
                 if (IsUsingItemsSource)
                 {
                     // see discussion in XML comment above.
-                    #pragma warning suppress 6503 // "Property get methods should not throw exceptions."
                     throw new NotSupportedException(SR.ItemCollectionShouldUseInnerSyncRoot);
                 }
 
                 return _internalView.SyncRoot;
             }
         }
-#pragma warning restore 1634, 1691
 
         /// <summary>
         ///     Gets a value indicating whether the IList has a fixed size.
@@ -1978,17 +1975,12 @@ namespace System.Windows.Controls
         // be sure that we reference that member on the derived class.
         private new void VerifyRefreshNotDeferred()
         {
-            #pragma warning disable 1634, 1691 // about to use PreSharp message numbers - unknown to C#
-            #pragma warning disable 6503
             // If the Refresh is being deferred to change filtering or sorting of the
             // data by this CollectionView, then CollectionView will not reflect the correct
             // state of the underlying data.
 
             if (IsRefreshDeferred)
                 throw new InvalidOperationException(SR.NoCheckOrChangeWhenDeferred);
-
-            #pragma warning restore 6503
-            #pragma warning restore 1634, 1691
         }
 
         // SortDescription was added/removed to/from this ItemCollection.SortDescriptions, refresh CollView

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBoxItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBoxItem.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,7 +14,7 @@ using System.Windows.Input;
 using System.Windows.Controls.Primitives;
 
 // Disable CS3001: Warning as Error: not CLS-compliant
-#pragma warning disable 3001
+#pragma warning disable CS3001
 
 namespace System.Windows.Controls
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -19,7 +19,7 @@ using System.Windows.Input;
 using System.Windows.Controls.Primitives;
 
 // Disable CS3001: Warning as Error: not CLS-compliant
-#pragma warning disable 3001
+#pragma warning disable CS3001
 
 namespace System.Windows.Controls
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Page.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Page.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,11 +14,6 @@ using System.Windows.Markup;
 using System.Windows.Documents;
 using MS.Internal.KnownBoxes;
 using MS.Internal;
-
-//In order to avoid generating warnings about unknown message numbers and 
-//unknown pragmas when compiling your C# source code with the actual C# compiler, 
-//you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Controls
 {
@@ -658,7 +653,7 @@ namespace System.Windows.Controls
             }
 
             // NOTE (Huwang 03/09/2007): The code below walks up the TemplatedParent chain until it finds the first Frame or Window. It does not 
-            // check whether Window.Content or Frame.Content is Page. So it allows the scenario where Page can be in any element�s template and 
+            // check whether Window.Content or Frame.Content is Page. So it allows the scenario where Page can be in any element’s template and 
             // be parented by any element as long as the template is nested inside a Window or Frame, as demoed below
             //
             // <Window>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Page.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Page.cs
@@ -156,9 +156,7 @@ namespace System.Windows.Controls
                 VerifyAccess();
                 if (WindowService == null)
                 {
-#pragma warning disable 6503
                     throw new InvalidOperationException(SR.CannotQueryPropertiesWhenPageNotInTreeWithWindow);
-#pragma warning restore 6503
                 }
                 return WindowService.Title;
             }
@@ -213,9 +211,7 @@ namespace System.Windows.Controls
                 VerifyAccess();
                 if (WindowService == null)
                 {
-#pragma warning disable 6503
                     throw new InvalidOperationException(SR.CannotQueryPropertiesWhenPageNotInTreeWithWindow);
-#pragma warning restore 6503
                 }                
                 return WindowService.Height;
             }
@@ -267,9 +263,7 @@ namespace System.Windows.Controls
                 VerifyAccess();
                 if (WindowService == null)
                 {
-#pragma warning disable 6503
                     throw new InvalidOperationException(SR.CannotQueryPropertiesWhenPageNotInTreeWithWindow);
-#pragma warning restore 6503
                 }                
                 return WindowService.Width;
             }
@@ -365,9 +359,7 @@ namespace System.Windows.Controls
                 VerifyAccess();
                 if (WindowService == null)
                 {
-#pragma warning disable 6503
                     throw new InvalidOperationException(SR.CannotQueryPropertiesWhenPageNotInTreeWithWindow);
-#pragma warning restore 6503
                 }
 
                 // Return false if it is not NavigationWindow.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordBox.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-// Description: The stock password control.
-//
-
 using System.ComponentModel;
 using System.Security;
 using System.Windows.Media;
@@ -17,8 +13,6 @@ using MS.Internal;
 using MS.Internal.KnownBoxes;
 using MS.Internal.Telemetry.PresentationFramework;
 using System.Windows.Controls.Primitives;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Controls
 {
@@ -185,7 +179,6 @@ namespace System.Windows.Controls
 
                 using (SecureString securePassword = new SecureString())
                 {
-                    #pragma warning suppress 6506 // value is set to String.Empty if it was null.
                     for (int i = 0; i < value.Length; i++)
                     {
                         securePassword.AppendChar(value[i]);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DocumentViewerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DocumentViewerBase.cs
@@ -2,17 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-// Description: DocumentViewerBase is a minimal base class, providing only
-//              the functionality common across document viewing scenarios.
-//              The base class provides no user interface, very few properties,
-//              and minimal policy. Functionality included in the base class:
-//              BringIntoView support & Print API services
-//              and Annotation support.
-//
-#pragma warning disable 1634, 1691  // avoid generating warnings about unknown
-// message numbers and unknown pragmas for PRESharp contol
-
 using System.Collections;               // IEnumerator
 using System.Collections.ObjectModel;   // ReadOnlyCollection<T>
 using System.Windows.Annotations;       // AnnotationService
@@ -1787,5 +1776,3 @@ namespace System.Windows.Controls.Primitives
         #endregion IServiceProvider
     }
 }
-#pragma warning enable 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DocumentViewerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DocumentViewerBase.cs
@@ -1549,11 +1549,9 @@ namespace System.Windows.Controls.Primitives
                     {
                         pageNumber = Convert.ToInt32(args.Parameter, System.Globalization.CultureInfo.CurrentCulture);
                     }
-#pragma warning disable 56502 // Allow empty catch statements.
                     catch (InvalidCastException) { }
                     catch (OverflowException) { }
                     catch (FormatException) { }
-#pragma warning restore 56502
 
                     if (pageNumber >= 0)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
@@ -2724,9 +2724,6 @@ namespace System.Windows.Controls.Primitives
             }
         }
 
-        // Not interested in the unmanaged error codes. Error return values detected and handled. Extended error information not needed.
-#pragma warning disable 6523
-
         /// <summary>
         ///     Returns information about the mouse cursor size.
         /// </summary>
@@ -2866,8 +2863,6 @@ namespace System.Windows.Controls.Primitives
         {
             return _secHelper.GetWindowRect();
         }
-
-#pragma warning restore 6523
 
         #endregion Positioning
 
@@ -3299,10 +3294,6 @@ namespace System.Windows.Controls.Primitives
                 return root as Visual;
             }
 
-// newWindow is referenced by the _window static field, but
-// PreSharp will think that newWindow is local and should be disposed.
-#pragma warning disable 6518
-
             internal void BuildWindow(int x, int y, Visual placementTarget,
                 bool transparent, HwndSourceHook hook, AutoResizedEventHandler handler, HwndDpiChangedEventHandler dpiChangedHandler)
             {
@@ -3386,8 +3377,6 @@ namespace System.Windows.Controls.Primitives
                 // add the DpiChagnedEventHandler
                 newWindow.DpiChanged += dpiChangedHandler;
             }
-
-#pragma warning restore 6518
 
             private static bool ConnectedToForegroundWindow(IntPtr window)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
@@ -26,10 +26,6 @@ using MS.Win32;
 
 using CommonDependencyProperty = MS.Internal.PresentationFramework.CommonDependencyPropertyAttribute;
 
-// Disable pragma warnings to enable PREsharp pragmas
-#pragma warning disable 1634, 1691
-
-
 namespace System.Windows.Controls.Primitives
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ScrollContentPresenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ScrollContentPresenter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -568,13 +568,8 @@ namespace System.Windows.Controls
                 return Rect.Empty;
             }
 
-            // This is a false positive by PreSharp. visual cannot be null because of the 'if' check above
-#pragma warning disable 1634, 1691
-#pragma warning disable 56506
             // Compute the child's rect relative to (0,0) in our coordinate space.
             GeneralTransform childTransform = visual.TransformToAncestor(this);
-#pragma warning restore 56506
-#pragma warning restore 1634, 1691
 
             rectangle = childTransform.TransformBounds(rectangle);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Selector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Selector.cs
@@ -17,9 +17,6 @@ using MS.Internal.Controls;
 
 using BuildInfo = MS.Internal.PresentationFramework.BuildInfo;
 
-// Disable CS3001: Warning as Error: not CLS-compliant
-#pragma warning disable 3001
-
 namespace System.Windows.Controls.Primitives
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ToggleButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ToggleButton.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,9 +9,6 @@ using System.Windows.Threading;
 using System.Windows.Automation.Peers;
 
 using MS.Internal.KnownBoxes;
-
-// Disable CS3001: Warning as Error: not CLS-compliant
-#pragma warning disable 3001
 
 namespace System.Windows.Controls.Primitives
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,7 +10,7 @@ using System.Windows.Media;
 using MS.Internal.Telemetry.PresentationFramework;
 
 // Disable CS3001: Warning as Error: not CLS-compliant
-#pragma warning disable 3001
+#pragma warning disable CS3001
 
 namespace System.Windows.Controls
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RowDefinition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RowDefinition.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -22,14 +22,7 @@ using BuildInfo = MS.Internal.PresentationFramework.BuildInfo;
 //                  \wcp\Framework\Ms\Utility\GridContentElementCollection.tb
 //                  \wcp\Framework\Ms\Utility\RowDefinitionCollection.ti
 //
-//
-//
-//
-
-//
 //---------------------------------------------------------------------------
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Controls
 {
@@ -798,12 +791,12 @@ namespace System.Windows.Controls
                     {
                         if (_index == -1)
                         {
-                            #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                            // IEnumerator.Current is documented to throw this exception
                             throw new InvalidOperationException(SR.EnumeratorNotStarted);
                         }
                         else
                         {
-                            #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                            // IEnumerator.Current is documented to throw this exception
                             throw new InvalidOperationException(SR.EnumeratorReachedEnd);
                         }
                     }
@@ -824,12 +817,12 @@ namespace System.Windows.Controls
                     {
                         if (_index == -1)
                         {
-                            #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                            // IEnumerator.Current is documented to throw this exception
                             throw new InvalidOperationException(SR.EnumeratorNotStarted);
                         }
                         else
                         {
-                            #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                            // IEnumerator.Current is documented to throw this exception
                             throw new InvalidOperationException(SR.EnumeratorReachedEnd);
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Stack.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Stack.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -243,13 +243,9 @@ namespace System.Windows.Controls
             {
                 return Rect.Empty;
             }
-#pragma warning disable 1634, 1691
-#pragma warning disable 56506
             // Compute the child's rect relative to (0,0) in our coordinate space.
-            // This is a false positive by PreSharp. visual cannot be null because of the 'if' check above
             GeneralTransform childTransform = visual.TransformToAncestor(this);
-#pragma warning restore 56506
-#pragma warning restore 1634, 1691
+
             rectangle = childTransform.TransformBounds(rectangle);
 
             // We can't do any work unless we're scrolling.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/StickyNote.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/StickyNote.cs
@@ -2,16 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// In order to disable Presharp warning 6507 - Prefer 'string.IsNullOrEmpty(value)' over checks for null and/or emptiness,
-// we have to disable warnings 1634 and 1691 to make the compiler happy first.
-#pragma warning disable 1634, 1691
-
-//
-// Description: Implementation of StickyNoteControl control.
-//
-//              See spec at StickyNoteControlSpec.mht
-//
-
 using System.Globalization;
 using System.Xml;
 using MS.Internal;
@@ -28,7 +18,6 @@ using System.Windows.Ink;
 using System.Windows.Input;
 using System.Windows.Media;
 using MS.Utility;
-
 
 namespace System.Windows.Controls
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TabItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TabItem.cs
@@ -14,7 +14,7 @@ using System.Windows.Data;
 using System.Windows.Controls.Primitives;
 
 // Disable CS3001: Warning as Error: not CLS-compliant
-#pragma warning disable 3001
+#pragma warning disable CS3001
 
 namespace System.Windows.Controls
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -23,8 +23,6 @@ using MS.Internal.Controls;
 using MS.Internal.PresentationFramework;
 using MS.Internal.Telemetry.PresentationFramework;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Controls
 {
     /// <summary>
@@ -1851,7 +1849,7 @@ Debug.Assert(lineCount == LineCount);
             {
                 if(CheckFlags(Flags.ContentChangeInProgress))
                 {
-                    #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                    // IEnumerator.Current is documented to throw this exception
                     throw new InvalidOperationException(SR.TextContainerChangingReentrancyInvalid);
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -4138,9 +4138,3 @@ Debug.Assert(lineCount == LineCount);
         #endregion Dependency Property Helpers
     }
 }
-
-
-// Disable pragma warnings to enable PREsharp pragmas
-#pragma warning restore 1634, 1691
-
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
@@ -1493,13 +1493,9 @@ namespace System.Windows.Controls
                 return Rect.Empty;
             }
 
-#pragma warning disable 1634, 1691
-#pragma warning disable 56506
             // Compute the child's rect relative to (0,0) in our coordinate space.
-            // This is a false positive by PreSharp. visual cannot be null because of the 'if' check above
             GeneralTransform childTransform = visual.TransformToAncestor(this);
-#pragma warning restore 56506
-#pragma warning restore 1634, 1691
+
             rectangle = childTransform.TransformBounds(rectangle);
 
             // We can't do any work unless we're scrolling.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/CornerRadiusConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/CornerRadiusConverter.cs
@@ -1,21 +1,12 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-//
-// 
-//
-// Description: Contains the CornerRadiusConverter: TypeConverter for the CornerRadiusclass.
-//
-//
 
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;
 using System.Reflection;
 using MS.Internal;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {
@@ -105,9 +96,6 @@ namespace System.Windows
             throw GetConvertFromException(source);
         }
 
-//Workaround for PreSharp bug - it complains about value being possibly null even though there is a check above
-#pragma warning disable 56506
-
         /// <summary>
         /// ConvertTo - Attempt to convert a CornerRadius to the given type
         /// </summary>
@@ -133,7 +121,6 @@ namespace System.Windows
 
             if (!(value is CornerRadius))
             {
-                #pragma warning suppress 6506 // value is obviously not null
                 throw new ArgumentException(SR.Format(SR.UnexpectedParameterType, value.GetType(), typeof(CornerRadius)), "value");
             }
 
@@ -147,9 +134,6 @@ namespace System.Windows
 
             throw new ArgumentException(SR.Format(SR.CannotConvertType, typeof(CornerRadius), destinationType.FullName));
         }
-
-//Workaround for PreSharp bug - it complains about value being possibly null even though there is a check above
-#pragma warning restore 56506
 
         #endregion Public Methods
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/Binding.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/Binding.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -146,19 +146,6 @@ namespace System.Windows.Data
         {
             FrameworkElement.RemoveHandler(element, TargetUpdatedEvent, handler);
         }
-
-
-        // PreSharp uses message numbers that the C# compiler doesn't know about.
-        // Disable the C# complaints, per the PreSharp documentation.
-        #pragma warning disable 1634, 1691
-
-        // PreSharp checks that the type of the DP agrees with the type of the static
-        // accessors.  But setting the type of the DP to XmlNamespaceManager would
-        // load System.Xml during the static cctor, which is considered a perf bug.
-        // So instead we set the type of the DP to 'object' and use the
-        // ValidateValueCallback to ensure that only values of the right type are allowed.
-        // Meanwhile, disable the PreSharp warning
-        #pragma warning disable 7008
 
         /// <summary>
         /// The XmlNamespaceManager to use to perform Namespace aware XPath queries in XmlData bindings

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/Binding.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/Binding.cs
@@ -178,10 +178,6 @@ namespace System.Windows.Data
             return (value == null) || SystemXmlHelper.IsXmlNamespaceManager(value);
         }
 
-        #pragma warning restore 7008
-        #pragma warning restore 1634, 1691
-
-
         //------------------------------------------------------
         //
         //  Constructors

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
@@ -1627,14 +1627,6 @@ namespace System.Windows.Data
             string stringFormat = EffectiveStringFormat;
             Invariant.Assert(converter != null || stringFormat != null);
 
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-            #pragma warning disable 1634, 1691
-
-            // PreSharp complains about catching NullReference (and other) exceptions.
-            // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-            #pragma warning disable 56500
-
             object convertedValue = null;
             try
             {
@@ -1684,9 +1676,6 @@ namespace System.Windows.Data
                 convertedValue = DependencyProperty.UnsetValue;
             }
 
-            #pragma warning restore 56500
-            #pragma warning restore 1634, 1691
-
             return convertedValue;
         }
 
@@ -1697,14 +1686,6 @@ namespace System.Windows.Data
                                          CultureInfo culture)
         {
             Invariant.Assert(converter != null);
-
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-            #pragma warning disable 1634, 1691
-
-            // PreSharp complains about catching NullReference (and other) exceptions.
-            // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-            #pragma warning disable 56500
 
             object convertedValue = null;
             try
@@ -1747,9 +1728,6 @@ namespace System.Windows.Data
                 }
                 convertedValue = DependencyProperty.UnsetValue;
             }
-
-            #pragma warning restore 56500
-            #pragma warning restore 1634, 1691
 
             return convertedValue;
         }
@@ -1994,15 +1972,6 @@ namespace System.Windows.Data
                 return value;
             }
 
-
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-            #pragma warning disable 1634, 1691
-
-            // PreSharp complains about catching NullReference (and other) exceptions.
-            // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-            #pragma warning disable 56500
-
             try
             {
                 BeginSourceUpdate();
@@ -2037,9 +2006,6 @@ namespace System.Windows.Data
             {
                 EndSourceUpdate();
             }
-
-            #pragma warning restore 56500
-            #pragma warning restore 1634, 1691
 
             OnSourceUpdated();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -2189,14 +2189,6 @@ namespace System.Windows.Data
                 TypeConverter converter = DefaultValueConverter.GetConverter(dp.PropertyType);
                 if (converter != null && converter.CanConvertFrom(value.GetType()))
                 {
-                    // PreSharp uses message numbers that the C# compiler doesn't know about.
-                    // Disable the C# complaints, per the PreSharp documentation.
-                    #pragma warning disable 1634, 1691
-
-                    // PreSharp complains about catching NullReference (and other) exceptions.
-                    // It doesn't recognize that IsCriticalException() handles these correctly.
-                    #pragma warning disable 56500
-
                     try
                     {
                         result = converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
@@ -2214,9 +2206,6 @@ namespace System.Windows.Data
                     catch // non CLS compliant exception
                     {
                     }
-
-                    #pragma warning restore 56500
-                    #pragma warning restore 1634, 1691
                 }
 
                 if (!success)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingGroup.cs
@@ -1249,14 +1249,6 @@ namespace System.Windows.Data
                 IEditableObject ieo = items[i] as IEditableObject;
                 if (ieo != null)
                 {
-                    // PreSharp uses message numbers that the C# compiler doesn't know about.
-                    // Disable the C# complaints, per the PreSharp documentation.
-                    #pragma warning disable 1634, 1691
-
-                    // PreSharp complains about catching NullReference (and other) exceptions.
-                    // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-                    #pragma warning disable 56500
-
                     try
                     {
                         ieo.EndEdit();
@@ -1270,9 +1262,6 @@ namespace System.Windows.Data
                         AddValidationError(error);
                         result = false;
                     }
-
-                    #pragma warning restore 56500
-                    #pragma warning restore 1634, 1691
                 }
             }
             return result;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1415,9 +1415,6 @@ namespace System.Windows.Data
         // and throw if that is the case.
         internal void VerifyRefreshNotDeferred()
         {
-            #pragma warning disable 1634, 1691 // about to use PreSharp message numbers - unknown to C#
-            #pragma warning disable 6503
-
             if (AllowsCrossThreadChanges)
                 VerifyAccess();
 
@@ -1427,9 +1424,6 @@ namespace System.Windows.Data
 
             if (IsRefreshDeferred)
                 throw new InvalidOperationException(SR.NoCheckOrChangeWhenDeferred);
-
-            #pragma warning restore 6503
-            #pragma warning restore 1634, 1691
         }
 
         internal void InvalidateEnumerableWrapper()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ObjectDataProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ObjectDataProvider.cs
@@ -436,14 +436,6 @@ namespace System.Windows.Data
             string  error   = null; // string that describes known error
             e = null;
 
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-            #pragma warning disable 1634, 1691
-
-            // PreSharp complains about catching NullReference (and other) exceptions.
-            // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-            #pragma warning disable 56500
-
             Debug.Assert(_objectType != null);
 
             try
@@ -489,9 +481,6 @@ namespace System.Windows.Data
                 e = new InvalidOperationException(SR.Format(SR.ObjectDataProviderNonCLSException, _objectType.Name));
             }
 
-            #pragma warning restore 56500
-            #pragma warning restore 1634, 1691
-
             if (e != null || error != null)
             {
                 // report known errors through TraceData (instead of throwing exceptions)
@@ -521,14 +510,6 @@ namespace System.Windows.Data
 
             object[] parameters = new object[_methodParameters.Count];
             _methodParameters.CopyTo(parameters, 0);
-
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-            #pragma warning disable 1634, 1691
-
-            // PreSharp complains about catching NullReference (and other) exceptions.
-            // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-            #pragma warning disable 56500
 
             try
             {
@@ -578,9 +559,6 @@ namespace System.Windows.Data
                 error = null;   // indicate unknown error
                 e = new InvalidOperationException(SR.Format(SR.ObjectDataProviderNonCLSExceptionInvoke, MethodName, _objectType.Name));
             }
-
-            #pragma warning restore 56500
-            #pragma warning restore 1634, 1691
 
             if (e != null || error != null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlNamespaceMapping.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlNamespaceMapping.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -90,13 +90,7 @@ namespace System.Windows.Data
             if (object.ReferenceEquals(mappingB, null))
                 return false;
 
-#pragma warning disable 1634, 1691
-
-            // presharp false positive for null-checking on mappings
-            #pragma warning suppress 56506
             return ((mappingA.Prefix == mappingB.Prefix) && (mappingA.Uri == mappingB.Uri)) ;
-
-#pragma warning restore 1634, 1691
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CaretElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CaretElement.cs
@@ -18,9 +18,6 @@ using System.Windows.Controls.Primitives;
 
 namespace System.Windows.Documents
 {
-    // Disable pragma warnings to enable PREsharp pragmas
-#pragma warning disable 1634, 1691
-
     /// <summary>
     /// This class is sealed because it calls OnVisualChildrenChanged virtual in the
     /// constructor and it does not override it, but derived classes could.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CaretElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CaretElement.cs
@@ -1135,10 +1135,7 @@ namespace System.Windows.Documents
         {
             Invariant.Assert(_isSelectionActive, "Blink animation should only be required for an owner with active selection.");
 
-            // Disable PreSharp#6523 - Win32 GetCaretBlinkTime can return "0"
-            // without the error if SetCaretBlinkTime set as "0".
-#pragma warning disable 6523
-
+            // Win32 GetCaretBlinkTime can return "0" without the error if SetCaretBlinkTime set as "0".
             int caretBlinkTime = (int)SafeNativeMethods.GetCaretBlinkTime();
             if (caretBlinkTime == 0)
             {
@@ -1146,8 +1143,6 @@ namespace System.Windows.Documents
                 // exception.
                 return -1;
             }
-
-#pragma warning restore 6523
 
             return caretBlinkTime;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequence.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequence.cs
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-// Description:
-//      Implements the FixedDocumentSequence element
-//
-
 using MS.Internal.Documents;
 using System.Collections;
 using System.Collections.Specialized;
@@ -17,8 +12,6 @@ using System.Windows.Threading;     // Dispatcher
 using System.Windows.Media;         // Visual
 using System.Windows.Markup; // IAddChild, ContentProperty
 using System.Windows.Navigation;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Documents
 {
@@ -323,7 +316,6 @@ namespace System.Windows.Documents
             if (contentPosition is DocumentSequenceTextPointer dsTextPointer)
             {
 
-#pragma warning suppress 6506 // dsTextPointer is obviously not null
                 childPaginator = GetPaginator(dsTextPointer.ChildBlock.DocRef);
                 childContentPosition = dsTextPointer.ChildPointer as ContentPosition;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextContainer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,14 +6,6 @@ using MS.Internal;
 using MS.Internal.Documents;
 using System.Collections.Specialized;
 using System.Collections.ObjectModel;
-
-//
-// Description:
-//      DocumentSequenceTextContainer is a TextContainer that aggregates
-//      0 or more TextContainer and expose them as single TextContainer.
-//
-
-#pragma warning disable 1634, 1691 // To enable presharp warning disables (#pragma suppress) below.
 
 namespace System.Windows.Documents
 {
@@ -311,7 +303,6 @@ namespace System.Windows.Documents
         {
             get
             {
-                #pragma warning suppress 56503
                 throw new NotImplementedException();
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextPointer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextPointer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,8 +10,6 @@ using MS.Internal;
 //      for FixedDocumentSequence. It is the base class for DocumentSequenceTextPointer and
 //      DocumentSequenceTextPointer.
 //
-
-#pragma warning disable 1634, 1691 // To enable presharp warning disables (#pragma suppress) below.
 
 namespace System.Windows.Documents
 {
@@ -412,7 +410,6 @@ namespace System.Windows.Documents
         {
             get
             {
-                #pragma warning suppress 56503
                 throw new NotImplementedException();
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextContainer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,13 +7,6 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using System.Collections;
-
-//
-// Description:
-//      Implements the FixedTextContainer
-//
-
-#pragma warning disable 1634, 1691 // To enable presharp warning disables (#pragma suppress) below.
 
 namespace System.Windows.Documents
 {
@@ -279,7 +272,6 @@ namespace System.Windows.Documents
         {
             get
             {
-                #pragma warning suppress 56503
                 throw new NotImplementedException();
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextPointer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextPointer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,8 +10,6 @@ using MS.Internal;
 //      for Fixed Document. It is the base class for FixedTextPosition and
 //      FixedTextPointer.
 //
-
-#pragma warning disable 1634, 1691 // To enable presharp warning disables (#pragma suppress) below.
 
 namespace System.Windows.Documents
 {
@@ -632,7 +630,6 @@ namespace System.Windows.Documents
         {
             get
             {
-                #pragma warning suppress 56503
                 throw new NotImplementedException();
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ImmComposition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ImmComposition.cs
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-// Description:
-//  This class handles IMM32 IME's composition string and support level 3 input to TextBox and RichTextBox.
-//
-
 using System.Runtime.InteropServices;
 using System.Collections;
 using System.Windows.Media;
@@ -16,9 +11,6 @@ using MS.Win32;
 using MS.Internal.Documents;
 using MS.Internal;
 using MS.Internal.Interop;
-
-// Enable presharp pragma warning suppress directives.
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Documents
 {
@@ -424,9 +416,6 @@ namespace System.Windows.Documents
                 {
                     result = new char[size / sizeof(short)];
 
-                    // 3rd param is out and contains actual result of this call.
-                    // suppress Presharp 6031.
-#pragma warning suppress 6031
                     UnsafeNativeMethods.ImmGetCompositionString(new HandleRef(this, himc), NativeMethods.GCS_RESULTSTR, result, size);
                 }
             }
@@ -440,9 +429,7 @@ namespace System.Windows.Documents
                 if (size > 0)
                 {
                     composition = new char[size / sizeof(short)];
-                    // 3rd param is out and contains actual result of this call.
-                    // suppress Presharp 6031.
-#pragma warning suppress 6031
+
                     UnsafeNativeMethods.ImmGetCompositionString(new HandleRef(this, himc), NativeMethods.GCS_COMPSTR, composition, size);
 
                     //
@@ -470,9 +457,7 @@ namespace System.Windows.Documents
                         if (size > 0)
                         {
                             attributes = new byte[size / sizeof(byte)];
-                            // 3rd param is out and contains actual result of this call.
-                            // suppress Presharp 6031.
-#pragma warning suppress 6031
+
                             UnsafeNativeMethods.ImmGetCompositionString(new HandleRef(this, himc), NativeMethods.GCS_COMPATTR, attributes, size);
                         }
                     }
@@ -694,7 +679,7 @@ namespace System.Windows.Documents
                     //  - fail to lock IMC.
                     // Those cases are ignorable for us.
                     // In addition, it does not set win32 last error and we have no clue to handle error.
-#pragma warning suppress 6031
+
                     UnsafeNativeMethods.ImmSetCandidateWindow(new HandleRef(this, himc), ref candform);
                     UnsafeNativeMethods.ImmReleaseContext(new HandleRef(this, hwnd), new HandleRef(this, himc));
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/NullTextNavigator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/NullTextNavigator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,8 +9,6 @@ using MS.Internal;
 //      TextNavigator implementation for NullTextContainer
 //      This is primarily used by internal code.
 //
-
-#pragma warning disable 1634, 1691 // To enable presharp warning disables (#pragma suppress) below.
 
 namespace System.Windows.Documents
 {
@@ -494,8 +492,7 @@ namespace System.Windows.Documents
         {
             get
             {
-                    #pragma warning suppress 56503
-                    throw new NotImplementedException();
+                throw new NotImplementedException();
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RangeContentEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RangeContentEnumerator.cs
@@ -1,16 +1,13 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable 1634, 1691 // To enable presharp warning disables (#pragma suppress) below.
 //
 // Description: IEnumerator for TextRange and TextElement content.
 //
 
 using System.Collections;
 using MS.Internal;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Documents
 {
@@ -66,9 +63,6 @@ namespace System.Windows.Documents
 
                 if (_navigator == null)
                 {
-                    // Disable presharp 6503: Property get methods should not throw exceptions.
-                    // We must throw here -- it's part of the IEnumerator contract.
-                    #pragma warning suppress 6503
                     throw new InvalidOperationException(SR.EnumeratorNotStarted);
                 }
 
@@ -83,7 +77,7 @@ namespace System.Windows.Documents
 
                 if (_navigator.CompareTo(_end) >= 0)
                 {
-                    #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                    // IEnumerator.Current is documented to throw this exception
                     throw new InvalidOperationException(SR.EnumeratorReachedEnd);
                 }
 
@@ -93,7 +87,7 @@ namespace System.Windows.Documents
                 // which in turn can modify the TextContainer.
                 if (_generation != _start.TextContainer.Generation && !IsLogicalChildrenIterationInProgress)
                 {
-                    #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                    // IEnumerator.Current is documented to throw this exception
                     throw new InvalidOperationException(SR.EnumeratorVersionChanged);
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Serialization/SerializerProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Serialization/SerializerProvider.cs
@@ -1,21 +1,13 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 #if !DONOTREFPRINTINGASMMETA
-//
-//
-// Description: Manages plug-in document serializers
-//
-//              See spec at <Need to post existing spec>
-//
 
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Windows.Xps.Serialization;
 using Microsoft.Win32;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Documents.Serialization
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Table.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Table.cs
@@ -1,12 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-//
-// Description: Table implementation
-//
-//              See spec at WPP TableOM.doc
-//
 
 using System.Collections;
 using System.ComponentModel;
@@ -15,12 +9,10 @@ using System.Windows.Markup;
 using MS.Internal.PtsHost.UnsafeNativeMethods;
 using MS.Internal.Documents;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Documents
 {
     /// <summary>
-    /// Table implements 
+    /// Table implementation 
     /// </summary>
     [ContentProperty("RowGroups")]
     public class Table : Block, IAddChild, IAcceptInsertion
@@ -483,12 +475,12 @@ namespace System.Windows.Documents
                 {
                     if (_currentChildType == ChildrenTypes.BeforeFirst)
                     {
-                        #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                        // IEnumerator.Current is documented to throw this exception
                         throw new InvalidOperationException(SR.EnumeratorNotStarted);
                     }
                     if (_currentChildType == ChildrenTypes.AfterLast)
                     {
-                        #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                        // IEnumerator.Current is documented to throw this exception
                         throw new InvalidOperationException(SR.EnumeratorReachedEnd);
                     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TableRowGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TableRowGroup.cs
@@ -332,6 +332,3 @@ namespace System.Windows.Documents
         //------------------------------------------------------
     }
 }
-
-#pragma warning restore 1634, 1691
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TableRowGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TableRowGroup.cs
@@ -1,17 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-//
-// Description: Table row group implementation
-//
-//              See spec at WPP TableOM.doc
-//
-
-//In order to avoid generating warnings about unknown message numbers and
-//unknown pragmas when compiling your C# source code with the actual C# compiler,
-//you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 using MS.Internal.PtsTable;
 using System.ComponentModel;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditor.cs
@@ -16,11 +16,6 @@ using MS.Win32;
 using MS.Internal.Documents;
 using MS.Internal.Commands; // CommandHelpers
 
-#pragma warning disable 1634, 1691 // To enable presharp warning disables (#pragma suppress) below.
-//
-// Description: Text editing service for controls.
-//
-
 namespace System.Windows.Documents
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElement.cs
@@ -1,13 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 //
 // Description: Base class for content in text based FrameworkElement.
 //
-
-// Enable presharp pragma warning suppress directives.
-#pragma warning disable 1634, 1691
 
 using System.Collections;
 using System.ComponentModel;
@@ -111,9 +108,6 @@ namespace System.Windows.Documents
                 // extracted before the final insert.
 
                 SplayTreeNode startNode = start.GetScopingNode();
-                // Suppress presharp 6506: Parameter 'end' to this public method must be validated.
-                // We already validated it indirectly above, when calling ValidationHelper.VerifyPositionPair.
-                #pragma warning suppress 6506
                 SplayTreeNode endNode = end.GetScopingNode();
 
                 if (startNode == _textElementNode)
@@ -153,8 +147,6 @@ namespace System.Windows.Documents
                 }
                 else
                 {
-                    // Presharp doesn't understand that by design TextPointer.TextContainer can never be null.
-                    #pragma warning suppress 6506
                     if (tree == start.TextContainer)
                     {
                         //
@@ -188,8 +180,6 @@ namespace System.Windows.Documents
                             tree.EndChange();
                         }
 
-                        // Presharp doesn't understand that by design TextPointer.TextContainer can never be null.
-                        #pragma warning suppress 56506
                         start.TextContainer.BeginChange();
                         try
                         {
@@ -245,8 +235,6 @@ namespace System.Windows.Documents
                 {
                     tree = EnsureTextContainer();
 
-                    // Presharp doesn't understand that by design EnsureTextContainer can never return null.
-                    #pragma warning suppress 6506
                     tree.BeginChange();
                     try
                     {
@@ -262,8 +250,6 @@ namespace System.Windows.Documents
             {
                 tree = textPosition.TextContainer;
 
-                // Presharp doesn't understand that by design TextPointer.TextContainer can never be null.
-                #pragma warning suppress 56506
                 tree.BeginChange();
                 try
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElementEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElementEnumerator.cs
@@ -1,18 +1,14 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-// Description: IEnumerator for TextRange and TextElement content.
-//
-// 
-
 using MS.Internal;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Documents
 {
+    /// <summary>
+    /// IEnumerator for TextRange and TextElement content.
+    /// </summary>
     internal class TextElementEnumerator<TextElementType> : IEnumerator<TextElementType> where TextElementType : TextElement
     {
         //------------------------------------------------------
@@ -84,13 +80,13 @@ namespace System.Windows.Documents
             { 
                 if (_navigator == null)
                 {
-                    #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                    // IEnumerator.Current is documented to throw this exception
                     throw new InvalidOperationException(SR.EnumeratorNotStarted);
                 }
 
                 if (_current == null)
                 {
-                    #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                    // IEnumerator.Current is documented to throw this exception
                     throw new InvalidOperationException(SR.EnumeratorReachedEnd);
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRange.cs
@@ -2,16 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-// Description: a high-level tool for editing text based FrameworkElements.
-//
-
 using MS.Internal;
 using System.Xml;
 using System.IO;
 using System.Windows.Markup; // Parser
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Documents
 {
@@ -788,7 +782,6 @@ namespace System.Windows.Documents
             if (!TextSchema.IsCharacterProperty(formattingProperty) &&
                 !TextSchema.IsParagraphProperty(formattingProperty))
             {
-                #pragma warning suppress 6506 // formattingProperty is obviously not null
                 throw new ArgumentException(SR.Format(SR.TextEditorPropertyIsNotApplicableForTextFormatting, formattingProperty.Name));
             }
 
@@ -857,7 +850,6 @@ namespace System.Windows.Documents
             if (!TextSchema.IsCharacterProperty(formattingProperty) &&
                 !TextSchema.IsParagraphProperty(formattingProperty))
             {
-                #pragma warning suppress 6506 // formattingProperty is obviously not null
                 throw new ArgumentException(SR.Format(SR.TextEditorPropertyIsNotApplicableForTextFormatting, formattingProperty.Name));
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ZoomPercentageConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ZoomPercentageConverter.cs
@@ -183,8 +183,7 @@ namespace System.Windows.Documents
                             isValidArg = true;
                         }
                     }
-                    // Allow empty catch statements.
-#pragma warning disable 56502
+
 
                     // Catch only the expected parse exceptions
                     catch (ArgumentOutOfRangeException) { }
@@ -192,9 +191,7 @@ namespace System.Windows.Documents
                     catch (FormatException) { }
                     catch (OverflowException) { }
 
-                    // Disallow empty catch statements.
-#pragma warning restore 56502
-                }
+            }
 
                 // Argument wasn't a valid percent, set error value.
                 if (!isValidArg)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ZoomPercentageConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ZoomPercentageConverter.cs
@@ -7,9 +7,6 @@
 //                ZoomPercentage property of DocumentViewer.
 //
 
-// Used to support the warnings disabled below
-#pragma warning disable 1634, 1691
-
 using System.Globalization;
 using System.Windows.Data;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkContentElement.cs
@@ -14,19 +14,10 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Markup;
 
-#if DEBUG
-#endif
-
 using MS.Internal;
 using MS.Internal.KnownBoxes;
 using MS.Internal.PresentationFramework;
 using MS.Utility;
-
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 namespace System.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
@@ -23,15 +23,8 @@ using MS.Internal.KnownBoxes;
 using MS.Internal.PresentationFramework;    // SafeSecurityHelper
 using MS.Utility;
 
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
-
 namespace System.Windows
 {
-
     /// <summary>
     /// HorizontalAlignment - The HorizontalAlignment enum is used to describe
     /// how element is positioned or stretched horizontally within a parent's layout slot.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElementFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElementFactory.cs
@@ -14,8 +14,6 @@ using System.Windows.Media.Media3D;
 using MS.Utility;
 using MS.Internal;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows
 {
     /// <summary>
@@ -87,7 +85,6 @@ namespace System.Windows
                         !typeof(FrameworkContentElement).IsAssignableFrom(value) &&
                         !typeof(Visual3D).IsAssignableFrom(value))
                     {
-                        #pragma warning suppress 6506 // value is obviously not null
                         throw new ArgumentException(SR.Format(SR.MustBeFrameworkOr3DDerived, value.Name));
                     }
                 }
@@ -219,7 +216,6 @@ namespace System.Windows
                 throw new NotSupportedException(SR.Format(SR.ModifyingLogicalTreeViaStylesNotImplemented, value, "FrameworkElementFactory.SetValue"));
             }
 
-            #pragma warning suppress 6506 // dp.DefaultMetadata is never null
             if (dp.ReadOnly)
             {
                 // Read-only properties will not be consulting FrameworkElementFactory for value.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/ActiveXHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/ActiveXHost.cs
@@ -32,10 +32,6 @@ using MS.Internal;
 using MS.Internal.Controls;
 using MS.Win32;
 
-// Since we disable PreSharp warnings in this file, PreSharp warning is unknown to C# compiler.
-// We first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 namespace System.Windows.Interop
 {
     #region ActiveXHost

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -12,9 +12,6 @@ using MS.Internal.Interop;
 using System.Windows.Media;
 using System.Runtime.InteropServices;
 using System.Windows.Threading;
-
-// Disable pragma warnings to enable PREsharp pragmas
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Interop
 {
@@ -475,7 +472,6 @@ namespace System.Windows.Interop
             if(disposing)
             {
                 // Verify the thread has access to the context.
-#pragma warning suppress 6519
                  VerifyAccess();
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/AttributeData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/AttributeData.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,12 +9,6 @@
 \***************************************************************************/
 
 using System;
-
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 #if !PBTCOMPILER
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -37,12 +37,6 @@ using MS.Internal.PresentationFramework;
 
 #endif
 
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
-
 #if PBTCOMPILER
 namespace MS.Internal.Markup
 #else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -21,12 +21,6 @@ using MS.Internal;
 using MS.Internal.Utility;
 using System.Windows.Navigation;
 
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
-
 namespace System.Windows.Markup
 {
     // Unlike the tokenizer and the writer, the reader knows the difference between CLR

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecords.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecords.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -26,12 +26,6 @@ using MS.Internal.PresentationFramework; // SafeSecurityHelper
 #endif
 
 using MS.Utility;
-
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 #if PBTCOMPILER
 namespace MS.Internal.Markup

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/KnownTypes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/KnownTypes.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -52,12 +52,6 @@ using System.Diagnostics;
 using System.Globalization;  // CultureInfo KnownType
 using System.Reflection;
 using MS.Utility;
-
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 #if PBTCOMPILER
 namespace MS.Internal.Markup

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/TemplateKeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/TemplateKeyConverter.cs
@@ -1,16 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/***************************************************************************\
-*
-*  Class for converting a given TemplateKey to a string
-*
-\***************************************************************************/
 using System.ComponentModel;        // for TypeConverter
 using System.Globalization;               // for CultureInfo
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Markup
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlParser.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -17,12 +17,6 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Globalization;
 using MS.Utility;
-
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 #if PBTCOMPILER
 namespace MS.Internal.Markup
@@ -96,7 +90,7 @@ namespace System.Windows.Markup
             // CS0618: A class member was marked with the Obsolete attribute, such that a warning 
             // will be issued when the class member is referenced. 
             textReader.ProhibitDtd = true;
-#pragma warning enable 0618 
+#pragma warning restore 0618 
 
             XmlCompatibilityReader xcr = new XmlCompatibilityReader(textReader,
                                                                     new IsXmlNamespaceSupportedCallback(IsXmlNamespaceSupported),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderConstants.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderConstants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,32 +10,6 @@
 
 // set this flag to turn on whitespace collapse rules.
 // #define UseValidatingReader
-
-
-/* Unmerged change from project 'PresentationFramework'
-Removed:
-using System;
-using System.Xml;
-using System.Xml.Serialization;
-using System.IO;
-using System.Text;
-using System.Collections;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Reflection;
-using System.Globalization;
-using MS.Utility;
-using System.Collections.Specialized;
-using Microsoft.Win32;
-using System.Runtime.InteropServices;
-using MS.Internal;
-*/
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 #if !PBTCOMPILER
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -22,12 +22,6 @@ using System.Reflection;
 using System.Globalization;
 using MS.Utility;
 using System.Collections.Specialized;
-
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 #if !PBTCOMPILER
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
@@ -25,12 +25,6 @@ using MS.Internal;  // CriticalExceptions
 
 #endif
 
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
-
 #if PBTCOMPILER
 namespace MS.Internal.Markup
 #else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -21,9 +21,6 @@ using MS.Internal.PresentationBuildTasks;
 using MS.Internal.PresentationFramework;
 using MS.Internal.Utility;  // AssemblyCacheEnum
 #endif
-
-// Since we disable PreSharp warnings in this file, we first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 #if PBTCOMPILER
 namespace MS.Internal.Markup

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/Generated/ThicknessAnimationBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/Generated/ThicknessAnimationBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,9 +7,6 @@
 //
 // Please see MilCodeGen.html for more information.
 //
-
-// Allow use of presharp: #pragma warning suppress <nnnn>
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Media.Animation
 {
@@ -133,10 +130,6 @@ namespace System.Windows.Media.Animation
 
             ArgumentNullException.ThrowIfNull(animationClock);
 
-            // We check for null above but presharp doesn't notice so we suppress the 
-            // warning here.
-
-#pragma warning suppress 6506
             if (animationClock.CurrentState == ClockState.Stopped)
             {
                 return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/Journal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/Journal.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -25,9 +25,6 @@ using System.Runtime.Serialization;
 
 using MS.Internal;
 using MS.Internal.AppModel;
-
-// Since we disable PreSharp warnings in this file, we first need to disable warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Navigation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/JournalEntry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/JournalEntry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+ï»¿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -17,11 +17,6 @@ using System.Runtime.Serialization;
 using MS.Internal.AppModel;
 using MS.Internal;
 using MS.Internal.Utility;
-
-//In order to avoid generating warnings about unknown message numbers and
-//unknown pragmas when compiling your C# source code with the actual C# compiler,
-//you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Navigation
 {
@@ -136,7 +131,7 @@ namespace System.Windows.Navigation
 
         /// <summary>
         /// Reads the attached property JournalEntry.Name from the given element.
-        /// Setting it at the root element of a navigator will update NavWin’s dropdown menu when navigating inside of that navigator.
+        /// Setting it at the root element of a navigator will update NavWinâ€™s dropdown menu when navigating inside of that navigator.
         /// </summary>
         /// <param name="dependencyObject">The element from which to read the attached property.</param>
         /// <returns>The property's value.</returns>
@@ -225,7 +220,7 @@ namespace System.Windows.Navigation
 
         /// <summary>
         /// Attached DependencyProperty for Name property.
-        /// Setting it at the root element of a navigator will update NavWin’s dropdown menu when navigating inside of that navigator.
+        /// Setting it at the root element of a navigator will update NavWinâ€™s dropdown menu when navigating inside of that navigator.
         /// </summary>
         public static readonly DependencyProperty NameProperty =
             DependencyProperty.RegisterAttached("Name", typeof(string), typeof(JournalEntry), new PropertyMetadata(String.Empty));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/JournalEntryListConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/JournalEntryListConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@
 //
 //
 //
-
-// Disable unknown #pragma warning for pragmas we use to exclude certain PreSharp violations
-#pragma warning disable 1634, 1691
 
 using System.Collections;
 using System.Collections.Specialized;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/JournalEntryListConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/JournalEntryListConverter.cs
@@ -29,9 +29,7 @@ namespace System.Windows.Navigation
         /// </summary>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-#pragma warning disable  6506
             return (value != null) ? ((JournalEntryStack)value).GetLimitedJournalEntryStackEnumerable() : null;
-#pragma warning restore 6506
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
@@ -1689,8 +1689,6 @@ namespace System.Windows.Navigation
             return true;
         }
 
-#pragma warning restore 6506
-
         //
         // bool INavigator.CanGoForward
         //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -28,11 +28,6 @@ using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Markup;
-
-//In order to avoid generating warnings about unknown message numbers and
-//unknown pragmas when compiling your C# source code with the actual C# compiler,
-//you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Navigation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
@@ -1505,7 +1505,6 @@ namespace System.Windows.Navigation
         /// Navigate to the source. Null source results in clearing existing content
         /// </summary>
         /// <value>returns bool to indicate if a navigation was started i.e. Navigating event was not cancelled</value>
-#pragma warning disable 6506  // Both source and navigationState can accept null as valid input.
         internal bool Navigate(Uri source, Object navigationState, bool sandboxExternalContent, bool navigateOnSourceChanged)
         {
             if (IsDisposed)
@@ -1614,17 +1613,11 @@ namespace System.Windows.Navigation
             }
         }
 
-#pragma warning restore 6506
-
-        //
-        // bool Navigate(Object root, Object navigationState)
-        //
         /// <summary>
         /// Navigate to content tree. Async state can be passed across the navigation
         /// and can be retrieved from the Navigation events.
         /// </summary>
         /// <value></value>
-#pragma warning disable 6506  // Both root and navigationState can accept null as vaild input.
         public bool Navigate(Object root, Object navigationState)
         {
             if (IsDisposed)
@@ -1858,7 +1851,6 @@ namespace System.Windows.Navigation
                     //we will end up with and which support Abort and which don't. These are
                     //not fatal errors so we safely ignore them.
 
-#pragma warning disable 6502
                     //Documented exception thrown by this method
                     catch (NotSupportedException)
                     {
@@ -1867,7 +1859,6 @@ namespace System.Windows.Navigation
                     catch (NotImplementedException)
                     {
                     }
-#pragma warning restore 6502
                 }
 
                 extraData = _navigateQueueItem.NavState;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/PropertyPath.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/PropertyPath.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -784,14 +784,6 @@ namespace System.Windows
 
             if (tc != null && tc.CanConvertFrom(typeof(string)))
             {
-                // PreSharp uses message numbers that the C# compiler doesn't know about.
-                // Disable the C# complaints, per the PreSharp documentation.
-                #pragma warning disable 1634, 1691
-
-                // PreSharp complains about catching NullReference (and other) exceptions.
-                // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-                #pragma warning disable 56500
-
                 try
                 {
                     value = tc.ConvertFromString(null, CultureInfo.InvariantCulture,
@@ -815,9 +807,6 @@ namespace System.Windows
                     if (throwOnError)
                         throw;
                 }
-
-                #pragma warning restore 56500
-                #pragma warning restore 1634, 1691
             }
 
             if (value == null && type.IsAssignableFrom(typeof(string)))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/PropertyPathConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/PropertyPathConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,8 +14,6 @@ using System.Globalization;
 using System.Reflection;
 using System.Windows.Markup;
 using MS.Internal.Data;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {
@@ -102,7 +100,6 @@ namespace System.Windows
                 return new PropertyPath((string)source, typeDescriptorContext);
             }
 
-            #pragma warning suppress 6506 // source is obviously not null
             throw new ArgumentException(SR.Format(SR.CannotConvertType, source.GetType().FullName, typeof(PropertyPath)));
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/RoutedPropertyChangedEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/RoutedPropertyChangedEventArgs.cs
@@ -1,9 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-// Disable CS3001, CS3003, CS3024: Warning as Error: not CLS-compliant
-#pragma warning disable 3001, 3003, 3024
 
 namespace System.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Setter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Setter.cs
@@ -1,20 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/***************************************************************************\
-*
-*
-*  TargetType property setting class.
-*
-*
-\***************************************************************************/
 using System.ComponentModel;
 using System.Windows.Markup;
 using System.Windows.Data;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
@@ -2,21 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/***************************************************************************\
-*
-*
-*  Style and templating.
-*
-*
-\***************************************************************************/
 using System.Collections;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows.Threading;
 using System.Windows.Markup;
 using MS.Utility;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {
@@ -174,7 +165,6 @@ namespace System.Windows
                     !typeof(FrameworkContentElement).IsAssignableFrom(value) &&
                     !(DefaultTargetType == value))
                 {
-                    #pragma warning suppress 6506 // value is obviously not null
                     throw new ArgumentException(SR.Format(SR.MustBeFrameworkDerived, value.Name));
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -103,7 +103,6 @@ namespace System.Windows
                 newThemeStyle.CheckTargetType(d);
                 newThemeStyle.Seal();
 
-#pragma warning disable 6503
                 // Check if the theme style has the OverridesDefaultStyle  property set on the target tag or any of its
                 // visual triggers. It is an error to specify the OverridesDefaultStyle  in your own ThemeStyle.
                 if (StyleHelper.IsSetOnContainer(FrameworkElement.OverridesDefaultStyleProperty, ref newThemeStyle.ContainerDependents, true))
@@ -116,7 +115,6 @@ namespace System.Windows
                 {
                     throw new InvalidOperationException(SR.CannotHaveEventHandlersInThemeStyle);
                 }
-#pragma warning restore 6503
             }
 
             themeStyleCache = newThemeStyle;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -23,12 +23,6 @@ using System.Windows.Markup;            // MarkupExtension
 using System.Threading;                 // Interlocked
 using MS.Internal.Data;                 // BindingValueChangedEventArgs
 
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
-
 namespace System.Windows
 {
     #region StyleHelper
@@ -5920,14 +5914,6 @@ namespace System.Windows
                     TypeConverter typeConverter = DefaultValueConverter.GetConverter(stateType);
                     if (typeConverter != null && typeConverter.CanConvertFrom(typeof(String)))
                     {
-                        // PreSharp uses message numbers that the C# compiler doesn't know about.
-                        // Disable the C# complaints, per the PreSharp documentation.
-                        #pragma warning disable 1634, 1691
-
-                        // PreSharp complains about catching NullReference (and other) exceptions.
-                        // It doesn't recognize that IsCritical[Application]Exception() handles these correctly.
-                        #pragma warning disable 56500
-
                         try
                         {
                             cachedValue = typeConverter.ConvertFromString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS, referenceString);
@@ -5942,9 +5928,6 @@ namespace System.Windows
                         {
                             // if the conversion failed, just use the unconverted value
                         }
-
-                        #pragma warning restore 56500
-                        #pragma warning restore 1634, 1691
                     }
 
                     // cache the converted value

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
@@ -89,13 +89,6 @@ namespace System.Windows
             return true;
         }
 
-// Disable Warning 6503 Property get methods should not throw exceptions.
-// By design properties below throw Win32Exception if there is an error when calling the native method
-#pragma warning disable 6503
-
-// Win32Exception will get the last Win32 error code in case of errors, so we don't have to.
-#pragma warning disable 6523
-
         #region Accessibility Parameters
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
@@ -4997,11 +4997,6 @@ namespace System.Windows
         }
         #endregion
 
-
-#pragma warning restore 6523
-
-#pragma warning restore 6503
-
         #region Cache and Implementation
 
         internal static void InvalidateCache()
@@ -5763,17 +5758,12 @@ namespace System.Windows
                             HandleRef desktopWnd = new HandleRef(null, IntPtr.Zero);
 
                             // Win32Exception will get the Win32 error code so we don't have to
-#pragma warning disable 6523
                             IntPtr dc = UnsafeNativeMethods.GetDC(desktopWnd);
 
-                            // Detecting error case from unmanaged call, required by PREsharp to throw a Win32Exception
-#pragma warning disable 6503
                             if (dc == IntPtr.Zero)
                             {
                                 throw new Win32Exception();
                             }
-#pragma warning restore 6503
-#pragma warning restore 6523
 
                             try
                             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
@@ -12,9 +12,6 @@ using MS.Win32;
 using MS.Internal;
 using MS.Internal.Interop;
 
-// Disable pragma warnings to enable PREsharp pragmas
-#pragma warning disable 1634, 1691
-
 namespace System.Windows
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -1007,10 +1007,6 @@ namespace System.Windows
 
         #region Value Changes
 
-        // The hwndNotify is referenced by the _hwndNotify static field, but
-        // PreSharp will think that the hwndNotify is local and should be disposed.
-#pragma warning disable 6518
-
         /// <summary>
         /// Ensures that a a notify-window is created corresponding to <see cref="ProcessDpiAwarenessContextValue"/>
         /// This is the default HWND used to listen for theme-change messages.
@@ -1183,8 +1179,6 @@ namespace System.Windows
 
             return dpiScale;
         }
-
-#pragma warning restore 6518
 
     private static void OnThemeChanged()
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -31,9 +31,6 @@ using System.Windows.Baml2006;
 using System.Xaml.Permissions;
 using System.Runtime.CompilerServices;
 
-// Disable pragma warnings to enable PREsharp pragmas
-#pragma warning disable 1634, 1691
-
 namespace System.Windows
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -796,7 +796,6 @@ namespace System.Windows
                 // There is no Assembly.Exists API to determine if an Assembly exists.
                 // There is also no way to determine if an Assembly's format is good prior to loading it.
                 // So, the exception must be caught. assembly will continue to be null and returned.
-#pragma warning disable 6502
                 catch (FileNotFoundException)
                 {
                 }
@@ -813,7 +812,6 @@ namespace System.Windows
                         RuntimeHelpers.RunClassConstructor(knownTypeHelper.TypeHandle);
                     }
                 }
-#pragma warning restore 6502
             }
 
             /// <summary>
@@ -912,8 +910,6 @@ namespace System.Windows
                 // There is no ResourceManager.HasManifest in order to detect this case before an exception is thrown.
                 // Likewise, there is no way to know if loading a resource will fail prior to loading it.
                 // So, the exceptions must be caught. stream will continue to be null and handled accordingly later.
-#pragma warning disable 6502
-
                 catch (MissingManifestResourceException)
                 {
                     // No usable resources in the assembly
@@ -928,8 +924,6 @@ namespace System.Windows
                     // Object not stored correctly
                 }
 #endif
-
-#pragma warning restore 6502
 
                 if (stream != null)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThicknessConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThicknessConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,8 +15,6 @@ using System.Runtime.CompilerServices;
 using System.Globalization;
 using System.Reflection;
 using MS.Internal;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -26,11 +26,6 @@ using SNM = Standard.NativeMethods;
 using HRESULT = MS.Internal.Interop.HRESULT;
 using Win32Error = MS.Internal.Interop.Win32Error;
 
-//In order to avoid generating warnings about unknown message numbers and
-//unknown pragmas when compiling your C# source code with the actual C# compiler,
-//you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
-
 namespace System.Windows
 {
     [Localizability(LocalizationCategory.Ignore)]
@@ -355,12 +350,11 @@ namespace System.Windows
             // If the callback function returns false on any enumerated window, or if there are no windows
             // found in the thread, the return value is false.
             // No need for use to actually check the return value.
-#pragma warning disable 6523
             UnsafeNativeMethods.EnumThreadWindows(SafeNativeMethods.GetCurrentThreadId(),
                                                   new NativeMethods.EnumThreadWindowsCallback(ThreadWindowsCallback),
                                                   NativeMethods.NullHandleRef);
-#pragma warning enable 6523
-            //disable those windows
+
+            // Disable those windows
             EnableThreadWindows(false);
 
             IntPtr hWndCapture = SafeNativeMethods.GetCapture();
@@ -2264,9 +2258,7 @@ namespace System.Windows
                 // SendMessage's return value is dependent on the message send.  WM_CLOSE
                 // return value just signify whether the WndProc handled the
                 // message or not, so it is not interesting
-#pragma warning disable 6523
                 UnsafeNativeMethods.UnsafeSendMessage(Handle, WindowMessage.WM_CLOSE, new IntPtr(), new IntPtr());
-#pragma warning enable 6523
             }
         }
 
@@ -2543,9 +2535,8 @@ namespace System.Windows
                 // Window sends WM_CLOSE (which in turn sends WM_DESTROY) to the hwnd when
                 // Window.Close() is called.  Thus, this HwndSource created by window is always
                 // disposed by HwndSource itself
-#pragma warning disable 56518
                 HwndSource source = new HwndSource(param);
-#pragma warning enable 56518
+
                 _swh = new SourceWindowHelper(source);
                 source.SizeToContentChanged += new EventHandler(OnSourceSizeToContentChanged);
 
@@ -3654,10 +3645,7 @@ namespace System.Windows
                 {
                     // Calls EnableWindow which returns the previous Window state
                     // (enable/disable) and we don't care about that here
-#pragma warning disable 6523
                     UnsafeNativeMethods.EnableWindowNoThrow(new HandleRef(null, hWnd), state);
-#pragma warning enable 6523
-
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -249,10 +249,8 @@ namespace System.Windows
                     // SendMessage's return value is dependent on the message send.  WM_SYSCOMMAND
                     // and WM_LBUTTONUP return value just signify whether the WndProc handled the
                     // message or not, so they are not interesting
-#pragma warning disable 6523
                     UnsafeNativeMethods.SendMessage( Handle, WindowMessage.WM_SYSCOMMAND, (IntPtr)NativeMethods.SC_MOUSEMOVE, IntPtr.Zero);
                     UnsafeNativeMethods.SendMessage( Handle, WindowMessage.WM_LBUTTONUP, IntPtr.Zero, IntPtr.Zero);
-#pragma warning restore 6523
                 }
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/DocumentStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/DocumentStream.cs
@@ -2,13 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Description:
-//  An XpsDocument stream represents the stream data for the document
-//  regardless of implementation of the backing streams.  It has logical
-//  operations that allow elevating from Read to SafeWrite and editing in place.
-
-#pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-
 using System;
 using System.Globalization;
 using System.IO;
@@ -155,7 +148,6 @@ namespace MS.Internal.Documents.Application
         // Since we have already closed the original file, we need to reopen it if we
         // fail to copy the file or open the new file.  After doing so, we rethrow the 
         // original exception so it can be handled at a higher level.
-#pragma warning suppress 56500 // suppress PreSharp Warning 56500: Avoid `swallowing errors by catching non-specific exceptions..
         catch
         {
             if (isFileSource)
@@ -173,7 +165,6 @@ namespace MS.Internal.Documents.Application
                 }
                 // If we fail to reopen the original file, rethrow an exception to
                 // indicate this specific error.
-#pragma warning suppress 56500 // suppress PreSharp Warning 56500: Avoid `swallowing errors by catching non-specific exceptions..
                 catch (Exception e)
                 {
                     Trace.SafeWrite(
@@ -585,7 +576,6 @@ namespace MS.Internal.Documents.Application
             // A failure to set attributes or ACLs is not fatal to the application, so we
             // do not want it to crash the application for the user, and thus catch all
             // exceptions here.
-#pragma warning suppress 56500 // suppress PreSharp Warning 56500: Avoid `swallowing errors by catching non-specific exceptions..
             catch
             {
                 // TODO: 1603621 back out changes in case of failure 
@@ -611,7 +601,6 @@ namespace MS.Internal.Documents.Application
             // In this case we catch all exceptions and then rethrow a new exception --
             // always using the same exception as a wrapper allows higher level
             // routines to respond to a failure specifically in this section.
-#pragma warning suppress 56500 // suppress PreSharp Warning 56500: Avoid `swallowing errors by catching non-specific exceptions..
             catch (Exception e)
             {
                 Trace.SafeWrite(
@@ -784,7 +773,6 @@ namespace MS.Internal.Documents.Application
                     temporary,
                     io);
             }
-#pragma warning suppress 56500 // suppress PreSharp Warning 56500: Avoid `swallowing errors by catching non-specific exceptions..
             catch (Exception exception)
             {
                 // not editing is not a critical failure for the application
@@ -946,7 +934,6 @@ namespace MS.Internal.Documents.Application
                     backupFile);
             }
         }
-#pragma warning suppress 56500 // suppress PreSharp Warning 56500: Avoid `swallowing errors by catching non-specific exceptions..
         catch(Exception e)
         {
             // We were unable to delete the backup file -- this is not fatal.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/ZoomComboBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/ZoomComboBox.cs
@@ -467,14 +467,8 @@ namespace MS.Internal.Documents.Application
                         SR.ZoomPercentageConverterStringFormat, zoomValue);
                     return true;
                 }
-                // Allow empty catch statements.
-#pragma warning disable 56502
-
                 catch (ArgumentNullException) { }
                 catch (FormatException) { }
-
-                // Disallow empty catch statements.
-#pragma warning restore 56502
             }
 
             // Invalid zoom value encountered.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/ZoomComboBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/ZoomComboBox.cs
@@ -1,10 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-// Description: A derived ComboBox with some extra functionality 
-// for the Zoom behaviours of DocumentApplicationUI.
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Globalization;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentApplicationDocumentViewer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentApplicationDocumentViewer.cs
@@ -1894,17 +1894,11 @@ namespace MS.Internal.Documents
                     isValidArg = true;
                 }
             }
-            // Allow empty catch statements.
-#pragma warning disable 56502
-
             // Catch only the expected parse exceptions
             catch (ArgumentOutOfRangeException) { }
             catch (ArgumentNullException) { }
             catch (FormatException) { }
             catch (OverflowException) { }
-
-            // Disallow empty catch statements.
-#pragma warning restore 56502
 
             return isValidArg;
         }
@@ -1992,16 +1986,10 @@ namespace MS.Internal.Documents
                     return int.Parse(pageNumberString, culture);
                 }
             }
-// Allow empty catch statements.
-#pragma warning disable 56502
-
             // Catch only the expected parse exceptions
             catch (ArgumentNullException) { }
             catch (FormatException) { }
             catch (OverflowException) { }
-
-// Disallow empty catch statements.
-#pragma warning restore 56502
 
             return _invalidPageNumber;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentApplicationDocumentViewer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentApplicationDocumentViewer.cs
@@ -4,10 +4,6 @@
 
 // Description: The main DocumentViewer subclass that drives the MongooseUI
 
-
-// Used to support the warnings disabled below
-#pragma warning disable 1634, 1691
-
 using MS.Internal.Documents.Application;
 using System;
 using System.Globalization;                 // For localization of string conversion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RMPublishingDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RMPublishingDialog.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
 
 using Microsoft.Win32;
 using System;
@@ -396,7 +394,6 @@ namespace MS.Internal.Documents
                 // Any exception above represents a failure to load templates.
                 // Failing to load them is not a fatal error, so we can safely
                 // continue with an empty list.
-#pragma warning suppress 56500 // suppress PreSharp Warning 56500: Avoid `swallowing errors by catching non-specific exceptions..
                 catch (Exception e)
                 {
                     // Nothing should be done here, as we purposely catch all exceptions.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementManager.cs
@@ -5,7 +5,6 @@
 // Description: 
 //    DocumentRightsManagementManager is an internal API for Mongoose to deal
 //    with Rights Management.
-#pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
 
 using System;
 using System.Collections.Generic;
@@ -1374,7 +1373,6 @@ namespace MS.Internal.Documents
             // the exception to allow it to be handled higher on the stack if it
             // is fatal (which includes all exceptions not specifically handled
             // by the error handler).
-#pragma warning suppress 56500 // suppress PreSharp Warning 56500: Avoid `swallowing errors by catching non-specific exceptions..
             catch (Exception exception)
             {
                 // This exception will be thrown if there is a problem

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/DocumentNUp.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/DocumentNUp.cs
@@ -20,8 +20,6 @@ using System.Globalization;
 
 using System.Printing;
 
-#pragma warning disable 1634, 1691 // Allows suppression of certain PreSharp messages
-
 namespace MS.Internal.Printing.Configuration
 {
     /// <summary>
@@ -181,16 +179,15 @@ namespace MS.Internal.Printing.Configuration
                         option._pagesPerSheet = reader.GetCurrentPropertyIntValueWithException();
                     }
                     // We want to catch internal FormatException to skip recoverable XML content syntax error
-                    #pragma warning suppress 56502
-                    #if _DEBUG
+#if _DEBUG
                     catch (FormatException e)
-                    #else
+#else
                     catch (FormatException)
-                    #endif
+#endif
                     {
-                        #if _DEBUG
+#if _DEBUG
                         Trace.WriteLine("-Error- " + e.Message);
-                        #endif
+#endif
                     }
 
                     handled = true;

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PageCanvasSize.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PageCanvasSize.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,8 +14,6 @@ Abstract:
 --*/
 
 using System.Xml;
-
-#pragma warning disable 1634, 1691 // Allows suppression of certain PreSharp messages
 
 namespace MS.Internal.Printing.Configuration
 {
@@ -198,16 +196,15 @@ namespace MS.Internal.Printing.Configuration
                         this._imageableSizeWidth = reader.GetCurrentPropertyIntValueWithException();
                     }
                     // We want to catch internal FormatException to skip recoverable XML content syntax error
-                    #pragma warning suppress 56502
-                    #if _DEBUG
+#if _DEBUG
                     catch (FormatException e)
-                    #else
+#else
                     catch (FormatException)
-                    #endif
+#endif
                     {
-                        #if _DEBUG
+#if _DEBUG
                         Trace.WriteLine("-Error- " + e.Message);
-                        #endif
+#endif
                     }
                 }
                 else if (reader.CurrentElementNameAttrValue == PrintSchemaTags.Keywords.PageImageableSizeKeys.ImageableSizeHeight)
@@ -217,16 +214,15 @@ namespace MS.Internal.Printing.Configuration
                         this._imageableSizeHeight = reader.GetCurrentPropertyIntValueWithException();
                     }
                     // We want to catch internal FormatException to skip recoverable XML content syntax error
-                    #pragma warning suppress 56502
-                    #if _DEBUG
+#if _DEBUG
                     catch (FormatException e)
-                    #else
+#else
                     catch (FormatException)
-                    #endif
+#endif
                     {
-                        #if _DEBUG
+#if _DEBUG
                         Trace.WriteLine("-Error- " + e.Message);
-                        #endif
+#endif
                     }
                 }
                 else if (reader.CurrentElementNameAttrValue == PrintSchemaTags.Keywords.PageImageableSizeKeys.ImageableArea)
@@ -249,16 +245,15 @@ namespace MS.Internal.Printing.Configuration
                                 this._imageableArea._originWidth = reader.GetCurrentPropertyIntValueWithException();
                             }
                             // We want to catch internal FormatException to skip recoverable XML content syntax error
-                            #pragma warning suppress 56502
-                            #if _DEBUG
+#if _DEBUG
                             catch (FormatException e)
-                            #else
+#else
                             catch (FormatException)
-                            #endif
+#endif
                             {
-                                #if _DEBUG
+#if _DEBUG
                                 Trace.WriteLine("-Error- " + e.Message);
-                                #endif
+#endif
                             }
                         }
                         else if (reader.CurrentElementNameAttrValue == PrintSchemaTags.Keywords.PageImageableSizeKeys.OriginHeight)
@@ -268,16 +263,15 @@ namespace MS.Internal.Printing.Configuration
                                 this._imageableArea._originHeight = reader.GetCurrentPropertyIntValueWithException();
                             }
                             // We want to catch internal FormatException to skip recoverable XML content syntax error
-                            #pragma warning suppress 56502
-                            #if _DEBUG
+#if _DEBUG
                             catch (FormatException e)
-                            #else
+#else
                             catch (FormatException)
-                            #endif
+#endif
                             {
-                                #if _DEBUG
+#if _DEBUG
                                 Trace.WriteLine("-Error- " + e.Message);
-                                #endif
+#endif
                             }
                         }
                         else if (reader.CurrentElementNameAttrValue == PrintSchemaTags.Keywords.PageImageableSizeKeys.ExtentWidth)
@@ -287,16 +281,15 @@ namespace MS.Internal.Printing.Configuration
                                 this._imageableArea._extentWidth = reader.GetCurrentPropertyIntValueWithException();
                             }
                             // We want to catch internal FormatException to skip recoverable XML content syntax error
-                            #pragma warning suppress 56502
-                            #if _DEBUG
+#if _DEBUG
                             catch (FormatException e)
-                            #else
+#else
                             catch (FormatException)
-                            #endif
+#endif
                             {
-                                #if _DEBUG
+#if _DEBUG
                                 Trace.WriteLine ("-Error- " + e.Message);
-                                #endif
+#endif
                             }
                         }
                         else if (reader.CurrentElementNameAttrValue == PrintSchemaTags.Keywords.PageImageableSizeKeys.ExtentHeight)
@@ -306,16 +299,15 @@ namespace MS.Internal.Printing.Configuration
                                 this._imageableArea._extentHeight = reader.GetCurrentPropertyIntValueWithException();
                             }
                             // We want to catch internal FormatException to skip recoverable XML content syntax error
-                            #pragma warning suppress 56502
-                            #if _DEBUG
+#if _DEBUG
                             catch (FormatException e)
-                            #else
+#else
                             catch (FormatException)
-                            #endif
+#endif
                             {
-                                #if _DEBUG
+#if _DEBUG
                                 Trace.WriteLine ("-Error- " + e.Message);
-                                #endif
+#endif
                             }
                         }
                         else

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PageMediaSize.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PageMediaSize.cs
@@ -20,8 +20,6 @@ using System.Globalization;
 
 using System.Printing;
 
-#pragma warning disable 1634, 1691 // Allows suppression of certain PreSharp messages
-
 namespace MS.Internal.Printing.Configuration
 {
     /// <summary>
@@ -223,20 +221,19 @@ namespace MS.Internal.Printing.Configuration
                                 convertOK = true;
                             }
                             // We want to catch internal FormatException to skip recoverable XML content syntax error
-                            #pragma warning suppress 56502
-                            #if _DEBUG
+#if _DEBUG
                             catch (FormatException e)
-                            #else
+#else
                             catch (FormatException)
-                            #endif
+#endif
                             {
-                                #if _DEBUG
+#if _DEBUG
                                 Trace.WriteLine("-Error- Invalid int value '" +
                                                 reader.CurrentElementTextValue +
                                                 "' at line number " + reader._xmlReader.LineNumber +
                                                 ", line position " + reader._xmlReader.LinePosition +
                                                 ": " + e.Message);
-                                #endif
+#endif
                             }
 
                             if (convertOK)

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PageResolution.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PageResolution.cs
@@ -21,8 +21,6 @@ using System.Globalization;
 
 using System.Printing;
 
-#pragma warning disable 1634, 1691 // Allows suppression of certain PreSharp messages
-
 namespace MS.Internal.Printing.Configuration
 {
     /// <summary>
@@ -202,16 +200,15 @@ namespace MS.Internal.Printing.Configuration
                         option._resolutionX = reader.GetCurrentPropertyIntValueWithException();
                     }
                     // We want to catch internal FormatException to skip recoverable XML content syntax error
-                    #pragma warning suppress 56502
-                    #if _DEBUG
+#if _DEBUG
                     catch (FormatException e)
-                    #else
+#else
                     catch (FormatException)
-                    #endif
+#endif
                     {
-                        #if _DEBUG
+#if _DEBUG
                         Trace.WriteLine("-Error- " + e.Message);
-                        #endif
+#endif
                     }
                 }
                 else if (reader.CurrentElementNameAttrValue == PrintSchemaTags.Keywords.PageResolutionKeys.ResolutionY)
@@ -221,16 +218,15 @@ namespace MS.Internal.Printing.Configuration
                         option._resolutionY = reader.GetCurrentPropertyIntValueWithException();
                     }
                     // We want to catch internal FormatException to skip recoverable XML content syntax error
-                    #pragma warning suppress 56502
-                    #if _DEBUG
+#if _DEBUG
                     catch (FormatException e)
-                    #else
+#else
                     catch (FormatException)
-                    #endif
+#endif
                     {
-                        #if _DEBUG
+#if _DEBUG
                         Trace.WriteLine("-Error- " + e.Message);
-                        #endif
+#endif
                     }
                 }
                 else if (reader.CurrentElementNameAttrValue == PrintSchemaTags.Keywords.PageResolutionKeys.QualitativeResolution)

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PageScaling.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PageScaling.cs
@@ -19,8 +19,6 @@ using System.Globalization;
 
 using System.Printing;
 
-#pragma warning disable 1634, 1691 // Allows suppression of certain PreSharp messages
-
 namespace MS.Internal.Printing.Configuration
 {
     /// <summary>
@@ -332,16 +330,15 @@ namespace MS.Internal.Printing.Configuration
                         }
                     }
                     // We want to catch internal FormatException to skip recoverable XML content syntax error
-                    #pragma warning suppress 56502
-                    #if _DEBUG
+#if _DEBUG
                     catch (FormatException e)
-                    #else
+#else
                     catch (FormatException)
-                    #endif
+#endif
                     {
-                        #if _DEBUG
+#if _DEBUG
                         Trace.WriteLine("-Error- " + e.Message);
-                        #endif
+#endif
                     }
                 }
                 else

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrintSchema.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrintSchema.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,8 +13,6 @@ Abstract:
 --*/
 
 using System.Xml;
-
-#pragma warning disable 1634, 1691 // Allows suppression of certain PreSharp messages
 
 /*  How to add new Print Schema standard feature keyword support in the WinFX APIs?
     - add new feature keyword to CapabilityName enum
@@ -2351,16 +2349,15 @@ namespace MS.Internal.Printing.Configuration
                 valueLocalName = reader.GetCurrentPropertyQNameValueWithException();
             }
             // We want to catch internal FormatException to skip recoverable XML content syntax error
-            #pragma warning suppress 56502
-            #if _DEBUG
+#if _DEBUG
             catch (FormatException e)
-            #else
+#else
             catch (FormatException)
-            #endif
+#endif
             {
-                #if _DEBUG
+#if _DEBUG
                 Trace.WriteLine("-Error- " + e.Message);
-                #endif
+#endif
             }
 
             if (valueLocalName != null)

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrtCap_Base.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrtCap_Base.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,8 +13,6 @@ Abstract:
 --*/
 
 using System.Xml;
-
-#pragma warning disable 1634, 1691 // Allows suppression of certain PreSharp messages
 
 namespace MS.Internal.Printing.Configuration
 {
@@ -309,16 +307,15 @@ namespace MS.Internal.Printing.Configuration
                     param._defaultValue = reader.GetCurrentPropertyIntValueWithException();
                 }
                 // We want to catch internal FormatException to skip recoverable XML content syntax error
-                #pragma warning suppress 56502
-                #if _DEBUG
+#if _DEBUG
                 catch (FormatException e)
-                #else
+#else
                 catch (FormatException)
-                #endif
+#endif
                 {
-                    #if _DEBUG
+#if _DEBUG
                     Trace.WriteLine("-Error- " + e.Message);
-                    #endif
+#endif
                 }
             }
             else if (reader.CurrentElementPSFNameAttrValue == PrintSchemaTags.Keywords.ParameterProps.MaxValue)
@@ -328,16 +325,15 @@ namespace MS.Internal.Printing.Configuration
                     param._maxValue = reader.GetCurrentPropertyIntValueWithException();
                 }
                 // We want to catch internal FormatException to skip recoverable XML content syntax error
-                #pragma warning suppress 56502
-                #if _DEBUG
+#if _DEBUG
                 catch (FormatException e)
-                #else
+#else
                 catch (FormatException)
-                #endif
+#endif
                 {
-                    #if _DEBUG
+#if _DEBUG
                     Trace.WriteLine("-Error- " + e.Message);
-                    #endif
+#endif
                 }
             }
             else if (reader.CurrentElementPSFNameAttrValue == PrintSchemaTags.Keywords.ParameterProps.MinValue)
@@ -347,16 +343,15 @@ namespace MS.Internal.Printing.Configuration
                     param._minValue = reader.GetCurrentPropertyIntValueWithException();
                 }
                 // We want to catch internal FormatException to skip recoverable XML content syntax error
-                #pragma warning suppress 56502
-                #if _DEBUG
+#if _DEBUG
                 catch (FormatException e)
-                #else
+#else
                 catch (FormatException)
-                #endif
+#endif
                 {
-                    #if _DEBUG
+#if _DEBUG
                     Trace.WriteLine("-Error- " + e.Message);
-                    #endif
+#endif
                 }
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrtCap_Reader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrtCap_Reader.cs
@@ -17,8 +17,6 @@ using System.Xml;
 using System.IO;
 using System.Globalization;
 
-#pragma warning disable 1634, 1691 // Allows suppression of certain PreSharp messages
-
 namespace MS.Internal.Printing.Configuration
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrtTicket_Base.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrtTicket_Base.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,8 +15,6 @@ Abstract:
 
 using System.Xml;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691 // Allows suppression of certain PreSharp messages
 
 namespace MS.Internal.Printing.Configuration
 {
@@ -526,18 +524,17 @@ namespace MS.Internal.Printing.Configuration
                 found = true;
             }
             // We want to catch internal FormatException to skip recoverable XML content syntax error
-            #pragma warning suppress 56502
-            #if _DEBUG
+#if _DEBUG
             catch (FormatException e)
-            #else
+#else
             catch (FormatException)
-            #endif
+#endif
             {
-                #if _DEBUG
+#if _DEBUG
                 Trace.WriteLine("-Warning- ignore invalid property value '" + valueText +
                                 "' for feature '" + this.OwnerFeature._featureName +
                                 "' property '" + propertyName + "' : " + e.Message);
-                #endif
+#endif
             }
 
             return found;
@@ -1257,18 +1254,17 @@ namespace MS.Internal.Printing.Configuration
                 found = true;
             }
             // We want to catch internal FormatException to skip recoverable XML content syntax error
-            #pragma warning suppress 56502
-            #if _DEBUG
+#if _DEBUG
             catch (FormatException e)
-            #else
+#else
             catch (FormatException)
-            #endif
+#endif
             {
-                #if _DEBUG
+#if _DEBUG
                 Trace.WriteLine("-Warning- ignore invalid parameter value '" + valueText +
                                 "' for parameter '" + this.OwnerParameter._parameterName +
                                 "' : " + e.Message);
-                #endif
+#endif
             }
 
             return found;

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/NGCSerializationManagerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/NGCSerializationManagerAsync.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -137,15 +137,6 @@ namespace System.Windows.Xps.Serialization
             Object arg
             )
         {
-            //
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-            #pragma warning disable 1634, 1691
-            //
-            // PreSharp complains about catching NullReference (and other) exceptions.
-            // This is an async model and we need to catch all exception ourselves and then
-            // send them to the completion delegate
-            #pragma warning disable 56500
             try
             {
                 if(!_serializationOperationCanceled)
@@ -198,8 +189,6 @@ namespace System.Windows.Xps.Serialization
 
                 return null;
             }
-            #pragma warning restore 56500
-            #pragma warning restore 1634, 1691
 
             return null;
         }
@@ -216,15 +205,6 @@ namespace System.Windows.Xps.Serialization
             Object arg
             )
         {
-            //
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-            #pragma warning disable 1634, 1691
-            //
-            // PreSharp complains about catching NullReference (and other) exceptions.
-            // This is an async model and we need to catch all exception ourselves and then
-            // send them to the completion delegate
-            #pragma warning disable 56500
             try
             {
                 // This logic must be mirrored in IsAsyncWorkPending see remarks.
@@ -330,8 +310,6 @@ namespace System.Windows.Xps.Serialization
 
                 return null;
             }
-            #pragma warning restore 56500
-            #pragma warning restore 1634, 1691
 
             return null;
         }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsDocumentEvent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsDocumentEvent.cs
@@ -1,12 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Windows.Xps.Packaging;
 using System.Printing;
-
-#pragma warning disable 1634, 1691 //Allows suppression of certain PreSharp messages
 
 namespace System.Windows.Xps.Serialization
 {

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMSerializationManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMSerializationManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,9 +10,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Xps.Packaging;
 using System.Xml;
-
-
-#pragma warning disable 1634, 1691 //Allows suppression of certain PreSharp messages
 
 namespace System.Windows.Xps.Serialization
 {
@@ -72,9 +69,6 @@ namespace System.Windows.Xps.Serialization
 
                 if (serializedObject is DocumentPaginator)
                 {
-                    // Prefast complains that serializedObject is not tested for null
-                    // It is tested a few lines up
-                    #pragma warning suppress 56506
                     if ((serializedObject as DocumentPaginator).Source is FixedDocument &&
                         serializedObject.GetType().ToString().Contains("FixedDocumentPaginator"))
                     {

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsSerializationManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsSerializationManager.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-
 
 using System.Collections;
 using System.ComponentModel;
@@ -13,8 +11,6 @@ using System.Windows.Documents;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using MS.Utility;
-
-#pragma warning disable 1634, 1691 //Allows suppression of certain PreSharp messages
 
 namespace System.Windows.Xps.Serialization
 {
@@ -103,9 +99,6 @@ namespace System.Windows.Xps.Serialization
 
             if( serializedObject is DocumentPaginator )
             {
-                // Prefast complains that serializedObject is not tested for null
-                // It is tested a few lines up
-                #pragma warning suppress 56506
                 if((serializedObject as DocumentPaginator).Source is FixedDocument &&
                     serializedObject.GetType().ToString().Contains( "FixedDocumentPaginator") )
                 {

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsSerializationManagerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsSerializationManagerAsync.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -124,15 +124,6 @@ namespace System.Windows.Xps.Serialization
             Object arg
             )
         {
-            //
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-            #pragma warning disable 1634, 1691
-            //
-            // PreSharp complains about catching NullReference (and other) exceptions.
-            // This is an async model and we need to catch all exception ourselves and then
-            // send them to the completion delegate
-            #pragma warning disable 56500
             try
             {
                 if(!_serializationOperationCanceled)
@@ -185,8 +176,6 @@ namespace System.Windows.Xps.Serialization
 
                 return null;
             }
-            #pragma warning restore 56500
-            #pragma warning restore 1634, 1691
 
             return null;
         }
@@ -202,15 +191,6 @@ namespace System.Windows.Xps.Serialization
             Object arg
             )
         {
-            //
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-            #pragma warning disable 1634, 1691
-            //
-            // PreSharp complains about catching NullReference (and other) exceptions.
-            // This is an async model and we need to catch all exception ourselves and then
-            // send them to the completion delegate
-            #pragma warning disable 56500
             try
             {
                 // This logic must be mirrored in IsAsyncWorkPending see remarks.
@@ -306,9 +286,6 @@ namespace System.Windows.Xps.Serialization
 
                 return null;
             }
-            #pragma warning restore 56500
-            #pragma warning restore 1634, 1691
-
 
             return null;
         }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceEnumerator.cs
@@ -1,11 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
-
-// Disable pragma warnings to enable PREsharp pragmas
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal
 {
@@ -38,7 +35,6 @@ namespace MS.Internal
             {
                 if( null == _StrongReference )
                 {
-#pragma warning suppress 6503
                     throw new System.InvalidOperationException(SR.Enumerator_VerifyContext);
                 }
                 return _StrongReference;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/TraceProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/TraceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,9 +10,7 @@
 using MS.Win32;
 using MS.Internal;
 using System.Runtime.InteropServices;
-using System.Globalization; //for CultureInfo
-
-#pragma warning disable 1634, 1691  //disable warnings about unknown pragma
+using System.Globalization; // for CultureInfo
 
 #if SYSTEM_XAML
 using System.Xaml;
@@ -484,7 +482,6 @@ namespace MS.Utility
 
         ~ClassicTraceProvider()
         {
-            #pragma warning suppress 6031  //presharp suppression
             ClassicEtw.UnregisterTraceGuids(_registrationHandle);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@ using System.Threading;
 using System.Windows.Threading;
 using MS.Internal;
 using MS.Internal.Interop;
-
-// Disable pragma warnings to enable PREsharp pragmas
-#pragma warning disable 1634, 1691
 
 namespace MS.Win32
 {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/IO/FileHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/IO/FileHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -141,11 +141,6 @@ namespace System.IO
             return stream;
         }
 
-        // PreSharp uses message numbers that the C# compiler doesn't know about.
-        // Disable the C# complaints, per the PreSharp documentation.
-        #pragma warning disable 1634, 1691
-        #pragma warning disable 56502 // disable PreSharp warning about empty catch blocks
-
         ///<summary>
         /// Delete a temporary file robustly.
         ///</summary>
@@ -171,6 +166,5 @@ namespace System.IO
                 }
             }
         }
-        #pragma warning restore 56502
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonGalleryCategoriesPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonGalleryCategoriesPanel.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -808,13 +808,9 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
             {
                 return Rect.Empty;
             }
-#pragma warning disable 1634, 1691
-#pragma warning disable 56506
             // Compute the child's rect relative to (0,0) in our coordinate space.
-            // This is a false positive by PreSharp. visual cannot be null because of the 'if' check above
             GeneralTransform childTransform = visual.TransformToAncestor(this);
-#pragma warning restore 56506
-#pragma warning restore 1634, 1691
+
             rectangle = childTransform.TransformBounds(rectangle);
 
             // We can't do any work unless we're scrolling.

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ValueSerializer.cs
@@ -9,8 +9,6 @@ using System.Xaml;
 using System.Xaml.Replacements;
 using MS.Internal.Serialization;
 
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
 namespace System.Windows.Markup
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Accessible.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Accessible.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,9 +8,6 @@ using System;
 using Accessibility;
 using System.Diagnostics;
 using MS.Win32;
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal.Automation
 {
@@ -47,9 +44,6 @@ namespace MS.Internal.Automation
                 catch (Exception e)
                 {
                     if (IsCriticalMSAAException(e))
-                        // PRESHARP will flag this as a warning 56503/6503: Property get methods should not throw exceptions
-                        // Since this Property is internal, we CAN throw an exception
-#pragma warning suppress 6503
                         throw;
 
                     return UnsafeNativeMethods.STATE_SYSTEM_UNAVAILABLE;
@@ -73,9 +67,6 @@ namespace MS.Internal.Automation
                     catch( Exception e )
                     {
                         if (IsCriticalMSAAException(e))
-                            // PRESHARP will flag this as a warning 56503/6503: Property get methods should not throw exceptions
-                            // Since this Property is internal, we CAN throw an exception
-#pragma warning suppress 6503
                             throw;
 
                         _hwnd = IntPtr.Zero;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ClientEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ClientEventManager.cs
@@ -174,13 +174,10 @@ namespace MS.Internal.Automation
                                 {
                                     ec.EventHandle.Dispose(); // Calls UiaCoreApi.UiaRemoveEvent
                                 }
-// PRESHARP: Warning - Catch statements should not have empty bodies
-#pragma warning disable 6502
                                 catch (ElementNotAvailableException)
                                 {
                                     // the element is gone already; continue on and remove the listener
                                 }
-#pragma warning restore 6502
                                 finally
                                 {
                                     ec.Dispose();

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ClientEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ClientEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,9 +10,6 @@ using System.Windows.Automation;
 using MS.Win32;
 
 using System;
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal.Automation
 {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
@@ -4,9 +4,6 @@
 
 // Description: Base proxy for HWNDs. Provides HWND-based children, HWND properties such as Enabled, Visible etc.
 
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 using System;
 using System.Windows;
 using System.Windows.Automation;
@@ -22,10 +19,6 @@ using NativeMethodsSetLastError = MS.Internal.UIAutomationClient.NativeMethodsSe
 
 namespace MS.Internal.Automation
 {
-    // Disable warning for obsolete types.  These are scheduled to be removed in M8.2 so
-    // only need the warning to come out for components outside of APT.
-#pragma warning disable 0618
-
     // Base proxy for HWNDs. Provides HWND-based children, HWND properties such as Enabled, Visible etc.
     internal class HwndProxyElementProvider:
         IRawElementProviderSimple,
@@ -149,8 +142,6 @@ namespace MS.Internal.Automation
                 // pid that this proxy lives in
                 int pid;
                 // GetWindowThreadProcessId does use SetLastError().  So a call to GetLastError() would be meanless.
-                // Disabling the PreSharp warning.
-#pragma warning suppress 6523
                 if (SafeNativeMethods.GetWindowThreadProcessId(_hwnd, out pid) == 0)
                 {
                     throw new ElementNotAvailableException();
@@ -420,8 +411,6 @@ namespace MS.Internal.Automation
             //
             int pid;
             // GetWindowThreadProcessId does use SetLastError().  So a call to GetLastError() would be meanless.
-            // Disabling the PreSharp warning.
-#pragma warning suppress 6523
             int guiThreadId = SafeNativeMethods.GetWindowThreadProcessId(_hwnd, out pid);
             if ( guiThreadId == 0 )
             {
@@ -534,10 +523,8 @@ namespace MS.Internal.Automation
             {
                 if (!SafeNativeMethods.IsWindow(_hwnd))
                 {
-                    // PreFast will flag this as a warning, 56503/6503: Property get methods should not throw exceptions.
                     // Since we communicate with the underlying control to get the information
                     // it is correct to throw an exception if that control is no longer there.
-#pragma warning suppress 6503
                     throw new ElementNotAvailableException();
                 }
 
@@ -583,9 +570,6 @@ namespace MS.Internal.Automation
                 // will test if that window is responding and will timeout after 5 seconds
                 // (Uses a timeout of 0 so that the check for non-responsive state returns immediately)
                 IntPtr dwResult;
-                // This is just a ping to the hwnd and no data is being returned so suppressing presharp:
-                // Call 'Marshal.GetLastWin32Error' or 'Marshal.GetHRForLastWin32Error' before any other interop call.
-#pragma warning suppress 56523
                 IntPtr ret = UnsafeNativeMethods.SendMessageTimeout(_hwnd, UnsafeNativeMethods.WM_NULL, IntPtr.Zero, IntPtr.Zero, UnsafeNativeMethods.SMTO_ABORTIFHUNG, 0, out dwResult);
                 if ( ret == IntPtr.Zero )
                 {
@@ -943,10 +927,8 @@ namespace MS.Internal.Automation
                 // if the hwnd is not valid there is nothing we can do
                 if (!SafeNativeMethods.IsWindow(_hwnd))
                 {
-                    // PreFast will flag this as a warning, 56503/6503: Property get methods should not throw exceptions.
                     // Since we communicate with the underlying control to get the information
                     // it is correct to throw an exception if that control is no longer there.
-#pragma warning suppress 6503
                     throw new ElementNotAvailableException();
                 }
 
@@ -1588,8 +1570,6 @@ namespace MS.Internal.Automation
         {
             int process;
             // GetWindowThreadProcessId does use SetLastError().  So a call to GetLastError() would be meanless.
-            // Disabling the PreSharp warning.
-#pragma warning suppress 6523
             int thread = SafeNativeMethods.GetWindowThreadProcessId(_hwnd, out process);
             if (thread == 0)
             {
@@ -2081,16 +2061,13 @@ namespace MS.Internal.Automation
                     if (Misc.GetMessage(ref msg, NativeMethods.HWND.NULL, 0, 0) == 0)
                         break;
 
-                    // TranslateMessage() will not set an error to be retrieved with GetLastError,
-                    // so set the pragma to ignore the PERSHARP warning.
-#pragma warning suppress 6031, 6523
+                    // TranslateMessage() will not set an error to be retrieved with GetLastError.
                     UnsafeNativeMethods.TranslateMessage(ref msg);
 
                     // From the Windows SDK documentation:
                     // The return value specifies the value returned by the window procedure.
                     // Although its meaning depends on the message being dispatched, the return
                     // value generally is ignored.
-#pragma warning suppress 6031, 6523
                     UnsafeNativeMethods.DispatchMessage(ref msg);
 
                     if (msg.message == UnsafeNativeMethods.WM_HOTKEY

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
@@ -1408,13 +1408,10 @@ namespace MS.Internal.Automation
                     }
                 }
             }
-// PRESHARP: Warning - Catch statements should not have empty bodies
-#pragma warning disable 6502
             catch (ElementNotAvailableException)
             {
                 // the subtree or its children are gone so quit trying to work with this UI
             }
-#pragma warning restore 6502
 
             if (SanityLoopCount == 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
@@ -1,11 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description: Miscellaneous helper routines
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using Microsoft.Win32.SafeHandles;
 using MS.Win32;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ProxyManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ProxyManager.cs
@@ -4,9 +4,6 @@
 
 // Description: Manages Win32 proxies
 
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 using System;
 using System.Windows.Automation;
 using System.Windows.Automation.Provider;
@@ -560,12 +557,10 @@ namespace MS.Internal.Automation
             if (count > 0)
             {
                 // Null and Empty string mean different things here.
-#pragma warning suppress 6507
                 if (imageName == null)
                     imageName = GetImageName(hwnd);
 
                 // Null and Empty string mean different things here.
-#pragma warning suppress 6507
                 if (imageName != null)
                 {
                     object entryOrArrayList;
@@ -646,7 +641,7 @@ namespace MS.Internal.Automation
                 ClientSideProviderDescription pi = (ClientSideProviderDescription)entry;
 
                 // Get the image name if necessary...
-#pragma warning suppress 6507 // Null and Empty string mean different things here.
+                // Null and Empty string mean different things here.
                 if (imageName == null && pi.ImageName != null)
                 {
                     imageName = GetImageName(hwnd);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/QueueProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/QueueProcessor.cs
@@ -4,9 +4,6 @@
 
 // Description: Class to create a queue on its own thread.
 
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 using System;
 using System.Threading;
 using System.Collections;
@@ -130,7 +127,6 @@ namespace MS.Internal.Automation
                     // The return value specifies the value returned by the window procedure.
                     // Although its meaning depends on the message being dispatched, the return
                     // value generally is ignored.
-#pragma warning suppress 6031, 6523
                     UnsafeNativeMethods.DispatchMessage(ref msg);
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/SafeHandles.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/SafeHandles.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,9 +10,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal.Automation
 {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/SafeProcessHandle.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/SafeProcessHandle.cs
@@ -1,9 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System.Windows.Automation;
 using Microsoft.Win32.SafeHandles;
@@ -24,8 +21,6 @@ namespace MS.Internal.Automation
 
             // Get process id...
             // GetWindowThreadProcessId does use SetLastError().  So a call to GetLastError() would be meanless.
-            // Disabling the PreSharp warning.
-#pragma warning suppress 6523
             if (SafeNativeMethods.GetWindowThreadProcessId(hwnd, out processId) == 0)
             {
                 throw new ElementNotAvailableException();

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Schema.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Schema.cs
@@ -1,11 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description: property/pattern/event information
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System.Windows;
 using System.Windows.Automation;
@@ -13,14 +10,11 @@ using System.Windows.Automation.Text;
 using System.Globalization;
 using System.Diagnostics;
 
-
 namespace MS.Internal.Automation
 {
-    // Disable warning for obsolete types.  These are scheduled to be removed in M8.2 so 
-    // only need the warning to come out for components outside of APT.
-#pragma warning disable 0618
-
-    // Information about automation properties and patterns
+    /// <summary>
+    /// Information about automation properties and patterns
+    /// </summary>
     internal sealed class Schema
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
@@ -1,11 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description: Imports from unmanaged UiaCore DLL
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Runtime.InteropServices;
@@ -1141,7 +1138,7 @@ namespace MS.Internal.Automation
                     // explicitly set it as a the errorInfo for this thread using SetErrorInfo, it works(!)...
                     // Note that the errorInfo can be null; in which case we just don't use it.
                     IntPtr errorInfoAsIntPtr = Marshal.GetIUnknownForObject(errorInfo);
-#pragma warning suppress 6031, 6532, 56031
+
                     SetErrorInfo(0, errorInfoAsIntPtr); // ignore return value
                     Marshal.Release(errorInfoAsIntPtr);
                 }
@@ -1594,7 +1591,6 @@ namespace MS.Internal.Automation
                     return null;
                 return new IRawElementProviderSimple[] { provider };
             }
-#pragma warning suppress 56500
             catch (Exception)
             {
                 // Must catch *all* exceptions here, even critical ones,

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/WinEventWrap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/WinEventWrap.cs
@@ -1,11 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description: Lightweight class to wrap Win32 WinEvents.
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Collections;
@@ -109,9 +106,7 @@ namespace MS.Internal.Automation
             foreach (int eventId in _eventIds)
             {
                 // There is no indication in the Windows SDK documentation that SetWinEventHook()
-                // will set an error to be retrieved with GetLastError, so set the pragma to ignore
-                // the PERSHARP warning.
-#pragma warning suppress 6523
+                // will set an error to be retrieved with GetLastError.
                 _hHooks[i] = UnsafeNativeMethods.SetWinEventHook(eventId, eventId, IntPtr.Zero, _winEventProc, 0, 0, _fFlags);
                 if (_hHooks[i] == IntPtr.Zero)
                 {
@@ -135,9 +130,7 @@ namespace MS.Internal.Automation
                 if (_hHooks[i] != IntPtr.Zero)
                 {
                     // There is no indication in the Windows SDK documentation that UnhookWinEvent()
-                    // will set an error to be retrieved with GetLastError, so set the pragma to ignore
-                    // the PERSHARP warning.
-#pragma warning suppress 6523
+                    // will set an error to be retrieved with GetLastError.
                     UnsafeNativeMethods.UnhookWinEvent(_hHooks[i]);
                     _hHooks[i] = IntPtr.Zero;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AndCondition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AndCondition.cs
@@ -1,10 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using MS.Internal.Automation;
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Automation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Automation.cs
@@ -1,13 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description: Facade class that groups together the main functionality that clients need to get started.
 //
-
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using MS.Internal.Automation;
 using MS.Win32;
@@ -93,8 +89,7 @@ namespace System.Windows.Automation
         public static string PropertyName( AutomationProperty property )
         {
             ArgumentNullException.ThrowIfNull(property);
-            // Suppress PRESHARP Parameter to this public method must be validated; element is checked above.
-#pragma warning suppress 56506
+
             string full = property.ProgrammaticName.Split('.')[1]; // remove portion before the ".", leaving just "NameProperty" or similar
             return full.Substring(0, full.Length - 8); // Slice away "Property" suffix
         }
@@ -107,8 +102,7 @@ namespace System.Windows.Automation
         public static string PatternName( AutomationPattern pattern )
         {
             ArgumentNullException.ThrowIfNull(pattern);
-            // Suppress PRESHARP Parameter to this public method must be validated; element is checked above.
-#pragma warning suppress 56506
+
             string full = pattern.ProgrammaticName;
             return full.Substring(0, full.Length - 26); // Slice away "InvokePatternIdentifiers.Pattern" to get just "Invoke"
         }
@@ -162,9 +156,6 @@ namespace System.Windows.Automation
                     else if ( ( scope & TreeScope.Element ) == TreeScope.Element )
                     {
                         // ...OR Element where the element implements WindowPattern
-                        // PRESHARP will flag this as warning 56506/6506:Parameter 'element' to this public method must be validated: A null-dereference can occur here.
-                        // False positive, element is checked, see above
-#pragma warning suppress 6506
                         object val = element.GetCurrentPropertyValue(AutomationElement.NativeWindowHandleProperty);
                         if ( val != null && val is int && (int)val != 0 )
                         {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AutomationElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AutomationElement.cs
@@ -14,9 +14,6 @@ using MS.Internal.Automation;
 using Microsoft.Win32.Diagnostics;
 #endif
 
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 namespace System.Windows.Automation
 {
     /// <summary>
@@ -506,9 +503,6 @@ namespace System.Windows.Automation
             }
 
             object value;
-            // PRESHARP will flag this as warning 56506/6506:Parameter 'property' to this public method must be validated: A null-dereference can occur here.
-            // False positive, property is checked, see above
-#pragma warning suppress 6506
              UiaCoreApi.UiaGetPropertyValue(_hnode, property.Id, out value);
             if (value != AutomationElement.NotSupported)
             {
@@ -1037,9 +1031,6 @@ namespace System.Windows.Automation
                 // Use (object) case to ensure we just do a ref check here, not call .Equals
                 if ((object)_cachedParent == (object)this)
                 {
-                    // PRESHARP will flag this as a warning 56503/6503: Property get methods should not throw exceptions
-                    // We've spec'd as throwing an Exception, and that's what we do PreSharp shouldn't complain
-#pragma warning suppress 6503
                     throw new InvalidOperationException(SR.CachedPropertyNotRequested);
                 }
 
@@ -1069,9 +1060,6 @@ namespace System.Windows.Automation
                 // Use (object) case to ensure we just do a ref check here, not call .Equals
                 if ((object)_cachedFirstChild == (object)this)
                 {
-                    // PRESHARP will flag this as a warning 56503/6503: Property get methods should not throw exceptions
-                    // We've spec'd as throwing an Exception, and that's what we do PreSharp shouldn't complain
-#pragma warning suppress 6503
                     throw new InvalidOperationException(SR.CachedPropertyNotRequested);
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ClientSideProviderDescription.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ClientSideProviderDescription.cs
@@ -1,11 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description: Structure containing information about a proxy
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System.Windows.Automation.Provider;
 
@@ -72,7 +69,6 @@ namespace System.Windows.Automation
         public ClientSideProviderDescription(ClientSideProviderFactoryCallback clientSideProviderFactoryCallback, string className)
         {
             // Null and Empty string mean different things here.
-#pragma warning suppress 6507
             if (className != null)
                 _className = className.ToLower( System.Globalization.CultureInfo.InvariantCulture );
             else
@@ -95,7 +91,6 @@ namespace System.Windows.Automation
         public ClientSideProviderDescription(ClientSideProviderFactoryCallback clientSideProviderFactoryCallback, string className, string imageName, ClientSideProviderMatchIndicator flags)
         {
             // Null and Empty string mean different things here
-#pragma warning suppress 6507
             if (className != null)
                 _className = className.ToLower( System.Globalization.CultureInfo.InvariantCulture );
             else
@@ -104,7 +99,6 @@ namespace System.Windows.Automation
             _flags = flags;
 
             // Null and Empty string mean different things here
-#pragma warning suppress 6507
             if (imageName != null)
                 _imageName = imageName.ToLower( System.Globalization.CultureInfo.InvariantCulture );
             else

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Condition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Condition.cs
@@ -1,10 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using MS.Internal.Automation;
 using System.Runtime.InteropServices;
@@ -67,8 +63,6 @@ namespace System.Windows.Automation
             }
 
             unsafe
-            // Suppress "Exposing unsafe code thru public interface" UiaCoreApi is trusted
-#pragma warning suppress 56505
             {
                 IntPtr* pdata = (IntPtr*)sh.handle;
                 for (int i = 0; i < conditions.Length; i++)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/OrCondition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/OrCondition.cs
@@ -1,9 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using MS.Internal.Automation;
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Text/TextRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Text/TextRange.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,9 +6,6 @@
 //
 //                  and moved to .Text subnamespace.
 //
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System.Diagnostics;
 using System.Globalization;
@@ -217,7 +214,7 @@ namespace System.Windows.Automation.Text
             // A null string is not should throw an ArgumentNullException while an empty string should throw an ArgumentException.
             // Therefore we can not use IsNullOrEmpty() here, suppress the warning.
             ArgumentNullException.ThrowIfNull(text);
-#pragma warning suppress 6507
+
             Misc.ValidateArgument(text.Length != 0, nameof(SR.TextMustNotBeNullOrEmpty));
 
             SafeTextRangeHandle hResultTextRange = UiaCoreApi.TextRange_FindText(_hTextRange, text, backward, ignoreCase);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Accessible.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Accessible.cs
@@ -6,10 +6,6 @@
 //              and default action
 //
 
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -394,12 +390,9 @@ namespace MS.Internal.AutomationProxies
                     catch (Exception e)
                     {
                         if (HandleIAccessibleException(e))
-                        {
-                            // PerSharp/PreFast will flag this as a warning, 6503/56503: Property get methods should not throw exceptions.
-                            // We are communicate with the underlying control to get the information.  
+                        { 
                             // The control may not be able to give us the information we need.
                             // Throw the correct exception to communicate the failure.
-#pragma warning suppress 6503
                             throw;
                         }
                         return null;
@@ -494,11 +487,8 @@ namespace MS.Internal.AutomationProxies
                 {
                     if (HandleIAccessibleException(e))
                     {
-                        // PerSharp/PreFast will flag this as a warning, 6503/56503: Property get methods should not throw exceptions.
-                        // We are communicate with the underlying control to get the information.  
                         // The control may not be able to give us the information we need.
                         // Throw the correct exception to communicate the failure.
-#pragma warning suppress 6503
                         throw;
                     }
                     return AccessibleState.Unavailable;
@@ -513,21 +503,16 @@ namespace MS.Internal.AutomationProxies
                 try
                 {
                     string value = FixBstr(_acc.get_accValue(_idChild));
-                    // PerSharp/PreFast will flag this as warning 6507/56507: Prefer 'string.IsNullOrEmpty(value)' over checks for null and/or emptiness.
                     // Need to convert nulls into an empty string, so need to just test for a null.
                     // Therefore we can not use IsNullOrEmpty() here, suppress the warning.
-#pragma warning suppress 6507
                     return value ?? "";
                 }
                 catch (Exception e)
                 {
                     if (HandleIAccessibleException(e))
                     {
-                        // PerSharp/PreFast will flag this as a warning, 6503/56503: Property get methods should not throw exceptions.
-                        // We are communicate with the underlying control to get the information.  
                         // The control may not be able to give us the information we need.
                         // Throw the correct exception to communicate the failure.
-#pragma warning suppress 6503
                         throw;
                     }
                     return "";
@@ -726,11 +711,8 @@ namespace MS.Internal.AutomationProxies
                 {
                     if (HandleIAccessibleException(e))
                     {
-                        // PerSharp/PreFast will flag this as a warning, 6503/56503: Property get methods should not throw exceptions.
-                        // We are communicate with the underlying control to get the information.  
                         // The control may not be able to give us the information we need.
                         // Throw the correct exception to communicate the failure.
-#pragma warning suppress 6503
                         throw;
                     }
                     return "";
@@ -865,12 +847,9 @@ namespace MS.Internal.AutomationProxies
                     catch (Exception e)
                     {
                         if (HandleIAccessibleException(e))
-                        {
-                            // PerSharp/PreFast will flag this as a warning, 6503/56503: Property get methods should not throw exceptions.
-                            // We are communicate with the underlying control to get the information.  
+                        { 
                             // The control may not be able to give us the information we need.
                             // Throw the correct exception to communicate the failure.
-#pragma warning suppress 6503
                             throw;
                         }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
@@ -263,13 +263,10 @@ namespace MS.Internal.AutomationProxies
                         return true;
                     }
                 }
-// PRESHARP: Warning - Catch statements should not have empty bodies
-#pragma warning disable 6502
                 catch (TimeoutException)
                 {
                     // Ignore this timeout error.  Avalon HwndWrappers have a problem with this WM_NCHITTEST call sometimes.
                 }
-#pragma warning restore 6502
             }
 
             // Copy the output bits

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
@@ -1,13 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;
 using MS.Win32;
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal.AutomationProxies
 {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/MSAANativeProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/MSAANativeProvider.cs
@@ -1,13 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description: Proxy for UI elements that are native IAccessible 
 //              implementations.  NativeMsaaProviderRoot creates
 //              instances of this class.
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Collections;
@@ -1084,9 +1081,7 @@ namespace MS.Internal.AutomationProxies
                     _knownRoot = (MsaaNativeProvider)Create(_hwnd, NativeMethods.CHILD_SELF, NativeMethods.OBJID_CLIENT);
                     if (_knownRoot == null)
                     {
-                        // PerSharp/PreFast will flag this as a warning, 6503/56503: Property get methods should not throw exceptions.
                         // When failing to create the element, the correct this to do is to throw an ElementNotAvailableException.
-#pragma warning suppress 6503
                         throw new ElementNotAvailableException();
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Misc.cs
@@ -4,10 +4,6 @@
 
 // Description: Miscellaneous helper routines
 
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 using Microsoft.Win32.SafeHandles;
 using MS.Win32;
 using System;
@@ -158,7 +154,6 @@ namespace MS.Internal.AutomationProxies
             // The return value specifies the value returned by the window procedure.
             // Although its meaning depends on the message being dispatched, the return
             // value generally is ignored.
-#pragma warning suppress 6031, 6523
             return UnsafeNativeMethods.DispatchMessage(ref msg);
         }
 
@@ -389,7 +384,6 @@ namespace MS.Internal.AutomationProxies
             IntPtr peer = hwnd;
 
             // If GetWindow fails we're going to exit, no need to call Marshal.GetLastWin32Error
-#pragma warning suppress 56523
             while ((peer = NativeMethodsSetLastError.GetWindow(peer, NativeMethods.GW_HWNDPREV)) != IntPtr.Zero)
             {
                 //
@@ -410,7 +404,6 @@ namespace MS.Internal.AutomationProxies
                 // Using invisible statics is an easy workaround to add names to controls without changing the visual UI.
                 //
                 // If GetWindowLong fails we're going to exit, no need to call Marshal.GetLastWin32Error
-#pragma warning suppress 56523
                 int error = 0;
                 int style = UnsafeNativeMethods.GetWindowLong(peer, NativeMethods.GWL_STYLE, out error);
                 if ((style & NativeMethods.WS_VISIBLE) != 0)
@@ -703,8 +696,6 @@ namespace MS.Internal.AutomationProxies
         internal static uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId)
         {
             // GetWindowThreadProcessId does use SetLastError().  So a call to GetLastError() would be meanless.
-            // Disabling the PreSharp warning.
-#pragma warning suppress 6523
             uint threadId = UnsafeNativeMethods.GetWindowThreadProcessId(hwnd, out processId);
 
             if (threadId == 0)
@@ -1445,9 +1436,7 @@ namespace MS.Internal.AutomationProxies
 
         internal static int ReleaseDC(IntPtr hwnd, IntPtr hdc)
         {
-            // If ReleaseDC fails we will not do anything with that information so just ignore the
-            // PRESHARP warnings.
-#pragma warning suppress 6031, 6523
+            // If ReleaseDC fails we will not do anything with that information
             return UnsafeNativeMethods.ReleaseDC(hwnd, hdc);
         }
 
@@ -1466,11 +1455,8 @@ namespace MS.Internal.AutomationProxies
 
         internal static IntPtr SelectObject(IntPtr hdc, IntPtr hObject)
         {
-            // There is no indication in the Windows SDK documentation that SelectObject()
-            // will set an error to be retrieved with GetLastError, so set the pragma to ignore
-            // the PRESHARP warning.  Anyway if ReleaseDC() fails here, nothing more can be done
-            // since the code is restoring the orginal object and discarding the temp object.
-#pragma warning suppress 6031, 6523
+            // There is no indication in the Windows SDK documentation that SelectObject() will set an error to be retrieved with GetLastError.
+            // Anyway if ReleaseDC() fails here, nothing more can be done since the code is restoring the orginal object and discarding the temp object.
             return UnsafeNativeMethods.SelectObject(hdc, hObject);
         }
 
@@ -1587,17 +1573,13 @@ namespace MS.Internal.AutomationProxies
                     if (!GetMessage(ref msg, IntPtr.Zero, 0, 0))
                         break;
 
-                    // TranslateMessage() will not set an error to be retrieved with GetLastError,
-                    // so set the pragma to ignore the PERSHARP warning.
-                    // the PERSHARP warning.
-#pragma warning suppress 6031, 6523
+                    // TranslateMessage() will not set an error to be retrieved with GetLastError
                     UnsafeNativeMethods.TranslateMessage(ref msg);
 
                     // From the Windows SDK documentation:
                     // The return value specifies the value returned by the window procedure.
                     // Although its meaning depends on the message being dispatched, the return
                     // value generally is ignored.
-#pragma warning suppress 6031, 6523
                     UnsafeNativeMethods.DispatchMessage(ref msg);
 
                     if (msg.message == NativeMethods.WM_HOTKEY && (short)msg.wParam == atom)
@@ -1635,9 +1617,7 @@ namespace MS.Internal.AutomationProxies
         internal static IntPtr SetWinEventHook(int eventMin, int eventMax, IntPtr hmodWinEventProc, NativeMethods.WinEventProcDef WinEventReentrancyFilter, uint idProcess, uint idThread, int dwFlags)
         {
             // There is no indication in the Windows SDK documentation that SetWinEventHook()
-            // will set an error to be retrieved with GetLastError, so set the pragma to ignore
-            // the PERSHARP warning.
-#pragma warning suppress 6523
+            // will set an error to be retrieved with GetLastError
             return UnsafeNativeMethods.SetWinEventHook(eventMin, eventMax, hmodWinEventProc, WinEventReentrancyFilter, idProcess, idThread, dwFlags);
         }
 
@@ -1730,9 +1710,7 @@ namespace MS.Internal.AutomationProxies
         internal static bool UnhookWinEvent(IntPtr winEventHook)
         {
             // There is no indication in the Windows SDK documentation that UnhookWinEvent()
-            // will set an error to be retrieved with GetLastError, so set the pragma to ignore
-            // the PERSHARP warning.
-#pragma warning suppress 6523
+            // will set an error to be retrieved with GetLastError
             return UnsafeNativeMethods.UnhookWinEvent(winEventHook);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,9 +14,6 @@
 //              Class ProxyHwnd: ProxyFragment, IRawElementProviderAdviseEvents
 //                  AdviseEventAdded
 //                  AdviseEventRemoved
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Windows;
@@ -176,10 +173,8 @@ namespace MS.Internal.AutomationProxies
                 // Only hwnd's can be labeled.
                 name = LocalizedName;
 
-                // PerSharp/PreFast will flag this as a warning 6507/56507: Prefer 'string.IsNullOrEmpty(name)' over checks for null and/or emptiness.
                 // It is valid to set LocalizedName to an empty string.  LocalizedName being an
                 // empty string will prevent the SendMessage(WM_GETTEXT) call.
-#pragma warning suppress 6507
                 if (name == null && GetParent() == null)
                 {
                     if (_fControlHasLabel)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxySimple.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxySimple.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -25,10 +25,6 @@
 //
 //
 //
-
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Windows.Automation;
@@ -244,12 +240,10 @@ namespace MS.Internal.AutomationProxies
             }
             else if (idProp == AutomationElement.AutomationIdProperty)
             {
-                // PerSharp/PreFast will flag this as a warning 6507/56507: Prefer 'string.IsNullOrEmpty(_sAutomationId)' over checks for null and/or emptiness.
                 // _sAutomationId being null is invalid, while being empty is a valid state.
                 // The use of IsNullOrEmpty while hide this.
-#pragma warning suppress 6507
                 System.Diagnostics.Debug.Assert(_sAutomationId != null, "_sAutomationId is null!");
-#pragma warning suppress 6507
+
                 return _sAutomationId.Length > 0 ? _sAutomationId : null;
             }
             else if (idProp == AutomationElement.IsOffscreenProperty)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WinEventTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WinEventTracker.cs
@@ -4,9 +4,6 @@
 
 // Description: Handles WinEvent notifications.
 
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 using System;
 using System.Collections;
 using System.Windows.Automation;
@@ -220,8 +217,7 @@ namespace MS.Internal.AutomationProxies
                     // Don't use the Misc.GetWindowThreadProcessId() helper since that throws; some events we want even
                     // though the hwnd is no longer valid (e.g. menu item events).
                     uint processId;
-                    // Disabling the PreSharp error since GetWindowThreadProcessId doesn't use SetLastError().
-    #pragma warning suppress 6523
+                    // GetWindowThreadProcessId doesn't use SetLastError().
                     if (UnsafeNativeMethods.GetWindowThreadProcessId(hwnd, out processId) != 0)
                     {
                         // Find the EventHookParams.  

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsAltTab.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsAltTab.cs
@@ -1,11 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description: HWND-based Alt-Tab (Task Switch) Window Proxy
-
-// PRESHARP: In order to avoid generating warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Text;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsEditBoxRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsEditBoxRange.cs
@@ -1,12 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description:
 // ITextRangeProvider interface for WindowsEditBox
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Collections;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsFormsLinkLabel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsFormsLinkLabel.cs
@@ -1,11 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description: Windows LinkLabel Proxy
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Windows.Automation;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListViewItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListViewItem.cs
@@ -5,10 +5,6 @@
 // Description: Win32 ListView Item proxy
 //
 
-
-// PRESHARP: In order to avoid generating warnings about unknown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
-
 using System;
 using System.Windows.Automation;
 using System.Windows.Automation.Provider;
@@ -749,10 +745,6 @@ namespace MS.Internal.AutomationProxies
 
         internal static void SetValue (string val, IntPtr hwnd, int item)
         {
-            // PerSharp/PreFast will flag this as warning 6507/56507: Prefer 'string.IsNullOrEmpty(val)' over checks for null and/or emptiness.
-            // An empty strings is valued here, while a null string is not.
-            // Therefore we can not use IsNullOrEmpty() here, suppress the warning.
-#pragma warning suppress 6507
             ArgumentNullException.ThrowIfNull(val);
 
             if (!WindowsListView.ListViewEditable (hwnd))

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -1,11 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description: HWND-based Menu Proxy
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Collections;
@@ -1264,8 +1261,6 @@ namespace MS.Internal.AutomationProxies
                                 UnsafeNativeMethods.TITLEBARINFO ti;
                                 if (!Misc.ProxyGetTitleBarInfo(_hwnd, out ti))
                                 {
-// Suppress Property get methods should not throw exceptions for internal getter
-#pragma warning suppress 6503
                                     throw new ElementNotAvailableException();
                                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEditRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEditRange.cs
@@ -1,12 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description:
 // Common code to support the ITextPointerProvider interface
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Collections;
@@ -240,10 +237,7 @@ namespace MS.Internal.AutomationProxies
                     ITextRange range = _range.GetDuplicate();
                     range.End = range.Start + maxLength;
                     text = range.Text;
-                    // PerSharp/PreFast will flag this as a warning 6507/56507: Prefer 'string.IsNullOrEmpty(text)' over checks for null and/or emptiness.
-                    // An empty strings is desirable, not a null string.  Cannot use IsNullOrEmpty().
-                    // Suppress the warning.
-#pragma warning suppress 6507
+
                     Debug.Assert(text == null || text.Length == maxLength);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTooltip.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTooltip.cs
@@ -1,11 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description: Tooltip Proxy
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System;
 using System.Windows.Automation;
@@ -211,7 +208,7 @@ namespace MS.Internal.AutomationProxies
                 int isDWMEnabled = 0; // DWM is not enabled
                 try
                 {
-#pragma warning suppress 56031 // No need to check return value; failure means it isn't enabled
+                    // No need to check return value; failure means it isn't enabled
                     UnsafeNativeMethods.DwmIsCompositionEnabled(out isDWMEnabled);
                 }
                 catch (DllNotFoundException)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/System/Windows/Automation/Provider/AutomationInteropProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/System/Windows/Automation/Provider/AutomationInteropProvider.cs
@@ -1,11 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description: Provides functionality that Win32/Avalon servers need (non-Avalon specific)
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using MS.Internal.Automation;
 
@@ -100,9 +97,6 @@ namespace System.Windows.Automation.Provider
             ArgumentNullException.ThrowIfNull(element);
             ArgumentNullException.ThrowIfNull(e);
 
-            // PRESHARP will flag this as warning 56506/6506:Parameter 'e' to this public method must be validated: A null-dereference can occur here.
-            // False positive, e is checked, see above
-#pragma warning suppress 6506
             UiaCoreProviderApi.UiaRaiseAutomationPropertyChangedEvent(element, e.Property.Id, e.OldValue, e.NewValue);
         }
 
@@ -119,9 +113,6 @@ namespace System.Windows.Automation.Provider
             ArgumentNullException.ThrowIfNull(provider);
             ArgumentNullException.ThrowIfNull(e);
 
-            // PRESHARP will flag this as warning 56506/6506:Parameter 'e' to this public method must be validated: A null-dereference can occur here.
-            // False positive, e is checked, see above
-#pragma warning suppress 6506
             if (e.EventId == AutomationElementIdentifiers.AsyncContentLoadedEvent)
             {
                 AsyncContentLoadedEventArgs asyncArgs = e as AsyncContentLoadedEventArgs;
@@ -132,9 +123,6 @@ namespace System.Windows.Automation.Provider
                 return;
             }
 
-            // PRESHARP will flag this as warning 56506/6506:Parameter 'e' to this public method must be validated: A null-dereference can occur here.
-            // False positive, e is checked, see above
-#pragma warning suppress 6506
             if (e.EventId == AutomationElementIdentifiers.NotificationEvent)
             {
                 NotificationEventArgs notificationArgs = e as NotificationEventArgs;
@@ -149,9 +137,6 @@ namespace System.Windows.Automation.Provider
                 return;
             }
 
-            // PRESHARP will flag this as warning 56506/6506:Parameter 'e' to this public method must be validated: A null-dereference can occur here.
-            // False positive, e is checked, see above
-#pragma warning suppress 6506
             if (e.EventId == AutomationElementIdentifiers.ActiveTextPositionChangedEvent)
             {
                 ActiveTextPositionChangedEventArgs activeTextPositionChangedArgs = e as ActiveTextPositionChangedEventArgs;
@@ -162,16 +147,10 @@ namespace System.Windows.Automation.Provider
                 return;
             }
 
-            // PRESHARP will flag this as warning 56506/6506:Parameter 'e' to this public method must be validated: A null-dereference can occur here.
-            // False positive, e is checked, see above
-#pragma warning suppress 6506
             if (e.EventId == WindowPatternIdentifiers.WindowClosedEvent && !(e is WindowClosedEventArgs))
                 ThrowInvalidArgument("e");
 
             // fire to all clients
-            // PRESHARP will flag this as warning 56506/6506:Parameter 'eventId' to this public method must be validated: A null-dereference can occur here.
-            // False positive, eventId is checked, see above
-#pragma warning suppress 6506
             UiaCoreProviderApi.UiaRaiseAutomationEvent(provider, eventId.Id);
         }
 
@@ -185,9 +164,6 @@ namespace System.Windows.Automation.Provider
             ArgumentNullException.ThrowIfNull(provider);
             ArgumentNullException.ThrowIfNull(e);
 
-            // PRESHARP will flag this as warning 56506/6506:Parameter 'e' to this public method must be validated: A null-dereference can occur here.
-            // False positive, e is checked, see above
-#pragma warning suppress 6506
             UiaCoreProviderApi.UiaRaiseStructureChangedEvent(provider, e.StructureChangeType, e.GetRuntimeId());
         }
         #endregion Public Methods

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/AutomationElementIdentifiers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/AutomationElementIdentifiers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,9 +9,6 @@ using MS.Internal.Automation;
 #if EVENT_TRACING_PROPERTY
 using Microsoft.Win32.Diagnostics;
 #endif
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Automation
 {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/Text/TextEnums.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/Text/TextEnums.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,10 +6,6 @@
 //
 //  
 //
-
-
-// PRESHARP: In order to avoid generating warnings about unkown message numbers and unknown pragmas.
-#pragma warning disable 1634, 1691
 
 using System.Runtime.InteropServices;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -360,16 +360,6 @@ namespace MS.Internal
             if (value == null)
                 return "<null>";
 
-            // PreSharp uses message numbers that the C# compiler doesn't know about.
-            // Disable the C# complaints, per the PreSharp documentation.
-            #pragma warning disable 1634, 1691
-
-            // PreSharp complains about catching NullReference (and other) exceptions.
-            // In this case, these are precisely the ones we want to catch the most,
-            // so that we can still print some kind of diagnostic information even
-            // about objects that implement ToString poorly.
-            #pragma warning disable 56500
-
             string result;
             try
             {
@@ -379,9 +369,6 @@ namespace MS.Internal
             {
                 result = "<unprintable>";
             }
-
-            #pragma warning restore 56500
-            #pragma warning restore 1634, 1691
 
             return AntiFormat(result);
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileDeflateTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileDeflateTransform.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,8 +6,6 @@
 //  Implementation of a helper class that provides a fully functional Stream on unmanaged ZLib in a fashion
 //  consistent with Office and RMA (see Creating Rights-Managed HTML Files at
 //  http://msdn.microsoft.com/library/default.asp?url=/library/en-us/rma/introduction.asp).
-
-#pragma warning disable 1634, 1691
 
 using System.IO;
 using System.IO.Compression;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileDeflateTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileDeflateTransform.cs
@@ -218,10 +218,9 @@ namespace MS.Internal.IO.Packaging.CompoundFile
                     //  - emit the header
                     //  - write out to the _baseStream
 
-                    // Suppress 6518 Local IDisposable object not disposed: 
-                    // Reason: The stream is not owned by us, therefore we cannot 
+                    // The stream is not owned by us, therefore we cannot 
                     // close the BinaryWriter as it will Close the stream underneath.
-#pragma warning disable 6518
+                    // TODO: Use leaveOpen ctor
                     BinaryWriter writer = new BinaryWriter(sink);
                     int bytesRead;
                     while ((bytesRead = PackagingUtilities.ReliableRead(source, sourceBuf, 0, sourceBuf.Length)) > 0)
@@ -274,7 +273,6 @@ namespace MS.Internal.IO.Packaging.CompoundFile
                     if (gcSinkBuf.IsAllocated)
                         gcSinkBuf.Free();
                 }
-#pragma warning restore 6518
             }
             finally
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
@@ -108,12 +108,10 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             // does -not- close the underlying stream.
             //
 
-// Suppress 6518 Local IDisposable object not disposed: 
-// Reason: The stream is not owned by the BlockManager, therefore we cannot 
-// close the BinaryWriter, as that would Close the stream underneath.
-#pragma warning disable 6518
+            // The stream is not owned by the BlockManager, therefore we cannot 
+            // close the BinaryWriter, as that would Close the stream underneath.
+            // TODO: Use leaveOpen ctor
             BinaryReader utf8Reader = new BinaryReader(_publishLicenseStream, Encoding.UTF8);
-#pragma warning restore 6518
 
             //
             // There follows a variable-length header (not to be confused with the physical
@@ -214,12 +212,11 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             // does -not- close the underlying stream.
             //
 
-// Suppress 6518 Local IDisposable object not disposed: 
-// Reason: The stream is not owned by the BlockManager, therefore we cannot 
-// close the BinaryWriter, as that would Close the stream underneath.
-#pragma warning disable 6518
+
+            // The stream is not owned by the BlockManager, therefore we cannot 
+            // close the BinaryWriter, as that would Close the stream underneath.
+            // TODO: Use leaveOpen ctor
             BinaryWriter utf8Writer = new BinaryWriter(_publishLicenseStream, Encoding.UTF8);
-#pragma warning restore 6518
 
             //
             // There follows a variable-length header (not to be confused with the physical

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
@@ -1,9 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+ï»¿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-// Allow use of presharp warning numbers [6518] unknown to the compiler
-#pragma warning disable 1634, 1691
 
 using System.Collections;
 using System.Collections.ObjectModel;
@@ -423,12 +420,12 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// <para>
         /// Returns true when the transform expects no further changes to its state.
         /// The contract is that if FixedSettings is false, an application can change
-        /// any of the transform’s properties with the promise that an exception will
+        /// any of the transformâ€™s properties with the promise that an exception will
         /// not be thrown.
         /// </para>
         /// <para>
         /// For the RightsManagementEncryptionTransform, FixedSettings becomes true the
-        /// first time the compound file code calls the object’s GetTransformedStream method.
+        /// first time the compound file code calls the objectâ€™s GetTransformedStream method.
         /// After that, any attempt to set the CryptoProvider property, or to call
         /// SavePublicLicense, throws InvalidOperationException.
         /// </para>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
@@ -1,13 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description:
 //  This is a helper class for pack:// Uris. This is a part of the 
 //  Metro Packaging Layer
-
-// Allow use of presharp warning numbers [6506] unknown to the compiler
-#pragma warning disable 1634, 1691
 
 using System.IO;                        // for Path class
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/StorageBasedPackageProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/StorageBasedPackageProperties.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -28,9 +28,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using MS.Internal.IO.Packaging.CompoundFile;
 using MS.Internal.WindowsBase;
-
-// Enable presharp pragma warning suppress directives.
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal.IO.Packaging
 {
@@ -586,7 +583,7 @@ namespace MS.Internal.IO.Packaging
                 }
                 finally
                 {
-#pragma warning suppress 6031 // suppressing a "by design" ignored return value
+                    // "by design" ignored return value
                     SafeNativeCompoundFileMethods.SafePropVariantClear(ref vals[0]);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/CallbackHandler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/CallbackHandler.cs
@@ -81,16 +81,13 @@ namespace MS.Internal.Security.RightsManagement
                         _callbackData = Marshal.PtrToStringUni(pvParam);
                     }
                 }
-// disabling PreSharp false positive. In this case we are actually re-throwing the same exception 
-// on the application thread inside WaitForCompletion() function
-#pragma warning disable 56500                  
+                // We are actually re-throwing the same exception on the application thread inside WaitForCompletion() function          
                 catch (Exception e)
                 {
                     // We catch all exceptions of the second worker thread (created by the unmanaged RM SDK)
                     // preserve them , and then rethrow later  on the main thread from the WaitForCompletion method
                     _exception = e;
                 }
-#pragma warning restore 56500
                 finally
                 {
                     // After this signal, OnStatus will NOT be invoked until we instigate another "transaction"

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/CallbackHandler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/CallbackHandler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,9 +7,6 @@
 
 using System.Threading;
 using System.Runtime.InteropServices;
-
-// Enable presharp pragma warning suppress directives.
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal.Security.RightsManagement
 {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/Errors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/Errors.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,9 +7,6 @@
 
 using System.Runtime.InteropServices;
 using System.Security.RightsManagement;
-
-// Enable presharp pragma warning suppress directives.
-#pragma warning disable 1634, 1691
 
 namespace MS.Internal.Security.RightsManagement
 {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/Errors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/Errors.cs
@@ -55,15 +55,12 @@ namespace MS.Internal.Security.RightsManagement
                     // to get a platform representation of the unmanaged HR code
                     Marshal.ThrowExceptionForHR(hr);
                 }
-// disabling PreSharp false positive. In this case we are actually re-throwing the same exception
-// wrapped in a more specific message
-#pragma warning disable 56500
+                // We are re-throwing the same exception wrapped in a more specific message
                 catch (Exception e)
                 {
                     // rethrow the exception as an inner exception of the RmExceptionGenericMessage
                     throw new RightsManagementException(SR.RmExceptionGenericMessage, e);
                 }
-#pragma warning restore 56500
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/DependencyPropertyDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/DependencyPropertyDescriptor.cs
@@ -1,12 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using MS.Internal.ComponentModel;
 using System.Reflection;
 using System.Windows;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.ComponentModel
 {
@@ -91,7 +89,6 @@ namespace System.ComponentModel
             }
             else
             {
-#pragma warning suppress 6506 // Property is obviously not null.
                 if (property.Attributes[typeof(DependencyPropertyAttribute)] is DependencyPropertyAttribute dpa)
                 {
                     dp = dpa.DependencyProperty;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/FormatVersion.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/FormatVersion.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,9 +7,6 @@
 //  Implementation of the FormatVersion class, which describes the versioning
 //  of an individual "format feature" within a compound file.
 //
-
-// Allow use of presharp warning numbers [6506] and [6518] unknown to the compiler
-#pragma warning disable 1634, 1691
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/FormatVersion.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/FormatVersion.cs
@@ -221,10 +221,6 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
             FormatVersion v = (FormatVersion) obj;
 
-            //PRESHARP:Parameter to this public method must be validated:  A null-dereference can occur here. 
-            //    Parameter 'v' to this public method must be validated:  A null-dereference can occur here. 
-            //This is a false positive as the checks above can gurantee no null dereference will occur  
-#pragma warning disable 6506
             if (!string.Equals(_featureIdentifier, v.FeatureIdentifier, StringComparison.OrdinalIgnoreCase)
                 || _reader != v.ReaderVersion
                 || _writer != v.WriterVersion
@@ -232,7 +228,6 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             {
                 return false;
             }
-#pragma warning restore 6506
 
             return true;
         }
@@ -301,10 +296,9 @@ namespace MS.Internal.IO.Packaging.CompoundFile
                 // Suppress 56518 Local IDisposable object not disposed: 
                 // Reason: The stream is not owned by the BlockManager, therefore we can 
                 // close the BinaryWriter as it will Close the stream underneath.        
-#pragma warning disable 6518
                 int len = 0;
                 BinaryWriter binarywriter = null;
-#pragma warning restore 6518
+
                 if (stream != null)
                 {
                     binarywriter = new BinaryWriter(stream, System.Text.Encoding.Unicode);
@@ -519,9 +513,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             // Suppress 56518 Local IDisposable object not disposed: 
             // Reason: The stream is not owned by the BlockManager, therefore we can 
             // close the BinaryWriter as it will Close the stream underneath.
-#pragma warning disable 6518
             BinaryReader streamReader = new BinaryReader(stream, System.Text.Encoding.Unicode);
-#pragma warning restore 6518
 
             return LoadFromBinaryReader(streamReader, out bytesRead);
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,8 +7,6 @@ using MS.Internal.IO.Packaging.CompoundFile;
 using CU = MS.Internal.IO.Packaging.CompoundFile.ContainerUtilities;
 using MS.Internal;
 using System.Runtime.InteropServices;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.IO.Packaging
 {
@@ -522,7 +520,6 @@ public class StorageInfo
 
         Invariant.Assert(streamArray  != null);
 
-        #pragma warning suppress 6506 // Invariant.Assert(streamArray  != null)
         return (StreamInfo[])streamArray.ToArray(typeof(StreamInfo));
     }
 
@@ -552,7 +549,6 @@ public class StorageInfo
 
         Invariant.Assert(storageArray != null);
 
-        #pragma warning suppress 6506 // Invariant.Assert(streamArray  != null)
         return (StorageInfo[])storageArray.ToArray(typeof(StorageInfo));
     }
 
@@ -650,7 +646,6 @@ public class StorageInfo
                         | SafeNativeCompoundFileConstants.STGM_SHARE_EXCLUSIVE,
                     0,
                     0,
-                #pragma warning suppress 6506 // Invariant.Assert(null != newStorage)
                 out newStorage.safeIStorage );
             if( SafeNativeCompoundFileConstants.S_OK != nativeCallErrorCode )
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageInfo.cs
@@ -828,7 +828,6 @@ public class StorageInfo
                 {
                     if (CriticalExceptions.IsCriticalException(e))
                     {
-                        // PreSharp Warning 56500
                         throw;
                     }
                     else

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/VersionPair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/VersionPair.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,9 +6,6 @@
 // Description:
 //  A major, minor version number pair.
 //
-
-// Allow use of presharp warning numbers [6506] unknown to the compiler
-#pragma warning disable 1634, 1691
 
 using System;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/VersionPair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/VersionPair.cs
@@ -251,15 +251,10 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
             VersionPair v = (VersionPair) obj;
 
-            //PRESHARP:Parameter to this public method must be validated:  A null-dereference can occur here. 
-            //    Parameter 'v' to this public method must be validated:  A null-dereference can occur here. 
-            //This is a false positive as the checks above can gurantee no null dereference will occur  
-#pragma warning disable 6506
             if (this != v)
             {
                 return false;
             }
-#pragma warning restore 6506
 
             return true;
         }
@@ -294,10 +289,6 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
             VersionPair v = (VersionPair) obj;
 
-            //PRESHARP:Parameter to this public method must be validated:  A null-dereference can occur here. 
-            //    Parameter 'v' to this public method must be validated:  A null-dereference can occur here. 
-            //This is a false positive as the checks above can gurantee no null dereference will occur  
-#pragma warning disable 6506
             if (this.Equals(obj))   // equal
             {
                 return 0;
@@ -307,7 +298,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             {
                 return -1;
             }
-#pragma warning restore 6506
+
             // greater than
             return 1;
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
@@ -1,12 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 // Description:
 //  This class provides api's to add/remove/verify signatures on an MMCF container.
-
-// Allow use of presharp warning numbers [6506] unknown to the compiler
-#pragma warning disable 1634, 1691
 
 using System.Security.Cryptography.Xml;                 // for SignedXml
 using System.Security.Cryptography.X509Certificates;    // for X509Certificate

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
@@ -480,11 +480,6 @@ namespace System.IO.Packaging
             if (certificate is not X509Certificate2 exSigner)
                 exSigner = new X509Certificate2(certificate.Handle);
 
-            //PRESHARP: Parameter to this public method must be validated:  A null-dereference can occur here.
-            //      Parameter 'exSigner' to this public method must be validated:  A null-dereference can occur here. 
-            //This is a false positive as the checks above can gurantee no null dereference will occur  
-#pragma warning disable 6506
-
             PackageDigitalSignature signature = null;
             PackagePart newSignaturePart = null;
             try
@@ -552,7 +547,6 @@ namespace System.IO.Packaging
                 newSignaturePart.CreateRelationship(certificatePartName, TargetMode.Internal, CertificatePart.RelationshipType);
                 signature.SetCertificatePart(certPart);
             }
-#pragma warning restore 6506
 
             _container.Flush();
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/LocalizedNameDescriptionPair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/LocalizedNameDescriptionPair.cs
@@ -53,7 +53,6 @@ namespace System.Security.RightsManagement
         /// </summary>
         public override bool Equals(object obj)
         {
-
             if ((obj == null) || (obj.GetType() != GetType()))
             {
                 return false;
@@ -61,13 +60,9 @@ namespace System.Security.RightsManagement
 
             LocalizedNameDescriptionPair localizedNameDescr = obj as LocalizedNameDescriptionPair;
             
-            //PRESHARP:Parameter to this public method must be validated:  A null-dereference can occur here. 
-            //This is a false positive as the checks above can gurantee no null dereference will occur  
-#pragma warning disable 6506
             return (string.Equals(localizedNameDescr.Name, Name, StringComparison.Ordinal))
                         &&
                     (string.Equals(localizedNameDescr.Description, Description, StringComparison.Ordinal));
-#pragma warning restore 6506
         }        
             
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/LocalizedNameDescriptionPair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/LocalizedNameDescriptionPair.cs
@@ -1,9 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-// Allow use of presharp warning numbers [6506] and [6518] unknown to the compiler
-#pragma warning disable 1634, 1691
 
 namespace System.Security.RightsManagement
 {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/PublishLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/PublishLicense.cs
@@ -1,12 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using MS.Internal.Security.RightsManagement;
-
-// Disable message about unknown message numbers so as to allow the suppression
-// of PreSharp warnings (whose numbers are unknown to the compiler).
-#pragma warning disable 1634, 1691
 
 namespace System.Security.RightsManagement
 {
@@ -145,12 +141,9 @@ namespace System.Security.RightsManagement
         /// </summary>
         public UseLicense AcquireUseLicense(SecureEnvironment secureEnvironment)
         {
-
             ArgumentNullException.ThrowIfNull(secureEnvironment);
 
             // The SecureEnvironment constructor makes sure ClientSession cannot be null.
-            // Accordingly suppressing preSharp warning about having to validate ClientSession.
-#pragma warning suppress 6506
             return secureEnvironment.ClientSession.AcquireUseLicense(_serializedPublishLicense, false);
         }
 
@@ -164,12 +157,9 @@ namespace System.Security.RightsManagement
         /// </summary>
         public UseLicense AcquireUseLicenseNoUI(SecureEnvironment secureEnvironment)
         {
-
             ArgumentNullException.ThrowIfNull(secureEnvironment);
 
             // The SecureEnvironment constructor makes sure ClientSession cannot be null.
-            // Accordingly suppressing preSharp warning about having to validate ClientSession.
-#pragma warning suppress 6506
             return secureEnvironment.ClientSession.AcquireUseLicense(_serializedPublishLicense, true);
         }        
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UnsignedPublishLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UnsignedPublishLicense.cs
@@ -1,14 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.ObjectModel;
 using MS.Internal.Security.RightsManagement;
 using MS.Internal;
-
-// Disable message about unknown message numbers so as to allow the suppression
-// of PreSharp warnings (whose numbers are unknown to the compiler).
-#pragma warning disable 1634, 1691
 
 namespace System.Security.RightsManagement
 {
@@ -95,8 +91,6 @@ namespace System.Security.RightsManagement
                                         _revocationPoint))
             {
                 // The SecureEnvironment constructor makes sure ClientSession cannot be null.
-                // Accordingly suppressing preSharp warning about having to validate ClientSession.
-#pragma warning suppress 6506
                 return secureEnvironment.ClientSession.SignIssuanceLicense(issuanceLicense, out authorUseLicense);
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UseLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UseLicense.cs
@@ -1,14 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.ObjectModel;
 
 using MS.Internal.Security.RightsManagement;
-
-// Disable message about unknown message numbers so as to allow the suppression
-// of PreSharp warnings (whose numbers are unknown to the compiler).
-#pragma warning disable 1634, 1691
 
 namespace System.Security.RightsManagement
 {
@@ -94,12 +90,9 @@ namespace System.Security.RightsManagement
         /// </summary>
         public CryptoProvider Bind (SecureEnvironment secureEnvironment)
         {
-
             ArgumentNullException.ThrowIfNull(secureEnvironment);
 
             // The SecureEnvironment constructor makes sure ClientSession cannot be null.
-            // Accordingly suppressing preSharp warning about having to validate ClientSession.
-#pragma warning suppress 6506
             return secureEnvironment.ClientSession.TryBindUseLicenseToAllIdentites(_serializedUseLicense);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/Int32RectValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/Int32RectValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,8 +10,6 @@
 //
 
 using System.Windows.Markup;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Converters
 {
@@ -66,8 +64,6 @@ namespace System.Windows.Converters
             if (value is Int32Rect instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/PointValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/PointValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,8 +10,6 @@
 //
 
 using System.Windows.Markup;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Converters
 {
@@ -66,8 +64,6 @@ namespace System.Windows.Converters
             if (value is Point instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/RectValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/RectValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,8 +10,6 @@
 //
 
 using System.Windows.Markup;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Converters
 {
@@ -66,8 +64,6 @@ namespace System.Windows.Converters
             if (value is Rect instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/SizeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/SizeValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,8 +10,6 @@
 //
 
 using System.Windows.Markup;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Converters
 {
@@ -66,8 +64,6 @@ namespace System.Windows.Converters
             if (value is Size instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/VectorValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/VectorValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,8 +10,6 @@
 //
 
 using System.Windows.Markup;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Converters
 {
@@ -66,8 +64,6 @@ namespace System.Windows.Converters
             if (value is Vector instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObjectType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObjectType.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {
@@ -42,7 +40,6 @@ namespace System.Windows
 
             if (!typeof(DependencyObject).IsAssignableFrom(systemType))
             {
-                #pragma warning suppress 6506 // systemType is obviously not null
                 throw new ArgumentException(SR.Format(SR.DTypeNotSupportForSystemType, systemType.Name));
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@ using System.Windows.Markup;    // For ValueSerializerAttribute
 using MS.Internal.WindowsBase;
 using System.Windows.Threading; // For DispatcherObject
 using System.Runtime.CompilerServices;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {
@@ -143,8 +141,6 @@ namespace System.Windows
             }
 
             // Authorize registering type for read-only access, create key.
-            #pragma warning suppress 6506 // typeMetadata is never null, since we generate default metadata if none is provided.
-
             // Apply type-specific metadata to owner type only
             property.OverrideMetadata(ownerType, typeMetadata, authorizationKey);
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Int32RectConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Int32RectConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {
@@ -109,8 +107,6 @@ namespace System.Windows
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/PointConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/PointConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {
@@ -109,8 +107,6 @@ namespace System.Windows
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/RectConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/RectConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {
@@ -109,8 +107,6 @@ namespace System.Windows
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/SizeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/SizeConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {
@@ -109,8 +107,6 @@ namespace System.Windows
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/VectorConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/VectorConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {
@@ -109,8 +107,6 @@ namespace System.Windows
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/LocalValueEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/LocalValueEnumerator.cs
@@ -1,10 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows
 {
@@ -69,13 +67,13 @@ namespace System.Windows
             {
                 if(_index == -1 )
                 {
-                    #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                    // IEnumerator.Current is documented to throw this exception
                     throw new InvalidOperationException(SR.LocalValueEnumerationReset);
                 }
 
                 if(_index >= Count )
                 {
-                    #pragma warning suppress 6503 // IEnumerator.Current is documented to throw this exception
+                    // IEnumerator.Current is documented to throw this exception
                     throw new InvalidOperationException(SR.LocalValueEnumerationOutOfBounds);
                 }
                 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Converters/Generated/MatrixValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Converters/Generated/MatrixValueSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,8 +10,6 @@
 //
 
 using System.Windows.Markup;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media.Converters
 {
@@ -66,8 +64,6 @@ namespace System.Windows.Media.Converters
             if (value is Matrix instance)
             {
 
-
-#pragma warning suppress 6506 // instance is obviously not null
                 return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Generated/MatrixConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Generated/MatrixConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,8 +11,6 @@
 
 using System.ComponentModel;
 using System.Globalization;
-
-#pragma warning disable 1634, 1691  // suppressing PreSharp warnings
 
 namespace System.Windows.Media
 {
@@ -109,8 +107,6 @@ namespace System.Windows.Media
                 if (destinationType == typeof(string))
                 {
                     // Delegate to the formatting/culture-aware ConvertToString method.
-
-                    #pragma warning suppress 6506 // instance is obviously not null
                     return instance.ConvertToString(null, culture);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -12,12 +12,6 @@ using System.Threading;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-
-// Disabling 1634 and 1691:
-// In order to avoid generating warnings about unknown message numbers and
-// unknown pragmas when compiling C# source code with the C# compiler,
-// you need to disable warnings 1634 and 1691. (Presharp Documentation)
-#pragma warning disable 1634, 1691
 
 namespace System.Windows.Threading
 {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/ElementHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/ElementHost.cs
@@ -185,10 +185,9 @@ namespace System.Windows.Forms.Integration
             set
             {
                 UIElement oldValue = Child;
-#pragma warning disable 1634, 1691
-#pragma warning disable 56526
+
                 _child = value;
-#pragma warning restore 1634, 1691, 56526
+
                 HostContainerInternal.Children.Clear();
                 if (_child != null)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/ElementHostPropertyMap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/ElementHostPropertyMap.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -16,10 +16,8 @@ namespace System.Windows.Forms.Integration
     internal sealed class ElementHostPropertyMap : PropertyMap
     {
         //Since the host controls our lifetime, we shouldn't be disposing it.
-#pragma warning disable 1634, 1691
-#pragma warning disable 56524
         private ElementHost _host;
-#pragma warning restore 1634, 1691, 56524
+
         public ElementHostPropertyMap(ElementHost host)
             : base(host)
         {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/PropertyMap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/PropertyMap.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -300,12 +300,9 @@ namespace System.Windows.Forms.Integration
             RunTranslator(translator, host, propertyName, value);
         }
 
-//Disable the PreSharp error 56500 Avoid `swallowing errors by catching non-specific exceptions.
-//In this specific case, we are catching the exception and firing an event which can be handled in user code
-//The user handling the event can make the determination on whether or not the exception should be rethrown
-//(Wrapped in an InvalidOperationException).
-#pragma warning disable 1634, 1691
-#pragma warning disable 56500
+        //In this specific case, we are catching the exception and firing an event which can be handled in user code
+        //The user handling the event can make the determination on whether or not the exception should be rethrown
+        //(Wrapped in an InvalidOperationException).
         internal void RunTranslator(PropertyTranslator translator, object host, string propertyName, object value)
         {
             try
@@ -325,8 +322,6 @@ namespace System.Windows.Forms.Integration
                 }
             }
         }
-#pragma warning restore 56500 
-#pragma warning restore 1634, 1691
 
         private event EventHandler<PropertyMappingExceptionEventArgs> _propertyMappingError;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/WindowsFormsHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/WindowsFormsHost.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -312,8 +312,6 @@ namespace System.Windows.Forms.Integration
             }
             set
             {
-#pragma warning disable 1634, 1691
-#pragma warning disable 56526
                 Control oldChild = Child;
                 SWF.Form form = value as SWF.Form;
                 if (form != null)
@@ -340,7 +338,6 @@ namespace System.Windows.Forms.Integration
                     _priorConstraint = new Size(double.NaN, double.NaN);
                 }
                 OnChildChanged(oldChild);
-#pragma warning restore 1634, 1691, 56526
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/AnimatableTemplate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/AnimatableTemplate.cs
@@ -65,9 +65,6 @@ namespace MS.Internal.MilCodeGen.ResourceModel
                     csFile.WriteBlock(
                         [[inline]]
                             [[Helpers.ManagedStyle.WriteFileHeader(filename, @"wpf\src\Graphics\codegen\mcg\generators\AnimatableTemplate.cs")]]
-
-                            // Allow suppression of certain presharp messages
-                            #pragma warning disable 1634, 1691
                             
                             using MS.Internal;
                             using MS.Utility;

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/AnimationBaseTemplate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/AnimationBaseTemplate.cs
@@ -101,9 +101,6 @@ namespace MS.Internal.MilCodeGen.ResourceModel
                         [[inline]]
                             [[Helpers.ManagedStyle.WriteFileHeader(fileName)]]
 
-                            // Allow use of presharp: #pragma warning suppress <nnnn>
-                            #pragma warning disable 1634, 1691
-
                             using MS.Internal;
 
                             using System;
@@ -329,10 +326,6 @@ namespace MS.Internal.MilCodeGen.ResourceModel
                         throw new ArgumentNullException("animationClock");
                     }
                     
-                    // We check for null above but presharp doesn't notice so we suppress the 
-                    // warning here.
-                    
-                    #pragma warning suppress 6506
                     if (animationClock.CurrentState == ClockState.Stopped)
                     {
                         return defaultDestinationValue;

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/Elements.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/Elements.cs
@@ -67,8 +67,6 @@ namespace MS.Internal.MilCodeGen.Generators
                             using System.Windows.Input;
                             using System.Windows.Media.Animation;
 
-                            #pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-
                             namespace [[e.Namespace]]
                             {
                                 partial class [[e.Name]] [[(e.ImplementsIAnimatable ? ": IAnimatable" : "")]]

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/IAnimatableHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/IAnimatableHelper.cs
@@ -79,17 +79,13 @@ namespace MS.Internal.MilCodeGen.Helpers
 
                         if (!AnimationStorage.IsPropertyAnimatable(this, dp))
                         {
-                    #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                             throw new ArgumentException(SR.Format(SR.Animation_DependencyPropertyIsNotAnimatable, dp.Name, this.GetType()), "dp");
-                    #pragma warning restore 56506
                         }
 
                         if (clock != null
                             && !AnimationStorage.IsAnimationValid(dp, clock.Timeline))
                         {
-                    #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                             throw new ArgumentException(SR.Format(SR.Animation_AnimationTimelineTypeMismatch, clock.Timeline.GetType(), dp.Name, dp.PropertyType), "clock");
-                    #pragma warning restore 56506
                         }
 
                         if (!HandoffBehaviorEnum.IsDefined(handoffBehavior))
@@ -151,9 +147,7 @@ namespace MS.Internal.MilCodeGen.Helpers
 
                         if (!AnimationStorage.IsPropertyAnimatable(this, dp))
                         {
-                    #pragma warning disable 56506 // Suppress presharp warning: Parameter 'dp' to this public method must be validated:  A null-dereference can occur here.
                             throw new ArgumentException(SR.Format(SR.Animation_DependencyPropertyIsNotAnimatable, dp.Name, this.GetType()), "dp");
-                    #pragma warning restore 56506
                         }
 
                         if (   animation != null

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/ManagedStruct.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/ManagedStruct.cs
@@ -715,12 +715,6 @@ namespace MS.Internal.MilCodeGen.Generators
                                 );
                     }
 
-                    csFile.Write(
-                        [[inline]]
-                            #pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-                        [[/inline]]
-                        );
-
                     // If the resource may not always be serializable as a string, we need to check if this instance can.
                     if (!resource.IsAlwaysSerializableAsString)
                     {
@@ -737,7 +731,6 @@ namespace MS.Internal.MilCodeGen.Generators
 
                                     [[resource.Name]] value = ([[resource.Name]])context.Instance;
 
-                                    #pragma warning suppress 6506 // value is obviously not null
                                     return value.CanSerializeToString();
                                 }
 
@@ -751,7 +744,6 @@ namespace MS.Internal.MilCodeGen.Generators
                                 // When invoked by the serialization engine we can convert to string only for some instances
                                 if (context != null && context.Instance != null)
                                 {
-                                    #pragma warning suppress 6506 // instance is obviously not null
                                     if (!instance.CanSerializeToString())
                                     {
                                         throw new NotSupportedException(SR.Converter_ConvertToNotSupported);
@@ -864,7 +856,6 @@ namespace MS.Internal.MilCodeGen.Generators
                                             {
                                                 [[serializationContextConvertTo]]// Delegate to the formatting/culture-aware ConvertToString method.
 
-                                                #pragma warning suppress 6506 // instance is obviously not null
                                                 return instance.ConvertToString(null, culture);
                                             }
                                         }
@@ -909,12 +900,6 @@ namespace MS.Internal.MilCodeGen.Generators
                                 );
                     }
 
-                    csFile.Write(
-                        [[inline]]
-                            #pragma warning disable 1634, 1691  // suppressing PreSharp warnings
-                        [[/inline]]
-                        );
-
                     // If always serializable to string, ensure that it's still the right type.
                     if (resource.IsAlwaysSerializableAsString)
                     {
@@ -947,7 +932,6 @@ namespace MS.Internal.MilCodeGen.Generators
 
                                 [[resource.Name]] instance  = ([[resource.Name]]) value;
 
-                                #pragma warning suppress 6506 // instance is obviously not null
                                 return instance.CanSerializeToString();
 
 
@@ -956,8 +940,8 @@ namespace MS.Internal.MilCodeGen.Generators
 
                         valueSerializerConvertTo =
                             [[inline]]
+							
                                 // When invoked by the serialization engine we can convert to string only for some instances
-                                #pragma warning suppress 6506 // instance is obviously not null
                                 if (!instance.CanSerializeToString())
                                 {
                                     // Let base throw an exception.
@@ -1023,7 +1007,6 @@ namespace MS.Internal.MilCodeGen.Generators
                                             [[resource.Name]] instance = ([[resource.Name]]) value;
                                             [[valueSerializerConvertTo]]
 
-                                            #pragma warning suppress 6506 // instance is obviously not null
                                             return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
                                         }
 


### PR DESCRIPTION
## Description

Similarly to #9903, remove obsolete warning suppressions, this time from PreSharp. This includes suppressions about unknown warning numbers and also the disable occurences of PreSharp-specific warnings.

- **There are no code changes at all**, so the compiled IL shall be identical.
- For the generated classes, MilCodeGen has been adjusted.

## Customer Impact

Cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10221)