### PR TITLE
Use source-generated regex instead of runtime compilation (SYSLIB1045)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -230,9 +230,6 @@ dotnet_diagnostic.IDE0300.severity = suggestion
 # IDE1006: Naming Styles
 dotnet_diagnostic.IDE1006.severity = suggestion
 
-# SYSLIB1045: Convert to 'GeneratedRegexAttribute'.
-dotnet_diagnostic.SYSLIB1045.severity = suggestion
-
 # ---------------------
 # Ref specific C# files
 # ---------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -925,7 +925,7 @@ namespace Microsoft.Build.Tasks.Windows
 
 
     // writing to a file, removing or updating uid
-    internal sealed class UidWriter
+    internal sealed partial class UidWriter
     {
         internal UidWriter(UidCollector collector, Stream source, Stream target)
         {
@@ -1101,7 +1101,7 @@ namespace Microsoft.Build.Tasks.Windows
             // escape all the Xml entities in the value
             string attributeValue = EscapedXmlEntities.Replace(
                 uid.Value,
-                EscapeMatchEvaluator
+                s_escapeMatchEvaluator
                 );
 
             string clause = string.Format(
@@ -1128,11 +1128,6 @@ namespace Microsoft.Build.Tasks.Windows
 
         private void WriteNewAttributeValue(string value)
         {
-            string attributeValue = EscapedXmlEntities.Replace(
-                value,
-                EscapeMatchEvaluator
-                );
-
             _targetWriter.Write(
                 string.Format(
                     TypeConverterHelper.InvariantEnglishUS,
@@ -1308,8 +1303,13 @@ namespace Microsoft.Build.Tasks.Windows
             Skip  = 1,  // skip the content
         }
 
-        private static Regex          EscapedXmlEntities   = new Regex("(<|>|\"|'|&)", RegexOptions.CultureInvariant | RegexOptions.Compiled);
-        private static MatchEvaluator EscapeMatchEvaluator = new MatchEvaluator(EscapeMatch);
+#if !NETFX
+        [GeneratedRegex("(<|>|\"|'|&)", RegexOptions.CultureInvariant)]
+        private static partial Regex EscapedXmlEntities { get; }
+#else
+        private static readonly Regex EscapedXmlEntities = new("(<|>|\"|'|&)", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+#endif
+        private static readonly MatchEvaluator s_escapeMatchEvaluator = new MatchEvaluator(EscapeMatch);
 
         /// <summary>
         /// the delegate to escape the matched pattern

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/WinRTSpellerInterop.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/WinRTSpellerInterop.cs
@@ -543,6 +543,9 @@ namespace System.Windows.Documents
             }
         }
 
+        [GeneratedRegex(@"\s*\#LID\s+(\d+)\s*", RegexOptions.Singleline | RegexOptions.CultureInvariant)]
+        private static partial Regex LexiconCultureRegex { get; }
+
         /// <summary>
         ///     Detect whether the <paramref name="line"/> is of the form #LID nnnn,
         ///     and if it is, try to instantiate a CultureInfo object with LCID nnnn.
@@ -553,9 +556,6 @@ namespace System.Windows.Documents
         /// </returns>
         private static CultureInfo TryParseLexiconCulture(string line)
         {
-            const string regexPattern = @"\s*\#LID\s+(\d+)\s*";
-            RegexOptions regexOptions = RegexOptions.Singleline | RegexOptions.CultureInvariant | RegexOptions.Compiled;
-
             CultureInfo result = CultureInfo.InvariantCulture;
 
             if (line == null)
@@ -563,7 +563,7 @@ namespace System.Windows.Documents
                 return result;
             }
 
-            string[] matches = Regex.Split(line.Trim(), regexPattern, regexOptions);
+            string[] matches = LexiconCultureRegex.Split(line.Trim());
 
             // We expect 1 exact match, which implies matches.Length == 3 (before, match, after)
             if (matches.Length != 3)


### PR DESCRIPTION
Fixes #10302

## Description

Use `GeneratedRegex` attribute to allow for source-generation of regexes at compile time for improved performance.

We only use regexes in two places which could effectively be removed but for now we should at least take advantage of the highest-performing form of regular expressions on .NET.

In the PBT case, we have to use a pre-processor statement to comfort NetFX scenario, which will later need naming-styles suppression.

Note: `RegexOptions.Compiled` is ignored in source-generated regexes, so I've removed it.

## Customer Impact

Improved performance, cleaner codebase.

## Regression

No.

## Testing

Local build.

## Risk

While the second occurence was fixed manually because analyzer won't flag it (guess nobody thought someone is declaring regex inline with a const), the change is straightforward.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10303)