### PR TITLE
[Cleanup] Convert typeof(Foo).Name to nameof(Foo) (IDE0082)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -251,9 +251,6 @@ dotnet_diagnostic.IDE0077.severity = suggestion
 # IDE0078: Use pattern matching
 dotnet_diagnostic.IDE0078.severity = suggestion
 
-# IDE0082: 'typeof' can be converted  to 'nameof'
-dotnet_diagnostic.IDE0082.severity = suggestion
-
 # IDE0100: Remove redundant equality
 dotnet_diagnostic.IDE0100.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/ModelVisual3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/ModelVisual3D.cs
@@ -77,7 +77,7 @@ namespace System.Windows.Media.Media3D
 
             if (visual3D == null)
             {
-                throw new System.ArgumentException(SR.Format(SR.Collection_BadType, this.GetType().Name, value.GetType().Name, typeof(Visual3D).Name));
+                throw new System.ArgumentException(SR.Format(SR.Collection_BadType, this.GetType().Name, value.GetType().Name, nameof(Visual3D)));
             }
 
             Children.Add(visual3D);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Viewport3DVisual.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Viewport3DVisual.cs
@@ -499,7 +499,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         protected override GeometryHitTestResult HitTestCore(GeometryHitTestParameters hitTestParameters)
         {
-            throw new NotSupportedException(SR.Format(SR.HitTest_Invalid, typeof(GeometryHitTestParameters).Name, this.GetType().Name));
+            throw new NotSupportedException(SR.Format(SR.HitTest_Invalid, nameof(GeometryHitTestParameters), this.GetType().Name));
         }
 
         internal Point WorldToViewport(Point4D point)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -2106,7 +2106,7 @@ namespace System.Windows.Controls
                     }
                     else
                     {
-                        throw new InvalidOperationException(SR.Format(SR.InvalidItemContainer, this.GetType().Name, typeof(MenuItem).Name, typeof(Separator).Name, itemContainer));
+                        throw new InvalidOperationException(SR.Format(SR.InvalidItemContainer, this.GetType().Name, nameof(MenuItem), nameof(Separator), itemContainer));
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/MenuBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/MenuBase.cs
@@ -502,7 +502,7 @@ namespace System.Windows.Controls.Primitives
                     }
                     else
                     {
-                        throw new InvalidOperationException(SR.Format(SR.InvalidItemContainer, this.GetType().Name, typeof(MenuItem).Name, typeof(Separator).Name, itemContainer));
+                        throw new InvalidOperationException(SR.Format(SR.InvalidItemContainer, this.GetType().Name, nameof(MenuItem), nameof(Separator), itemContainer));
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/StatusBar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/StatusBar.cs
@@ -121,7 +121,7 @@ namespace System.Windows.Controls.Primitives
                     }
                     else
                     {
-                        throw new InvalidOperationException(SR.Format(SR.InvalidItemContainer, this.GetType().Name, typeof(StatusBarItem).Name, typeof(Separator).Name, itemContainer));
+                        throw new InvalidOperationException(SR.Format(SR.InvalidItemContainer, this.GetType().Name, nameof(StatusBarItem), nameof(Separator), itemContainer));
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DeferrableContentConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DeferrableContentConverter.cs
@@ -78,7 +78,7 @@ namespace System.Windows
             T result = provider.GetService(typeof(T)) as T;
             if (result == null)
             {
-                throw new InvalidOperationException(SR.Format(SR.DeferringLoaderNoContext, typeof(DeferrableContentConverter).Name, typeof(T).Name));
+                throw new InvalidOperationException(SR.Format(SR.DeferringLoaderNoContext, nameof(DeferrableContentConverter), typeof(T).Name));
             }
             return result;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TableColumnCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TableColumnCollection.cs
@@ -276,7 +276,7 @@ namespace System.Windows.Documents
 
             if (item == null)
             {
-                throw new ArgumentException(SR.Format(SR.TableCollectionElementTypeExpected, typeof(TableColumn).Name), "value");
+                throw new ArgumentException(SR.Format(SR.TableCollectionElementTypeExpected, nameof(TableColumn)), "value");
             }
 
             return ((IList)_columnCollection).Add(value);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeSerialization.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeSerialization.cs
@@ -192,7 +192,7 @@ namespace System.Windows.Documents
             if (elementLevel == EmptyDocumentDepth && typeof(Run).IsAssignableFrom(rangeStart.ParentType))
             {
                 elementLevel++;
-                xmlWriter.WriteStartElement(typeof(Run).Name);
+                xmlWriter.WriteStartElement(nameof(Run));
             }
 
             // Create text navigator for reading the range's content
@@ -1185,8 +1185,8 @@ namespace System.Windows.Documents
                         // Write Source property as the complex property to specify the BitmapImage
                         // cache option as "OnLoad" instead of the default "OnDeman". Otherwise,
                         // we couldn't load the image by disposing WpfPayload package.
-                        xmlWriter.WriteStartElement($"{typeof(Image).Name}.{Image.SourceProperty.Name}");
-                        xmlWriter.WriteStartElement(typeof(System.Windows.Media.Imaging.BitmapImage).Name);
+                        xmlWriter.WriteStartElement($"{nameof(Image)}.{Image.SourceProperty.Name}");
+                        xmlWriter.WriteStartElement(nameof(Media.Imaging.BitmapImage));
                         xmlWriter.WriteAttributeString(System.Windows.Media.Imaging.BitmapImage.UriSourceProperty.Name, imageSource);
                         xmlWriter.WriteAttributeString(System.Windows.Media.Imaging.BitmapImage.CacheOptionProperty.Name, "OnLoad");
                         xmlWriter.WriteEndElement();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkTemplate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkTemplate.cs
@@ -375,8 +375,7 @@ namespace System.Windows
             if (templateRoot != null &&
                 typeof(FrameworkContentElement).IsAssignableFrom(templateRoot.Type))
             {
-                throw new ArgumentException(SR.Format(SR.VisualTreeRootIsFrameworkElement,
-                    typeof(FrameworkElement).Name, templateRoot.Type.Name));
+                throw new ArgumentException(SR.Format(SR.VisualTreeRootIsFrameworkElement, nameof(FrameworkElement), templateRoot.Type.Name));
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateContentLoader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateContentLoader.cs
@@ -22,14 +22,14 @@ namespace System.Windows
             T result = provider.GetService(typeof(T)) as T;
             if (result == null)
             {
-                throw new InvalidOperationException(SR.Format(SR.DeferringLoaderNoContext,typeof(TemplateContentLoader).Name, typeof(T).Name));
+                throw new InvalidOperationException(SR.Format(SR.DeferringLoaderNoContext,nameof(TemplateContentLoader), typeof(T).Name));
             }
             return result;
         }
 
         public override XamlReader Save(object value, IServiceProvider serviceProvider)
         {
-            throw new NotSupportedException(SR.Format(SR.DeferringLoaderNoSave, typeof(TemplateContentLoader).Name));
+            throw new NotSupportedException(SR.Format(SR.DeferringLoaderNoSave, nameof(TemplateContentLoader)));
         }
     }
 }


### PR DESCRIPTION
## Description

Analyzer fix, converts occurrences of `typeof(Foo).Name` to the compile-time generated `nameof(Foo)` alternative.

## Customer Impact

Cleaner codebase, impact is negligible perf-wise as its exception cases.

## Regression

No.

## Testing

Local build.

## Risk

Minimal.
