### PR TITLE
Remove locks in RadioButton and increase type safety (use generic types)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -67,12 +67,12 @@ namespace System.Windows.Controls
 
         private static void Register(string groupName, RadioButton radioButton)
         {
-            _groupNameToElements ??= new Dictionary<string, List<WeakReference<RadioButton>>>(1);
+            t_groupNameToElements ??= new Dictionary<string, List<WeakReference<RadioButton>>>(1);
 
-            if (!_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
+            if (!t_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
             {
                 elements = new List<WeakReference<RadioButton>>(2);
-                _groupNameToElements[groupName] = elements;
+                t_groupNameToElements[groupName] = elements;
             }
             else
             {
@@ -87,19 +87,19 @@ namespace System.Windows.Controls
 
         private static void Unregister(string groupName, RadioButton radioButton)
         {
-            Debug.Assert(_groupNameToElements is not null, "Unregister was called before Register");
+            Debug.Assert(t_groupNameToElements is not null, "Unregister was called before Register");
 
-            if (_groupNameToElements is null)
+            if (t_groupNameToElements is null)
                 return;
 
             // Get all elements bound to this key and remove this element
-            if (_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
+            if (t_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
             {
                 PurgeDead(elements, radioButton);
 
                 // If the group has zero elements, remove it
                 if (elements.Count == 0)
-                    _groupNameToElements.Remove(groupName);
+                    t_groupNameToElements.Remove(groupName);
             }
 
             _currentlyRegisteredGroupName.SetValue(radioButton, null);
@@ -123,10 +123,10 @@ namespace System.Windows.Controls
             {
                 Visual rootScope = KeyboardNavigation.GetVisualRoot(this);
 
-                _groupNameToElements ??= new Dictionary<string, List<WeakReference<RadioButton>>>(1);
+                t_groupNameToElements ??= new Dictionary<string, List<WeakReference<RadioButton>>>(1);
 
                 // Get all elements bound to this key and remove this element
-                if (_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
+                if (t_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
                 {
                     for (int i = elements.Count - 1; i >= 0; i--)
                     {
@@ -268,7 +268,7 @@ namespace System.Windows.Controls
         #region private data
 
         [ThreadStatic]
-        private static Dictionary<string, List<WeakReference<RadioButton>>> _groupNameToElements;
+        private static Dictionary<string, List<WeakReference<RadioButton>>> t_groupNameToElements;
 
         private static readonly UncommonField<string> _currentlyRegisteredGroupName = new UncommonField<string>();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -107,16 +107,11 @@ namespace System.Windows.Controls
 
         private static void PurgeDead(List<WeakReference<RadioButton>> elements, RadioButton elementToRemove)
         {
-            for (int i = 0; i < elements.Count; )
+            for (int i = elements.Count - 1; i >= 0; i--)
             {
-                WeakReference<RadioButton> weakReference = elements[i];
-                if (!weakReference.TryGetTarget(out RadioButton element) || element == elementToRemove)
+                if (!elements[i].TryGetTarget(out RadioButton element) || element == elementToRemove)
                 {
                     elements.RemoveAt(i);
-                }
-                else
-                {
-                    i++;
                 }
             }
         }
@@ -133,20 +128,18 @@ namespace System.Windows.Controls
                 // Get all elements bound to this key and remove this element
                 if (_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
                 {
-                    for (int i = 0; i < elements.Count; )
+                    for (int i = elements.Count - 1; i >= 0; i--)
                     {
-                        WeakReference<RadioButton> weakReference = elements[i];
-                        if (!weakReference.TryGetTarget(out RadioButton rb))
+                        if (elements[i].TryGetTarget(out RadioButton radioButton))
                         {
-                            // Remove dead instances
-                            elements.RemoveAt(i);
+                            // Uncheck all checked RadioButtons different from the current one
+                            if (radioButton != this && radioButton.IsChecked is true && rootScope == KeyboardNavigation.GetVisualRoot(radioButton))
+                                radioButton.UncheckRadioButton();
                         }
                         else
                         {
-                            // Uncheck all checked RadioButtons different from the current one
-                            if (rb != this && (rb.IsChecked == true) && rootScope == KeyboardNavigation.GetVisualRoot(rb))
-                                rb.UncheckRadioButton();
-                            i++;
+                            // Remove dead instances
+                            elements.RemoveAt(i);
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -4,6 +4,7 @@
 
 using System.Collections;
 using System.ComponentModel;
+using System.Runtime.InteropServices;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -69,10 +70,11 @@ namespace System.Windows.Controls
         {
             t_groupNameToElements ??= new Dictionary<string, List<WeakReference<RadioButton>>>(1);
 
-            if (!t_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
+            ref List<WeakReference<RadioButton>> elements = ref CollectionsMarshal.GetValueRefOrAddDefault(t_groupNameToElements, groupName, out bool exists);
+            if (!exists)
             {
+                // Create new collection
                 elements = new List<WeakReference<RadioButton>>(2);
-                t_groupNameToElements[groupName] = elements;
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -67,13 +67,13 @@ namespace System.Windows.Controls
 
         private static void Register(string groupName, RadioButton radioButton)
         {
-            _groupNameToElements ??= new Dictionary<string, ArrayList>(1);
+            _groupNameToElements ??= new Dictionary<string, List<WeakReference>>(1);
 
             lock (_groupNameToElements)
             {
-                if (!_groupNameToElements.TryGetValue(groupName, out ArrayList elements))
+                if (!_groupNameToElements.TryGetValue(groupName, out List<WeakReference> elements))
                 {
-                    elements = new ArrayList(1);
+                    elements = new List<WeakReference>(1);
                     _groupNameToElements[groupName] = elements;
                 }
                 else
@@ -95,7 +95,7 @@ namespace System.Windows.Controls
             lock (_groupNameToElements)
             {
                 // Get all elements bound to this key and remove this element
-                if (_groupNameToElements.TryGetValue(groupName, out ArrayList elements))
+                if (_groupNameToElements.TryGetValue(groupName, out List<WeakReference> elements))
                 {
                     PurgeDead(elements, radioButton);
                     if (elements.Count == 0)
@@ -107,11 +107,11 @@ namespace System.Windows.Controls
             _currentlyRegisteredGroupName.SetValue(radioButton, null);
         }
 
-        private static void PurgeDead(ArrayList elements, object elementToRemove)
+        private static void PurgeDead(List<WeakReference> elements, object elementToRemove)
         {
             for (int i = 0; i < elements.Count; )
             {
-                WeakReference weakReference = (WeakReference)elements[i];
+                WeakReference weakReference = elements[i];
                 object element = weakReference.Target;
                 if (element == null || element == elementToRemove)
                 {
@@ -131,16 +131,16 @@ namespace System.Windows.Controls
             {
                 Visual rootScope = KeyboardNavigation.GetVisualRoot(this);
 
-                _groupNameToElements ??= new Dictionary<string, ArrayList>(1);
+                _groupNameToElements ??= new Dictionary<string, List<WeakReference>>(1);
 
                 lock (_groupNameToElements)
                 {
                     // Get all elements bound to this key and remove this element
-                    ArrayList elements = _groupNameToElements[groupName];
+                    List<WeakReference> elements = _groupNameToElements[groupName];
                     // Haha, notice the unlikely but possible null-deref here
                     for (int i = 0; i < elements.Count; )
                     {
-                        WeakReference weakReference = (WeakReference)elements[i];
+                        WeakReference weakReference = elements[i];
                         RadioButton rb = weakReference.Target as RadioButton;
                         if (rb == null)
                         {
@@ -281,7 +281,7 @@ namespace System.Windows.Controls
         #region private data
 
         [ThreadStatic]
-        private static Dictionary<string, ArrayList> _groupNameToElements;
+        private static Dictionary<string, List<WeakReference>> _groupNameToElements;
 
         private static readonly UncommonField<string> _currentlyRegisteredGroupName = new UncommonField<string>();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -71,7 +71,7 @@ namespace System.Windows.Controls
 
             if (!_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
             {
-                elements = new List<WeakReference<RadioButton>>(1);
+                elements = new List<WeakReference<RadioButton>>(2);
                 _groupNameToElements[groupName] = elements;
             }
             else


### PR DESCRIPTION
## Description

Optimizes weird branching loops for cleanup, replace them with counting down loops instead.

- Replace `_groupNameToElements` `Hashtable` with `Dictionary<string, List<WeakReference<RadioButton>>>`.
- Use `List<WeakReference<RadioButton>>` instead of `ArrayList` to store weak references per group name.
- Use `WeakReference<RadioButton>` instead of untyped `WeakReference`.
- Initialize the List with at least 2 elements as we should expect more than 1 item per radio button group.
- Renamed `_groupNameToElements` to `t_groupNameToElements` as its `ThreadStatic` variable.
- I've also removed the locks on the collection as each `Thread` would gets its own copy anyways.
- Also we no longer walk the visual tree unless it is actually needed.

## Customer Impact

Increased performance, cleaner codebase for developers.

## Regression

No.

## Testing

Local build, extensive testing with radio buttons.

## Risk

Low to medium, I believe I've tested most of the edge cases as I was working on something with the build.
