### PR TITLE
Fix Potential Crash in Fluent High Contrast

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
@@ -640,8 +640,7 @@
 
     <Color x:Key="ControlStrongFillColorDefault">#2D3236</Color>
     <Color x:Key="ControlStrongFillColorDisabled">#2D3236</Color>
-
-    <Color x:Key="SystemColorWindowColor">Transparent</Color>
+    
     <Color x:Key="ControlSolidFillColorDefault">#2D3236</Color>
 
     <Color x:Key="SubtleFillColorTransparent">#2D3236</Color>


### PR DESCRIPTION
## Description
The theme generator for `Fluent` themes partially relies on common brushes, colors, and keys written in theme files, i.e. `Light.xaml`, `Dark.xaml` and `HC.xaml`. The current implementation of `HC.xaml` contains a duplication of `SystemColorWindowColor` key.
The resource dictionary loaded at runtime for High Contrast theme is Fluent.HC.xaml, which right now is correct but if/when we generate the same, it will result in duplication of that key and hence runtime crashing of applications on high contrast theme.

## Customer Impact
Fixes any future regression and crash on high contrast theme (Fluent)

## Testing
Local Build Pass

## Risk
Low, removal of a xaml key.
Does not violate API contract as the key is already present.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10229)