### PR TITLE
Fix interaction of RadioButton, shared bindings and hanging GC refs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -67,12 +67,12 @@ namespace System.Windows.Controls
 
         private static void Register(string groupName, RadioButton radioButton)
         {
-            _groupNameToElements ??= new Dictionary<string, List<WeakReference<RadioButton>>>(1);
+            t_groupNameToElements ??= new Dictionary<string, List<WeakReference<RadioButton>>>(1);
 
-            if (!_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
+            if (!t_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
             {
                 elements = new List<WeakReference<RadioButton>>(2);
-                _groupNameToElements[groupName] = elements;
+                t_groupNameToElements[groupName] = elements;
             }
             else
             {
@@ -87,19 +87,19 @@ namespace System.Windows.Controls
 
         private static void Unregister(string groupName, RadioButton radioButton)
         {
-            Debug.Assert(_groupNameToElements is not null, "Unregister was called before Register");
+            Debug.Assert(t_groupNameToElements is not null, "Unregister was called before Register");
 
-            if (_groupNameToElements is null)
+            if (t_groupNameToElements is null)
                 return;
 
             // Get all elements bound to this key and remove this element
-            if (_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
+            if (t_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
             {
                 PurgeDead(elements, radioButton);
 
                 // If the group has zero elements, remove it
                 if (elements.Count == 0)
-                    _groupNameToElements.Remove(groupName);
+                    t_groupNameToElements.Remove(groupName);
             }
 
             _currentlyRegisteredGroupName.SetValue(radioButton, null);
@@ -123,10 +123,10 @@ namespace System.Windows.Controls
             {
                 Visual rootScope = KeyboardNavigation.GetVisualRoot(this);
 
-                _groupNameToElements ??= new Dictionary<string, List<WeakReference<RadioButton>>>(1);
+                t_groupNameToElements ??= new Dictionary<string, List<WeakReference<RadioButton>>>(1);
 
                 // Get all elements bound to this key and remove this element
-                if (_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
+                if (t_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
                 {
                     for (int i = elements.Count - 1; i >= 0; i--)
                     {
@@ -268,7 +268,7 @@ namespace System.Windows.Controls
         #region private data
 
         [ThreadStatic]
-        private static Dictionary<string, List<WeakReference<RadioButton>>> _groupNameToElements;
+        private static Dictionary<string, List<WeakReference<RadioButton>>> t_groupNameToElements;
 
         private static readonly UncommonField<string> _currentlyRegisteredGroupName = new UncommonField<string>();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -107,16 +107,11 @@ namespace System.Windows.Controls
 
         private static void PurgeDead(List<WeakReference<RadioButton>> elements, RadioButton elementToRemove)
         {
-            for (int i = 0; i < elements.Count; )
+            for (int i = elements.Count - 1; i >= 0; i--)
             {
-                WeakReference<RadioButton> weakReference = elements[i];
-                if (!weakReference.TryGetTarget(out RadioButton element) || element == elementToRemove)
+                if (!elements[i].TryGetTarget(out RadioButton element) || element == elementToRemove)
                 {
                     elements.RemoveAt(i);
-                }
-                else
-                {
-                    i++;
                 }
             }
         }
@@ -133,20 +128,18 @@ namespace System.Windows.Controls
                 // Get all elements bound to this key and remove this element
                 if (_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
                 {
-                    for (int i = 0; i < elements.Count; )
+                    for (int i = elements.Count - 1; i >= 0; i--)
                     {
-                        WeakReference<RadioButton> weakReference = elements[i];
-                        if (!weakReference.TryGetTarget(out RadioButton rb))
+                        if (elements[i].TryGetTarget(out RadioButton radioButton))
                         {
-                            // Remove dead instances
-                            elements.RemoveAt(i);
+                            // Uncheck all checked RadioButtons different from the current one
+                            if (radioButton != this && radioButton.IsChecked is true && rootScope == KeyboardNavigation.GetVisualRoot(radioButton))
+                                radioButton.UncheckRadioButton();
                         }
                         else
                         {
-                            // Uncheck all checked RadioButtons different from the current one
-                            if (rb != this && (rb.IsChecked == true) && rootScope == KeyboardNavigation.GetVisualRoot(rb))
-                                rb.UncheckRadioButton();
-                            i++;
+                            // Remove dead instances
+                            elements.RemoveAt(i);
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
@@ -135,12 +136,21 @@ namespace System.Windows.Controls
                             // Uncheck all checked RadioButtons but this one
                             if (radioButton != this && radioButton.IsChecked is true)
                             {
-                                DependencyObject rootScope = KeyboardNavigation.GetVisualRoot(this);
-                                DependencyObject otherRoot = KeyboardNavigation.GetVisualRoot(radioButton);
+                                DependencyObject rootScope = InputElement.GetRootVisual(this);
+                                DependencyObject otherRoot = InputElement.GetRootVisual(radioButton);
 
                                 // If elements have the same group name but the visual roots are different, we still treat them
                                 // as unique since we want to promote reuse of group names to make them easier to work with.
                                 if (rootScope != otherRoot)
+                                    continue;
+
+                                // Allow binding sharing under the same visual root
+                                BindingExpression rootBindingSource = GetBindingExpression(IsCheckedProperty);
+                                BindingExpression otherBindingSource = radioButton.GetBindingExpression(IsCheckedProperty);
+
+                                if (rootBindingSource is not null && otherBindingSource is not null &&
+                                    rootBindingSource.SourceItem == otherBindingSource.SourceItem &&
+                                    rootBindingSource.SourcePropertyName == otherBindingSource.SourcePropertyName)
                                     continue;
 
                                 radioButton.UncheckRadioButton();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -4,6 +4,7 @@
 
 using System.Collections;
 using System.ComponentModel;
+using System.Runtime.InteropServices;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -69,10 +70,11 @@ namespace System.Windows.Controls
         {
             t_groupNameToElements ??= new Dictionary<string, List<WeakReference<RadioButton>>>(1);
 
-            if (!t_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
+            ref List<WeakReference<RadioButton>> elements = ref CollectionsMarshal.GetValueRefOrAddDefault(t_groupNameToElements, groupName, out bool exists);
+            if (!exists)
             {
+                // Create new collection
                 elements = new List<WeakReference<RadioButton>>(2);
-                t_groupNameToElements[groupName] = elements;
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -67,13 +67,13 @@ namespace System.Windows.Controls
 
         private static void Register(string groupName, RadioButton radioButton)
         {
-            _groupNameToElements ??= new Dictionary<string, ArrayList>(1);
+            _groupNameToElements ??= new Dictionary<string, List<WeakReference>>(1);
 
             lock (_groupNameToElements)
             {
-                if (!_groupNameToElements.TryGetValue(groupName, out ArrayList elements))
+                if (!_groupNameToElements.TryGetValue(groupName, out List<WeakReference> elements))
                 {
-                    elements = new ArrayList(1);
+                    elements = new List<WeakReference>(1);
                     _groupNameToElements[groupName] = elements;
                 }
                 else
@@ -95,7 +95,7 @@ namespace System.Windows.Controls
             lock (_groupNameToElements)
             {
                 // Get all elements bound to this key and remove this element
-                if (_groupNameToElements.TryGetValue(groupName, out ArrayList elements))
+                if (_groupNameToElements.TryGetValue(groupName, out List<WeakReference> elements))
                 {
                     PurgeDead(elements, radioButton);
                     if (elements.Count == 0)
@@ -107,11 +107,11 @@ namespace System.Windows.Controls
             _currentlyRegisteredGroupName.SetValue(radioButton, null);
         }
 
-        private static void PurgeDead(ArrayList elements, object elementToRemove)
+        private static void PurgeDead(List<WeakReference> elements, object elementToRemove)
         {
             for (int i = 0; i < elements.Count; )
             {
-                WeakReference weakReference = (WeakReference)elements[i];
+                WeakReference weakReference = elements[i];
                 object element = weakReference.Target;
                 if (element == null || element == elementToRemove)
                 {
@@ -131,16 +131,16 @@ namespace System.Windows.Controls
             {
                 Visual rootScope = KeyboardNavigation.GetVisualRoot(this);
 
-                _groupNameToElements ??= new Dictionary<string, ArrayList>(1);
+                _groupNameToElements ??= new Dictionary<string, List<WeakReference>>(1);
 
                 lock (_groupNameToElements)
                 {
                     // Get all elements bound to this key and remove this element
-                    ArrayList elements = _groupNameToElements[groupName];
+                    List<WeakReference> elements = _groupNameToElements[groupName];
                     // Haha, notice the unlikely but possible null-deref here
                     for (int i = 0; i < elements.Count; )
                     {
-                        WeakReference weakReference = (WeakReference)elements[i];
+                        WeakReference weakReference = elements[i];
                         RadioButton rb = weakReference.Target as RadioButton;
                         if (rb == null)
                         {
@@ -281,7 +281,7 @@ namespace System.Windows.Controls
         #region private data
 
         [ThreadStatic]
-        private static Dictionary<string, ArrayList> _groupNameToElements;
+        private static Dictionary<string, List<WeakReference>> _groupNameToElements;
 
         private static readonly UncommonField<string> _currentlyRegisteredGroupName = new UncommonField<string>();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -71,7 +71,7 @@ namespace System.Windows.Controls
 
             if (!_groupNameToElements.TryGetValue(groupName, out List<WeakReference<RadioButton>> elements))
             {
-                elements = new List<WeakReference<RadioButton>>(1);
+                elements = new List<WeakReference<RadioButton>>(2);
                 _groupNameToElements[groupName] = elements;
             }
             else


### PR DESCRIPTION
Fixes #9035
Fixes #2995

Marking it as draft right now due to the changes from #10251 being included. Only the latest commit is relevant.

## Description

This fixes actually two things, not just one and I'm fine with only fixing the #2995 / #9035 if desirable.

### First fix

First fix resolves #2995 / #9035 report that was also attempted in #8202 but was reverted in #10105 due to obvious issues.
Original method compares the visual root that's found using the following:
```csharp
DependencyObject rootScope = KeyboardNavigation.GetVisualRoot(this);
DependencyObject otherRoot = KeyboardNavigation.GetVisualRoot(radioButton);
```
The problem being that this search will result in `null` on Popups (hence why the original fix caused #10087), it will return `null` on radio buttons with closed Windows and depending on the focus situation it may return `null` on a fresh window.

Using `InputElement.GetRootVisual` instead we will retrieve the proper visual roots for Popups (PopupRoot), for open windows right after creation and for non-GCed `RadioButton`'s but detached from their visual root it will retrieve the container.

### Second fix/improvement
The original issue attempts to **share** a binding between two distincts visual roots using a singleton instance, which works until you have a hanging not-yet GCed `RadioButton` due to the reasons described in the first fix.

```csharp
BindingExpression rootBindingSource = GetBindingExpression(IsCheckedProperty);
BindingExpression otherBindingSource = radioButton.GetBindingExpression(IsCheckedProperty);
if (rootBindingSource is not null && otherBindingSource is not null &&
    rootBindingSource.SourceItem == otherBindingSource.SourceItem &&
    rootBindingSource.SourcePropertyName == otherBindingSource.SourcePropertyName)
    continue;
```

Excuse the checking verbosity, however,, this will allow for **shared** bindings (e.g. here - https://github.com/dotnet/wpf/issues/2995#issuecomment-628559516) to continue working properly even under the same visual root instead of just bound property being always false while retaining the usual **RadioButton** behavior and functionality. Updated with more stuff here [RadioButton.GroupName.Tests](https://github.com/h3xds1nz/RadioButton.GroupName.Tests), you'll have to update the `References`.

## Customer Impact

Resolving long standing issues concerning `RadioButton` and bindings.

## Regression

No.

## Testing

Local build, extensive testing with multiple reproduction samples.

## Risk

More testing is needed of course, but it would be a nice improvement to have this working. The second fix changes behavior, but changes it from non-working and appearing buggy to actually working nicely.
