### PR TITLE
[StyleCleanUp] ThreadStatic fields should not use inline initialization (CA2019)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -135,9 +135,6 @@ dotnet_diagnostic.CA1859.severity = suggestion
 # CA2011: Do not assign property within its setter
 dotnet_diagnostic.CA2011.severity = suggestion
 
-# CA2019: ThreadStatic fields should not use inline initialization
-dotnet_diagnostic.CA2019.severity = suggestion
-
 # Should change all internal IntPtr/UIntPtr to nint/uint. IntPtr/UIntPtr no
 # longer do checked operations so they are now equivalent.
 # CA2020: Prevent behavioral change caused by built-in operators of IntPtr/UIntPtr

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/Win32/UnsafeNativeMethodsPenimc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/Win32/UnsafeNativeMethodsPenimc.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -64,7 +64,7 @@ namespace MS.Win32.Penimc
         /// Whether or not the WISP Tablet Manager server object has been locked in the MTA.
         /// </summary>
         [ThreadStatic]
-        private static bool _wispManagerLocked = false;
+        private static bool _wispManagerLocked;
 
         [ThreadStatic]
         private static IPimcManager3 _pimcManagerThreadStatic;
@@ -73,7 +73,7 @@ namespace MS.Win32.Penimc
         /// The cookie for the PenIMC activation context.
         /// </summary>
         [ThreadStatic]
-        private static IntPtr _pimcActCtxCookie = IntPtr.Zero;
+        private static IntPtr _pimcActCtxCookie;
 
         #endregion
 
@@ -132,10 +132,8 @@ namespace MS.Win32.Penimc
         {
             get
             {
-                if (_pimcManagerThreadStatic == null)
-                {
-                    _pimcManagerThreadStatic = CreatePimcManager();
-                }
+                _pimcManagerThreadStatic ??= CreatePimcManager();
+
                 return _pimcManagerThreadStatic;
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Interop/TipTsfHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Interop/TipTsfHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -42,7 +42,7 @@ namespace MS.Internal.Interop
         /// Cache any in progress operation in case we get multiple calls.
         /// </summary>
         [ThreadStatic]
-        private static DispatcherOperation s_KbOperation = null;
+        private static DispatcherOperation s_KbOperation;
 
         /// <summary>
         /// If DispatcherProcessing is disabled, this will BeginInvoke the appropriate KB operation

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusLogic.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -218,7 +218,7 @@ namespace System.Windows.Input
         /// thread as there is one per specific touch stack InputProvider.
         /// </summary>
         [ThreadStatic]
-        private static StylusLogic _currentStylusLogic = null;
+        private static StylusLogic _currentStylusLogic;
 
         /// <summary>
         /// This property is backed by a ThreadStatic instance.  This will be instantiated

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusTouchDeviceBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusTouchDeviceBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -236,7 +236,7 @@ namespace System.Windows.Input
         #region Member Variables
 
         [ThreadStatic]
-        private static int _activeDeviceCount = 0;
+        private static int _activeDeviceCount;
 
         private TouchAction _lastAction = TouchAction.Move;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -2429,7 +2429,7 @@ namespace System.Windows
         // Keep LoadBamlSyncInfo stack so that the Outer LoadBaml and Inner LoadBaml( ) for the same
         // Uri share the related information.
         [ThreadStatic]
-        private static Stack<NestedBamlLoadInfo> s_NestedBamlLoadInfo = null;
+        private static Stack<NestedBamlLoadInfo> s_NestedBamlLoadInfo;
 
         private Uri                         _startupUri;
         private Uri                         _applicationMarkupBaseUri;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResourceKey.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResourceKey.cs
@@ -2280,7 +2280,7 @@ namespace System.Windows
         private SystemResourceKeyID _id;
 
         [ThreadStatic]
-        private static SystemResourceKey _srk = null;
+        private static SystemResourceKey _srk;
 #endif
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/TextSearchInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/TextSearchInternal.cs
@@ -846,10 +846,8 @@ namespace Microsoft.Windows.Controls
         {
             get
             {
-                if (_dummyElement == null)
-                {
-                    _dummyElement = new DummyObject();
-                }
+                _dummyElement ??= new DummyObject();
+
                 return _dummyElement;
             }
         }
@@ -889,7 +887,7 @@ namespace Microsoft.Windows.Controls
         private DispatcherTimer _timeoutTimer;
 
         [ThreadStatic]
-        private static DummyObject _dummyElement = new DummyObject();
+        private static DummyObject _dummyElement;
 
         #endregion
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Freezable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Freezable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -475,21 +475,16 @@ namespace System.Windows
         // FireChanged occurs.
         //
         [ThreadStatic]
-        static private EventStorage _eventStorage = null;
+        private static EventStorage _eventStorage;
 
         /// <summary>
         /// Property to access and intialize the thread static _eventStorage variable.
         /// </summary>
-        private EventStorage CachedEventStorage
+        private static EventStorage CachedEventStorage
         {
             get
             {
-                // make sure _eventStorage is not null - with ThreadStatic it appears that the second
-                // thread to access the variable will set this to null
-                if (_eventStorage == null)
-                {
-                    _eventStorage = new EventStorage(INITIAL_EVENTSTORAGE_SIZE);
-                }
+                _eventStorage ??= new EventStorage(INITIAL_EVENTSTORAGE_SIZE);
 
                 return _eventStorage;
             }


### PR DESCRIPTION
Fixes #10300 

## Description

Avoid initializing `[ThreadStatic]` variables inline to prevent mistakes as it may lead you into thinking that such value will be initialized for all instances of the variable, not just the first thread.

## Customer Impact

Cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low. I've checked that fields that require initialization are properly initialized elsewhere.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10301)