### PR TITLE
Fix InvalidCastException in Can/ConvertTo methods from KeyConverter

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -37,10 +37,10 @@ namespace System.Windows.Input
                 return false;
 
             // When invoked by the serialization engine we can convert to string only for known type
-            if (context is null || context.Instance is null)
+            if (context?.Instance is not Key key)
                 return false;
 
-            return IsDefinedKey((Key)context.Instance);
+            return IsDefinedKey(key);
         }
 
         /// <summary>
@@ -71,10 +71,9 @@ namespace System.Windows.Input
         {
             ArgumentNullException.ThrowIfNull(destinationType);
 
-            if (value is null || destinationType != typeof(string))
+            if (value is not Key key || destinationType != typeof(string))
                 throw GetConvertToException(value, destinationType);
 
-            Key key = (Key)value;
             return key switch
             {
                 Key.None => string.Empty,

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/System/Windows/Input/KeyConverterTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/System/Windows/Input/KeyConverterTests.cs
@@ -23,8 +23,7 @@ public class KeyConverterTests
         yield return new object?[] { new CustomTypeDescriptorContext(), typeof(Key), false };
         yield return new object?[] { new CustomTypeDescriptorContext { Instance = new object() }, null, false };
         yield return new object?[] { new CustomTypeDescriptorContext { Instance = new object() }, typeof(object), false };
-        // TODO: this should not throw.
-        //yield return new object?[] { new CustomTypeDescriptorContext { Instance = new object() }, typeof(string), false };
+        yield return new object?[] { new CustomTypeDescriptorContext { Instance = new object() }, typeof(string), false };
         yield return new object?[] { new CustomTypeDescriptorContext { Instance = new object() }, typeof(InstanceDescriptor), false };
         yield return new object?[] { new CustomTypeDescriptorContext { Instance = new object() }, typeof(Key), false };
         yield return new object?[] { new CustomTypeDescriptorContext { Instance = Key.None }, null, false };
@@ -40,6 +39,7 @@ public class KeyConverterTests
         yield return new object?[] { new CustomTypeDescriptorContext { Instance = Key.A }, null, false };
         yield return new object?[] { new CustomTypeDescriptorContext { Instance = Key.A }, typeof(object), false };
         yield return new object?[] { new CustomTypeDescriptorContext { Instance = Key.A }, typeof(string), true };
+        yield return new object?[] { new CustomTypeDescriptorContext { Instance = (int)Key.A }, typeof(string), false };
         yield return new object?[] { new CustomTypeDescriptorContext { Instance = Key.A }, typeof(InstanceDescriptor), false };
         yield return new object?[] { new CustomTypeDescriptorContext { Instance = Key.A }, typeof(Key), false };
         yield return new object?[] { new CustomTypeDescriptorContext { Instance = Key.OemClear }, null, false };
@@ -70,15 +70,6 @@ public class KeyConverterTests
     {
         var converter = new KeyConverter();
         Assert.Equal(expected, converter.CanConvertTo(context, destinationType));
-    }
-
-    [Fact]
-    public void CanConvertTo_InvokeToStringInstanceNotKey_ThrowsInvalidCastException()
-    {
-        // TODO: this should return false.
-        var converter = new KeyConverter();
-        var context = new CustomTypeDescriptorContext { Instance = new object() };
-        Assert.Throws<InvalidCastException>(() => converter.CanConvertTo(context, typeof(string)));
     }
 
     public static IEnumerable<object[]> ConvertTo_KeyToString_TestData()
@@ -142,7 +133,7 @@ public class KeyConverterTests
         Assert.Equal(expected, converter.ConvertTo(new CustomTypeDescriptorContext(), null, value, typeof(string)));
         Assert.Equal(expected, converter.ConvertTo(new CustomTypeDescriptorContext(), CultureInfo.InvariantCulture, value, typeof(string)));
     }
-    
+
     [Theory]
     [InlineData((Key)int.MinValue)]
     [InlineData((Key)(-1))]
@@ -158,27 +149,14 @@ public class KeyConverterTests
 
     [Theory]
     [InlineData(null)]
-    // TODO: this should not throw InvalidCastException.
-    //[InlineData("", "")]
-    //[InlineData("value", "value")]
+    [InlineData("")]
+    [InlineData("value")]
     public void ConvertTo_InvokeNotKeyToStringNull_ThrowsNotSupportedException(object? value)
     {
         var converter = new KeyConverter();
         Assert.Throws<NotSupportedException>(() => converter.ConvertTo(value, typeof(string)));
         Assert.Throws<NotSupportedException>(() => converter.ConvertTo(new CustomTypeDescriptorContext(), null, value, typeof(string)));
         Assert.Throws<NotSupportedException>(() => converter.ConvertTo(new CustomTypeDescriptorContext(), CultureInfo.InvariantCulture, value, typeof(string)));
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData("value")]
-    public void ConvertTo_InvokeNotKeyToStringNotNull_ThrowsInvalidCastException(object value)
-    {
-        // TODO: this should not throw InvalidCastException.
-        var converter = new KeyConverter();
-        Assert.Throws<InvalidCastException>(() => converter.ConvertTo(value, typeof(string)));
-        Assert.Throws<InvalidCastException>(() => converter.ConvertTo(new CustomTypeDescriptorContext(), null, value, typeof(string)));
-        Assert.Throws<InvalidCastException>(() => converter.ConvertTo(new CustomTypeDescriptorContext(), CultureInfo.InvariantCulture, value, typeof(string)));
     }
 
     public static IEnumerable<object?[]> ConvertTo_CantConvert_TestData()

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/System/Windows/Input/KeyValueSerializerTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/System/Windows/Input/KeyValueSerializerTests.cs
@@ -58,25 +58,13 @@ public class KeyValueSerializerTests
 
     [Theory]
     [InlineData(null)]
-    // TODO: this should not throw InvalidCastException.
-    //[InlineData("", "")]
-    //[InlineData("value", "value")]
+    [InlineData("")]
+    [InlineData("value")]
     public void ConvertToString_InvokeNotKeyToStringNull_ThrowsNotSupportedException(object? value)
     {
         var serializer = new KeyValueSerializer();
         Assert.Throws<NotSupportedException>(() => serializer.ConvertToString(value, null));
         Assert.Throws<NotSupportedException>(() => serializer.ConvertToString(value, new CustomValueSerializerContext()));
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData("value")]
-    public void ConvertToString_InvokeNotKeyNotNull_ThrowsInvalidCastException(object value)
-    {
-        // TODO: this should not throw InvalidCastException.
-        var serializer = new KeyValueSerializer();
-        Assert.Throws<InvalidCastException>(() => serializer.ConvertToString(value, null));
-        Assert.Throws<InvalidCastException>(() => serializer.ConvertToString(value, new CustomValueSerializerContext()));
     }
 
     public static IEnumerable<object?[]> CanConvertFromString_TestData()


### PR DESCRIPTION
## Description

Sending this in now when #8215 was finally merged as I've discovered this during development of #9697 but wanted to wait until I can fix the TODOs in the unit tests as well.

Fixes `InvalidCastException` thrown from `CanConvertTo` when unboxing cast is performed on `value` that was not `null` but was of a different type than `Key` or the underlying storage (`int`), e.g. an object or a different value type.
Can* methods should not (and converters do not intentionally) throw in them but this is simple a programmer's error, it is not documented behavior either, hence the fix for this.

https://learn.microsoft.com/en-us/dotnet/api/system.windows.input.keyconverter.canconvertto?view=windowsdesktop-8.0

Fixes the same issue in `ConvertTo` by throwing the proper (NotSupported) exception.

https://learn.microsoft.com/en-us/dotnet/api/system.windows.input.keyconverter.convertto?view=windowsdesktop-8.0

## Customer Impact

Less unexpected exceptions thrown.

## Regression

No.

## Testing

Local build, unit test.

## Risk

There might be a concern that a code was passing `int` instead of `Key` which is the underlying storage type, so it survives the unboxing hard cast that was being performed but not the type `is` check. We may therefore for back-compat include check for both `Key` and `int` but other converters just check for their type, so in my honest opinion it would be best to unify the behaviour and mention in release notes.
