### PR TITLE
Optimize conversion of MouseGesture from/to string, reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseActionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseActionConverter.cs
@@ -8,12 +8,12 @@ using System.Globalization;
 namespace System.Windows.Input
 {
     /// <summary>
-    /// Converter class for converting between a <see langword="string"/> and <see cref="MouseAction"/>.
+    /// Converter class for converting between a <see cref="string"/> and <see cref="MouseAction"/>.
     /// </summary>
     public class MouseActionConverter : TypeConverter
     {
         ///<summary>
-        /// Used to check whether we can convert a <see langword="string"/> into a <see cref="MouseAction"/>.
+        /// Used to check whether we can convert a <see cref="string"/> into a <see cref="MouseAction"/>.
         ///</summary>
         ///<param name="context">ITypeDescriptorContext</param>
         ///<param name="sourceType">type to convert from</param>
@@ -25,11 +25,11 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// Used to check whether we can convert specified value to <see langword="string"/>.
+        /// Used to check whether we can convert specified value to <see cref="string"/>.
         /// </summary>
         /// <param name="context">ITypeDescriptorContext</param>
         /// <param name="destinationType">Type to convert to</param>
-        /// <returns><see langword="true"/> if conversion to <see langword="string"/> is possible, <see langword="false"/> otherwise.</returns>
+        /// <returns><see langword="true"/> if conversion to <see cref="string"/> is possible, <see langword="false"/> otherwise.</returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
             // We can convert to an InstanceDescriptor or to a string
@@ -45,12 +45,12 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// Converts <paramref name="source"/> of <see langword="string"/> type to its <see cref="MouseAction"/> represensation.
+        /// Converts <paramref name="source"/> of <see cref="string"/> type to its <see cref="MouseAction"/> represensation.
         /// </summary>
         /// <param name="context">Parser Context</param>
         /// <param name="culture">Culture Info</param>
         /// <param name="source">MouseAction String</param>
-        /// <returns>A <see cref="MouseAction"/> representing the <see langword="string"/> specified by <paramref name="source"/>.</returns>
+        /// <returns>A <see cref="MouseAction"/> representing the <see cref="string"/> specified by <paramref name="source"/>.</returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object source)
         {
             if (source is not string mouseAction)
@@ -80,13 +80,13 @@ namespace System.Windows.Input
         };
 
         /// <summary>
-        /// Converts a <paramref name="value"/> of <see cref="MouseAction"/> to its <see langword="string"/> represensation.
+        /// Converts a <paramref name="value"/> of <see cref="MouseAction"/> to its <see cref="string"/> represensation.
         /// </summary>
         /// <param name="context">Serialization Context</param>
         /// <param name="culture">Culture Info</param>
         /// <param name="value">MouseAction value </param>
         /// <param name="destinationType">Type to Convert</param>
-        /// <returns>A <see langword="string"/> representing the <see cref="MouseAction"/> specified by <paramref name="value"/>.</returns>
+        /// <returns>A <see cref="string"/> representing the <see cref="MouseAction"/> specified by <paramref name="value"/>.</returns>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
             ArgumentNullException.ThrowIfNull(destinationType);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseActionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseActionConverter.cs
@@ -1,7 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
 using System.ComponentModel;
 using System.Globalization;
 
@@ -57,20 +57,27 @@ namespace System.Windows.Input
                 throw GetConvertFromException(source);
 
             ReadOnlySpan<char> mouseActionToken = mouseAction.AsSpan().Trim();
-            return mouseActionToken switch
-            {
-                _ when mouseActionToken.IsEmpty => MouseAction.None, // Special casing as produced by "ConvertTo"
-                _ when mouseActionToken.Equals("None", StringComparison.OrdinalIgnoreCase) => MouseAction.None,
-                _ when mouseActionToken.Equals("LeftClick", StringComparison.OrdinalIgnoreCase) => MouseAction.LeftClick,
-                _ when mouseActionToken.Equals("RightClick", StringComparison.OrdinalIgnoreCase) => MouseAction.RightClick,
-                _ when mouseActionToken.Equals("MiddleClick", StringComparison.OrdinalIgnoreCase) => MouseAction.MiddleClick,
-                _ when mouseActionToken.Equals("WheelClick", StringComparison.OrdinalIgnoreCase) => MouseAction.WheelClick,
-                _ when mouseActionToken.Equals("LeftDoubleClick", StringComparison.OrdinalIgnoreCase) => MouseAction.LeftDoubleClick,
-                _ when mouseActionToken.Equals("RightDoubleClick", StringComparison.OrdinalIgnoreCase) => MouseAction.RightDoubleClick,
-                _ when mouseActionToken.Equals("MiddleDoubleClick", StringComparison.OrdinalIgnoreCase) => MouseAction.MiddleDoubleClick,
-                _ => throw new NotSupportedException(SR.Format(SR.Unsupported_MouseAction, mouseActionToken.ToString()))
-            };
+
+            return ConvertFromImpl(mouseActionToken);
         }
+
+        /// <summary>
+        /// Converts <paramref name="mouseActionToken"/> to its <see cref="MouseAction"/> represensation.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static MouseAction ConvertFromImpl(ReadOnlySpan<char> mouseActionToken) => mouseActionToken switch
+        {
+            _ when mouseActionToken.IsEmpty => MouseAction.None, // Special casing as produced by "ConvertTo"
+            _ when mouseActionToken.Equals("None", StringComparison.OrdinalIgnoreCase) => MouseAction.None,
+            _ when mouseActionToken.Equals("LeftClick", StringComparison.OrdinalIgnoreCase) => MouseAction.LeftClick,
+            _ when mouseActionToken.Equals("RightClick", StringComparison.OrdinalIgnoreCase) => MouseAction.RightClick,
+            _ when mouseActionToken.Equals("MiddleClick", StringComparison.OrdinalIgnoreCase) => MouseAction.MiddleClick,
+            _ when mouseActionToken.Equals("WheelClick", StringComparison.OrdinalIgnoreCase) => MouseAction.WheelClick,
+            _ when mouseActionToken.Equals("LeftDoubleClick", StringComparison.OrdinalIgnoreCase) => MouseAction.LeftDoubleClick,
+            _ when mouseActionToken.Equals("RightDoubleClick", StringComparison.OrdinalIgnoreCase) => MouseAction.RightDoubleClick,
+            _ when mouseActionToken.Equals("MiddleDoubleClick", StringComparison.OrdinalIgnoreCase) => MouseAction.MiddleDoubleClick,
+            _ => throw new NotSupportedException(SR.Format(SR.Unsupported_MouseAction, mouseActionToken.ToString()))
+        };
 
         /// <summary>
         /// Converts a <paramref name="value"/> of <see cref="MouseAction"/> to its <see langword="string"/> represensation.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGesture.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGesture.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -53,13 +53,13 @@ namespace System.Windows.Input
         /// </summary>
         /// <param name="mouseAction">Mouse Action</param>
         /// <param name="modifiers">Modifiers</param>
-        public MouseGesture( MouseAction mouseAction,ModifierKeys modifiers)   // acclerator action
+        public MouseGesture(MouseAction mouseAction, ModifierKeys modifiers)   // acclerator action
         {
-            if (!MouseGesture.IsDefinedMouseAction(mouseAction))
-                throw new InvalidEnumArgumentException("mouseAction", (int)mouseAction, typeof(MouseAction));
+            if (!MouseActionConverter.IsDefinedMouseAction(mouseAction))
+                throw new InvalidEnumArgumentException(nameof(mouseAction), (int)mouseAction, typeof(MouseAction));
 
             if (!ModifierKeysConverter.IsDefinedModifierKeys(modifiers))
-                throw new InvalidEnumArgumentException("modifiers", (int)modifiers, typeof(ModifierKeys));
+                throw new InvalidEnumArgumentException(nameof(modifiers), (int)modifiers, typeof(ModifierKeys));
 
             _modifiers = modifiers;
             _mouseAction = mouseAction;
@@ -86,12 +86,13 @@ namespace System.Windows.Input
             }
             set 
             {
-                if (!MouseGesture.IsDefinedMouseAction((MouseAction)value))
-                    throw new InvalidEnumArgumentException("value", (int)value, typeof(MouseAction));
+                if (!MouseActionConverter.IsDefinedMouseAction(value))
+                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(MouseAction));
+
                 if (_mouseAction != value)
                 {
-                    _mouseAction = (MouseAction)value;
-                    OnPropertyChanged("MouseAction");
+                    _mouseAction = value;
+                    OnPropertyChanged(nameof(MouseAction));
                 }
             }
         }
@@ -107,13 +108,13 @@ namespace System.Windows.Input
             }
             set 
             {
-                if (!ModifierKeysConverter.IsDefinedModifierKeys((ModifierKeys)value))
-                    throw new InvalidEnumArgumentException("value", (int)value, typeof(ModifierKeys));
+                if (!ModifierKeysConverter.IsDefinedModifierKeys(value))
+                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ModifierKeys));
 
                 if (_modifiers != value)
                 {
-                    _modifiers = (ModifierKeys)value;
-                    OnPropertyChanged("Modifiers");
+                    _modifiers = value;
+                    OnPropertyChanged(nameof(Modifiers));
                 }
             }
         }
@@ -135,12 +136,6 @@ namespace System.Windows.Input
             return false;
         }
 
-
-        // Helper like Enum.IsDefined,  for MouseAction.
-        internal static bool IsDefinedMouseAction(MouseAction mouseAction)
-        {
-            return (mouseAction >= MouseAction.None && mouseAction <= MouseAction.MiddleDoubleClick);
-        }
 #endregion Public Methods
 
         #region Internal NotifyProperty changed

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGestureConverter.cs
@@ -1,14 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-//
-//
-//
-// Description: MouseGestureConverter - Converts a MouseGesture string 
-//              to the *Type* that the string represents 
-//
-//
 
 using System.ComponentModel;    // for TypeConverter
 using System.Globalization;     // for CultureInfo
@@ -16,7 +7,7 @@ using System.Globalization;     // for CultureInfo
 namespace System.Windows.Input
 {
     /// <summary>
-    /// MouseGesture - Converter class for converting between a string and the Type of a MouseGesture
+    /// Converter class for converting between a <see cref="string"/> and <see cref="MouseGesture"/>.
     /// </summary>
     public class MouseGestureConverter : TypeConverter
     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGestureConverter.cs
@@ -72,8 +72,8 @@ namespace System.Windows.Input
             int index = trimmedSource.LastIndexOf('+');
             if (index >= 0)
             {
-                ReadOnlySpan<char> mouseActionToken = trimmedSource.Slice(index + 1).TrimStart();
-                ReadOnlySpan<char> modifiersToken = trimmedSource.Slice(0, index).TrimEnd();
+                ReadOnlySpan<char> mouseActionToken = trimmedSource.Slice(index + 1).Trim();
+                ReadOnlySpan<char> modifiersToken = trimmedSource.Slice(0, index).Trim();
 
                 return new MouseGesture(MouseActionConverter.ConvertFromImpl(mouseActionToken), ModifierKeysConverter.ConvertFromImpl(modifiersToken));
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGestureConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -31,14 +31,7 @@ namespace System.Windows.Input
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
             // We can only handle string.
-            if (sourceType == typeof(string))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return sourceType == typeof(string);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGestureConverter.cs
@@ -34,6 +34,26 @@ namespace System.Windows.Input
             return sourceType == typeof(string);
         }
 
+        ///<summary>
+        ///TypeConverter method override. 
+        ///</summary>
+        ///<param name="context">ITypeDescriptorContext</param>
+        ///<param name="destinationType">Type to convert to</param>
+        ///<returns>true if conversion is possible</returns>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            // We can convert to an InstanceDescriptor or to a string.
+            if (destinationType != typeof(string))
+                return false;
+
+            // When invoked by the serialization engine we can convert to string only for known type
+            if (context?.Instance is not MouseGesture mouseGesture)
+                return false;
+
+            return ModifierKeysConverter.IsDefinedModifierKeys(mouseGesture.Modifiers) &&
+                   MouseActionConverter.IsDefinedMouseAction(mouseGesture.MouseAction);
+        }
+
         /// <summary>
         /// ConvertFrom
         /// </summary>
@@ -95,31 +115,6 @@ namespace System.Windows.Input
                 }
             }
             throw GetConvertFromException(source);
-        }
-
-        ///<summary>
-        ///TypeConverter method override. 
-        ///</summary>
-        ///<param name="context">ITypeDescriptorContext</param>
-        ///<param name="destinationType">Type to convert to</param>
-        ///<returns>true if conversion is possible</returns>
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-        {
-            // We can convert to an InstanceDescriptor or to a string.
-            if (destinationType == typeof(string))
-            {
-                // When invoked by the serialization engine we can convert to string only for known type
-                if (context != null && context.Instance != null)
-                {
-                    MouseGesture mouseGesture = context.Instance as MouseGesture;
-                    if (mouseGesture != null)
-                    {
-                        return (ModifierKeysConverter.IsDefinedModifierKeys(mouseGesture.Modifiers) 
-                               && MouseActionConverter.IsDefinedMouseAction(mouseGesture.MouseAction));
-                    }
-                 }
-            }
-            return false;
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGestureConverter.cs
@@ -16,24 +16,28 @@ namespace System.Windows.Input
         /// </summary>
         private static readonly MouseActionConverter s_mouseActionConverter = new();
 
-        ///<summary>
-        /// CanConvertFrom()
-        ///</summary>
-        ///<param name="context">ITypeDescriptorContext</param>
-        ///<param name="sourceType">type to convert from</param>
-        ///<returns>true if the given type can be converted, false otherwise</returns>
+        /// <summary>
+        /// Returns whether or not this class can convert from a given <paramref name="sourceType"/>.
+        /// </summary>
+        /// <param name="context">The <see cref="ITypeDescriptorContext"/> for this call.</param>
+        /// <param name="sourceType">The <see cref="Type"/> being queried for support.</param>
+        /// <returns>
+        /// <see langword="true"/> if the given <paramref name="sourceType"/> can be converted, <see langword="false"/> otherwise.
+        /// </returns>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
             // We can only handle string.
             return sourceType == typeof(string);
         }
 
-        ///<summary>
-        ///TypeConverter method override. 
-        ///</summary>
-        ///<param name="context">ITypeDescriptorContext</param>
-        ///<param name="destinationType">Type to convert to</param>
-        ///<returns>true if conversion is possible</returns>
+        /// <summary>
+        /// Returns whether or not this class can convert to a given <paramref name="destinationType"/>.
+        /// </summary>
+        /// <param name="context">The <see cref="ITypeDescriptorContext"/> for this call.</param>
+        /// <param name="destinationType">The <see cref="Type"/> being queried for support.</param>
+        /// <returns>
+        /// <see langword="true"/> if this class can convert to <paramref name="destinationType"/>, <see langword="false"/> otherwise.
+        /// </returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
             // We can convert to an InstanceDescriptor or to a string.
@@ -49,12 +53,15 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// ConvertFrom
+        /// Converts <paramref name="source"/> of <see cref="string"/> type to its <see cref="MouseGesture"/> represensation.
         /// </summary>
-        /// <param name="context">Parser Context</param>
-        /// <param name="culture">Culture Info</param>
-        /// <param name="source">MouseGesture String</param>
-        /// <returns></returns>
+        /// <param name="context">This parameter is ignored during the call.</param>
+        /// <param name="culture">This parameter is ignored during the call.</param>
+        /// <param name="source">The object to convert to a <see cref="MouseGesture"/>.</param>
+        /// <returns>
+        /// A new instance of <see cref="MouseGesture"/> class representing the data contained in <paramref name="source"/>.
+        /// </returns>
+        /// <exception cref="NotSupportedException">Thrown in case the <paramref name="source"/> was not a <see cref="string"/>.</exception>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object source)
         {
             if (source is not string sourceString)
@@ -76,13 +83,20 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// ConvertTo()
+        /// Attempts to convert a <see cref="MouseGesture"/> object to the <paramref name="destinationType"/>.
         /// </summary>
-        /// <param name="context">Serialization Context</param>
-        /// <param name="culture">Culture Info</param>
-        /// <param name="value">MouseGesture value </param>
-        /// <param name="destinationType">Type to Convert</param>
-        /// <returns>string if parameter is a MouseGesture</returns>
+        /// <param name="context">This parameter is ignored during the call.</param>
+        /// <param name="culture">This parameter is ignored during the call.</param>
+        /// <param name="value">The object to convert to a <paramref name="destinationType"/>.</param>
+        /// <param name="destinationType">The <see cref="Type"/> to convert <paramref name="value"/> to.</param>
+        /// <returns>
+        /// The <paramref name="value"/> formatted to its <see cref="string"/> representation.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown in case <paramref name="destinationType"/> was <see langword="null"/>.</exception>
+        /// <exception cref="NotSupportedException">
+        /// Thrown in case the <paramref name="destinationType"/> was not a <see cref="string"/>
+        /// or <paramref name="value"/> was not a <see cref="MouseGesture"/>.
+        /// </exception>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
             ArgumentNullException.ThrowIfNull(destinationType);
@@ -99,6 +113,7 @@ namespace System.Windows.Input
 
             string mouseAction = (string)s_mouseActionConverter.ConvertTo(context, culture, mouseGesture.MouseAction, destinationType);
 
+            // This returns the converted MouseAction only
             if (mouseGesture.Modifiers is ModifierKeys.None)
                 return mouseAction;
 
@@ -109,5 +124,3 @@ namespace System.Windows.Input
         }
     }
 }
-
-

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
@@ -58,6 +58,18 @@ namespace System.Windows.Input
 
             ReadOnlySpan<char> modifiersToken = stringSource.AsSpan().Trim();
 
+            return ConvertFromImpl(modifiersToken);
+        }
+
+        /// <summary>
+        /// Converts <paramref name="modifiersToken"/> to its <see cref="ModifierKeys"/> represensation.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="modifiersToken"/> is expected to have <see cref="ModifierKeys"/> separated with '+', with any amount of whitespace.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ModifierKeys ConvertFromImpl(ReadOnlySpan<char> modifiersToken)
+        {
             // Empty token means there were no modifiers, exit early
             if (modifiersToken.IsEmpty)
                 return ModifierKeys.None;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -135,10 +135,32 @@ namespace System.Windows.Input
             };
         }
 
-        private static string ConvertMultipleModifiers(ModifierKeys modifiers)
+        /// <summary>
+        /// This is a proxy function for <see cref="ConvertMultipleModifiers(ModifierKeys, Span{char})"/>
+        /// so we do not initialize a stack-allocated buffer when we do not need to.
+        /// </summary>
+        /// <param name="modifiers">The modifiers bits to format.</param>
+        /// <returns>Formatted <paramref name="modifiers"/> in [modifier_1]+[modifier_2] format.</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string ConvertMultipleModifiers(ModifierKeys modifiers)
+        {
+            return new string(ConvertMultipleModifiers(modifiers, stackalloc char[22]));
+        }
+
+        /// <summary>
+        /// Format multiple <paramref name="modifiers"/> into <paramref name="modifierSpan"/>-provided buffer.
+        /// </summary>
+        /// <param name="modifiers">The modifiers bits to format.</param>
+        /// <param name="modifierSpan">The buffer to write formatted modifiers into.</param>
+        /// <returns>Formatted <paramref name="modifiers"/> in [modifier_1]+[modifier_2] format.</returns>
+        /// <remarks>
+        /// Make sure the <paramref name="modifierSpan"/> is at least 22 chars long, otherwise conversion might fail.
+        /// </remarks>
+        internal static ReadOnlySpan<char> ConvertMultipleModifiers(ModifierKeys modifiers, Span<char> modifierSpan)
         {
             // Ctrl+Alt+Windows+Shift is the maximum char length, though the composition of such value is improbable
-            Span<char> modifierSpan = stackalloc char[22];
+            Debug.Assert(modifierSpan.Length > 21);
+
             int totalLength = 0;
 
             if (modifiers.HasFlag(ModifierKeys.Control))
@@ -153,14 +175,14 @@ namespace System.Windows.Input
             if (modifiers.HasFlag(ModifierKeys.Shift))
                 AppendWithDelimiter("Shift", ref totalLength, ref modifierSpan);
 
-            //Helper function to concatenate modifiers
+            // Helper function to concatenate modifiers
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static void AppendWithDelimiter(string literal, ref int totalLength, ref Span<char> modifierSpan)
             {
                 // If this is not the first modifier in the span, we prepend a delimiter (e.g. Ctrl -> Ctrl+Alt)
                 if (totalLength > 0)
                 {
-                    "+".CopyTo(modifierSpan.Slice(totalLength));
+                    modifierSpan[totalLength] = '+';
                     totalLength++;
                 }
 
@@ -168,7 +190,7 @@ namespace System.Windows.Input
                 totalLength += literal.Length;
             }
 
-            return new string(modifierSpan.Slice(0, totalLength));
+            return modifierSpan.Slice(0, totalLength);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Parsing optimization for `MouseGesture` and its conversion from/to string. Also adds documentation for whole class.
I've additionally removed the duplicated functionality in `MouseGesture` to check for `MouseAction` validity.

### ConvertFrom Benchmarks

| Method   | source               | Mean [ns]  | Error [ns] | StdDev [ns] | Gen0   | Allocated [B] |
|--------- |--------------------- |-----------:|-----------:|------------:|-------:|--------------:|
| Original |   Ctr(...)ick   [29] | 238.962 ns |  3.9509 ns |   3.6956 ns | 0.0238 |        400 B |
| PR__EDIT |   Ctr(...)ick   [29] |  30.909 ns |  0.3631 ns |   0.3396 ns | 0.0019 |           32 B |
| Original | Ctrl (...)Click [31] | 271.305 ns |  3.0945 ns |   2.7432 ns | 0.0310 |         520 B |
| PR__EDIT | Ctrl (...)Click [30] |  38.710 ns |  0.4011 ns |   0.3556 ns | 0.0019 |          32 B |
| Original | Ctrl+LeftClick       | 203.858 ns |  1.2445 ns |   1.1641 ns | 0.0119 |          200 B |
| PR__EDIT | Ctrl+LeftClick       |  16.343 ns |  0.1529 ns |   0.1430 ns | 0.0019 |        32 B |
| Original | LeftClick            | 100.071 ns |  0.4549 ns |   0.4033 ns | 0.0057 |        96 B |
| PR__EDIT | LeftClick            |   9.861 ns |  0.1375 ns |   0.1219 ns | 0.0019 |     32 B |

```csharp
[Benchmark]
[Arguments("Ctrl + Alt +  MiddleDoubleClick")]
[Arguments("  Ctrl +  MiddleDoubleClick  ")]
[Arguments("Ctrl+LeftClick")]
[Arguments("LeftClick")]
public MouseGesture Original(object source)
{
   return (MouseGesture)oldMouseGestureConverter.ConvertFrom(null, null, source);
}
```

### ConvertFrom Benchmarks
| Method   | source               | Mean [ns]  | Error [ns] | StdDev [ns] | Gen0   | Allocated [B] |
|--------- |--------------------- |-----------:|-----------:|------------:|-------:|--------------:|
| Original | Syste(...)sture [33] | 183.925 ns |  1.9113 ns |   1.7878 ns | 0.0153 |          256 B |
| PR__EDIT | Syste(...)sture [33] |  23.399 ns |  0.4599 ns |   0.6296 ns | 0.0062 |            104 B |
| Original | Syste(...)sture [33] | 158.744 ns |  0.6850 ns |   0.6073 ns | 0.0029 |         48 B |
| PR__EDIT | Syste(...)sture [33] |   7.592 ns |  0.0938 ns |   0.0832 ns | 0.0014 |            24 B |
| Original | Syste(...)sture [33] | 173.100 ns |  1.2477 ns |   1.1060 ns | 0.0086 |         144 B |
| PR__EDIT | Syste(...)sture [33] |  21.988 ns |  0.4355 ns |   0.4074 ns | 0.0052 |        88 B |
| Original | Syste(...)sture [33] | 172.577 ns |  1.1510 ns |   0.9611 ns | 0.0029 |            48 B |
| PR__EDIT | Syste(...)sture [33] |   7.650 ns |  0.1691 ns |   0.1582 ns | 0.0014 |       24 B |

```csharp
public static IEnumerable<object> GestureData
{
   get
   {
       yield return new MouseGesture(MouseAction.LeftDoubleClick, ModifierKeys.Control | ModifierKeys.Shift);
       yield return new MouseGesture(MouseAction.LeftClick, ModifierKeys.None);
       yield return new MouseGesture(MouseAction.RightDoubleClick, ModifierKeys.Control);
       yield return new MouseGesture(MouseAction.None, ModifierKeys.None);
   }
}

[Benchmark]
[ArgumentsSource(nameof(GestureData))]
public string Original(object source)
{
   return (string)oldMouseGestureConverter.ConvertTo(null, null, source, typeof(string));
}
```

## Customer Impact

Increased performance, decreased allocations.

## Regression

No.

## Testing

Local build, backed with #10263.

## Risk

Low, changes have been tested extensively.

There is a behavioral change related to the fact that type converters of `MouseAction` and `ModifierKeys` are no longer retrieved via `TypeDescriptor.GetConverter` but rather used statically, which is aligned with how `KeyGestureConverter` and most of other converters using other types that have converters are implemented. This provides around 80-90% of the performance benefit, allows use of `ReadOnlySpan<char>` to pass slices to the converter methods (as you cannot box it in `object`), etc.

I haven't found any evidence of people registering custom type converters for those enums, needless to say that you may just register one for `MouseGesture` if you wish to influence the output for this type directly.