### PR TITLE
Avoid zero-length array allocations and storing them in static fields (CA1825)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -95,9 +95,6 @@ dotnet_diagnostic.CA1822.severity = suggestion
 # CA1823: Avoid unused private fields
 dotnet_diagnostic.CA1823.severity = suggestion
 
-# CA1825: Avoid zero-length array allocations
-dotnet_diagnostic.CA1825.severity = suggestion
-
 # CA1834: Use StringBuilder.Append(char) for single character strings
 dotnet_diagnostic.CA1834.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -982,11 +982,10 @@ namespace MS.Internal
 
                 // eventSetter = new EventSetter();
                 //
-                CodeExpression[] esParams = {};
                 CodeVariableReferenceExpression cvreES = new CodeVariableReferenceExpression(EVENTSETTER);
                 CodeAssignStatement casES = new CodeAssignStatement(cvreES,
                                                                     new CodeObjectCreateExpression(KnownTypes.Types[(int)KnownElements.EventSetter],
-                                                                                                   esParams));
+                                                                                                   Array.Empty<CodeExpression>()));
 
                 // eventSetter.Event = Button.ClickEvent;
                 //
@@ -3160,9 +3159,8 @@ namespace MS.Internal
             //
             CodeObjectCreateExpression coce;
             CodeVariableReferenceExpression cvre = new CodeVariableReferenceExpression(APPVAR);
-            CodeExpression[] ctorParams = {};
 
-            coce = new CodeObjectCreateExpression(appClassName, ctorParams);
+            coce = new CodeObjectCreateExpression(appClassName, Array.Empty<CodeExpression>());
 
             CodeVariableDeclarationStatement cvds = new CodeVariableDeclarationStatement(appClassName, APPVAR, coce);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsTable/RowSpanVector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsTable/RowSpanVector.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -156,7 +156,6 @@ namespace MS.Internal.PtsTable
         /// <returns>Array of cells. May be empty</returns>
         internal void GetSpanCells(out TableCell[] cells, out bool isLastRowOfAnySpan)
         {
-            cells = s_noCells;
             isLastRowOfAnySpan = false;
 
             //  iterate the tail of entries (if any) 
@@ -204,10 +203,13 @@ namespace MS.Internal.PtsTable
                 
                 _size = j + 1;
             }
-
-            #if DEBUG
+            else
+            {
+                cells = Array.Empty<TableCell>();
+            }
+#if DEBUG
             _index = -1;
-            #endif // DEBUG
+#endif
         }
 
         #endregion Internal Methods 
@@ -265,8 +267,6 @@ namespace MS.Internal.PtsTable
         private int _size;                              //  current size of the list
         private int _index;                             //  index used for iteration (GetFirst / GetNext)
         private const int c_defaultCapacity = 8;        //  default capacity
-        private static TableCell[] s_noCells = Array.Empty<TableCell>();  //  empty array RowSpanVector returns to rows that do not 
-                                                        //  have row spanned cells
         #endregion Private Fields 
 
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/GuidGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/GuidGenerator.cs
@@ -33,7 +33,7 @@ namespace WinRT
                 var sigMethod = helperType.GetMethod("GetGuidSignature", BindingFlags.Static | BindingFlags.Public);
                 if (sigMethod != null)
                 {
-                    return (string)sigMethod.Invoke(null, new Type[] { });
+                    return (string)sigMethod.Invoke(null, Array.Empty<Type>());
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GridViewAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GridViewAutomationPeer.cs
@@ -147,7 +147,7 @@ namespace System.Windows.Automation.Peers
                 return array.ToArray();
             }
 
-            return new IRawElementProviderSimple[0] ;
+            return Array.Empty<IRawElementProviderSimple>();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/InkCanvas.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/InkCanvas.cs
@@ -2309,7 +2309,7 @@ namespace System.Windows.Controls
             //
             // attempt to clear selection
             //
-            ChangeInkCanvasSelection(new StrokeCollection(), new UIElement[]{});
+            ChangeInkCanvasSelection(new StrokeCollection(), Array.Empty<UIElement>());
 
             return !InkCanvasSelection.HasSelection;
         }
@@ -2325,7 +2325,7 @@ namespace System.Windows.Controls
             if ( InkCanvasSelection.HasSelection )
             {
                 // Reset the current selection
-                CoreChangeSelection(new StrokeCollection(), new UIElement[] { }, raiseSelectionChangedEvent);
+                CoreChangeSelection(new StrokeCollection(), Array.Empty<UIElement>(), raiseSelectionChangedEvent);
             }
         }
 
@@ -2510,7 +2510,7 @@ namespace System.Windows.Controls
         {
             if (selectedElements == null)
             {
-                return new UIElement[]{};
+                return Array.Empty<UIElement>();
             }
 
             List<UIElement> elements = new List<UIElement>();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Slider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Slider.cs
@@ -966,7 +966,7 @@ namespace System.Windows.Controls
                     }
 
                 default:
-                    return new CustomPopupPlacement[]{};
+                    return Array.Empty<CustomPopupPlacement>();
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSchema.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSchema.cs
@@ -502,7 +502,7 @@ namespace System.Windows.Documents
             }
             else if (typeof(LineBreak).IsAssignableFrom(type))
             {
-                return _emptyPropertyList;
+                return Array.Empty<DependencyProperty>();
             }
             else if (typeof(Floater).IsAssignableFrom(type))
             {
@@ -560,7 +560,7 @@ namespace System.Windows.Documents
             }
 
             Invariant.Assert(false, "We do not expect any unknown elements derived directly from TextElement. Schema must have been checking for that");
-            return _emptyPropertyList; // to make compiler happy
+            return Array.Empty<DependencyProperty>(); // to make compiler happy
         }
 
         // Compares two values for equality
@@ -1201,9 +1201,6 @@ namespace System.Windows.Documents
             { 
                 UIElement.AllowDropProperty,
             };
-
-        // Empty property list
-        private static readonly DependencyProperty[] _emptyPropertyList = new DependencyProperty[] { };
 
         // Structural property list.
         // NB: Existing code depends on these being inheritable properties.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
@@ -4432,7 +4432,7 @@ namespace System.Windows.Markup
         /// </summary>
         internal static NamespaceMapEntry[] GetDefaultNamespaceMaps()
         {
-            return (NamespaceMapEntry[])_defaultNamespaceMapTable.Clone();
+            return Array.Empty<NamespaceMapEntry>();
         }
 
 #endregion Properties
@@ -4440,12 +4440,7 @@ namespace System.Windows.Markup
 #region Data
 
         // array of our defaultAssemblies.
-        private static readonly string[] _defaultAssemblies = {"WindowsBase", "PresentationCore", "PresentationFramework"};
-
-        // array of namespaceMaps the map an xmlns namespaceURI
-        // to the assembly and urtNamespace to search in when resolving the xml
-
-        private static readonly NamespaceMapEntry[] _defaultNamespaceMapTable = { };
+        private static readonly string[] _defaultAssemblies = { "WindowsBase", "PresentationCore", "PresentationFramework" };
 
 #endregion Data
     }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlMemberInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlMemberInvoker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,7 +13,6 @@ namespace System.Xaml.Schema
     {
         private static XamlMemberInvoker s_Directive;
         private static XamlMemberInvoker s_Unknown;
-        private static object[] s_emptyObjectArray = Array.Empty<object>();
 
         private XamlMember _member;
         private NullableReference<MethodInfo> _shouldSerializeMethod;
@@ -65,7 +64,7 @@ namespace System.Xaml.Schema
             }
             else
             {
-                return UnderlyingGetter.Invoke(instance, s_emptyObjectArray);
+                return UnderlyingGetter.Invoke(instance, Array.Empty<object>());
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Schema.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Schema.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Description: property/pattern/event information
 
+using System;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Text;
@@ -338,7 +338,7 @@ namespace MS.Internal.Automation
             new AutomationPropertyInfo( null,                            ScrollPattern.VerticalViewSizeProperty,                 typeof(double),                (double)100                    ),
             new AutomationPropertyInfo( convertToBool,                   ScrollPattern.HorizontallyScrollableProperty,           typeof(bool),                  false                          ),
             new AutomationPropertyInfo( convertToBool,                   ScrollPattern.VerticallyScrollableProperty,             typeof(bool),                  false                          ),
-            new AutomationPropertyInfo( convertToElementArray,           SelectionPattern.SelectionProperty,                     typeof(AutomationElement[]),   new AutomationElement[]{}      ),
+            new AutomationPropertyInfo( convertToElementArray,           SelectionPattern.SelectionProperty,                     typeof(AutomationElement[]),   Array.Empty<AutomationElement>()),
             new AutomationPropertyInfo( convertToBool,                   SelectionPattern.CanSelectMultipleProperty,             typeof(bool),                  false                          ),
             new AutomationPropertyInfo( convertToBool,                   SelectionPattern.IsSelectionRequiredProperty,           typeof(bool),                  false                          ),
             new AutomationPropertyInfo( null,                            GridPattern.RowCountProperty,                           typeof(int),                   0                              ),
@@ -351,7 +351,7 @@ namespace MS.Internal.Automation
             new AutomationPropertyInfo( convertToDockPosition,           DockPattern.DockPositionProperty,                       typeof(DockPosition),          DockPosition.None              ),
             new AutomationPropertyInfo( convertToExpandCollapseState,    ExpandCollapsePattern.ExpandCollapseStateProperty,      typeof(ExpandCollapseState),   ExpandCollapseState.LeafNode   ),
             new AutomationPropertyInfo( null,                            MultipleViewPattern.CurrentViewProperty,                typeof(int),                   0                              ),
-            new AutomationPropertyInfo( null,                            MultipleViewPattern.SupportedViewsProperty,             typeof(int []),                new int [0]                    ),
+            new AutomationPropertyInfo( null,                            MultipleViewPattern.SupportedViewsProperty,             typeof(int []),                Array.Empty<int>()             ),
             new AutomationPropertyInfo( convertToBool,                   WindowPattern.CanMaximizeProperty,                      typeof(bool),                  false                          ),
             new AutomationPropertyInfo( convertToBool,                   WindowPattern.CanMinimizeProperty,                      typeof(bool),                  false                          ),
             new AutomationPropertyInfo( convertToWindowVisualState,      WindowPattern.WindowVisualStateProperty,                typeof(WindowVisualState),     WindowVisualState.Normal       ),
@@ -360,11 +360,11 @@ namespace MS.Internal.Automation
             new AutomationPropertyInfo( convertToBool,                   WindowPattern.IsTopmostProperty,                        typeof(bool),                  false                          ),
             new AutomationPropertyInfo( convertToBool,                   SelectionItemPattern.IsSelectedProperty,                typeof(bool),                  false                          ),
             new AutomationPropertyInfo( convertToElement,                SelectionItemPattern.SelectionContainerProperty,        typeof(AutomationElement),     null                           ),
-            new AutomationPropertyInfo( convertToElementArray,           TablePattern.RowHeadersProperty,                        typeof(AutomationElement []),  new AutomationElement [0]      ),
-            new AutomationPropertyInfo( convertToElementArray,           TablePattern.ColumnHeadersProperty,                     typeof(AutomationElement []),  new AutomationElement [0]      ),
+            new AutomationPropertyInfo( convertToElementArray,           TablePattern.RowHeadersProperty,                        typeof(AutomationElement[]),   Array.Empty<AutomationElement>()),
+            new AutomationPropertyInfo( convertToElementArray,           TablePattern.ColumnHeadersProperty,                     typeof(AutomationElement[]),   Array.Empty<AutomationElement>()),
             new AutomationPropertyInfo( convertToRowOrColumnMajor,       TablePattern.RowOrColumnMajorProperty,                  typeof(RowOrColumnMajor),      RowOrColumnMajor.Indeterminate ),
-            new AutomationPropertyInfo( convertToElementArray,           TableItemPattern.RowHeaderItemsProperty,                typeof(AutomationElement []),  new AutomationElement [0]      ),
-            new AutomationPropertyInfo( convertToElementArray,           TableItemPattern.ColumnHeaderItemsProperty,             typeof(AutomationElement []),  new AutomationElement [0]      ),
+            new AutomationPropertyInfo( convertToElementArray,           TableItemPattern.RowHeaderItemsProperty,                typeof(AutomationElement[]),   Array.Empty<AutomationElement>()),
+            new AutomationPropertyInfo( convertToElementArray,           TableItemPattern.ColumnHeaderItemsProperty,             typeof(AutomationElement[]),   Array.Empty<AutomationElement>()),
             new AutomationPropertyInfo( convertToToggleState,            TogglePattern.ToggleStateProperty,                      typeof(ToggleState),           ToggleState.Indeterminate      ),
             new AutomationPropertyInfo( convertToBool,                   TransformPattern.CanMoveProperty,                       typeof(bool),                  false                          ),
             new AutomationPropertyInfo( convertToBool,                   TransformPattern.CanResizeProperty,                     typeof(bool),                  false                          ),

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
@@ -450,7 +450,7 @@ namespace MS.Internal.Automation
             if (requestedData == null)
             {
                 Debug.Assert(offsets == null && treeStructures == null, "if nothin found, all out params shoud be null");
-                return new UiaCacheResponse[] {}; // Return empty cacheresponse, not null.
+                return Array.Empty<UiaCacheResponse>(); // Return empty cacheresponse, not null.
             }
 
             Debug.Assert(offsets.Length == treeStructures.Length);
@@ -869,7 +869,7 @@ namespace MS.Internal.Automation
             CheckError(RawTextPattern_GetSelection(hobj, out arr));
             if (arr == null)
             {
-                return new SafeTextRangeHandle[] { };
+                return Array.Empty<SafeTextRangeHandle>();
             }
             SafeTextRangeHandle[] result = new SafeTextRangeHandle[arr.Length];
             for (int i = 0; i < arr.Length; i++)
@@ -885,7 +885,7 @@ namespace MS.Internal.Automation
             CheckError(RawTextPattern_GetVisibleRanges(hobj, out arr));
             if (arr == null)
             {
-                return new SafeTextRangeHandle[] { };
+                return Array.Empty<SafeTextRangeHandle>();
             }
             SafeTextRangeHandle[] result = new SafeTextRangeHandle[arr.Length];
             for (int i = 0; i < arr.Length; i++)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/CacheRequest.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/CacheRequest.cs
@@ -407,7 +407,7 @@ namespace System.Windows.Automation
             {
                 if(_defaultUiaCacheRequest == null)
                 {
-                    _defaultUiaCacheRequest = new UiaCoreApi.UiaCacheRequest(Automation.ControlViewCondition, TreeScope.Element, new AutomationProperty[] { AutomationElement.RuntimeIdProperty }, new AutomationPattern[] { }, AutomationElementMode.Full);
+                    _defaultUiaCacheRequest = new UiaCoreApi.UiaCacheRequest(Automation.ControlViewCondition, TreeScope.Element, new AutomationProperty[] { AutomationElement.RuntimeIdProperty }, Array.Empty<AutomationPattern>(), AutomationElementMode.Full);
                 }
                 return _defaultUiaCacheRequest;
             }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/MSAANativeProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/MSAANativeProvider.cs
@@ -570,7 +570,7 @@ namespace MS.Internal.AutomationProxies
 
             Accessible[] accessibles = _acc.GetSelection();
             if (accessibles == null)
-                return new IRawElementProviderSimple[] {};
+                return Array.Empty<IRawElementProviderSimple>();
 
             IRawElementProviderSimple [] rawEPS= new IRawElementProviderSimple[accessibles.Length];
             for (int i=0;i<accessibles.Length;i++)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEdit.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEdit.cs
@@ -239,7 +239,7 @@ namespace MS.Internal.AutomationProxies
             }
 
             if (range == null)
-                return new ITextRangeProvider[] { };
+                return Array.Empty<ITextRangeProvider>();
             else
                 return new ITextRangeProvider[] { new WindowsRichEditRange(range, this) };
         }
@@ -249,7 +249,7 @@ namespace MS.Internal.AutomationProxies
             ITextRange range = GetVisibleRange();
 
             if (range == null)
-                return new ITextRangeProvider[] { };
+                return Array.Empty<ITextRangeProvider>();
             else
                 return new ITextRangeProvider[] { new WindowsRichEditRange(range, this) };
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/ControlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/ControlType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -70,13 +70,13 @@ namespace System.Windows.Automation
         internal static ControlType Register(AutomationIdentifierConstants.ControlTypes id, string programmaticName, string stId,
                                 AutomationProperty[] requiredProperties)
         {
-            return ControlType.Register(id, programmaticName, stId, requiredProperties, Array.Empty<AutomationPattern>(), new AutomationPattern[0][]);
+            return ControlType.Register(id, programmaticName, stId, requiredProperties, Array.Empty<AutomationPattern>(), Array.Empty<AutomationPattern[]>());
         }
 
         //Required patterns, never supported patterns and required properties are set to an empty array
         internal static ControlType Register(AutomationIdentifierConstants.ControlTypes id, string programmaticName, string stId)
         {
-            return ControlType.Register(id, programmaticName, stId, Array.Empty<AutomationProperty>(), Array.Empty<AutomationPattern>(), new AutomationPattern[0][]);
+            return ControlType.Register(id, programmaticName, stId, Array.Empty<AutomationProperty>(), Array.Empty<AutomationPattern>(), Array.Empty<AutomationPattern[]>());
         }
         #endregion
         
@@ -232,7 +232,7 @@ namespace System.Windows.Automation
                                                                                                                                                     });
 
         /// <summary>ControlType ID: Document - Lets a user view/manipulate multiple pages of text.</summary>
-        public static readonly ControlType Document = ControlType.Register(AutomationIdentifierConstants.ControlTypes.Document, "ControlType.Document", nameof(SR.LocalizedControlTypeDocument), new AutomationProperty[0],
+        public static readonly ControlType Document = ControlType.Register(AutomationIdentifierConstants.ControlTypes.Document, "ControlType.Document", nameof(SR.LocalizedControlTypeDocument), Array.Empty<AutomationProperty>(),
                                                                                                         new AutomationPattern[] { ValuePatternIdentifiers.Pattern },
                                                                                                         new AutomationPattern[][] {
                                                                                                                                     new AutomationPattern[] { ScrollPatternIdentifiers.Pattern } ,


### PR DESCRIPTION
Fixes #10286

## Description

This PR mainly resolves `CA1825` but in some cases goes a step further over standard analyzer fix.

- In addition to using singleton over allocating zero-length array everytime, we want to avoid storing those in `readonly` fields (whether they're marked or not), as the pointer to such array is already accessible via `Array.Empty<Type>()`.
- `XamlTypeMapper` was going step further and cloning this zero-length array even. Happy days.
- `RowSpanVector` was performing unnecessary assigment if the branch was not taken.

## Customer Impact

Increased performance, decreased allocations.

## Regression

No.

## Testing

Local build.

## Risk

Should be low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10267)