### PR TITLE
Optimize conversion of KeyGesture from/to string, reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGesture.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGesture.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -287,9 +287,9 @@ namespace System.Windows.Input
         {
             // combine the gesture and the display string, producing a string
             // that the type converter will recognize
-            if (!String.IsNullOrEmpty(keyDisplayString))
+            if (!string.IsNullOrEmpty(keyDisplayString))
             {
-                keyGestureToken += KeyGestureConverter.DISPLAYSTRING_SEPARATOR + keyDisplayString;
+                keyGestureToken += DisplayStringSeparator + keyDisplayString;
             }
 
             return _keyGestureConverter.ConvertFromInvariantString(keyGestureToken) as KeyGesture;
@@ -307,6 +307,7 @@ namespace System.Windows.Input
         private Key            _key = Key.None;
         private string         _displayString;
         private const char MULTIPLEGESTURE_DELIMITER = ';';
+        private const char DisplayStringSeparator = ',';
         private static TypeConverter _keyGestureConverter = new KeyGestureConverter();
         //private static bool    _classRegistered = false;
 #endregion Private Fields

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -30,16 +30,8 @@ namespace System.Windows.Input
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
             // We can only handle string.
-            if (sourceType == typeof(string))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return sourceType == typeof(string);
         }
-
 
         ///<summary>
         ///TypeConverter method override.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
@@ -138,11 +138,10 @@ namespace System.Windows.Input
             // You will only get string.Empty from KeyConverter for Key.None and we've checked that above
             string strKey = (string)s_keyConverter.ConvertTo(context, culture, keyGesture.Key, destinationType);
 
-            // No modifiers, just binding (possibly with with display string)
+            // No modifiers, just binding (possibly with with display string) -> "F5,Refresh"
             if (keyGesture.Modifiers is ModifierKeys.None)
                 return string.IsNullOrEmpty(keyGesture.DisplayString) ? strKey : $"{strKey},{keyGesture.DisplayString}";
 
-            // Prepend modifiers
             ReadOnlySpan<char> modifierSpan = ModifierKeysConverter.ConvertMultipleModifiers(keyGesture.Modifiers, stackalloc char[22]);
 
             // Append display string if there's any, like "Ctrl+A,Description"

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
@@ -11,6 +11,11 @@ namespace System.Windows.Input
     /// </summary>
     public class KeyGestureConverter : TypeConverter
     {
+        /// <summary>
+        /// To aid with conversion from <see cref="Key"/> to <see cref="string"/>. 
+        /// </summary>
+        private static readonly KeyConverter s_keyConverter = new();
+
         ///<summary>
         ///CanConvertFrom()
         ///</summary>
@@ -117,7 +122,7 @@ namespace System.Windows.Input
                 return string.Empty;
 
             // You will only get string.Empty from KeyConverter for Key.None and we've checked that above
-            string strKey = (string)keyConverter.ConvertTo(context, culture, keyGesture.Key, destinationType);
+            string strKey = (string)s_keyConverter.ConvertTo(context, culture, keyGesture.Key, destinationType);
 
             // Prepend modifiers if there are any (TODO: ConvertMultipleModifiers is gonna crumble on no matching mods)
             ReadOnlySpan<char> modifierSpan = ModifierKeysConverter.ConvertMultipleModifiers(keyGesture.Modifiers, stackalloc char[22]);
@@ -144,9 +149,6 @@ namespace System.Windows.Input
         {
             return key >= Key.None && key <= Key.OemClear;
         }
-
-        private static KeyConverter keyConverter = new KeyConverter();
-
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
@@ -1,20 +1,13 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
-//
-//
-//
-// Description: KeyGestureConverter - Converts a KeyGesture string
-//              to the *Type* that the string represents
-//
 using System.ComponentModel;    // for TypeConverter
 using System.Globalization;     // for CultureInfo
 
 namespace System.Windows.Input
 {
     /// <summary>
-    /// KeyGesture - Converter class for converting between a string and the Type of a KeyGesture
+    /// Converter class for converting between a <see cref="string"/> and <see cref="KeyGesture"/>.
     /// </summary>
     public class KeyGestureConverter : TypeConverter
     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
@@ -16,24 +16,28 @@ namespace System.Windows.Input
         /// </summary>
         private static readonly KeyConverter s_keyConverter = new();
 
-        ///<summary>
-        ///CanConvertFrom()
-        ///</summary>
-        ///<param name="context">ITypeDescriptorContext</param>
-        ///<param name="sourceType">type to convert from</param>
-        ///<returns>true if the given type can be converted, false otherwise</returns>
+        /// <summary>
+        /// Returns whether or not this class can convert from a given <paramref name="sourceType"/>.
+        /// </summary>
+        /// <param name="context">The <see cref="ITypeDescriptorContext"/> for this call.</param>
+        /// <param name="sourceType">The <see cref="Type"/> being queried for support.</param>
+        /// <returns>
+        /// <see langword="true"/> if the given <paramref name="sourceType"/> can be converted, <see langword="false"/> otherwise.
+        /// </returns>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
             // We can only handle string.
             return sourceType == typeof(string);
         }
 
-        ///<summary>
-        ///TypeConverter method override.
-        ///</summary>
-        ///<param name="context">ITypeDescriptorContext</param>
-        ///<param name="destinationType">Type to convert to</param>
-        ///<returns>true if conversion	is possible</returns>
+        /// <summary>
+        /// Returns whether or not this class can convert to a given <paramref name="destinationType"/>.
+        /// </summary>
+        /// <param name="context">The <see cref="ITypeDescriptorContext"/> for this call.</param>
+        /// <param name="destinationType">The <see cref="Type"/> being queried for support.</param>
+        /// <returns>
+        /// <see langword="true"/> if this class can convert to <paramref name="destinationType"/>, <see langword="false"/> otherwise.
+        /// </returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
             // We can convert to an InstanceDescriptor or to a string.
@@ -48,12 +52,15 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// ConvertFrom()
+        /// Converts <paramref name="source"/> of <see cref="string"/> type to its <see cref="KeyGesture"/> represensation.
         /// </summary>
-        /// <param name="context"></param>
-        /// <param name="culture"></param>
-        /// <param name="source"></param>
-        /// <returns></returns>
+        /// <param name="context">This parameter is ignored during the call.</param>
+        /// <param name="culture">This parameter is ignored during the call.</param>
+        /// <param name="source">The object to convert to a <see cref="KeyGesture"/>.</param>
+        /// <returns>
+        /// A new instance of <see cref="KeyGesture"/> class representing the data contained in <paramref name="source"/>.
+        /// </returns>
+        /// <exception cref="NotSupportedException">Thrown in case the <paramref name="source"/> was not a <see cref="string"/>.</exception>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object source)
         {
             if (source is not string sourceString)
@@ -96,13 +103,20 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// ConvertTo()
+        /// Attempt to convert a <see cref="KeyGesture"/> class to the <paramref name="destinationType"/>.
         /// </summary>
-        /// <param name="context"></param>
-        /// <param name="culture"></param>
-        /// <param name="value"></param>
-        /// <param name="destinationType"></param>
-        /// <returns></returns>
+        /// <param name="context">This parameter is ignored during the call.</param>
+        /// <param name="culture">This parameter is ignored during the call.</param>
+        /// <param name="value">The object to convert to a <paramref name="destinationType"/>.</param>
+        /// <param name="destinationType">The <see cref="Type"/> to convert <paramref name="value"/> to.</param>
+        /// <returns>
+        /// The <paramref name="value"/> formatted to its <see cref="string"/> representation.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown in case <paramref name="destinationType"/> was <see langword="null"/>.</exception>
+        /// <exception cref="NotSupportedException">
+        /// Thrown in case the <paramref name="destinationType"/> was not a <see cref="string"/>
+        /// or <paramref name="value"/> was not a <see cref="KeyGesture"/>.
+        /// </exception>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
             ArgumentNullException.ThrowIfNull(destinationType);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
@@ -42,20 +42,14 @@ namespace System.Windows.Input
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
             // We can convert to an InstanceDescriptor or to a string.
-            if (destinationType == typeof(string))
-            {
-                // When invoked by the serialization engine we can convert to string only for known type
-                if (context != null && context.Instance != null)
-                {
-                    KeyGesture keyGesture = context.Instance as KeyGesture;
-                    if (keyGesture != null)
-                    {
-                        return (ModifierKeysConverter.IsDefinedModifierKeys(keyGesture.Modifiers)
-                                && IsDefinedKey(keyGesture.Key));
-                    }
-                }
-            }
-            return false;
+            if (destinationType != typeof(string))
+                return false;
+
+            // When invoked by the serialization engine we can convert to string only for known type
+            if (context?.Instance is not KeyGesture keyGesture)
+                return false;
+
+            return ModifierKeysConverter.IsDefinedModifierKeys(keyGesture.Modifiers) && IsDefinedKey(keyGesture.Key);
         }
 
         /// <summary>
@@ -166,10 +160,14 @@ namespace System.Windows.Input
             throw GetConvertToException(value,destinationType);
         }
 
-        // Check for Valid enum, as any int can be casted to the enum.
+        /// <summary>
+        /// Helper function similar to <see cref="Enum.IsDefined{Key}(Key)"/>, just lighter and faster.
+        /// </summary>
+        /// <param name="key">The value to test against.</param>
+        /// <returns><see langword="true"/> if <paramref name="key"/> falls in enumeration range, <see langword="false"/> otherwise.</returns>
         internal static bool IsDefinedKey(Key key)
         {
-            return (key >= Key.None && key <= Key.OemClear);
+            return key >= Key.None && key <= Key.OemClear;
         }
 
         private static KeyConverter keyConverter = new KeyConverter();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGestureConverter.cs
@@ -138,13 +138,12 @@ namespace System.Windows.Input
             // You will only get string.Empty from KeyConverter for Key.None and we've checked that above
             string strKey = (string)s_keyConverter.ConvertTo(context, culture, keyGesture.Key, destinationType);
 
-            // Prepend modifiers if there are any (TODO: ConvertMultipleModifiers is gonna crumble on no matching mods)
-            ReadOnlySpan<char> modifierSpan = ModifierKeysConverter.ConvertMultipleModifiers(keyGesture.Modifiers, stackalloc char[22]);
-            if (modifierSpan.IsEmpty)
-            {
-                // No modifiers, just binding (possibly with with display string)
+            // No modifiers, just binding (possibly with with display string)
+            if (keyGesture.Modifiers is ModifierKeys.None)
                 return string.IsNullOrEmpty(keyGesture.DisplayString) ? strKey : $"{strKey},{keyGesture.DisplayString}";
-            }
+
+            // Prepend modifiers
+            ReadOnlySpan<char> modifierSpan = ModifierKeysConverter.ConvertMultipleModifiers(keyGesture.Modifiers, stackalloc char[22]);
 
             // Append display string if there's any, like "Ctrl+A,Description"
             if (!string.IsNullOrEmpty(keyGesture.DisplayString))

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -101,7 +101,7 @@ namespace System.Windows.Input
         /// </summary>
         /// <param name="keyToken">The string to convert from.</param>
         /// <returns>A <see cref="Key"/> value corresponding to the specified string, <see cref="Key.None"/> if <paramref name="keyToken"/> was empty.</returns>
-        private static Key GetKeyFromString(ReadOnlySpan<char> keyToken)
+        internal static Key GetKeyFromString(ReadOnlySpan<char> keyToken)
         {
             // If the token is empty, we presume "None" as our value but it is a success
             if (keyToken.IsEmpty)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -8,12 +8,12 @@ using System.Globalization;     // for CultureInfo
 namespace System.Windows.Input
 {
     /// <summary>
-    /// Converter class for converting between a <see langword="string"/> and <see cref="Key"/>.
+    /// Converter class for converting between a <see cref="string"/> and <see cref="Key"/>.
     /// </summary>
     public class KeyConverter : TypeConverter
     {
         ///<summary>
-        /// Used to check whether we can convert a <see langword="string"/> into a <see cref="Key"/>.
+        /// Used to check whether we can convert a <see cref="string"/> into a <see cref="Key"/>.
         ///</summary>
         ///<param name="context">ITypeDescriptorContext</param>
         ///<param name="sourceType">type to convert from</param>
@@ -25,11 +25,11 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// Used to check whether we can convert specified value to <see langword="string"/>.
+        /// Used to check whether we can convert specified value to <see cref="string"/>.
         /// </summary>
         /// <param name="context">ITypeDescriptorContext</param>
         /// <param name="destinationType">Type to convert to</param>
-        /// <returns><see langword="true"/> if conversion to <see langword="string"/> is possible, <see langword="false"/> otherwise.</returns>
+        /// <returns><see langword="true"/> if conversion to <see cref="string"/> is possible, <see langword="false"/> otherwise.</returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
             // We can convert to a string
@@ -44,12 +44,12 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// Converts <paramref name="source"/> of <see langword="string"/> type to its <see cref="Key"/> representation.
+        /// Converts <paramref name="source"/> of <see cref="string"/> type to its <see cref="Key"/> representation.
         /// </summary>
         /// <param name="context">Parser Context</param>
         /// <param name="culture">Culture Info</param>
         /// <param name="source">Key String</param>
-        /// <returns>A <see cref="Key"/> representing the <see langword="string"/> specified by <paramref name="source"/>.</returns>
+        /// <returns>A <see cref="Key"/> representing the <see cref="string"/> specified by <paramref name="source"/>.</returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object source)
         {
             if (source is not string stringSource)
@@ -60,13 +60,13 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// Converts a <paramref name="value"/> of <see cref="Key"/> type to its <see langword="string"/> representation.
+        /// Converts a <paramref name="value"/> of <see cref="Key"/> type to its <see cref="string"/> representation.
         /// </summary>
         /// <param name="context">Serialization Context</param>
         /// <param name="culture">Culture Info</param>
         /// <param name="value">Key value </param>
         /// <param name="destinationType">Type to Convert</param>
-        /// <returns>A <see langword="string"/> representing the <see cref="Key"/> specified by <paramref name="value"/>.</returns>
+        /// <returns>A <see cref="string"/> representing the <see cref="Key"/> specified by <paramref name="value"/>.</returns>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
             ArgumentNullException.ThrowIfNull(destinationType);
@@ -100,7 +100,9 @@ namespace System.Windows.Input
         /// Helper function that performs the conversion of <paramref name="keyToken"/> to the <see cref="Key"/> enum.
         /// </summary>
         /// <param name="keyToken">The string to convert from.</param>
-        /// <returns>A <see cref="Key"/> value corresponding to the specified string, <see cref="Key.None"/> if <paramref name="keyToken"/> was empty.</returns>
+        /// <returns>
+        /// A <see cref="Key"/> value corresponding to the specified string, <see cref="Key.None"/> if <paramref name="keyToken"/> was empty.
+        /// </returns>
         internal static Key GetKeyFromString(ReadOnlySpan<char> keyToken)
         {
             // If the token is empty, we presume "None" as our value but it is a success

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
@@ -58,6 +58,18 @@ namespace System.Windows.Input
 
             ReadOnlySpan<char> modifiersToken = stringSource.AsSpan().Trim();
 
+            return ConvertFromImpl(modifiersToken);
+        }
+
+        /// <summary>
+        /// Converts <paramref name="modifiersToken"/> to its <see cref="ModifierKeys"/> represensation.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="modifiersToken"/> is expected to have <see cref="ModifierKeys"/> separated with '+', with any amount of whitespace.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ModifierKeys ConvertFromImpl(ReadOnlySpan<char> modifiersToken)
+        {
             // Empty token means there were no modifiers, exit early
             if (modifiersToken.IsEmpty)
                 return ModifierKeys.None;


### PR DESCRIPTION
## Description

Parsing optimization for `KeyGesture` and its conversion from/to string. Also adds documentation for whole class.

Including both .NET 9/main vs PR benchmarks, to show improvements in #9683 / #9697 / #9683 in perspective.

### ConvertFrom Benchmarks (.NET 9 vs PR)

| Method   |Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 299.15 ns |   4.620 ns |    4.322 ns | 0.0439 |          93 B |         736 B |
| PR__EDIT |  57.63 ns |   0.533 ns |    0.499 ns | 0.0062 |          93 B |         104 B |
| Original | 193.40 ns |   2.449 ns |    2.171 ns | 0.0157 |          93 B |         264 B |
| PR__EDIT |   30.03 ns |   0.635 ns |    0.679 ns | 0.0062 |          93 B |         104 B |
| Original | 147.75 ns |   1.653 ns |    1.546 ns | 0.0091 |          93 B |         152 B |
| PR__EDIT | 20.74 ns |   0.122 ns |    0.114 ns | 0.0019 |          93 B |          32 B |

### ConvertFrom Benchmarks (main vs PR)
| Method   |Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |   106.77 ns |   2.063 ns |    2.755 ns |          93 B | 0.0257 |         432 B |
| PR__EDIT |   57.50 ns |   0.813 ns |    0.721 ns |          93 B | 0.0062 |         104 B |
| Original |   50.17 ns |   0.870 ns |    0.814 ns |          93 B | 0.0124 |         208 B |
| PR__EDIT |  30.08 ns |   0.610 ns |    0.571 ns |          93 B | 0.0062 |         104 B |
| Original |  32.98 ns |   0.514 ns |    0.456 ns | 0.0057 |          93 B |          96 B |
| PR__EDIT | 20.94 ns |   0.170 ns |    0.151 ns | 0.0019 |          93 B |          32 B |

```csharp
[Arguments(" Ctrl + Shift + F10, This is a Test Gesture ")]
[Arguments("Ctrl+F10,This is a Test Gesture")]
[Arguments("Ctrl+F10")]
public KeyGesture Original(object source)
{
    return (KeyGesture)keyGestureConverter.ConvertFrom(null, null, source);
}
```

### ConvertTo (.NET 9 vs PR) Benchmarks

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |   66.92 ns |   1.322 ns |    1.522 ns | 0.0210 |         107 B |         352 B |
| PR__EDIT |   32.34 ns |   0.671 ns |    0.628 ns | 0.0072 |         107 B |         120 B |
| Original |  35.69 ns |   0.745 ns |    0.887 ns | 0.0091 |         107 B |         152 B |
| PR__EDIT |   15.97 ns |   0.359 ns |    0.428 ns | 0.0062 |         107 B |         104 B |
| Original |   35.27 ns |   0.698 ns |    0.618 ns | 0.0086 |         107 B |         144 B |
| PR__EDIT |  21.76 ns |   0.290 ns |    0.257 ns | 0.0038 |         107 B |          64 B |
| Original |  22.17 ns |  0.359 ns |   0.318 ns | 0.0043 |         107 B |          72 B |
| PR__EDIT |  7.71 ns |  0.140 ns |   0.131 ns | 0.0014 |         107 B |          24 B |

### ConvertTo (main vs PR) Benchmarks
| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  44.108 ns |  0.9124 ns |   1.5738 ns | 0.0176 |         107 B |         296 B |
| PR__EDIT |  32.482 ns |  0.7140 ns |   0.7333 ns | 0.0072 |         107 B |         120 B |
| Original |  20.743 ns |  0.4282 ns |   0.3796 ns | 0.0076 |         107 B |         128 B |
| PR__EDIT | 16.058 ns |  0.3185 ns |   0.2823 ns | 0.0062 |         107 B |         104 B |
| Original | 24.343 ns |  0.5292 ns |   0.6094 ns | 0.0072 |         107 B |         120 B |
| PR__EDIT |  22.066 ns |  0.2735 ns |   0.2558 ns | 0.0038 |         107 B |          64 B |
| Original |  12.664 ns |  0.1591 ns |   0.1329 ns | 0.0029 |         107 B |          48 B |
| PR__EDIT |  7.950 ns |  0.1524 ns |   0.1426 ns | 0.0014 |         107 B |          24 B |

```csharp
yield return new KeyGesture(Key.F10, ModifierKeys.Control | ModifierKeys.Shift, "This is a Test Gesture");
yield return new KeyGesture(Key.F10, ModifierKeys.None, "This is a Test Gesture");
yield return new KeyGesture(Key.F10, ModifierKeys.Control);
yield return new KeyGesture(Key.F10, ModifierKeys.None);

public KeyGesture Original(object source)
{
    return (string)keyGestureConverter.ConvertTo(null, null, source, typeof(string));
}
```



## Customer Impact

Increased performance, decreased allocations, less static memory.

## Regression

No.

## Testing

Local build, backed with #10259.

## Risk

Low, changes have been tested extensively.
