### PR TITLE
Fix flaky tests

### DIFF
--- a/eng/WpfArcadeSdk/tools/FolderPaths.props
+++ b/eng/WpfArcadeSdk/tools/FolderPaths.props
@@ -9,6 +9,7 @@
     <WpfCycleBreakersDir>$(RepoRoot)src\Microsoft.DotNet.Wpf\cycle-breakers\</WpfCycleBreakersDir>
     <WpfApiCompatBaselineDir>$(RepoRoot)src\Microsoft.DotNet.Wpf\ApiCompat\Baselines\</WpfApiCompatBaselineDir>
     <WpfSourceDir>$(RepoRoot)src\Microsoft.DotNet.Wpf\src\</WpfSourceDir>
+    <WpfRedistDir>$(RepoRoot)src\Microsoft.DotNet.Wpf\redist\</WpfRedistDir>
     <WpfGraphicsPath>$(WpfSourceDir)WpfGfx\</WpfGraphicsPath>
     <WpfGraphicsDir>$(WpfGraphicsPath)</WpfGraphicsDir>
     <WpfPresentationNativeDir>$(WpfSourceDir)PresentationNative\</WpfPresentationNativeDir>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/Directory.Build.targets
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/Directory.Build.targets
@@ -2,10 +2,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <_PackagingNativePath Condition="'$(WpfRuntimeIdentifier)'=='win-x64' And '$(Configuration)' != 'Debug'">$(ArtifactsDir)packaging\$(Configuration)\x64\Microsoft.DotNet.Wpf.GitHub</_PackagingNativePath>
-    <_PackagingNativePath Condition="'$(WpfRuntimeIdentifier)'=='win-x64' And '$(Configuration)' == 'Debug'">$(ArtifactsDir)packaging\$(Configuration)\x64\Microsoft.DotNet.Wpf.GitHub.Debug</_PackagingNativePath>
-    <_PackagingNativePath Condition="'$(WpfRuntimeIdentifier)'=='win-x86' And '$(Configuration)' != 'Debug'">$(ArtifactsDir)packaging\$(Configuration)\Microsoft.DotNet.Wpf.GitHub</_PackagingNativePath>
-    <_PackagingNativePath Condition="'$(WpfRuntimeIdentifier)'=='win-x86' And '$(Configuration)' == 'Debug'">$(ArtifactsDir)packaging\$(Configuration)\Microsoft.DotNet.Wpf.GitHub.Debug</_PackagingNativePath>
+    <_PackagingNativePath>$(ArtifactsPackagingDir)$(GitHubTransportPackageName)\runtimes\$(WpfRuntimeIdentifier)\native\</_PackagingNativePath>
   </PropertyGroup>
 
   <!--
@@ -15,12 +12,45 @@
           BeforeTargets="AssignTargetPaths"
           Returns="@(None)">
     <ItemGroup>
-      <!-- These exist to ensure that dependencies (esp. native ones) are binplaced with tests correctly -->
-      <None Include="$(_PackagingNativePath)\runtimes\$(WpfRuntimeIdentifier)\native\*.dll"
+      <!--
+        These exist to ensure that dependencies (esp. native ones) are binplaced with tests correctly.
+        We use the explicit file names instead of globbing to make the build fail if the dlls were not found.
+      -->
+      <_WpfNativeDependency Include="$(_PackagingNativePath)D3DCompiler_47_cor3.dll" Condition="'$(WpfRuntimeIdentifier)' != 'win-arm64'" />
+      <_WpfNativeDependency Include="$(_PackagingNativePath)PresentationNative_cor3.dll" />
+      <_WpfNativeDependency Include="$(_PackagingNativePath)vcruntime140d.dll" Condition="'$(Configuration)' == 'Debug'" />
+      <_WpfNativeDependency Include="$(_PackagingNativePath)vcruntime140_cor3.dll" Condition="'$(Configuration)' != 'Debug'" />
+      <_WpfNativeDependency Include="$(_PackagingNativePath)PenImc_cor3.dll" />
+      <_WpfNativeDependency Include="$(_PackagingNativePath)wpfgfx_cor3.dll" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Include="@(_WpfNativeDependency)"
             CopyToOutputDirectory="PreserveNewest"
             Visible="False" />
     </ItemGroup>
   </Target>
+
+  <!--
+    Include native dependencies as project reference to make sure that they are built before the test projects and before the task IncludeNativeDependencies is executed.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="$(WpfRedistDir)D3DCompiler\D3DCompiler.vcxproj"
+                      ReferenceOutputAssembly="False"
+                      Visible="False" />
+    <ProjectReference Include="$(WpfRedistDir)PresentationNative\PresentationNative.vcxproj"
+                      ReferenceOutputAssembly="False"
+                      Visible="False" />
+    <ProjectReference Include="$(WpfRedistDir)VCRuntime\VCRuntime.vcxproj"
+                      ReferenceOutputAssembly="False"
+                      Visible="False" />
+    <ProjectReference Include="$(WpfSourceDir)PenImc\dll\PenImc.vcxproj"
+                      ReferenceOutputAssembly="False"
+                      Visible="True" />
+    <ProjectReference Include="$(WpfSourceDir)WpfGfx\core\dll\wpfgfx.vcxproj"
+                      ReferenceOutputAssembly="False"
+                      Visible="False" />
+  </ItemGroup>
 
   <!--
    Referencing packages that reference the desktop package causes grief with building internally. Currently this


### PR DESCRIPTION
Fixes dotnet/wpf#10250

## Description
This fixes the flaky tests which was caused by the native dependencies sometime not being built before the test projects. This PR adds an explicit reference to the projects of the native dependencies to make sure that it's built in the right order and also adds some protection by including the files explictly instead of using file globbing to make the build fail with an error which contain the path of the file missing instead of the tests failing to start, which improves the build logs in case of error.

## Customer Impact
None, tests only.

## Regression
No.

## Testing
Did a bunch of local builds and it fails on 1 out of 5 build before this PR and I did ~10 local builds with this PR and it didn't failed. I also validated the build order in the build log.

## Risk
Low to none, tests only.

/cc @JeremyKuhne since you worked in that area too lately.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10304)