### PR TITLE
Remove array allocation during SystemParametersInfo cache invalidation

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
@@ -4999,56 +4999,56 @@ namespace System.Windows
 
         #region Cache and Implementation
 
+        private static ReadOnlySpan<short> CachedParameters => [NativeMethods.SPI_SETFOCUSBORDERWIDTH,
+                                                                NativeMethods.SPI_SETFOCUSBORDERHEIGHT,
+                                                                NativeMethods.SPI_SETHIGHCONTRAST,
+                                                                NativeMethods.SPI_SETMOUSEVANISH,
+                                                                NativeMethods.SPI_SETDROPSHADOW,
+                                                                NativeMethods.SPI_SETFLATMENU,
+                                                                NativeMethods.SPI_SETWORKAREA,
+                                                                NativeMethods.SPI_SETICONMETRICS,
+                                                                NativeMethods.SPI_SETKEYBOARDCUES,
+                                                                NativeMethods.SPI_SETKEYBOARDDELAY,
+                                                                NativeMethods.SPI_SETKEYBOARDPREF,
+                                                                NativeMethods.SPI_SETKEYBOARDSPEED,
+                                                                NativeMethods.SPI_SETSNAPTODEFBUTTON,
+                                                                NativeMethods.SPI_SETWHEELSCROLLLINES,
+                                                                NativeMethods.SPI_SETMOUSEHOVERTIME,
+                                                                NativeMethods.SPI_SETMOUSEHOVERHEIGHT,
+                                                                NativeMethods.SPI_SETMOUSEHOVERWIDTH,
+                                                                NativeMethods.SPI_SETMENUDROPALIGNMENT,
+                                                                NativeMethods.SPI_SETMENUFADE,
+                                                                NativeMethods.SPI_SETMENUSHOWDELAY,
+                                                                NativeMethods.SPI_SETCOMBOBOXANIMATION,
+                                                                NativeMethods.SPI_SETCLIENTAREAANIMATION,
+                                                                NativeMethods.SPI_SETCURSORSHADOW,
+                                                                NativeMethods.SPI_SETGRADIENTCAPTIONS,
+                                                                NativeMethods.SPI_SETHOTTRACKING,
+                                                                NativeMethods.SPI_SETLISTBOXSMOOTHSCROLLING,
+                                                                NativeMethods.SPI_SETMENUANIMATION,
+                                                                NativeMethods.SPI_SETSELECTIONFADE,
+                                                                NativeMethods.SPI_SETSTYLUSHOTTRACKING,
+                                                                NativeMethods.SPI_SETTOOLTIPANIMATION,
+                                                                NativeMethods.SPI_SETTOOLTIPFADE,
+                                                                NativeMethods.SPI_SETUIEFFECTS,
+                                                                NativeMethods.SPI_SETANIMATION,
+                                                                NativeMethods.SPI_SETCARETWIDTH,
+                                                                NativeMethods.SPI_SETFOREGROUNDFLASHCOUNT,
+                                                                NativeMethods.SPI_SETDRAGFULLWINDOWS,
+                                                                NativeMethods.SPI_SETBORDER,
+                                                                NativeMethods.SPI_SETNONCLIENTMETRICS,
+                                                                NativeMethods.SPI_SETDRAGWIDTH,
+                                                                NativeMethods.SPI_SETDRAGHEIGHT,
+                                                                NativeMethods.SPI_SETPENWINDOWS,
+                                                                NativeMethods.SPI_SETSHOWSOUNDS,
+                                                                NativeMethods.SPI_SETMOUSEBUTTONSWAP];
+
         internal static void InvalidateCache()
         {
-            // Invalidate all Parameters
-            int[] param = {  NativeMethods.SPI_SETFOCUSBORDERWIDTH,
-                             NativeMethods.SPI_SETFOCUSBORDERHEIGHT,
-                             NativeMethods.SPI_SETHIGHCONTRAST,
-                             NativeMethods.SPI_SETMOUSEVANISH,
-                             NativeMethods.SPI_SETDROPSHADOW,
-                             NativeMethods.SPI_SETFLATMENU,
-                             NativeMethods.SPI_SETWORKAREA,
-                             NativeMethods.SPI_SETICONMETRICS,
-                             NativeMethods.SPI_SETKEYBOARDCUES,
-                             NativeMethods.SPI_SETKEYBOARDDELAY,
-                             NativeMethods.SPI_SETKEYBOARDPREF,
-                             NativeMethods.SPI_SETKEYBOARDSPEED,
-                             NativeMethods.SPI_SETSNAPTODEFBUTTON,
-                             NativeMethods.SPI_SETWHEELSCROLLLINES,
-                             NativeMethods.SPI_SETMOUSEHOVERTIME,
-                             NativeMethods.SPI_SETMOUSEHOVERHEIGHT,
-                             NativeMethods.SPI_SETMOUSEHOVERWIDTH,
-                             NativeMethods.SPI_SETMENUDROPALIGNMENT,
-                             NativeMethods.SPI_SETMENUFADE,
-                             NativeMethods.SPI_SETMENUSHOWDELAY,
-                             NativeMethods.SPI_SETCOMBOBOXANIMATION,
-                             NativeMethods.SPI_SETCLIENTAREAANIMATION,
-                             NativeMethods.SPI_SETCURSORSHADOW,
-                             NativeMethods.SPI_SETGRADIENTCAPTIONS,
-                             NativeMethods.SPI_SETHOTTRACKING,
-                             NativeMethods.SPI_SETLISTBOXSMOOTHSCROLLING,
-                             NativeMethods.SPI_SETMENUANIMATION,
-                             NativeMethods.SPI_SETSELECTIONFADE,
-                             NativeMethods.SPI_SETSTYLUSHOTTRACKING,
-                             NativeMethods.SPI_SETTOOLTIPANIMATION,
-                             NativeMethods.SPI_SETTOOLTIPFADE,
-                             NativeMethods.SPI_SETUIEFFECTS,
-                             NativeMethods.SPI_SETANIMATION,
-                             NativeMethods.SPI_SETCARETWIDTH,
-                             NativeMethods.SPI_SETFOREGROUNDFLASHCOUNT,
-                             NativeMethods.SPI_SETDRAGFULLWINDOWS,
-                             NativeMethods.SPI_SETBORDER,
-                             NativeMethods.SPI_SETNONCLIENTMETRICS,
-                             NativeMethods.SPI_SETDRAGWIDTH,
-                             NativeMethods.SPI_SETDRAGHEIGHT,
-                             NativeMethods.SPI_SETPENWINDOWS,
-                             NativeMethods.SPI_SETSHOWSOUNDS,
-                             NativeMethods.SPI_SETMOUSEBUTTONSWAP};
-
-            for (int i = 0; i < param.Length; i++)
+            // Invalidate cached system parameters
+            for (int i = 0; i < CachedParameters.Length; i++)
             {
-                InvalidateCache(param[i]);
+                InvalidateCache(CachedParameters[i]);
             }
         }
 


### PR DESCRIPTION
## Description

Removes array allocation during `SystemParametersInfo` cache invalidation when a theme is changed, saving unnecessary allocation and overhead. We could alternatively keep it in method, while that removes the allocation it won't provide the 10ns execution benefit due to the stack init, and imho there's no reason why it couldn't be outside method, there's no readibility issue.

### Method execution difference

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|---------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| ORIIGINAL |  58.89 ns |   0.889 ns |    0.832 ns | 0.0119 |         424 B |         200 B |
| PR__EDIT    | 47.03 ns |   0.198 ns |    0.176 ns |      - |          60 B |             - |

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build.

## Risk

Minimal, just getting the data from binary directly instead of heap-allocating an array.
