### PR TITLE
Remove obsolete/dead code overloads and options from MimeObjectFactory

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppModelKnownContentFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppModelKnownContentFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -25,12 +25,12 @@ namespace MS.Internal.AppModel
         // <summary>
         // Creates an object instance from a Baml stream and it's Uri
         // </summary>
-        internal static object BamlConverter(Stream stream, Uri baseUri, bool canUseTopLevelBrowser, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter)
+        internal static object BamlConverter(Stream stream, Uri baseUri, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter)
         {
-            return BamlConverterCore(stream, baseUri, canUseTopLevelBrowser, sandboxExternalContent, allowAsync, isJournalNavigation, out asyncObjectConverter, false);
+            return BamlConverterCore(stream, baseUri, sandboxExternalContent, allowAsync, isJournalNavigation, out asyncObjectConverter, false);
         }
 
-        internal static object BamlConverterCore(Stream stream, Uri baseUri, bool canUseTopLevelBrowser, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter, bool isUnsafe)
+        internal static object BamlConverterCore(Stream stream, Uri baseUri, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter, bool isUnsafe)
         {
             asyncObjectConverter = null;
             if (isUnsafe)
@@ -64,12 +64,12 @@ namespace MS.Internal.AppModel
         // <summary>
         // Creates an object instance from a Xaml stream and it's Uri
         // </summary>
-        internal static object XamlConverter(Stream stream, Uri baseUri, bool canUseTopLevelBrowser, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter)
+        internal static object XamlConverter(Stream stream, Uri baseUri, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter)
         {
-            return XamlConverterCore(stream, baseUri, canUseTopLevelBrowser, sandboxExternalContent, allowAsync, isJournalNavigation, out asyncObjectConverter, false);
+            return XamlConverterCore(stream, baseUri, sandboxExternalContent, allowAsync, isJournalNavigation, out asyncObjectConverter, false);
         }
 
-        internal static object XamlConverterCore(Stream stream, Uri baseUri, bool canUseTopLevelBrowser, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter, bool isUnsafe)
+        internal static object XamlConverterCore(Stream stream, Uri baseUri, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter, bool isUnsafe)
         {
             asyncObjectConverter = null;
 
@@ -123,21 +123,17 @@ namespace MS.Internal.AppModel
             }
         }
 
-        internal static object HtmlXappConverter(Stream stream, Uri baseUri, bool canUseTopLevelBrowser, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter)
+        internal static object HtmlXappConverter(Stream stream, Uri baseUri, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter)
         {
-            return HtmlXappConverterCore(stream, baseUri, canUseTopLevelBrowser, sandboxExternalContent, allowAsync, isJournalNavigation, out asyncObjectConverter, false);
+            return HtmlXappConverterCore(stream, baseUri, sandboxExternalContent, allowAsync, isJournalNavigation, out asyncObjectConverter, false);
         }
 
-        internal static object HtmlXappConverterCore(Stream stream, Uri baseUri, bool canUseTopLevelBrowser, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter, bool isUnsafe)
+        internal static object HtmlXappConverterCore(Stream stream, Uri baseUri, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter, bool isUnsafe)
         {
             asyncObjectConverter = null;
             if (isUnsafe)
             {
                 throw new InvalidOperationException(SR.Format(SR.BamlIsNotSupportedOutsideOfApplicationResources));
-            }
-            if (canUseTopLevelBrowser)
-            {
-                return null;
             }
 
             if (string.Equals(baseUri.Scheme, BaseUriHelper.PackAppBaseUri.Scheme, StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppModelKnownContentFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppModelKnownContentFactory.cs
@@ -22,14 +22,9 @@ namespace MS.Internal.AppModel
     // delgate to close stream. 
     internal static class AppModelKnownContentFactory
     {
-        // <summary>
-        // Creates an object instance from a Baml stream and it's Uri
-        // </summary>
-        internal static object BamlConverter(Stream stream, Uri baseUri, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter)
-        {
-            return BamlConverterCore(stream, baseUri, sandboxExternalContent, allowAsync, isJournalNavigation, out asyncObjectConverter, false);
-        }
-
+        /// <summary>
+        /// Creates an object instance from a Baml stream and its Uri
+        /// </summary>
         internal static object BamlConverterCore(Stream stream, Uri baseUri, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter, bool isUnsafe)
         {
             asyncObjectConverter = null;
@@ -61,14 +56,9 @@ namespace MS.Internal.AppModel
             return Application.LoadBamlStreamWithSyncInfo(stream, pc);
         }
 
-        // <summary>
-        // Creates an object instance from a Xaml stream and it's Uri
-        // </summary>
-        internal static object XamlConverter(Stream stream, Uri baseUri, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter)
-        {
-            return XamlConverterCore(stream, baseUri, sandboxExternalContent, allowAsync, isJournalNavigation, out asyncObjectConverter, false);
-        }
-
+        /// <summary>
+        /// Creates an object instance from a Xaml stream and its Uri
+        /// </summary>
         internal static object XamlConverterCore(Stream stream, Uri baseUri, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter, bool isUnsafe)
         {
             asyncObjectConverter = null;
@@ -121,11 +111,6 @@ namespace MS.Internal.AppModel
             {
                 throw args.Error;
             }
-        }
-
-        internal static object HtmlXappConverter(Stream stream, Uri baseUri, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter)
-        {
-            return HtmlXappConverterCore(stream, baseUri, sandboxExternalContent, allowAsync, isJournalNavigation, out asyncObjectConverter, false);
         }
 
         internal static object HtmlXappConverterCore(Stream stream, Uri baseUri, bool sandboxExternalContent, bool allowAsync, bool isJournalNavigation, out XamlReader asyncObjectConverter, bool isUnsafe)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -2003,7 +2003,6 @@ namespace System.Windows
             MimeObjectFactory.RegisterCore(MimeTypeMapper.HtmMime, htmlxappFactoryDelegate);
             MimeObjectFactory.RegisterCore(MimeTypeMapper.HtmlMime, htmlxappFactoryDelegate);
             MimeObjectFactory.RegisterCore(MimeTypeMapper.XbapMime, htmlxappFactoryDelegate);
-
         }
 
         // This function returns the resource stream including resource and content file.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -2925,12 +2925,7 @@ namespace System.Windows.Navigation
                 _webResponse = response;
                 _asyncObjectConverter = null;
 
-
-                // canUseTopLevelBrowserForHTMLRendering will be true for TopLevel navigation away from browser hosted app. If that is the case
-                // o will be null.
-                // We don't support browser hosting since .NET Core 3.0, so therefore canUseTopLevelBrowserForHTMLRendering = false
-                bool canUseTopLevelBrowserForHTMLRendering = false;
-                Object o = MimeObjectFactory.GetObjectAndCloseStreamCore(bindStream, contentType, destinationUri, canUseTopLevelBrowserForHTMLRendering, sandBoxContent, true /*allowAsync*/, IsJournalNavigation(navigateInfo), out _asyncObjectConverter, IsUnsafe);
+                Object o = MimeObjectFactory.GetObjectAndCloseStreamCore(bindStream, contentType, destinationUri, sandBoxContent, allowAsync: true, IsJournalNavigation(navigateInfo), out _asyncObjectConverter, IsUnsafe);
 
                 if (o != null)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -216,7 +216,7 @@ namespace System.Windows
                 // It can be a sync/async converter. It's the converter's responsiblity to close the stream.
                 // If it fails to find a convert, this call will return null.
                 System.Windows.Markup.XamlReader asyncObjectConverter;
-                ResourceDictionary loadedRD = MimeObjectFactory.GetObjectAndCloseStreamCore(s, contentType, uri, false, false, false /*allowAsync*/, false /*isJournalNavigation*/, out asyncObjectConverter, IsUnsafe)
+                ResourceDictionary loadedRD = MimeObjectFactory.GetObjectAndCloseStreamCore(s, contentType, uri, false, false /*allowAsync*/, false /*isJournalNavigation*/, out asyncObjectConverter, IsUnsafe)
                                             as ResourceDictionary;
 
                 if (loadedRD == null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -215,11 +215,7 @@ namespace System.Windows
                 // MimeObjectFactory.GetObjectAndCloseStream will try to find the object converter basing on the mime type.
                 // It can be a sync/async converter. It's the converter's responsiblity to close the stream.
                 // If it fails to find a convert, this call will return null.
-                System.Windows.Markup.XamlReader asyncObjectConverter;
-                ResourceDictionary loadedRD = MimeObjectFactory.GetObjectAndCloseStreamCore(s, contentType, uri, false, false /*allowAsync*/, false /*isJournalNavigation*/, out asyncObjectConverter, IsUnsafe)
-                                            as ResourceDictionary;
-
-                if (loadedRD == null)
+                if (MimeObjectFactory.GetObjectAndCloseStreamCore(s, contentType, uri, false, allowAsync: false, false, out _, IsUnsafe) is not ResourceDictionary loadedRD)
                 {
                     throw new InvalidOperationException(SR.Format(SR.ResourceDictionaryLoadFromFailure, _source.ToString()));
                 }


### PR DESCRIPTION
## Description

Removes the non-core delegate type, its methods and the always-initialized dictionary of 9 items since they were never registered and the normal Register method is never called, freeing some memory usage.

Also removes `canUseTopLevelBrowser` from the signature as thats irrelevant on .NET Core since XBAP removal.

## Customer Impact

Slightly less memory usage thanks to the dictionary removal.

## Regression

No.

## Testing

Local build.

## Risk

Minimum.
