### PR TITLE
Optimize Color/Brush parsing and string conversion, reduce allocs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -54,6 +54,7 @@
     <Compile Include="$(WpfSharedDir)\MS\Internal\LegacyPriorityQueue.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\SequentialUshortCollection.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\SizeLimitedCache.cs" />
+	<Compile Include="$(WpfSharedDir)\MS\Internal\ValueTokenizerHelper.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\Commands\CommandLibraryHelper.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\Generated\AlignmentXValidation.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\Generated\AlignmentYValidation.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -739,6 +739,7 @@
     <Compile Include="System\Windows\Media\ColorContext.cs" />
     <Compile Include="System\Windows\Media\ColorContextHelper.cs" />
     <Compile Include="System\Windows\Media\ColorConverter.cs" />
+    <Compile Include="System\Windows\Media\ColorKind.cs" />
     <Compile Include="System\Windows\Media\ColorTransform.cs" />
     <Compile Include="System\Windows\Media\ColorTransformHelper.cs" />
     <Compile Include="System\Windows\Media\CombinedGeometry.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using MS.Internal;
 
 #pragma warning disable 1634, 1691  // suppressing PreSharp warnings
@@ -255,45 +255,55 @@ namespace System.Windows.Media
         /// </returns>
         internal string ConvertToString(string format, IFormatProvider provider)
         {
-            if (context == null)
+            if (context is null)
             {
-                if (format == null)
-                {
-                    return string.Create(provider, stackalloc char[128], $"#{this.sRgbColor.a:X2}{this.sRgbColor.r:X2}{this.sRgbColor.g:X2}{this.sRgbColor.b:X2}");
-                }
-                else
+                if (format is not null)
                 {
                     // Helper to get the numeric list separator for a given culture.
-                    char separator = MS.Internal.TokenizerHelper.GetNumericListSeparator(provider);
-                    return string.Format(provider,
-                        $"sc#{{1:{format}}}{{0}} {{2:{format}}}{{0}} {{3:{format}}}{{0}} {{4:{format}}}",
-                        separator, scRgbColor.a, scRgbColor.r, scRgbColor.g, scRgbColor.b);
+                    char separator = TokenizerHelper.GetNumericListSeparator(provider);
+
+                    DefaultInterpolatedStringHandler stringBuilder = new(1, 7, provider, stackalloc char[128]);
+                    stringBuilder.AppendLiteral("sc#");
+                    stringBuilder.AppendFormatted(scRgbColor.a, format: format);
+                    stringBuilder.AppendFormatted(separator);
+                    stringBuilder.AppendFormatted(scRgbColor.r, format: format);
+                    stringBuilder.AppendFormatted(separator);
+                    stringBuilder.AppendFormatted(scRgbColor.g, format: format);
+                    stringBuilder.AppendFormatted(separator);
+                    stringBuilder.AppendFormatted(scRgbColor.b, format: format);
+
+                    return stringBuilder.ToStringAndClear();
                 }
+
+                return string.Create(provider, stackalloc char[128], $"#{sRgbColor.a:X2}{sRgbColor.r:X2}{sRgbColor.g:X2}{sRgbColor.b:X2}");
             }
             else
             {
-                char separator = MS.Internal.TokenizerHelper.GetNumericListSeparator(provider);
+                char separator = TokenizerHelper.GetNumericListSeparator(provider);
 
-                format = c_scRgbFormat;
-
-                //First Stepmake sure that nothing that should not be escaped is escaped
+                // 1) Make sure that nothing that should not be escaped is escaped
                 Uri safeUnescapedUri = new Uri(context.ProfileUri.GetComponents(UriComponents.SerializationInfoString, UriFormat.SafeUnescaped),
-                                                    context.ProfileUri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative);
-                //Second Step make sure that everything that should escaped is escaped
-                String uriString = safeUnescapedUri.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped);
+                                               context.ProfileUri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative);
 
-                var sb = new StringBuilder();
-                sb.AppendFormat(provider, "{0}{1} ", Parsers.ContextColor, uriString);
-                sb.AppendFormat(provider,"{1:" + format + "}{0}",separator,scRgbColor.a);
-                for (int i = 0; i < nativeColorValue.Length; ++i )
+                // 2) Make sure that everything that should escaped is escaped
+                string uriString = safeUnescapedUri.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped);
+
+                DefaultInterpolatedStringHandler stringBuilder = new(3, 7, provider, stackalloc char[256]);
+
+                // Append "ContextColor file://something " format
+                stringBuilder.AppendLiteral(Parsers.ContextColor);
+                stringBuilder.AppendLiteral(uriString);
+                stringBuilder.AppendLiteral(" ");
+
+                stringBuilder.AppendFormatted(scRgbColor.a, format: c_scRgbFormat);
+
+                for (int i = 0; i < nativeColorValue.Length; i++)
                 {
-                    sb.AppendFormat(provider,"{0:" + format + "}",nativeColorValue[i]);
-                    if (i < nativeColorValue.Length - 1)
-                    {
-                        sb.AppendFormat(provider,"{0}",separator);
-                    }
+                    stringBuilder.AppendFormatted(separator);
+                    stringBuilder.AppendFormatted(nativeColorValue[i], format: c_scRgbFormat);
                 }
-                return sb.ToString();
+
+                return stringBuilder.ToStringAndClear();
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
@@ -35,29 +35,23 @@ namespace System.Windows.Media
         ///</summary>
         private static Color FromProfile(Uri profileUri)
         {
-            Color c1 = new Color();
+            Color color = new();
 
-            c1.context = new ColorContext(profileUri);
-            c1.scRgbColor.a = 1.0f;
-            c1.scRgbColor.r = 0.0f;
-            c1.scRgbColor.g = 0.0f;
-            c1.scRgbColor.b = 0.0f;
-            c1.sRgbColor.a = 255;
-            c1.sRgbColor.r = 0;
-            c1.sRgbColor.g = 0;
-            c1.sRgbColor.b = 0;
-            if (c1.context != null)
-            {
-                c1.nativeColorValue = new float[c1.context.NumChannels];
-                for (int i = 0; i < c1.nativeColorValue.Length; i++)
-                {
-                    c1.nativeColorValue[i] = 0.0f;
-                }
-            }
+            color.context = new ColorContext(profileUri);
+            color.scRgbColor.a = 1.0f;
+            color.scRgbColor.r = 0.0f;
+            color.scRgbColor.g = 0.0f;
+            color.scRgbColor.b = 0.0f;
+            color.sRgbColor.a = 255;
+            color.sRgbColor.r = 0;
+            color.sRgbColor.g = 0;
+            color.sRgbColor.b = 0;
 
-            c1.isFromScRgb = false;
+            color.nativeColorValue = new float[color.context.NumChannels];
 
-            return c1;
+            color.isFromScRgb = false;
+
+            return color;
         }
 
         ///<summary>
@@ -65,39 +59,36 @@ namespace System.Windows.Media
         ///</summary>
         public static Color FromAValues(float a, float[] values, Uri profileUri)
         {
-            Color c1 = Color.FromProfile(profileUri);
+            return FromAValues(a, values, profileUri);
+        }
 
-            if (values == null)
-            {
-                throw new ArgumentException(SR.Format(SR.Color_DimensionMismatch, null));
-            }
+        ///<summary>
+        /// FromAValues - general constructor for multichannel color values with explicit alpha channel and color context, i.e. spectral colors
+        ///</summary>
+        internal static Color FromAValues(float alpha, Span<float> values, Uri profileUri)
+        {
+            Color color = FromProfile(profileUri);
 
-            if (values.Length != c1.nativeColorValue.Length)
-            {
+            if (values.IsEmpty || values.Length != color.nativeColorValue.Length)
                 throw new ArgumentException(SR.Format(SR.Color_DimensionMismatch, null));
-            }
 
             for (int numChannels = 0; numChannels < values.Length; numChannels++)
-            {
-                c1.nativeColorValue[numChannels] = values[numChannels];
-            }
-            c1.ComputeScRgbValues();
-            c1.scRgbColor.a = a;
-            if (a < 0.0f)
-            {
-                a = 0.0f;
-            }
-            else if (a > 1.0f)
-            {
-                a = 1.0f;
-            }
+                color.nativeColorValue[numChannels] = values[numChannels];
 
-            c1.sRgbColor.a = (byte)((a * 255.0f) + 0.5f);
-            c1.sRgbColor.r = ScRgbTosRgb(c1.scRgbColor.r);
-            c1.sRgbColor.g = ScRgbTosRgb(c1.scRgbColor.g);
-            c1.sRgbColor.b = ScRgbTosRgb(c1.scRgbColor.b);
+            color.ComputeScRgbValues();
+            color.scRgbColor.a = alpha;
 
-            return c1;
+            if (alpha < 0.0f)
+                alpha = 0.0f;
+            else if (alpha > 1.0f)
+                alpha = 1.0f;
+
+            color.sRgbColor.a = (byte)((alpha * 255.0f) + 0.5f);
+            color.sRgbColor.r = ScRgbTosRgb(color.scRgbColor.r);
+            color.sRgbColor.g = ScRgbTosRgb(color.scRgbColor.g);
+            color.sRgbColor.b = ScRgbTosRgb(color.scRgbColor.b);
+
+            return color;
         }
 
         ///<summary>
@@ -105,9 +96,7 @@ namespace System.Windows.Media
         ///</summary>
         public static Color FromValues(float[] values, Uri profileUri)
         {
-            Color c1 = Color.FromAValues(1.0f, values, profileUri);
-
-            return c1;
+            return FromAValues(1.0f, values, profileUri);
         }
 
         ///<summary>
@@ -190,8 +179,7 @@ namespace System.Windows.Media
         ///</summary>
         public static Color FromRgb(byte r, byte g, byte b)// legacy sRGB interface, bytes are required to properly round trip
         {
-            Color c1 = Color.FromArgb(0xff, r, g, b);
-            return c1;
+            return FromArgb(0xff, r, g, b);
         }
         #endregion Constructors
 
@@ -295,7 +283,7 @@ namespace System.Windows.Media
                 String uriString = safeUnescapedUri.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped);
 
                 var sb = new StringBuilder();
-                sb.AppendFormat(provider, "{0}{1} ", Parsers.s_ContextColor, uriString);
+                sb.AppendFormat(provider, "{0}{1} ", Parsers.ContextColor, uriString);
                 sb.AppendFormat(provider,"{1:" + format + "}{0}",separator,scRgbColor.a);
                 for (int i = 0; i < nativeColorValue.Length; ++i )
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorConverter.cs
@@ -54,21 +54,15 @@ namespace System.Windows.Media
         /// A NotSupportedException is thrown if the example object is null or is not a valid type
         /// which can be converted to a Color.
         /// </exception>
-        public override object ConvertFrom(ITypeDescriptorContext td, System.Globalization.CultureInfo ci, object value)
+        public override object ConvertFrom(ITypeDescriptorContext td, CultureInfo ci, object value)
         {
-            if (null == value)
-            {
+            if (value is null)
                 throw GetConvertFromException(value);
-            }
 
-            String s = value as string;
-
-            if (null == s)
-            {
-                throw new ArgumentException(SR.Format(SR.General_BadType, "ConvertFrom"), "value");
-            }
+            if (value is not string valueString)
+                throw new ArgumentException(SR.Format(SR.General_BadType, nameof(ConvertFrom), nameof(value)));
             
-            return Parsers.ParseColor(value as string, ci, td);        
+            return Parsers.ParseColor(valueString, ci, td);        
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorConverter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
@@ -29,7 +28,7 @@ namespace System.Windows.Media
         /// <param name="context">ITypeDescriptorContext</param>
         /// <param name="destinationType">Type to convert to</param>
         /// <returns>true if conversion is possible</returns>
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) 
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
             return destinationType == typeof(InstanceDescriptor) || base.CanConvertTo(context, destinationType);
         }
@@ -39,12 +38,7 @@ namespace System.Windows.Media
         ///</summary>
         public static new object ConvertFromString(string value)
         {
-            if ( null == value)
-            {
-                return null;
-            }
-            
-            return Parsers.ParseColor(value, null);
+            return value is not null ? Parsers.ParseColor(value, null) : null;
         }
 
         /// <summary>
@@ -61,8 +55,8 @@ namespace System.Windows.Media
 
             if (value is not string valueString)
                 throw new ArgumentException(SR.Format(SR.General_BadType, nameof(ConvertFrom), nameof(value)));
-            
-            return Parsers.ParseColor(valueString, ci, td);        
+
+            return Parsers.ParseColor(valueString, ci, td);
         }
 
         /// <summary>
@@ -79,18 +73,17 @@ namespace System.Windows.Media
         /// <returns>converted value</returns>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            if (destinationType != null && value is Color)
+            if (destinationType != null && value is Color color)
             {
                 if (destinationType == typeof(InstanceDescriptor))
                 {
-                    MethodInfo mi = typeof(Color).GetMethod("FromArgb", new Type[]{typeof(byte), typeof(byte), typeof(byte), typeof(byte)});
-                    Color c = (Color)value;
-                    return new InstanceDescriptor(mi, new object[]{c.A, c.R, c.G, c.B});
+                    MethodInfo mi = typeof(Color).GetMethod("FromArgb", new Type[] { typeof(byte), typeof(byte), typeof(byte), typeof(byte) });
+
+                    return new InstanceDescriptor(mi, new object[] { color.A, color.R, color.G, color.B });
                 }
                 else if (destinationType == typeof(string))
                 {
-                    Color c = (Color)value;
-                    return c.ToString(culture);
+                    return color.ToString(culture);
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorConverter.cs
@@ -20,14 +20,7 @@ namespace System.Windows.Media
         /// </summary>
         public override bool CanConvertFrom(ITypeDescriptorContext td, Type t)
         {
-            if (t == typeof(string))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return t == typeof(string);
         }
 
         /// <summary>
@@ -38,12 +31,7 @@ namespace System.Windows.Media
         /// <returns>true if conversion is possible</returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) 
         {
-            if (destinationType == typeof(InstanceDescriptor)) 
-            {
-                return true;
-            }
-
-            return base.CanConvertTo(context, destinationType);
+            return destinationType == typeof(InstanceDescriptor) || base.CanConvertTo(context, destinationType);
         }
         
         ///<summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorKind.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorKind.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Media
+{
+    /// <summary>
+    /// Encapsulates color kinds as categorized via <see cref="KnownColors.MatchColor(string)"/>
+    /// </summary>
+    internal enum ColorKind
+    {
+        /// <summary>
+        /// Unused but it is the default value.
+        /// </summary>
+        Unknown = 0,
+        /// <summary>
+        /// Just a standard #HEXCOLOR format.
+        /// </summary>
+        NumericColor = 1,
+        /// <summary>
+        /// Color prefixed with "ContextColor ".
+        /// </summary>
+        ContextColor = 2,
+        /// <summary>
+        /// Color prefixed with "sc#".
+        /// </summary>
+        ScRgbColor = 3,
+        /// <summary>
+        /// Fallback if none of the previous ones matched.
+        /// </summary>
+        KnownColor = 4
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorKind.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorKind.cs
@@ -5,7 +5,7 @@
 namespace System.Windows.Media
 {
     /// <summary>
-    /// Encapsulates color kinds as categorized via <see cref="KnownColors.MatchColor(string)"/>
+    /// Encapsulates color kinds as categorized via <see cref="KnownColors.MatchColor(ReadOnlySpan{char})"/>
     /// </summary>
     internal enum ColorKind
     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorTransform.cs
@@ -126,11 +126,15 @@ namespace System.Windows.Media
             _colorTransformHelper = new ColorTransformHelper();
         }
 
+        /// <remarks>
+        /// NOTE: If we ever wish to support more than 8 color channels, the color-parsing code path must be adjusted to support it:
+        /// <see cref="MS.Internal.Parsers.ParseContextColor(ReadOnlySpan{char}, IFormatProvider, ComponentModel.ITypeDescriptorContext)"/>.
+        /// </remarks>
         private long ICM2Color(Span<float> srcValue)
         {
             long colorValue;
 
-            if (srcValue.Length < 3 || srcValue.Length > 8)
+            if (srcValue.Length is < 3 or > 8)
             {
                 throw new NotSupportedException(); // Only support color spaces with 3,4,5,6,7,8 channels
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
@@ -244,7 +244,7 @@ namespace System.Windows.Media
             if (colorString.StartsWith("sc#", StringComparison.Ordinal))
                 return ColorKind.ScRgbColor;
 
-            if (colorString.StartsWith(Parsers.s_ContextColor, StringComparison.OrdinalIgnoreCase))
+            if (colorString.StartsWith(Parsers.ContextColor, StringComparison.OrdinalIgnoreCase))
                 return ColorKind.ContextColor;
 
             return ColorKind.KnownColor;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 #if PBTCOMPILER
 namespace MS.Internal.Markup
 #else
-using System.Windows.Media;
 using MS.Internal;
-using System.Collections.Generic;
-
-using System;
 
 namespace System.Windows.Media
 #endif
@@ -251,397 +249,542 @@ namespace System.Windows.Media
         }
 #endif
 
-        /// Return the KnownColor from a color string.  If there's no match, KnownColor.UnknownColor
+        /// <summary>
+        /// Return the <see cref="KnownColor"/> from a color string. If there's no match, returns <see cref="KnownColor.UnknownColor"/>.
+        /// </summary>
+        /// <param name="colorString">The color name to parse from.</param>
+        /// <returns>The parsed <see cref="KnownColor"/> value or <see cref="KnownColor.UnknownColor"/> if no match.</returns>
         internal static KnownColor ColorStringToKnownColor(string colorString)
         {
-            if (null != colorString)
+            if (!string.IsNullOrEmpty(colorString))
             {
-                // We use invariant culture because we don't globalize our color names
-                string colorUpper = colorString.ToUpper(System.Globalization.CultureInfo.InvariantCulture);
+                // In case we're dealing with a lowercase character, we uppercase it
+                char firstChar = colorString[0];
+                if (firstChar >= 'a' && firstChar <= 'z')
+                    firstChar ^= (char)0x20;
 
-                // Use String.Equals because it does explicit equality
-                // StartsWith/EndsWith are culture sensitive and are 4-7 times slower than Equals
-
-                switch (colorUpper.Length)
+                switch (colorString.Length)
                 {
                     case 3:
-                        if (colorUpper.Equals("RED")) return KnownColor.Red;
-                        if (colorUpper.Equals("TAN")) return KnownColor.Tan;
+                        if (colorString.Equals("Red", StringComparison.OrdinalIgnoreCase))
+                            return KnownColor.Red;
+                        if (colorString.Equals("Tan", StringComparison.OrdinalIgnoreCase))
+                            return KnownColor.Tan;
                         break;
                     case 4:
-                    switch(colorUpper[0])
-                    {
-                        case 'A':
-                            if (colorUpper.Equals("AQUA")) return KnownColor.Aqua;
-                            break;
-                        case 'B':
-                            if (colorUpper.Equals("BLUE")) return KnownColor.Blue;
-                            break;
-                        case 'C':
-                            if (colorUpper.Equals("CYAN")) return KnownColor.Cyan;
-                            break;
-                        case 'G':
-                            if (colorUpper.Equals("GOLD")) return KnownColor.Gold;
-                            if (colorUpper.Equals("GRAY")) return KnownColor.Gray;
-                            break;
-                        case 'L':
-                            if (colorUpper.Equals("LIME")) return KnownColor.Lime;
-                            break;
-                        case 'N':
-                            if (colorUpper.Equals("NAVY")) return KnownColor.Navy;
-                            break;
-                        case 'P':
-                            if (colorUpper.Equals("PERU")) return KnownColor.Peru;
-                            if (colorUpper.Equals("PINK")) return KnownColor.Pink;
-                            if (colorUpper.Equals("PLUM")) return KnownColor.Plum;
-                            break;
-                        case 'S':
-                            if (colorUpper.Equals("SNOW")) return KnownColor.Snow;
-                            break;
-                        case 'T':
-                            if (colorUpper.Equals("TEAL")) return KnownColor.Teal;
-                            break;
-                    }
+                        switch (firstChar)
+                        {
+                            case 'A':
+                                if (colorString.Equals("Aqua", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Aqua;
+                                break;
+                            case 'B':
+                                if (colorString.Equals("Blue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Blue;
+                                break;
+                            case 'C':
+                                if (colorString.Equals("Cyan", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Cyan;
+                                break;
+                            case 'G':
+                                if (colorString.Equals("Gold", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Gold;
+                                if (colorString.Equals("Gray", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Gray;
+                                break;
+                            case 'L':
+                                if (colorString.Equals("Lime", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Lime;
+                                break;
+                            case 'N':
+                                if (colorString.Equals("Navy", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Navy;
+                                break;
+                            case 'P':
+                                if (colorString.Equals("Peru", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Peru;
+                                if (colorString.Equals("Pink", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Pink;
+                                if (colorString.Equals("Plum", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Plum;
+                                break;
+                            case 'S':
+                                if (colorString.Equals("Snow", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Snow;
+                                break;
+                            case 'T':
+                                if (colorString.Equals("Teal", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Teal;
+                                break;
+                        }
                         break;
                     case 5:
-                    switch(colorUpper[0])
-                    {
-                        case 'A':
-                            if (colorUpper.Equals("AZURE")) return KnownColor.Azure;
-                            break;
-                        case 'B':
-                            if (colorUpper.Equals("BEIGE")) return KnownColor.Beige;
-                            if (colorUpper.Equals("BLACK")) return KnownColor.Black;
-                            if (colorUpper.Equals("BROWN")) return KnownColor.Brown;
-                            break;
-                        case 'C':
-                            if (colorUpper.Equals("CORAL")) return KnownColor.Coral;
-                            break;
-                        case 'G':
-                            if (colorUpper.Equals("GREEN")) return KnownColor.Green;
-                            break;
-                        case 'I':
-                            if (colorUpper.Equals("IVORY")) return KnownColor.Ivory;
-                            break;
-                        case 'K':
-                            if (colorUpper.Equals("KHAKI")) return KnownColor.Khaki;
-                            break;
-                        case 'L':
-                            if (colorUpper.Equals("LINEN")) return KnownColor.Linen;
-                            break;
-                        case 'O':
-                            if (colorUpper.Equals("OLIVE")) return KnownColor.Olive;
-                            break;
-                        case 'W':
-                            if (colorUpper.Equals("WHEAT")) return KnownColor.Wheat;
-                            if (colorUpper.Equals("WHITE")) return KnownColor.White;
-                            break;
-                    }
+                        switch (firstChar)
+                        {
+                            case 'A':
+                                if (colorString.Equals("Azure", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Azure;
+                                break;
+                            case 'B':
+                                if (colorString.Equals("Beige", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Beige;
+                                if (colorString.Equals("Black", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Black;
+                                if (colorString.Equals("Brown", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Brown;
+                                break;
+                            case 'C':
+                                if (colorString.Equals("Coral", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Coral;
+                                break;
+                            case 'G':
+                                if (colorString.Equals("Green", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Green;
+                                break;
+                            case 'I':
+                                if (colorString.Equals("Ivory", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Ivory;
+                                break;
+                            case 'K':
+                                if (colorString.Equals("Khaki", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Khaki;
+                                break;
+                            case 'L':
+                                if (colorString.Equals("Linen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Linen;
+                                break;
+                            case 'O':
+                                if (colorString.Equals("Olive", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Olive;
+                                break;
+                            case 'W':
+                                if (colorString.Equals("Wheat", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Wheat;
+                                if (colorString.Equals("White", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.White;
+                                break;
+                        }
                         break;
                     case 6:
-                    switch(colorUpper[0])
-                    {
-                        case 'B':
-                            if (colorUpper.Equals("BISQUE")) return KnownColor.Bisque;
-                            break;
-                        case 'I':
-                            if (colorUpper.Equals("INDIGO")) return KnownColor.Indigo;
-                            break;
-                        case 'M':
-                            if (colorUpper.Equals("MAROON")) return KnownColor.Maroon;
-                            break;
-                        case 'O':
-                            if (colorUpper.Equals("ORANGE")) return KnownColor.Orange;
-                            if (colorUpper.Equals("ORCHID")) return KnownColor.Orchid;
-                            break;
-                        case 'P':
-                            if (colorUpper.Equals("PURPLE")) return KnownColor.Purple;
-                            break;
-                        case 'S':
-                            if (colorUpper.Equals("SALMON")) return KnownColor.Salmon;
-                            if (colorUpper.Equals("SIENNA")) return KnownColor.Sienna;
-                            if (colorUpper.Equals("SILVER")) return KnownColor.Silver;
-                            break;
-                        case 'T':
-                            if (colorUpper.Equals("TOMATO")) return KnownColor.Tomato;
-                            break;
-                        case 'V':
-                            if (colorUpper.Equals("VIOLET")) return KnownColor.Violet;
-                            break;
-                        case 'Y':
-                            if (colorUpper.Equals("YELLOW")) return KnownColor.Yellow;
-                            break;
-                    }
+                        switch (firstChar)
+                        {
+                            case 'B':
+                                if (colorString.Equals("Bisque", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Bisque;
+                                break;
+                            case 'I':
+                                if (colorString.Equals("Indigo", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Indigo;
+                                break;
+                            case 'M':
+                                if (colorString.Equals("Maroon", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Maroon;
+                                break;
+                            case 'O':
+                                if (colorString.Equals("Orange", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Orange;
+                                if (colorString.Equals("Orchid", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Orchid;
+                                break;
+                            case 'P':
+                                if (colorString.Equals("Purple", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Purple;
+                                break;
+                            case 'S':
+                                if (colorString.Equals("Salmon", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Salmon;
+                                if (colorString.Equals("Sienna", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Sienna;
+                                if (colorString.Equals("Silver", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Silver;
+                                break;
+                            case 'T':
+                                if (colorString.Equals("Tomato", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Tomato;
+                                break;
+                            case 'V':
+                                if (colorString.Equals("Violet", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Violet;
+                                break;
+                            case 'Y':
+                                if (colorString.Equals("Yellow", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Yellow;
+                                break;
+                        }
                         break;
                     case 7:
-                    switch(colorUpper[0])
-                    {
-                        case 'C':
-                            if (colorUpper.Equals("CRIMSON")) return KnownColor.Crimson;
-                            break;
-                        case 'D':
-                            if (colorUpper.Equals("DARKRED")) return KnownColor.DarkRed;
-                            if (colorUpper.Equals("DIMGRAY")) return KnownColor.DimGray;
-                            break;
-                        case 'F':
-                            if (colorUpper.Equals("FUCHSIA")) return KnownColor.Fuchsia;
-                            break;
-                        case 'H':
-                            if (colorUpper.Equals("HOTPINK")) return KnownColor.HotPink;
-                            break;
-                        case 'M':
-                            if (colorUpper.Equals("MAGENTA")) return KnownColor.Magenta;
-                            break;
-                        case 'O':
-                            if (colorUpper.Equals("OLDLACE")) return KnownColor.OldLace;
-                            break;
-                        case 'S':
-                            if (colorUpper.Equals("SKYBLUE")) return KnownColor.SkyBlue;
-                            break;
-                        case 'T':
-                            if (colorUpper.Equals("THISTLE")) return KnownColor.Thistle;
-                            break;
-                    }
+                        switch (firstChar)
+                        {
+                            case 'C':
+                                if (colorString.Equals("Crimson", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Crimson;
+                                break;
+                            case 'D':
+                                if (colorString.Equals("DarkRed", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkRed;
+                                if (colorString.Equals("DimGray", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DimGray;
+                                break;
+                            case 'F':
+                                if (colorString.Equals("Fuchsia", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Fuchsia;
+                                break;
+                            case 'H':
+                                if (colorString.Equals("HotPink", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.HotPink;
+                                break;
+                            case 'M':
+                                if (colorString.Equals("Magenta", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Magenta;
+                                break;
+                            case 'O':
+                                if (colorString.Equals("OldLace", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.OldLace;
+                                break;
+                            case 'S':
+                                if (colorString.Equals("SkyBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.SkyBlue;
+                                break;
+                            case 'T':
+                                if (colorString.Equals("Thistle", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Thistle;
+                                break;
+                        }
                         break;
                     case 8:
-                    switch(colorUpper[0])
-                    {
-                        case 'C':
-                            if (colorUpper.Equals("CORNSILK")) return KnownColor.Cornsilk;
-                            break;
-                        case 'D':
-                            if (colorUpper.Equals("DARKBLUE")) return KnownColor.DarkBlue;
-                            if (colorUpper.Equals("DARKCYAN")) return KnownColor.DarkCyan;
-                            if (colorUpper.Equals("DARKGRAY")) return KnownColor.DarkGray;
-                            if (colorUpper.Equals("DEEPPINK")) return KnownColor.DeepPink;
-                            break;
-                        case 'H':
-                            if (colorUpper.Equals("HONEYDEW")) return KnownColor.Honeydew;
-                            break;
-                        case 'L':
-                            if (colorUpper.Equals("LAVENDER")) return KnownColor.Lavender;
-                            break;
-                        case 'M':
-                            if (colorUpper.Equals("MOCCASIN")) return KnownColor.Moccasin;
-                            break;
-                        case 'S':
-                            if (colorUpper.Equals("SEAGREEN")) return KnownColor.SeaGreen;
-                            if (colorUpper.Equals("SEASHELL")) return KnownColor.SeaShell;
-                            break;
-                    }
+                        switch (firstChar)
+                        {
+                            case 'C':
+                                if (colorString.Equals("Cornsilk", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Cornsilk;
+                                break;
+                            case 'D':
+                                if (colorString.Equals("DarkBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkBlue;
+                                if (colorString.Equals("DarkCyan", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkCyan;
+                                if (colorString.Equals("DarkGray", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkGray;
+                                if (colorString.Equals("DeepPink", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DeepPink;
+                                break;
+                            case 'H':
+                                if (colorString.Equals("Honeydew", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Honeydew;
+                                break;
+                            case 'L':
+                                if (colorString.Equals("Lavender", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Lavender;
+                                break;
+                            case 'M':
+                                if (colorString.Equals("Moccasin", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Moccasin;
+                                break;
+                            case 'S':
+                                if (colorString.Equals("SeaGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.SeaGreen;
+                                if (colorString.Equals("SeaShell", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.SeaShell;
+                                break;
+                        }
                         break;
                     case 9:
-                    switch(colorUpper[0])
-                    {
-                        case 'A':
-                            if (colorUpper.Equals("ALICEBLUE")) return KnownColor.AliceBlue;
-                            break;
-                        case 'B':
-                            if (colorUpper.Equals("BURLYWOOD")) return KnownColor.BurlyWood;
-                            break;
-                        case 'C':
-                            if (colorUpper.Equals("CADETBLUE")) return KnownColor.CadetBlue;
-                            if (colorUpper.Equals("CHOCOLATE")) return KnownColor.Chocolate;
-                            break;
-                        case 'D':
-                            if (colorUpper.Equals("DARKGREEN")) return KnownColor.DarkGreen;
-                            if (colorUpper.Equals("DARKKHAKI")) return KnownColor.DarkKhaki;
-                            break;
-                        case 'F':
-                            if (colorUpper.Equals("FIREBRICK")) return KnownColor.Firebrick;
-                            break;
-                        case 'G':
-                            if (colorUpper.Equals("GAINSBORO")) return KnownColor.Gainsboro;
-                            if (colorUpper.Equals("GOLDENROD")) return KnownColor.Goldenrod;
-                            break;
-                        case 'I':
-                            if (colorUpper.Equals("INDIANRED")) return KnownColor.IndianRed;
-                            break;
-                        case 'L':
-                            if (colorUpper.Equals("LAWNGREEN")) return KnownColor.LawnGreen;
-                            if (colorUpper.Equals("LIGHTBLUE")) return KnownColor.LightBlue;
-                            if (colorUpper.Equals("LIGHTCYAN")) return KnownColor.LightCyan;
-                            if (colorUpper.Equals("LIGHTGRAY")) return KnownColor.LightGray;
-                            if (colorUpper.Equals("LIGHTPINK")) return KnownColor.LightPink;
-                            if (colorUpper.Equals("LIMEGREEN")) return KnownColor.LimeGreen;
-                            break;
-                        case 'M':
-                            if (colorUpper.Equals("MINTCREAM")) return KnownColor.MintCream;
-                            if (colorUpper.Equals("MISTYROSE")) return KnownColor.MistyRose;
-                            break;
-                        case 'O':
-                            if (colorUpper.Equals("OLIVEDRAB")) return KnownColor.OliveDrab;
-                            if (colorUpper.Equals("ORANGERED")) return KnownColor.OrangeRed;
-                            break;
-                        case 'P':
-                            if (colorUpper.Equals("PALEGREEN")) return KnownColor.PaleGreen;
-                            if (colorUpper.Equals("PEACHPUFF")) return KnownColor.PeachPuff;
-                            break;
-                        case 'R':
-                            if (colorUpper.Equals("ROSYBROWN")) return KnownColor.RosyBrown;
-                            if (colorUpper.Equals("ROYALBLUE")) return KnownColor.RoyalBlue;
-                            break;
-                        case 'S':
-                            if (colorUpper.Equals("SLATEBLUE")) return KnownColor.SlateBlue;
-                            if (colorUpper.Equals("SLATEGRAY")) return KnownColor.SlateGray;
-                            if (colorUpper.Equals("STEELBLUE")) return KnownColor.SteelBlue;
-                            break;
-                        case 'T':
-                            if (colorUpper.Equals("TURQUOISE")) return KnownColor.Turquoise;
-                            break;
-                    }
+                        switch (firstChar)
+                        {
+                            case 'A':
+                                if (colorString.Equals("AliceBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.AliceBlue;
+                                break;
+                            case 'B':
+                                if (colorString.Equals("BurlyWood", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.BurlyWood;
+                                break;
+                            case 'C':
+                                if (colorString.Equals("CadetBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.CadetBlue;
+                                if (colorString.Equals("Chocolate", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Chocolate;
+                                break;
+                            case 'D':
+                                if (colorString.Equals("DarkGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkGreen;
+                                if (colorString.Equals("DarkKhaki", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkKhaki;
+                                break;
+                            case 'F':
+                                if (colorString.Equals("Firebrick", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Firebrick;
+                                break;
+                            case 'G':
+                                if (colorString.Equals("Gainsboro", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Gainsboro;
+                                if (colorString.Equals("Goldenrod", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Goldenrod;
+                                break;
+                            case 'I':
+                                if (colorString.Equals("IndianRed", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.IndianRed;
+                                break;
+                            case 'L':
+                                if (colorString.Equals("LawnGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LawnGreen;
+                                if (colorString.Equals("LightBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LightBlue;
+                                if (colorString.Equals("LightCyan", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LightCyan;
+                                if (colorString.Equals("LightGray", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LightGray;
+                                if (colorString.Equals("LightPink", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LightPink;
+                                if (colorString.Equals("LimeGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LimeGreen;
+                                break;
+                            case 'M':
+                                if (colorString.Equals("MintCream", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.MintCream;
+                                if (colorString.Equals("MistyRose", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.MistyRose;
+                                break;
+                            case 'O':
+                                if (colorString.Equals("OliveDrab", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.OliveDrab;
+                                if (colorString.Equals("OrangeRed", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.OrangeRed;
+                                break;
+                            case 'P':
+                                if (colorString.Equals("PaleGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.PaleGreen;
+                                if (colorString.Equals("PeachPuff", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.PeachPuff;
+                                break;
+                            case 'R':
+                                if (colorString.Equals("RosyBrown", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.RosyBrown;
+                                if (colorString.Equals("RoyalBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.RoyalBlue;
+                                break;
+                            case 'S':
+                                if (colorString.Equals("SlateBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.SlateBlue;
+                                if (colorString.Equals("SlateGray", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.SlateGray;
+                                if (colorString.Equals("SteelBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.SteelBlue;
+                                break;
+                            case 'T':
+                                if (colorString.Equals("Turquoise", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Turquoise;
+                                break;
+                        }
                         break;
                     case 10:
-                    switch(colorUpper[0])
-                    {
-                        case 'A':
-                            if (colorUpper.Equals("AQUAMARINE")) return KnownColor.Aquamarine;
-                            break;
-                        case 'B':
-                            if (colorUpper.Equals("BLUEVIOLET")) return KnownColor.BlueViolet;
-                            break;
-                        case 'C':
-                            if (colorUpper.Equals("CHARTREUSE")) return KnownColor.Chartreuse;
-                            break;
-                        case 'D':
-                            if (colorUpper.Equals("DARKORANGE")) return KnownColor.DarkOrange;
-                            if (colorUpper.Equals("DARKORCHID")) return KnownColor.DarkOrchid;
-                            if (colorUpper.Equals("DARKSALMON")) return KnownColor.DarkSalmon;
-                            if (colorUpper.Equals("DARKVIOLET")) return KnownColor.DarkViolet;
-                            if (colorUpper.Equals("DODGERBLUE")) return KnownColor.DodgerBlue;
-                            break;
-                        case 'G':
-                            if (colorUpper.Equals("GHOSTWHITE")) return KnownColor.GhostWhite;
-                            break;
-                        case 'L':
-                            if (colorUpper.Equals("LIGHTCORAL")) return KnownColor.LightCoral;
-                            if (colorUpper.Equals("LIGHTGREEN")) return KnownColor.LightGreen;
-                            break;
-                        case 'M':
-                            if (colorUpper.Equals("MEDIUMBLUE")) return KnownColor.MediumBlue;
-                            break;
-                        case 'P':
-                            if (colorUpper.Equals("PAPAYAWHIP")) return KnownColor.PapayaWhip;
-                            if (colorUpper.Equals("POWDERBLUE")) return KnownColor.PowderBlue;
-                            break;
-                        case 'S':
-                            if (colorUpper.Equals("SANDYBROWN")) return KnownColor.SandyBrown;
-                            break;
-                        case 'W':
-                            if (colorUpper.Equals("WHITESMOKE")) return KnownColor.WhiteSmoke;
-                            break;
-                    }
+                        switch (firstChar)
+                        {
+                            case 'A':
+                                if (colorString.Equals("Aquamarine", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Aquamarine;
+                                break;
+                            case 'B':
+                                if (colorString.Equals("BlueViolet", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.BlueViolet;
+                                break;
+                            case 'C':
+                                if (colorString.Equals("Chartreuse", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Chartreuse;
+                                break;
+                            case 'D':
+                                if (colorString.Equals("DarkOrange", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkOrange;
+                                if (colorString.Equals("DarkOrchid", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkOrchid;
+                                if (colorString.Equals("DarkSalmon", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkSalmon;
+                                if (colorString.Equals("DarkViolet", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkViolet;
+                                if (colorString.Equals("DodgerBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DodgerBlue;
+                                break;
+                            case 'G':
+                                if (colorString.Equals("GhostWhite", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.GhostWhite;
+                                break;
+                            case 'L':
+                                if (colorString.Equals("LightCoral", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LightCoral;
+                                if (colorString.Equals("LightGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LightGreen;
+                                break;
+                            case 'M':
+                                if (colorString.Equals("MediumBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.MediumBlue;
+                                break;
+                            case 'P':
+                                if (colorString.Equals("PapayaWhip", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.PapayaWhip;
+                                if (colorString.Equals("PowderBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.PowderBlue;
+                                break;
+                            case 'S':
+                                if (colorString.Equals("SandyBrown", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.SandyBrown;
+                                break;
+                            case 'W':
+                                if (colorString.Equals("WhiteSmoke", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.WhiteSmoke;
+                                break;
+                        }
                         break;
                     case 11:
-                    switch(colorUpper[0])
-                    {
-                        case 'D':
-                            if (colorUpper.Equals("DARKMAGENTA")) return KnownColor.DarkMagenta;
-                            if (colorUpper.Equals("DEEPSKYBLUE")) return KnownColor.DeepSkyBlue;
-                            break;
-                        case 'F':
-                            if (colorUpper.Equals("FLORALWHITE")) return KnownColor.FloralWhite;
-                            if (colorUpper.Equals("FORESTGREEN")) return KnownColor.ForestGreen;
-                            break;
-                        case 'G':
-                            if (colorUpper.Equals("GREENYELLOW")) return KnownColor.GreenYellow;
-                            break;
-                        case 'L':
-                            if (colorUpper.Equals("LIGHTSALMON")) return KnownColor.LightSalmon;
-                            if (colorUpper.Equals("LIGHTYELLOW")) return KnownColor.LightYellow;
-                            break;
-                        case 'N':
-                            if (colorUpper.Equals("NAVAJOWHITE")) return KnownColor.NavajoWhite;
-                            break;
-                        case 'S':
-                            if (colorUpper.Equals("SADDLEBROWN")) return KnownColor.SaddleBrown;
-                            if (colorUpper.Equals("SPRINGGREEN")) return KnownColor.SpringGreen;
-                            break;
-                        case 'T':
-                            if (colorUpper.Equals("TRANSPARENT")) return KnownColor.Transparent;
-                            break;
-                        case 'Y':
-                            if (colorUpper.Equals("YELLOWGREEN")) return KnownColor.YellowGreen;
-                            break;
-                    }
+                        switch (firstChar)
+                        {
+                            case 'D':
+                                if (colorString.Equals("DarkMagenta", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkMagenta;
+                                if (colorString.Equals("DeepSkyBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DeepSkyBlue;
+                                break;
+                            case 'F':
+                                if (colorString.Equals("FloralWhite", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.FloralWhite;
+                                if (colorString.Equals("ForestGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.ForestGreen;
+                                break;
+                            case 'G':
+                                if (colorString.Equals("GreenYellow", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.GreenYellow;
+                                break;
+                            case 'L':
+                                if (colorString.Equals("LightSalmon", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LightSalmon;
+                                if (colorString.Equals("LightYellow", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LightYellow;
+                                break;
+                            case 'N':
+                                if (colorString.Equals("NavajoWhite", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.NavajoWhite;
+                                break;
+                            case 'S':
+                                if (colorString.Equals("SaddleBrown", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.SaddleBrown;
+                                if (colorString.Equals("SpringGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.SpringGreen;
+                                break;
+                            case 'T':
+                                if (colorString.Equals("Transparent", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.Transparent;
+                                break;
+                            case 'Y':
+                                if (colorString.Equals("YellowGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.YellowGreen;
+                                break;
+                        }
                         break;
                     case 12:
-                    switch(colorUpper[0])
-                    {
-                        case 'A':
-                            if (colorUpper.Equals("ANTIQUEWHITE")) return KnownColor.AntiqueWhite;
-                            break;
-                        case 'D':
-                            if (colorUpper.Equals("DARKSEAGREEN")) return KnownColor.DarkSeaGreen;
-                            break;
-                        case 'L':
-                            if (colorUpper.Equals("LIGHTSKYBLUE")) return KnownColor.LightSkyBlue;
-                            if (colorUpper.Equals("LEMONCHIFFON")) return KnownColor.LemonChiffon;
-                            break;
-                        case 'M':
-                            if (colorUpper.Equals("MEDIUMORCHID")) return KnownColor.MediumOrchid;
-                            if (colorUpper.Equals("MEDIUMPURPLE")) return KnownColor.MediumPurple;
-                            if (colorUpper.Equals("MIDNIGHTBLUE")) return KnownColor.MidnightBlue;
-                            break;
-                    }
+                        switch (firstChar)
+                        {
+                            case 'A':
+                                if (colorString.Equals("AntiqueWhite", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.AntiqueWhite;
+                                break;
+                            case 'D':
+                                if (colorString.Equals("DarkSeaGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkSeaGreen;
+                                break;
+                            case 'L':
+                                if (colorString.Equals("LightSkyBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LightSkyBlue;
+                                if (colorString.Equals("LemonChiffon", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LemonChiffon;
+                                break;
+                            case 'M':
+                                if (colorString.Equals("MediumOrchid", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.MediumOrchid;
+                                if (colorString.Equals("MediumPurple", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.MediumPurple;
+                                if (colorString.Equals("MidnightBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.MidnightBlue;
+                                break;
+                        }
                         break;
                     case 13:
-                    switch(colorUpper[0])
-                    {
-                        case 'D':
-                            if (colorUpper.Equals("DARKSLATEBLUE")) return KnownColor.DarkSlateBlue;
-                            if (colorUpper.Equals("DARKSLATEGRAY")) return KnownColor.DarkSlateGray;
-                            if (colorUpper.Equals("DARKGOLDENROD")) return KnownColor.DarkGoldenrod;
-                            if (colorUpper.Equals("DARKTURQUOISE")) return KnownColor.DarkTurquoise;
-                            break;
-                        case 'L':
-                            if (colorUpper.Equals("LIGHTSEAGREEN")) return KnownColor.LightSeaGreen;
-                            if (colorUpper.Equals("LAVENDERBLUSH")) return KnownColor.LavenderBlush;
-                            break;
-                        case 'P':
-                            if (colorUpper.Equals("PALEGOLDENROD")) return KnownColor.PaleGoldenrod;
-                            if (colorUpper.Equals("PALETURQUOISE")) return KnownColor.PaleTurquoise;
-                            if (colorUpper.Equals("PALEVIOLETRED")) return KnownColor.PaleVioletRed;
-                            break;
-                    }
+                        switch (firstChar)
+                        {
+                            case 'D':
+                                if (colorString.Equals("DarkSlateBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkSlateBlue;
+                                if (colorString.Equals("DarkSlateGray", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkSlateGray;
+                                if (colorString.Equals("DarkGoldenrod", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkGoldenrod;
+                                if (colorString.Equals("DarkTurquoise", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkTurquoise;
+                                break;
+                            case 'L':
+                                if (colorString.Equals("LightSeaGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LightSeaGreen;
+                                if (colorString.Equals("LavenderBlush", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LavenderBlush;
+                                break;
+                            case 'P':
+                                if (colorString.Equals("PaleGoldenrod", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.PaleGoldenrod;
+                                if (colorString.Equals("PaleTurquoise", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.PaleTurquoise;
+                                if (colorString.Equals("PaleVioletRed", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.PaleVioletRed;
+                                break;
+                        }
                         break;
                     case 14:
-                    switch(colorUpper[0])
-                    {
-                        case 'B':
-                            if (colorUpper.Equals("BLANCHEDALMOND")) return KnownColor.BlanchedAlmond;
-                            break;
-                        case 'C':
-                            if (colorUpper.Equals("CORNFLOWERBLUE")) return KnownColor.CornflowerBlue;
-                            break;
-                        case 'D':
-                            if (colorUpper.Equals("DARKOLIVEGREEN")) return KnownColor.DarkOliveGreen;
-                            break;
-                        case 'L':
-                            if (colorUpper.Equals("LIGHTSLATEGRAY")) return KnownColor.LightSlateGray;
-                            if (colorUpper.Equals("LIGHTSTEELBLUE")) return KnownColor.LightSteelBlue;
-                            break;
-                        case 'M':
-                            if (colorUpper.Equals("MEDIUMSEAGREEN")) return KnownColor.MediumSeaGreen;
-                            break;
-                    }
+                        switch (firstChar)
+                        {
+                            case 'B':
+                                if (colorString.Equals("BlanchedAlmond", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.BlanchedAlmond;
+                                break;
+                            case 'C':
+                                if (colorString.Equals("CornflowerBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.CornflowerBlue;
+                                break;
+                            case 'D':
+                                if (colorString.Equals("DarkOliveGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.DarkOliveGreen;
+                                break;
+                            case 'L':
+                                if (colorString.Equals("LightSlateGray", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LightSlateGray;
+                                if (colorString.Equals("LightSteelBlue", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.LightSteelBlue;
+                                break;
+                            case 'M':
+                                if (colorString.Equals("MediumSeaGreen", StringComparison.OrdinalIgnoreCase))
+                                    return KnownColor.MediumSeaGreen;
+                                break;
+                        }
                         break;
                     case 15:
-                        if (colorUpper.Equals("MEDIUMSLATEBLUE")) return KnownColor.MediumSlateBlue;
-                        if (colorUpper.Equals("MEDIUMTURQUOISE")) return KnownColor.MediumTurquoise;
-                        if (colorUpper.Equals("MEDIUMVIOLETRED")) return KnownColor.MediumVioletRed;
+                        if (colorString.Equals("MediumSlateBlue", StringComparison.OrdinalIgnoreCase))
+                            return KnownColor.MediumSlateBlue;
+                        if (colorString.Equals("MediumTurquoise", StringComparison.OrdinalIgnoreCase))
+                            return KnownColor.MediumTurquoise;
+                        if (colorString.Equals("MediumVioletRed", StringComparison.OrdinalIgnoreCase))
+                            return KnownColor.MediumVioletRed;
                         break;
                     case 16:
-                        if (colorUpper.Equals("MEDIUMAQUAMARINE")) return KnownColor.MediumAquamarine;
+                        if (colorString.Equals("MediumAquamarine", StringComparison.OrdinalIgnoreCase))
+                            return KnownColor.MediumAquamarine;
                         break;
                     case 17:
-                        if (colorUpper.Equals("MEDIUMSPRINGGREEN")) return KnownColor.MediumSpringGreen;
+                        if (colorString.Equals("MediumSpringGreen", StringComparison.OrdinalIgnoreCase))
+                            return KnownColor.MediumSpringGreen;
                         break;
                     case 20:
-                        if (colorUpper.Equals("LIGHTGOLDENRODYELLOW")) return KnownColor.LightGoldenrodYellow;
+                        if (colorString.Equals("LightGoldenrodYellow", StringComparison.OrdinalIgnoreCase))
+                            return KnownColor.LightGoldenrodYellow;
                         break;
                 }
             }
+
             // colorString was null or not found
             return KnownColor.UnknownColor;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
@@ -181,11 +181,11 @@ namespace System.Windows.Media
         }
 
         /// Return the solid color brush from a color string.  If there's no match, null
-        public static SolidColorBrush ColorStringToKnownBrush(string s)
+        public static SolidColorBrush ColorStringToKnownBrush(ReadOnlySpan<char> colorString)
         {
-            if (null != s)
-            {
-                KnownColor result = ColorStringToKnownColor(s);
+            if (!colorString.IsEmpty)
+            {   // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
+                KnownColor result = ColorStringToKnownColor(colorString.ToString());
 
                 // If the result is UnknownColor, that means this string wasn't found
                 if (result != KnownColor.UnknownColor)
@@ -194,6 +194,7 @@ namespace System.Windows.Media
                     return SolidColorBrushFromUint((uint)result);
                 }
             }
+
             return null;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
@@ -242,8 +242,7 @@ namespace System.Windows.Media
                 return ColorKind.NumericColor;
 
             if (colorString.StartsWith("sc#", StringComparison.Ordinal))
-                return ColorKind.ScRgbColor; // TODO: This originally didn't return, so isKnownColor was true as well but it doesn't matter,
-                                             // isScRgbColor always went first in the calling methods
+                return ColorKind.ScRgbColor;
 
             if (colorString.StartsWith(Parsers.s_ContextColor, StringComparison.OrdinalIgnoreCase))
                 return ColorKind.ContextColor;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
@@ -235,7 +235,7 @@ namespace System.Windows.Media
         /// <param name="colorString">The color string to categorize.</param>
         /// <returns>A <see cref="ColorKind"/> specifying the input string format.</returns>
         /// <remarks><see cref="ColorKind.KnownColor"/> is used as a fallback value.</remarks>
-        internal static ColorKind MatchColor(string colorString)
+        internal static ColorKind MatchColor(ReadOnlySpan<char> colorString)
         {
             if ((colorString.Length is 4 or 5 or 7 or 9) && (colorString[0] == '#'))
                 return ColorKind.NumericColor;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
@@ -229,49 +229,25 @@ namespace System.Windows.Media
             return scp;
         }
 
-        internal static void MatchColor(string colorString, out bool isKnownColor, out bool isNumericColor, out bool isContextColor, out bool isScRgbColor)
+        /// <summary>
+        /// Matches the input string against known color formats.
+        /// </summary>
+        /// <param name="colorString">The color string to categorize.</param>
+        /// <returns>A <see cref="ColorKind"/> specifying the input string format.</returns>
+        /// <remarks><see cref="ColorKind.KnownColor"/> is used as a fallback value.</remarks>
+        internal static ColorKind MatchColor(string colorString)
         {
-            string trimmedString = colorString;
+            if ((colorString.Length is 4 or 5 or 7 or 9) && (colorString[0] == '#'))
+                return ColorKind.NumericColor;
 
-            if (((trimmedString.Length == 4) ||
-                (trimmedString.Length == 5) ||
-                (trimmedString.Length == 7) ||
-                (trimmedString.Length == 9)) &&
-                (trimmedString[0] == '#'))
-            {
-                isNumericColor = true;
-                isScRgbColor = false;
-                isKnownColor = false;
-                isContextColor = false;
-                return;
-            }
-            else
-                isNumericColor = false;
+            if (colorString.StartsWith("sc#", StringComparison.Ordinal))
+                return ColorKind.ScRgbColor; // TODO: This originally didn't return, so isKnownColor was true as well but it doesn't matter,
+                                             // isScRgbColor always went first in the calling methods
 
-            if ((trimmedString.StartsWith("sc#", StringComparison.Ordinal) == true))
-            {
-                isNumericColor = false;
-                isScRgbColor = true;
-                isKnownColor = false;
-                isContextColor = false;
-            }
-            else
-            {
-                isScRgbColor = false;
-            }
+            if (colorString.StartsWith(Parsers.s_ContextColor, StringComparison.OrdinalIgnoreCase))
+                return ColorKind.ContextColor;
 
-            if ((trimmedString.StartsWith(Parsers.s_ContextColor, StringComparison.OrdinalIgnoreCase) == true))
-            {
-                isContextColor = true;
-                isScRgbColor = false;
-                isKnownColor = false;
-                return;
-            }
-            else
-            {
-                isContextColor = false;
-                isKnownColor = true;
-            }
+            return ColorKind.KnownColor;
         }
 #endif
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
@@ -229,9 +229,9 @@ namespace System.Windows.Media
             return scp;
         }
 
-        static internal string MatchColor(string colorString, out bool isKnownColor, out bool isNumericColor, out bool isContextColor, out bool isScRgbColor)
+        internal static void MatchColor(string colorString, out bool isKnownColor, out bool isNumericColor, out bool isContextColor, out bool isScRgbColor)
         {
-            string trimmedString = colorString.Trim();
+            string trimmedString = colorString;
 
             if (((trimmedString.Length == 4) ||
                 (trimmedString.Length == 5) ||
@@ -243,7 +243,7 @@ namespace System.Windows.Media
                 isScRgbColor = false;
                 isKnownColor = false;
                 isContextColor = false;
-                return trimmedString;
+                return;
             }
             else
                 isNumericColor = false;
@@ -265,15 +265,13 @@ namespace System.Windows.Media
                 isContextColor = true;
                 isScRgbColor = false;
                 isKnownColor = false;
-                return trimmedString;
+                return;
             }
             else
             {
                 isContextColor = false;
                 isKnownColor = true;
             }
-
-            return trimmedString;
         }
 #endif
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
@@ -182,8 +182,8 @@ namespace System.Windows.Media
         public static SolidColorBrush ColorStringToKnownBrush(ReadOnlySpan<char> colorString)
         {
             if (!colorString.IsEmpty)
-            {   // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
-                KnownColor result = ColorStringToKnownColor(colorString.ToString());
+            {
+                KnownColor result = ColorStringToKnownColor(colorString);
 
                 // If the result is UnknownColor, that means this string wasn't found
                 if (result != KnownColor.UnknownColor)
@@ -254,9 +254,15 @@ namespace System.Windows.Media
         /// </summary>
         /// <param name="colorString">The color name to parse from.</param>
         /// <returns>The parsed <see cref="KnownColor"/> value or <see cref="KnownColor.UnknownColor"/> if no match.</returns>
+#if !PBTCOMPILER
+        internal static KnownColor ColorStringToKnownColor(ReadOnlySpan<char> colorString)
+        {
+            if (!colorString.IsEmpty)
+#else
         internal static KnownColor ColorStringToKnownColor(string colorString)
         {
             if (!string.IsNullOrEmpty(colorString))
+#endif
             {
                 // In case we're dealing with a lowercase character, we uppercase it
                 char firstChar = colorString[0];

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -195,7 +195,8 @@ namespace MS.Internal
             bool isNumericColor;
             bool isScRgbColor;
             bool isContextColor;
-            string trimmedColor = KnownColors.MatchColor(color, out isPossibleKnowColor, out isNumericColor, out isContextColor, out isScRgbColor);
+            string trimmedColor = color.Trim();
+            KnownColors.MatchColor(trimmedColor, out isPossibleKnowColor, out isNumericColor, out isContextColor, out isScRgbColor);
 
             if ((isPossibleKnowColor == false) &&
                 (isNumericColor == false) &&
@@ -243,7 +244,8 @@ namespace MS.Internal
             bool isNumericColor;
             bool isScRgbColor;
             bool isContextColor;
-            string trimmedColor = KnownColors.MatchColor(brush, out isPossibleKnownColor, out isNumericColor, out isContextColor, out isScRgbColor);
+            string trimmedColor = brush.Trim();
+            KnownColors.MatchColor(trimmedColor, out isPossibleKnownColor, out isNumericColor, out isContextColor, out isScRgbColor);
 
             if (trimmedColor.Length == 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -78,63 +78,44 @@ namespace MS.Internal
             return ( Color.FromArgb ((byte)a, (byte)r, (byte)g, (byte)b) );
         }
 
-    internal const string s_ContextColor = "ContextColor ";
-    internal const string s_ContextColorNoSpace = "ContextColor";
+        internal const string ContextColor = "ContextColor ";
 
-    static private Color ParseContextColor(string trimmedColor, IFormatProvider formatProvider, ITypeDescriptorContext context)
+        private static Color ParseContextColor(ReadOnlySpan<char> trimmedColor, IFormatProvider formatProvider, ITypeDescriptorContext context)
         {
-            if (!trimmedColor.StartsWith(s_ContextColor, StringComparison.OrdinalIgnoreCase))
-            {
+            if (!trimmedColor.StartsWith(ContextColor, StringComparison.OrdinalIgnoreCase))
                 throw new FormatException(SR.Parsers_IllegalToken);
-            }
 
-            string tokens = trimmedColor.Substring(s_ContextColor.Length);
-            tokens = tokens.Trim();
-            string[] preSplit = tokens.Split(' ');
-            if (preSplit.Length < 2)
-            {
+            // Skip "ContextColor " prefix
+            ReadOnlySpan<char> tokens = trimmedColor.Slice(ContextColor.Length).Trim();
+
+            // Check whether the format is at least e.g. "file://profile.icc 1.0"
+            Span<Range> splitSegments = stackalloc Range[4];
+
+            if (tokens.Split(splitSegments, ' ') < 2)
                 throw new FormatException(SR.Parsers_IllegalToken);
-            }
 
-            tokens = tokens.Substring(preSplit[0].Length);
+            // Retrieve "file://profile.icc" part
+            string profileString = tokens[splitSegments[0]].ToString();
+            // Skip "file://profile.icc" part
+            ReadOnlySpan<char> colorPart = tokens.Slice(profileString.Length);
 
-            TokenizerHelper th = new TokenizerHelper(tokens, formatProvider);
-            string[] split = tokens.Split(new Char[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            int numTokens = split.Length;
+            // Retrieve alpha value
+            ValueTokenizerHelper tokenizer = new(colorPart, formatProvider);
+            float alpha = float.Parse(tokenizer.NextTokenRequired(), formatProvider);
 
-            float alpha = Convert.ToSingle(th.NextTokenRequired(), formatProvider);
+            // While we do not support colors with more than 8 channels, the underlying initialization code will take care of it,
+            // so here we just silently count the color values and let it throw NotImplementedException in the color translation code-path.
+            int numTokens = colorPart.Count(',');
+            Span<float> values = stackalloc float[numTokens];
 
-            float[] values = new float[numTokens - 1];
+            for (int i = 0; i < values.Length; i++)
+                values[i] = float.Parse(tokenizer.NextTokenRequired(), formatProvider);
 
-            for (int i = 0; i < numTokens - 1; i++)
-            {
-                values[i] = Convert.ToSingle(th.NextTokenRequired(), formatProvider);
-            }
+            UriHolder uriHolder = TypeConverterHelper.GetUriFromUriContext(context, profileString);
+            Uri profileUri = uriHolder.BaseUri is not null ? new Uri(uriHolder.BaseUri, uriHolder.OriginalUri) : uriHolder.OriginalUri;
 
-            string profileString = preSplit[0];
-
-            UriHolder uriHolder = TypeConverterHelper.GetUriFromUriContext(context,profileString);
-
-            Uri profileUri;
-
-            if (uriHolder.BaseUri != null)
-            {
-                profileUri = new Uri(uriHolder.BaseUri, uriHolder.OriginalUri);
-            }
-            else
-            {
-                profileUri = uriHolder.OriginalUri;
-            }
-
-            Color result = Color.FromAValues(alpha, values, profileUri);
-
-            // If the number of color values found does not match the number of channels in the profile, we must throw
-            if (result.ColorContext.NumChannels != values.Length)
-            {
-                throw new FormatException(SR.Parsers_IllegalToken);
-            }
-
-            return result;
+            // If the number of color values found does not match the number of channels in the profile, FromAValues will throw
+            return Color.FromAValues(alpha, values, profileUri);
         }
 
         private static Color ParseScRgbColor(ReadOnlySpan<char> trimmedColor, IFormatProvider formatProvider)
@@ -195,8 +176,8 @@ namespace MS.Internal
             if (colorKind is ColorKind.NumericColor)
                 return ParseHexColor(trimmedColor);
 
-            if (colorKind is ColorKind.ContextColor) // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
-                return ParseContextColor(trimmedColor.ToString(), formatProvider, context);
+            if (colorKind is ColorKind.ContextColor)
+                return ParseContextColor(trimmedColor, formatProvider, context);
 
             if (colorKind is ColorKind.ScRgbColor)
                 return ParseScRgbColor(trimmedColor, formatProvider);
@@ -232,8 +213,8 @@ namespace MS.Internal
             if (colorKind is ColorKind.NumericColor)
                 return new SolidColorBrush(ParseHexColor(trimmedColor));
 
-            if (colorKind is ColorKind.ContextColor) // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
-                return new SolidColorBrush(ParseContextColor(trimmedColor.ToString(), formatProvider, context));
+            if (colorKind is ColorKind.ContextColor)
+                return new SolidColorBrush(ParseContextColor(trimmedColor, formatProvider, context));
 
             if (colorKind is ColorKind.ScRgbColor)
                 return new SolidColorBrush(ParseScRgbColor(trimmedColor, formatProvider));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -1,81 +1,86 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-//  Synopsis: Implements class Parsers for internal use of type converters
 
 using System.ComponentModel;
 using System.Windows.Media;
 
 namespace MS.Internal
 {
+    /// <summary>
+    /// Implements class Parsers for internal use of type converters
+    /// </summary>
     internal static partial class Parsers
     {
-        private const int s_zeroChar = (int) '0';
-        private const int s_aLower   = (int) 'a';
-        private const int s_aUpper   = (int) 'A';
+        /// <summary>
+        /// Map from an ASCII char to its hex value, e.g. arr['b'] == 11. 0xFF means it's not a hex digit.
+        /// </summary>
+        private static ReadOnlySpan<byte> CharToHexLookup =>
+        [
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 0-15
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 16-31
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 32-47
+            0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  0x8,  0x9,  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 48-63
+            0xFF, 0xA,  0xB,  0xC,  0xD,  0xE,  0xF,  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 64-79
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 80-95
+            0xFF, 0xa,  0xb,  0xc,  0xd,  0xe,  0xf,                                                        // 96-102
+        ];
 
-        static private int ParseHexChar(char c )
+        /// <summary>
+        /// Parses a 0-9 and a-f / A-F character to its respective number.
+        /// </summary>
+        /// <exception cref="FormatException"></exception>
+        private static int ParseHexChar(char hexChar)
         {
-            int intChar = (int) c;
+            int intChar;
 
-            if ((intChar >= s_zeroChar) && (intChar <= (s_zeroChar+9)))
-            {
-                return (intChar-s_zeroChar);
-            }
+            // This also eliminates the bounds check
+            if (hexChar >= CharToHexLookup.Length || (intChar = CharToHexLookup[hexChar]) == 0xFF)
+                throw new FormatException(SR.Parsers_IllegalToken);
 
-            if ((intChar >= s_aLower) && (intChar <= (s_aLower+5)))
-            {
-                return (intChar-s_aLower + 10);
-            }
-
-            if ((intChar >= s_aUpper) && (intChar <= (s_aUpper+5)))
-            {
-                return (intChar-s_aUpper + 10);
-            }
-            throw new FormatException(SR.Parsers_IllegalToken);
+            return intChar;
         }
 
-        static private Color ParseHexColor(ReadOnlySpan<char> trimmedColor)
+        private static Color ParseHexColor(ReadOnlySpan<char> trimmedColor)
         {
-            int a,r,g,b;
-            a = 255;
+            int a, r, g, b;
 
-            if ( trimmedColor.Length > 7 )
+            if (trimmedColor.Length > 7) // #00000000 (ARGB)
             {
-                a = ParseHexChar(trimmedColor[1]) * 16 + ParseHexChar(trimmedColor[2]);
-                r = ParseHexChar(trimmedColor[3]) * 16 + ParseHexChar(trimmedColor[4]);
-                g = ParseHexChar(trimmedColor[5]) * 16 + ParseHexChar(trimmedColor[6]);
-                b = ParseHexChar(trimmedColor[7]) * 16 + ParseHexChar(trimmedColor[8]);
+                a = ParseHexChar(trimmedColor[1]) << 4 + ParseHexChar(trimmedColor[2]);
+                r = ParseHexChar(trimmedColor[3]) << 4 + ParseHexChar(trimmedColor[4]);
+                g = ParseHexChar(trimmedColor[5]) << 4 + ParseHexChar(trimmedColor[6]);
+                b = ParseHexChar(trimmedColor[7]) << 4 + ParseHexChar(trimmedColor[8]);
             }
-            else if ( trimmedColor.Length > 5)
+            else if (trimmedColor.Length > 5) // #000000 (RGB)
             {
-                r = ParseHexChar(trimmedColor[1]) * 16 + ParseHexChar(trimmedColor[2]);
-                g = ParseHexChar(trimmedColor[3]) * 16 + ParseHexChar(trimmedColor[4]);
-                b = ParseHexChar(trimmedColor[5]) * 16 + ParseHexChar(trimmedColor[6]);
+                a = 255;
+                r = ParseHexChar(trimmedColor[1]) << 4 + ParseHexChar(trimmedColor[2]);
+                g = ParseHexChar(trimmedColor[3]) << 4 + ParseHexChar(trimmedColor[4]);
+                b = ParseHexChar(trimmedColor[5]) << 4 + ParseHexChar(trimmedColor[6]);
             }
-            else if (trimmedColor.Length > 4)
+            else if (trimmedColor.Length > 4) // #0000 (single-digit ARGB)
             {
                 a = ParseHexChar(trimmedColor[1]);
-                a = a + a*16;
+                a += a << 4;
                 r = ParseHexChar(trimmedColor[2]);
-                r = r + r*16;
+                r += r << 4;
                 g = ParseHexChar(trimmedColor[3]);
-                g = g + g*16;
+                g += g << 4;
                 b = ParseHexChar(trimmedColor[4]);
-                b = b + b*16;
+                b += b << 4;
             }
-            else
+            else // #000 (single-digit RGB)
             {
+                a = 255;
                 r = ParseHexChar(trimmedColor[1]);
-                r = r + r*16;
+                r += r << 4;
                 g = ParseHexChar(trimmedColor[2]);
-                g = g + g*16;
+                g += g << 4;
                 b = ParseHexChar(trimmedColor[3]);
-                b = b + b*16;
+                b += b << 4;
             }
 
-            return ( Color.FromArgb ((byte)a, (byte)r, (byte)g, (byte)b) );
+            return Color.FromArgb((byte)a, (byte)r, (byte)g, (byte)b);
         }
 
         internal const string ContextColor = "ContextColor ";

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -191,31 +191,23 @@ namespace MS.Internal
         /// </summary>
         internal static Color ParseColor(string color, IFormatProvider formatProvider, ITypeDescriptorContext context)
         {
-            bool isPossibleKnowColor;
-            bool isNumericColor;
-            bool isScRgbColor;
-            bool isContextColor;
             string trimmedColor = color.Trim();
-            KnownColors.MatchColor(trimmedColor, out isPossibleKnowColor, out isNumericColor, out isContextColor, out isScRgbColor);
+            ColorKind colorKind = KnownColors.MatchColor(trimmedColor);
 
-            if ((isPossibleKnowColor == false) &&
-                (isNumericColor == false) &&
-                (isScRgbColor == false) &&
-                (isContextColor== false))
-            {
+            //NOTE: This can never be true as MatchColor will return KnownColor unconditionally, so we may as well remove it in next commit
+            if (colorKind is not ColorKind.NumericColor or ColorKind.ContextColor or ColorKind.ScRgbColor or ColorKind.KnownColor)
                 throw new FormatException(SR.Parsers_IllegalToken);
-            }
 
             //Is it a number?
-            if (isNumericColor)
+            if (colorKind is ColorKind.NumericColor)
             {
                 return ParseHexColor(trimmedColor);
             }
-            else if (isContextColor)
+            else if (colorKind is ColorKind.ContextColor)
             {
                 return ParseContextColor(trimmedColor, formatProvider, context);
             }
-            else if (isScRgbColor)
+            else if (colorKind is ColorKind.ScRgbColor)
             {
                 return ParseScRgbColor(trimmedColor, formatProvider);
             }
@@ -240,12 +232,8 @@ namespace MS.Internal
         /// </summary>
         internal static Brush ParseBrush(string brush, IFormatProvider formatProvider, ITypeDescriptorContext context)
         {
-            bool isPossibleKnownColor;
-            bool isNumericColor;
-            bool isScRgbColor;
-            bool isContextColor;
             string trimmedColor = brush.Trim();
-            KnownColors.MatchColor(trimmedColor, out isPossibleKnownColor, out isNumericColor, out isContextColor, out isScRgbColor);
+            ColorKind colorKind = KnownColors.MatchColor(trimmedColor);
 
             if (trimmedColor.Length == 0)
             {
@@ -256,22 +244,22 @@ namespace MS.Internal
             // extra tokens as we do with TokenizerHelper.  If we return one of the solid color
             // brushes then the ParseColor routine (or ColorStringToKnownColor) matched the entire
             // input.
-            if (isNumericColor)
+            if (colorKind is ColorKind.NumericColor)
             {
                 return (new SolidColorBrush(ParseHexColor(trimmedColor)));
             }
 
-            if (isContextColor)
+            if (colorKind is ColorKind.ContextColor)
             {
                 return (new SolidColorBrush(ParseContextColor(trimmedColor, formatProvider, context)));
             }
 
-            if (isScRgbColor)
+            if (colorKind is ColorKind.ScRgbColor)
             {
                 return (new SolidColorBrush(ParseScRgbColor(trimmedColor, formatProvider)));
             }
 
-            if (isPossibleKnownColor)
+            if (colorKind is ColorKind.KnownColor)
             {
                 SolidColorBrush scp = KnownColors.ColorStringToKnownBrush(trimmedColor);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -36,7 +36,7 @@ namespace MS.Internal
             throw new FormatException(SR.Parsers_IllegalToken);
         }
 
-        static private Color ParseHexColor(string trimmedColor)
+        static private Color ParseHexColor(ReadOnlySpan<char> trimmedColor)
         {
             int a,r,g,b;
             a = 255;
@@ -191,7 +191,7 @@ namespace MS.Internal
         /// </summary>
         internal static Color ParseColor(string color, IFormatProvider formatProvider, ITypeDescriptorContext context)
         {
-            string trimmedColor = color.Trim();
+            ReadOnlySpan<char> trimmedColor = color.AsSpan().Trim();
             ColorKind colorKind = KnownColors.MatchColor(trimmedColor);
 
             // Check that our assumption stays true
@@ -200,13 +200,14 @@ namespace MS.Internal
             if (colorKind is ColorKind.NumericColor)
                 return ParseHexColor(trimmedColor);
 
-            if (colorKind is ColorKind.ContextColor)
-                return ParseContextColor(trimmedColor, formatProvider, context);
+            if (colorKind is ColorKind.ContextColor) // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
+                return ParseContextColor(trimmedColor.ToString(), formatProvider, context);
 
-            if (colorKind is ColorKind.ScRgbColor)
-                return ParseScRgbColor(trimmedColor, formatProvider);
+            if (colorKind is ColorKind.ScRgbColor) // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
+                return ParseScRgbColor(trimmedColor.ToString(), formatProvider);
 
-            KnownColor knownColor = KnownColors.ColorStringToKnownColor(trimmedColor);
+            // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
+            KnownColor knownColor = KnownColors.ColorStringToKnownColor(trimmedColor.ToString());
             if (knownColor == KnownColor.UnknownColor)
                 throw new FormatException(SR.Parsers_IllegalToken);
 
@@ -221,8 +222,8 @@ namespace MS.Internal
         /// </summary>
         internal static Brush ParseBrush(string brush, IFormatProvider formatProvider, ITypeDescriptorContext context)
         {
-            string trimmedColor = brush.Trim();
-            if (trimmedColor.Length == 0)
+            ReadOnlySpan<char> trimmedColor = brush.AsSpan().Trim();
+            if (trimmedColor.IsEmpty)
                 throw new FormatException(SR.Parser_Empty);
 
             ColorKind colorKind = KnownColors.MatchColor(trimmedColor);
@@ -236,11 +237,11 @@ namespace MS.Internal
             if (colorKind is ColorKind.NumericColor)
                 return new SolidColorBrush(ParseHexColor(trimmedColor));
 
-            if (colorKind is ColorKind.ContextColor)
-                return new SolidColorBrush(ParseContextColor(trimmedColor, formatProvider, context));
+            if (colorKind is ColorKind.ContextColor) // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
+                return new SolidColorBrush(ParseContextColor(trimmedColor.ToString(), formatProvider, context));
 
-            if (colorKind is ColorKind.ScRgbColor)
-                return new SolidColorBrush(ParseScRgbColor(trimmedColor, formatProvider));
+            if (colorKind is ColorKind.ScRgbColor) // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
+                return new SolidColorBrush(ParseScRgbColor(trimmedColor.ToString(), formatProvider));
 
             // NULL is returned when the color was not valid
             SolidColorBrush solidColorBrush = KnownColors.ColorStringToKnownBrush(trimmedColor);
@@ -262,13 +263,11 @@ namespace MS.Internal
         /// <summary>
         /// Parse a PathFigureCollection string.
         /// </summary>
-        internal static PathFigureCollection ParsePathFigureCollection(
-            string pathString,
-            IFormatProvider formatProvider)
+        internal static PathFigureCollection ParsePathFigureCollection(string pathString, IFormatProvider formatProvider)
         {
-            PathStreamGeometryContext context = new PathStreamGeometryContext();
+            PathStreamGeometryContext context = new();
 
-            AbbreviatedGeometryParser parser = new AbbreviatedGeometryParser();
+            AbbreviatedGeometryParser parser = new();
 
             parser.ParseToGeometryContext(context, pathString, 0 /* curIndex */);
             

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -137,40 +137,35 @@ namespace MS.Internal
             return result;
         }
 
-        static private Color ParseScRgbColor(string trimmedColor, IFormatProvider formatProvider)
+        private static Color ParseScRgbColor(ReadOnlySpan<char> trimmedColor, IFormatProvider formatProvider)
         {
             if (!trimmedColor.StartsWith("sc#", StringComparison.Ordinal))
-            {
                 throw new FormatException(SR.Parsers_IllegalToken);
-            }
 
-            string tokens = trimmedColor.Substring(3, trimmedColor.Length - 3);
+            // Skip prefix (sc#)
+            ReadOnlySpan<char> tokens = trimmedColor.Slice(3);
 
             // The tokenizer helper will tokenize a list based on the IFormatProvider.
-            TokenizerHelper th = new TokenizerHelper(tokens, formatProvider);
-            float[] values = new float[4];
+            ValueTokenizerHelper tokenizer = new(tokens, formatProvider);
+            Span<float> values = stackalloc float[4];
 
             for (int i = 0; i < 3; i++)
-            {
-                values[i] = Convert.ToSingle(th.NextTokenRequired(), formatProvider);
-            }
+                values[i] = float.Parse(tokenizer.NextTokenRequired(), formatProvider);
 
-            if (th.NextToken())
+            if (tokenizer.NextToken())
             {
-                values[3] = Convert.ToSingle(th.GetCurrentToken(), formatProvider);
+                values[3] = float.Parse(tokenizer.GetCurrentToken(), formatProvider);
 
                 // We should be out of tokens at this point
-                if (th.NextToken())
+                if (tokenizer.NextToken())
                 {
                     throw new FormatException(SR.Parsers_IllegalToken);
                 }
 
                 return Color.FromScRgb(values[0], values[1], values[2], values[3]);
             }
-            else
-            {
-                return Color.FromScRgb(1.0f, values[0], values[1], values[2]);
-            }
+
+            return Color.FromScRgb(1.0f, values[0], values[1], values[2]);
         }
 
         /// <summary>
@@ -203,8 +198,8 @@ namespace MS.Internal
             if (colorKind is ColorKind.ContextColor) // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
                 return ParseContextColor(trimmedColor.ToString(), formatProvider, context);
 
-            if (colorKind is ColorKind.ScRgbColor) // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
-                return ParseScRgbColor(trimmedColor.ToString(), formatProvider);
+            if (colorKind is ColorKind.ScRgbColor)
+                return ParseScRgbColor(trimmedColor, formatProvider);
 
             // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
             KnownColor knownColor = KnownColors.ColorStringToKnownColor(trimmedColor.ToString());
@@ -240,8 +235,8 @@ namespace MS.Internal
             if (colorKind is ColorKind.ContextColor) // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
                 return new SolidColorBrush(ParseContextColor(trimmedColor.ToString(), formatProvider, context));
 
-            if (colorKind is ColorKind.ScRgbColor) // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
-                return new SolidColorBrush(ParseScRgbColor(trimmedColor.ToString(), formatProvider));
+            if (colorKind is ColorKind.ScRgbColor)
+                return new SolidColorBrush(ParseScRgbColor(trimmedColor, formatProvider));
 
             // NULL is returned when the color was not valid
             SolidColorBrush solidColorBrush = KnownColors.ColorStringToKnownBrush(trimmedColor);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -194,34 +194,23 @@ namespace MS.Internal
             string trimmedColor = color.Trim();
             ColorKind colorKind = KnownColors.MatchColor(trimmedColor);
 
-            //NOTE: This can never be true as MatchColor will return KnownColor unconditionally, so we may as well remove it in next commit
-            if (colorKind is not ColorKind.NumericColor or ColorKind.ContextColor or ColorKind.ScRgbColor or ColorKind.KnownColor)
+            // Check that our assumption stays true
+            Debug.Assert(colorKind is ColorKind.NumericColor or ColorKind.ContextColor or ColorKind.ScRgbColor or ColorKind.KnownColor);
+
+            if (colorKind is ColorKind.NumericColor)
+                return ParseHexColor(trimmedColor);
+
+            if (colorKind is ColorKind.ContextColor)
+                return ParseContextColor(trimmedColor, formatProvider, context);
+
+            if (colorKind is ColorKind.ScRgbColor)
+                return ParseScRgbColor(trimmedColor, formatProvider);
+
+            KnownColor knownColor = KnownColors.ColorStringToKnownColor(trimmedColor);
+            if (knownColor == KnownColor.UnknownColor)
                 throw new FormatException(SR.Parsers_IllegalToken);
 
-            //Is it a number?
-            if (colorKind is ColorKind.NumericColor)
-            {
-                return ParseHexColor(trimmedColor);
-            }
-            else if (colorKind is ColorKind.ContextColor)
-            {
-                return ParseContextColor(trimmedColor, formatProvider, context);
-            }
-            else if (colorKind is ColorKind.ScRgbColor)
-            {
-                return ParseScRgbColor(trimmedColor, formatProvider);
-            }
-            else
-            {
-                KnownColor kc = KnownColors.ColorStringToKnownColor(trimmedColor);
-
-                if (kc == KnownColor.UnknownColor)
-                {
-                    throw new FormatException(SR.Parsers_IllegalToken);
-                }
-
-                return Color.FromUInt32((uint)kc);
-            }
+            return Color.FromUInt32((uint)knownColor);
         }
 
         /// <summary>
@@ -233,53 +222,37 @@ namespace MS.Internal
         internal static Brush ParseBrush(string brush, IFormatProvider formatProvider, ITypeDescriptorContext context)
         {
             string trimmedColor = brush.Trim();
+            if (trimmedColor.Length == 0)
+                throw new FormatException(SR.Parser_Empty);
+
             ColorKind colorKind = KnownColors.MatchColor(trimmedColor);
 
-            if (trimmedColor.Length == 0)
-            {
-                throw new FormatException(SR.Parser_Empty);
-            }
+            // Check that our assumption stays true
+            Debug.Assert(colorKind is ColorKind.NumericColor or ColorKind.ContextColor or ColorKind.ScRgbColor or ColorKind.KnownColor);
 
             // Note that because trimmedColor is exactly brush.Trim() we don't have to worry about
-            // extra tokens as we do with TokenizerHelper.  If we return one of the solid color
-            // brushes then the ParseColor routine (or ColorStringToKnownColor) matched the entire
-            // input.
+            // extra tokens as we do with TokenizerHelper. If we return one of the solid color brushes
+            // then the ParseColor routine (or ColorStringToKnownColor) matched the entire input.
             if (colorKind is ColorKind.NumericColor)
-            {
-                return (new SolidColorBrush(ParseHexColor(trimmedColor)));
-            }
+                return new SolidColorBrush(ParseHexColor(trimmedColor));
 
             if (colorKind is ColorKind.ContextColor)
-            {
-                return (new SolidColorBrush(ParseContextColor(trimmedColor, formatProvider, context)));
-            }
+                return new SolidColorBrush(ParseContextColor(trimmedColor, formatProvider, context));
 
             if (colorKind is ColorKind.ScRgbColor)
-            {
-                return (new SolidColorBrush(ParseScRgbColor(trimmedColor, formatProvider)));
-            }
+                return new SolidColorBrush(ParseScRgbColor(trimmedColor, formatProvider));
 
-            if (colorKind is ColorKind.KnownColor)
-            {
-                SolidColorBrush scp = KnownColors.ColorStringToKnownBrush(trimmedColor);
+            // NULL is returned when the color was not valid
+            SolidColorBrush solidColorBrush = KnownColors.ColorStringToKnownBrush(trimmedColor);
 
-                if (scp != null)
-                {
-                    return scp;
-                }
-            }
-
-            // If it's not a color, so the content is illegal.
-            throw new FormatException(SR.Parsers_IllegalToken);
+            return solidColorBrush is not null ? solidColorBrush : throw new FormatException(SR.Parsers_IllegalToken);
         }
 
 
         /// <summary>
         /// ParseTransform - parse a Transform from a string
         /// </summary>
-        internal static Transform ParseTransform(
-            string transformString,
-            IFormatProvider formatProvider)
+        internal static Transform ParseTransform(string transformString, IFormatProvider formatProvider)
         {
             Matrix matrix = Matrix.Parse(transformString);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -182,8 +182,7 @@ namespace MS.Internal
             if (colorKind is ColorKind.ScRgbColor)
                 return ParseScRgbColor(trimmedColor, formatProvider);
 
-            // NOTE: This ToString() is not regression, but it is currently blocked by #9669 and #9364
-            KnownColor knownColor = KnownColors.ColorStringToKnownColor(trimmedColor.ToString());
+            KnownColor knownColor = KnownColors.ColorStringToKnownColor(trimmedColor);
             if (knownColor == KnownColor.UnknownColor)
                 throw new FormatException(SR.Parsers_IllegalToken);
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ValueTokenizerHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ValueTokenizerHelper.cs
@@ -1,0 +1,317 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using MS.Internal.WindowsBase;
+
+namespace MS.Internal
+{
+    /// <summary>
+    /// Represents a <see langword="ref struct"/> implementation of <see cref="TokenizerHelper"/> operating over <see cref="ReadOnlySpan{char}"/>.
+    /// </summary>
+    internal ref struct ValueTokenizerHelper
+    {
+        /// <summary>
+        /// Constructor for <see cref="ValueTokenizerHelper"/> which accepts an <see cref="IFormatProvider"/>.
+        /// If the <see cref="IFormatProvider"/> is <see langword="null"/>, we use the thread's <see cref="IFormatProvider"/> info.
+        /// We will use ',' as the list separator, unless it's the same as the decimal separator.
+        /// If it *is*, then we can't determine if, say, "23,5" is one number or two. In this case, we will use ";" as the separator.
+        /// </summary>
+        /// <param name="input"> The string which will be tokenized. </param>
+        /// <param name="formatProvider"> The <see cref="IFormatProvider"/> which controls this tokenization. </param>
+        internal ValueTokenizerHelper(ReadOnlySpan<char> input, IFormatProvider formatProvider) : this(input, '\'', GetNumericListSeparator(formatProvider)) { }
+
+        /// <summary>
+        /// Initialize the <see cref="ValueTokenizerHelper"/> with the string to tokenize,
+        /// the char which represents quotes and the list separator.
+        /// </summary>
+        /// <param name="input"> The string to tokenize. </param>
+        /// <param name="quoteChar"> The quote char. </param>
+        /// <param name="separator"> The list separator. </param>
+        internal ValueTokenizerHelper(ReadOnlySpan<char> input, char quoteChar, char separator)
+        {
+            _input = input;
+            _currentTokenIndex = -1;
+            _quoteChar = quoteChar;
+            _argSeparator = separator;
+
+            // immediately forward past any whitespace so
+            // NextToken() logic always starts on the first
+            // character of the next token.
+            while (_charIndex < _input.Length)
+            {
+                if (!char.IsWhiteSpace(_input[_charIndex]))
+                    break;
+
+                ++_charIndex;
+            }
+        }
+
+        /// <summary>
+        /// Returns the next available token or <see cref="ReadOnlySpan{char}.Empty"/> if there's none ready.
+        /// </summary>
+        /// <returns>A slice of the next token or <see cref="ReadOnlySpan{char}.Empty"/>.</returns>
+        internal readonly ReadOnlySpan<char> GetCurrentToken()
+        {
+            // If there's no current token, return an empty span
+            if (_currentTokenIndex < 0)
+            {
+                return ReadOnlySpan<char>.Empty;
+            }
+
+            return _input.Slice(_currentTokenIndex, _currentTokenLength);
+        }
+
+        /// <summary>
+        /// Throws an exception if there is any non-whitespace left un-parsed.
+        /// </summary>
+        internal readonly void LastTokenRequired()
+        {
+            if (_charIndex != _input.Length)
+            {
+                throw new InvalidOperationException(SR.Format(SR.TokenizerHelperExtraDataEncountered, _charIndex, _input.ToString()));
+            }
+        }
+
+        /// <summary>
+        /// Advances to the next token.
+        /// </summary>
+        /// <returns><see langword="true"/> if next token was found, <see langword="false"/> if at end of string.</returns>
+        internal bool NextToken()
+        {
+            return NextToken(false);
+        }
+
+        /// <summary>
+        /// Advances to the next token, throwing an exception if not present.
+        /// </summary>
+        /// <returns>A slice of the next next token.</returns>
+        internal ReadOnlySpan<char> NextTokenRequired()
+        {
+            if (!NextToken(false))
+            {
+                throw new InvalidOperationException(SR.Format(SR.TokenizerHelperPrematureStringTermination, _input.ToString()));
+            }
+
+            return GetCurrentToken();
+        }
+
+        /// <summary>
+        /// Advances to the next token, throwing an exception if not present.
+        /// </summary>
+        /// <returns>A slice of the next next token.</returns>
+        internal ReadOnlySpan<char> NextTokenRequired(bool allowQuotedToken)
+        {
+            if (!NextToken(allowQuotedToken))
+            {
+                throw new InvalidOperationException(SR.Format(SR.TokenizerHelperPrematureStringTermination, _input.ToString()));
+            }
+
+            return GetCurrentToken();
+        }
+
+        /// <summary>
+        /// Advances to the next token.
+        /// </summary>
+        /// <returns><see langword="true"/> if next token was found, <see langword="false"/> if at end of string.</returns>
+        internal bool NextToken(bool allowQuotedToken)
+        {
+            // use the currently-set separator character.
+            return NextToken(allowQuotedToken, _argSeparator);
+        }
+
+        /// <summary>
+        /// Advances to the next token. A separator character can be specified which overrides the one previously set.
+        /// </summary>
+        /// <returns><see langword="true"/> if next token was found, <see langword="false"/> if at end of string.</returns>
+        internal bool NextToken(bool allowQuotedToken, char separator)
+        {
+            _currentTokenIndex = -1; // reset the currentTokenIndex
+            _foundSeparator = false; // reset
+
+            // If we're at end of the string, just return false.
+            if (_charIndex >= _input.Length)
+            {
+                return false;
+            }
+
+            char currentChar = _input[_charIndex];
+
+            Debug.Assert(!char.IsWhiteSpace(currentChar), "Token started on Whitespace");
+
+            // setup the quoteCount
+            int quoteCount = 0;
+
+            // If we are allowing a quoted token and this token begins with a quote,
+            // set up the quote count and skip the initial quote
+            if (allowQuotedToken && _quoteChar == currentChar)
+            {
+                quoteCount++; // increment quote count
+                ++_charIndex; // move to next character
+            }
+
+            int newTokenIndex = _charIndex;
+            int newTokenLength = 0;
+
+            // loop until hit end of string or hit a , or whitespace
+            // if at end of string ust return false.
+            while (_charIndex < _input.Length)
+            {
+                currentChar = _input[_charIndex];
+
+                // if have a QuoteCount and this is a quote
+                // decrement the quoteCount
+                if (quoteCount > 0)
+                {
+                    // if anything but a quoteChar we move on
+                    if (_quoteChar == currentChar)
+                    {
+                        --quoteCount;
+
+                        // if at zero which it always should for now
+                        // break out of the loop
+                        if (0 == quoteCount)
+                        {
+                            ++_charIndex; // move past the quote
+                            break;
+                        }
+                    }
+                }
+                else if (char.IsWhiteSpace(currentChar) || (currentChar == separator))
+                {
+                    if (currentChar == separator)
+                    {
+                        _foundSeparator = true;
+                    }
+                    break;
+                }
+
+                ++_charIndex;
+                ++newTokenLength;
+            }
+
+            // if quoteCount isn't zero we hit the end of the string
+            // before the ending quote
+            if (quoteCount > 0)
+            {
+                throw new InvalidOperationException(SR.Format(SR.TokenizerHelperMissingEndQuote, _input.ToString()));
+            }
+
+            ScanToNextToken(separator); // move so at the start of the nextToken for next call
+
+            // finally made it, update the _currentToken values
+            _currentTokenIndex = newTokenIndex;
+            _currentTokenLength = newTokenLength;
+
+            if (_currentTokenLength < 1)
+            {
+                throw new InvalidOperationException(SR.Format(SR.TokenizerHelperEmptyToken, _charIndex, _input.ToString()));
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Helper function to move the _charIndex to the next token or to the end of the string.
+        /// </summary>
+        /// <param name="separator"></param>
+        /// <exception cref="InvalidOperationException"></exception>
+        private void ScanToNextToken(char separator)
+        {
+            // if already at end of the string don't bother
+            if (_charIndex < _input.Length)
+            {
+                char currentChar = _input[_charIndex];
+
+                // check that the currentChar is a space or the separator.  If not
+                // we have an error. this can happen in the quote case
+                // that the char after the quotes string isn't a char.
+                if (!(char.IsWhiteSpace(currentChar) || (currentChar == separator)))
+                {
+                    throw new InvalidOperationException(SR.Format(SR.TokenizerHelperExtraDataEncountered, _charIndex, _input.ToString()));
+                }
+
+                // loop until hit a character that isn't
+                // an argument separator or whitespace.
+                int argSepCount = 0;
+                while (_charIndex < _input.Length)
+                {
+                    currentChar = _input[_charIndex];
+
+                    if (currentChar == separator)
+                    {
+                        _foundSeparator = true;
+                        ++argSepCount;
+                        _charIndex++;
+
+                        if (argSepCount > 1)
+                        {
+                            throw new InvalidOperationException(SR.Format(SR.TokenizerHelperEmptyToken, _charIndex, _input.ToString()));
+                        }
+                    }
+                    else if (char.IsWhiteSpace(currentChar))
+                    {
+                        ++_charIndex;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                // if there was a separatorChar then we shouldn't be
+                // at the end of string or means there was a separator
+                // but there isn't an arg
+
+                if (argSepCount > 0 && _charIndex >= _input.Length)
+                {
+                    throw new InvalidOperationException(SR.Format(SR.TokenizerHelperEmptyToken, _charIndex, _input.ToString()));
+                }
+            }
+        }
+
+        // Helper to get the numeric list separator for a given IFormatProvider.
+        // Separator is a comma [,] if the decimal separator is not a comma, or a semicolon [;] otherwise.
+        internal static char GetNumericListSeparator(IFormatProvider provider)
+        {
+            char numericSeparator = ',';
+
+            // Get the NumberFormatInfo out of the provider, if possible
+            // If the IFormatProvider doesn't not contain a NumberFormatInfo, then
+            // this method returns the current culture's NumberFormatInfo.
+            NumberFormatInfo numberFormat = NumberFormatInfo.GetInstance(provider);
+
+            Debug.Assert(numberFormat != null);
+
+            // Is the decimal separator is the same as the list separator?
+            // If so, we use the ";".
+            if ((numberFormat.NumberDecimalSeparator.Length > 0) && (numericSeparator == numberFormat.NumberDecimalSeparator[0]))
+            {
+                numericSeparator = ';';
+            }
+
+            return numericSeparator;
+        }
+
+        internal readonly bool FoundSeparator
+        {
+            get
+            {
+                return _foundSeparator;
+            }
+        }
+
+        private readonly char _quoteChar;
+        private readonly char _argSeparator;
+        private readonly ReadOnlySpan<char> _input;
+
+        private int _charIndex;
+        private bool _foundSeparator;
+
+        internal int _currentTokenIndex;
+        internal int _currentTokenLength;
+    }
+}


### PR DESCRIPTION
Currently blocked by #9364 / #9669, hence draft.

## Description

Optimizes parsing of colors and brushes from string and also conversion of colors to string.
It currently cherry-picks #9669 with additional modification for non-PBT assemblies and also the ref-struct tokenizer from #9364, but it is directly dependent due to several changes over those previously done.

#### ParseContextColor (normal)

| Method            | Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Gen0   | Allocated [B] |
|------------------ |----------:|-----------:|------------:|--------------:|-------:|--------------:|
| Original |  528.9 ns |   10.28 ns |    13.01 ns |       3,138 B | 0.0763 |        1288 B |
| PR__EDIT |  331.3 ns |    2.51 ns |     2.22 ns |       1,517 B | 0.0114 |         192 B |

#### ParseContextColor (edge case)

| Method            | Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Gen0   | Allocated [B] |
|------------------ |----------:|-----------:|------------:|--------------:|-------:|--------------:|
| Original |  687.2 ns |    6.62 ns |     5.87 ns |       2,971 B | 0.1040 |        1752 B |
| PR__EDIT |  384.9 ns |    0.90 ns |     0.84 ns |       1,517 B | 0.0114 |         192 B |

#### ToString with Round-trip format

| Method    | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|---------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  425.0 ns |    1.64 ns |     1.37 ns | 0.0181 |       3,864 B |         304 B |
| PR__EDIT |  321.7 ns |    0.89 ns |     0.79 ns | 0.0048 |         833 B |          80 B |

#### ToString with ColorContext

| Method  |  Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|---------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  601.2 ns |    4.31 ns |     3.60 ns | 0.0668 |       4,029 B |        1120 B |
| PR__EDIT | 419.1 ns |    1.29 ns |     1.15 ns | 0.0138 |       1,506 B |         232 B |

#### Source data
```csharp
// Benchmark 1
"ContextColor file://C:/Windows/system32/spool/drivers/color/RSWOP.icm 1.0, 0.0, 0.5, 1.0, 1.0"
// Benchmark 2
"ContextColor file://C:/Windows/system32/spool/drivers/color/RSWOP.icm 1.0,            1.0, 0.5,       0.0,       1.0"
// Benchmark 3+4
private static MILColorF scRgbColor = new() { a = 0.7667f, b = 0.2254f, g = 1.0f, r = 0.8458488f };
// Benchmark 4
uriString = "file://C:/Windows/system32/spool/drivers/color/RSWOP.icm",
```

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, assert tests.

## Risk

Low to medium; will follow-up with unit tests once we're in that timeframe and past WPF tests.
