### PR TITLE
Use stack-allocated/inline arrays with fixed lengths in more spaces

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/VersionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/VersionHelper.cs
@@ -37,7 +37,7 @@ namespace MS.Internal
         /// If parsing succeeded, the parsed version. Otherwise a version instance with all parts set to zero.
         /// If <paramref name="s"/> contains * the version build and/or revision numbers are set to <see cref="ushort.MaxValue"/>.
         /// </param>
-        /// <param name="hasWildcard">If parsing succeeds, indicates if a wilcard character was found in the version.</param>
+        /// <param name="hasWildcard">If parsing succeeds, indicates if a wildcard character was found in the version.</param>
         /// <returns>True when parsing succeeds completely (i.e. every character in the string was consumed), false otherwise.</returns>
         internal static bool TryParseAssemblyVersion(string s, bool allowWildcard, out Version version, out bool hasWildcard)
         {
@@ -80,7 +80,7 @@ namespace MS.Internal
                 return false;
             }
 
-            ushort[] values = new ushort[4];
+            Span<ushort> values = stackalloc ushort[4];
             int lastExplicitValue = hasWildcard ? elements.Length - 1 : elements.Length;
             bool parseError = false;
             for (int i = 0; i < lastExplicitValue; i++)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Bezier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Bezier.cs
@@ -110,10 +110,10 @@ namespace MS.Internal.Ink
 
             Debug.Assert(to - from >= 4);
             int d = (to - from) / 4;
-            int[] i = { from, from + d, (to + from) / 2, to - d, to };
+            ReadOnlySpan<int> indices = [from, from + d, (to + from) / 2, to - d, to];
 
             // Test for "cubicness"
-            return CoCubic(data, i, error);
+            return CoCubic(data, indices, error);
         }
 
 
@@ -407,32 +407,32 @@ namespace MS.Internal.Ink
         /// Checks whether five points are co-cubic within tolerance
         /// </summary>
         /// <param name="data">In: Data points</param>
-        /// <param name="i">In: Array of 5 indices</param>
+        /// <param name="indices">In: Array of 5 indices</param>
         /// <param name="fitError">In: tolerated error - squared</param>
         /// <returns>Return true if extended</returns>
-        private static bool CoCubic(CuspData data, int[] i, double fitError)
+        private static bool CoCubic(CuspData data, ReadOnlySpan<int> indices, double fitError)
         {
             /* Our error estimate is (t[4]-t[0])^4 times the 4th divided difference
             * of the points with resect to the nodes. The divided difference is
             * equal to Sum(c(i)*p[i]), where c(i)=Product(t[i]-t[j]: j != i)
-            * (See Conte & deBoor's Elementary Numerical Analysis, Excercise 2.2-1).
+            * (See Conte & deBoor's Elementary Numerical Analysis, Exercise 2.2-1).
             * We multiply each factor in the product by t[4]-t[0].
             */
-            double d04 = data.Node(i[4]) - data.Node(i[0]);
-            double d01 = d04 / (data.Node(i[1]) - data.Node(i[0]));
-            double d02 = d04 / (data.Node(i[2]) - data.Node(i[0]));
-            double d03 = d04 / (data.Node(i[3]) - data.Node(i[0]));
-            double d12 = d04 / (data.Node(i[2]) - data.Node(i[1]));
-            double d13 = d04 / (data.Node(i[3]) - data.Node(i[1]));
-            double d14 = d04 / (data.Node(i[4]) - data.Node(i[1]));
-            double d23 = d04 / (data.Node(i[3]) - data.Node(i[2]));
-            double d24 = d04 / (data.Node(i[4]) - data.Node(i[2]));
-            double d34 = d04 / (data.Node(i[4]) - data.Node(i[3]));
-            Vector P =  d01 * d02 * d03 * data.XY(i[0]) - 
-                        d01 * d12 * d13 * d14 * data.XY(i[1]) + 
-                        d02 * d12 * d23 * d24 * data.XY(i[2]) - 
-                        d03 * d13 * d23 * d34 * data.XY(i[3]) + 
-                        d14 * d24 * d34 * data.XY(i[4]);
+            double d04 = data.Node(indices[4]) - data.Node(indices[0]);
+            double d01 = d04 / (data.Node(indices[1]) - data.Node(indices[0]));
+            double d02 = d04 / (data.Node(indices[2]) - data.Node(indices[0]));
+            double d03 = d04 / (data.Node(indices[3]) - data.Node(indices[0]));
+            double d12 = d04 / (data.Node(indices[2]) - data.Node(indices[1]));
+            double d13 = d04 / (data.Node(indices[3]) - data.Node(indices[1]));
+            double d14 = d04 / (data.Node(indices[4]) - data.Node(indices[1]));
+            double d23 = d04 / (data.Node(indices[3]) - data.Node(indices[2]));
+            double d24 = d04 / (data.Node(indices[4]) - data.Node(indices[2]));
+            double d34 = d04 / (data.Node(indices[4]) - data.Node(indices[3]));
+            Vector P =  d01 * d02 * d03 * data.XY(indices[0]) - 
+                        d01 * d12 * d13 * d14 * data.XY(indices[1]) + 
+                        d02 * d12 * d23 * d24 * data.XY(indices[2]) - 
+                        d03 * d13 * d23 * d34 * data.XY(indices[3]) + 
+                        d14 * d24 * d34 * data.XY(indices[4]);
 
             return ((P * P) < fitError);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/InkSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/InkSerializer.cs
@@ -268,13 +268,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
             return;
         }
 
-        private static ReadOnlySpan<byte> Base64HeaderBytes => [(byte)'b',
-                                                                (byte)'a',
-                                                                (byte)'s',
-                                                                (byte)'e',
-                                                                (byte)'6',
-                                                                (byte)'4',
-                                                                (byte)':'];
+        private static ReadOnlySpan<byte> Base64HeaderBytes => "base64:"u8;
 
 #if OLD_ISF
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/MetricEntry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/MetricEntry.cs
@@ -45,12 +45,13 @@ namespace MS.Internal.Ink.InkSerializedFormat
     internal class MetricEntry
     {
         //Maximum buffer size required to store the largest MetricEntry
-        private static int MAX_METRIC_DATA_BUFF = 24;
+        private const int MAX_METRIC_DATA_BUFF = 24;
+        // We always allocate the max buffer needed to store the largest possible Metric Information blob
+        private readonly byte[] _data = new byte[MAX_METRIC_DATA_BUFF];
 
         private KnownTagCache.KnownTagIndex _tag = 0;
         private uint _size = 0;
         private MetricEntry _next;
-        private byte[] _data = new Byte[MAX_METRIC_DATA_BUFF]; // We always allocate the max buffer needed to store the largest possible Metric Information blob
         private static MetricEntryList[] _metricEntryOptional;
 
         // helpers for Ink-local property metrics for X/Y coordiantes

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media3D/LineUtil.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media3D/LineUtil.cs
@@ -490,18 +490,18 @@ namespace MS.Internal.Media3D
             }
         
             bool inside = true;
-            bool[] middle = new bool[3];        // True if ray origin in middle for coord i.
-            double[] plane = new double[3];     // Candidate BBox Planes
-            int i;                              // General Loop Counter
-        
+            Span<bool> middle = stackalloc bool[3];        // True if ray origin in middle for coord i.
+            Span<double> plane = stackalloc double[3];     // Candidate BBox Planes
+            int i;                                         // General Loop Counter
+
             // Find all candidate planes; select the plane nearest to the ray origin
             // for each coordinate.
-        
-            double[] rgfMin = new double[] { box.X, box.Y, box.Z };
-            double[] rgfMax = new double[] { box.X + box.SizeX, box.Y + box.SizeY, box.Z + box.SizeZ };
-            double[] rgfRayPos = new double[] { origin.X, origin.Y, origin.Z };
-            double[] rgfRayDir = new double[] { direction.X, direction.Y, direction.Z };
-        
+
+            ReadOnlySpan<double> rgfMin = [box.X, box.Y, box.Z];
+            ReadOnlySpan<double> rgfMax = [box.X + box.SizeX, box.Y + box.SizeY, box.Z + box.SizeZ];
+            ReadOnlySpan<double> rgfRayPos = [origin.X, origin.Y, origin.Z];
+            ReadOnlySpan<double> rgfRayDir = [direction.X, direction.Y, direction.Z];
+
             for (i = 0; i < 3; ++i)
             {
                 if (rgfRayPos[i] < rgfMin[i])

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
@@ -1023,12 +1023,12 @@ namespace MS.Internal
             ItemValueStorageField.ClearValue(owner);
         }
 
-        internal static void ClearItemValueStorage(DependencyObject owner, int[] dpIndices)
+        internal static void ClearItemValueStorage(DependencyObject owner, ReadOnlySpan<int> dpIndices)
         {
             ClearItemValueStorageRecursive(ItemValueStorageField.GetValue(owner), dpIndices);
         }
 
-        private static void ClearItemValueStorageRecursive(WeakDictionary<object, List<KeyValuePair<int, object>>> itemValueStorage, int[] dpIndices)
+        private static void ClearItemValueStorageRecursive(WeakDictionary<object, List<KeyValuePair<int, object>>> itemValueStorage, ReadOnlySpan<int> dpIndices)
         {
             if (itemValueStorage != null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
@@ -1552,7 +1552,7 @@ namespace System.Windows.Controls
 
             // Text selection is inherently different from speller highlights.  We are guaranteed a single contiguous range.
             // As such, we can optimize our algorithm to choose arrange over measure.
-            int[] offsets = new int[] { currentSelectionRange.StartIndex, currentSelectionRange.StartIndex + currentSelectionRange.PositionsAdded };
+            ReadOnlySpan<int> offsets = [currentSelectionRange.StartIndex, currentSelectionRange.StartIndex + currentSelectionRange.PositionsAdded];
 
             using (TextBoxLine line = new TextBoxLine(this))
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GroupItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GroupItem.cs
@@ -352,7 +352,7 @@ namespace System.Windows.Controls
 
         void IContainItemStorage.ClearValue(DependencyProperty dp)
         {
-            Helper.ClearItemValueStorage(this, new int[] {dp.GlobalIndex});
+            Helper.ClearItemValueStorage(this, [dp.GlobalIndex]);
         }
 
         void IContainItemStorage.Clear()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
@@ -3974,7 +3974,7 @@ namespace System.Windows.Controls
 
         void IContainItemStorage.ClearValue(DependencyProperty dp)
         {
-            Helper.ClearItemValueStorage(this, new int[] {dp.GlobalIndex});
+            Helper.ClearItemValueStorage(this, [dp.GlobalIndex]);
         }
 
         void IContainItemStorage.Clear()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
@@ -3377,8 +3377,7 @@ namespace System.Windows.Documents
 
         internal void ComputePreferredCodePage()
         {
-            int[] CodePageList = {
-                1252, 932, 949, 1361, 936, 950, 1253, 1254, 1258, 1255, 1256, 1257, 1251, 874, 1250, 437, 850 };
+            ReadOnlySpan<int> CodePageList = [1252, 932, 949, 1361, 936, 950, 1253, 1254, 1258, 1255, 1256, 1257, 1251, 874, 1250, 437, 850];
 
             CodePage = 1252;
             CharSet = 0;
@@ -3388,9 +3387,9 @@ namespace System.Windows.Documents
                 byte[] rgBytes = new byte[Name.Length * 6];
                 char[] rgChars = new char[Name.Length * 6];
 
-                for (int i = 0; i < CodePageList.Length; i++)
+                foreach (int codePage in CodePageList)
                 {
-                    Encoding e = InternalEncoding.GetEncoding(CodePageList[i]);
+                    Encoding e = InternalEncoding.GetEncoding(codePage);
 
                     int cb = e.GetBytes(Name, 0, Name.Length, rgBytes, 0);
                     int cch = e.GetChars(rgBytes, 0, cb, rgChars, 0);
@@ -3409,8 +3408,8 @@ namespace System.Windows.Documents
                         // This code page can encode this font name.
                         if (k == cch)
                         {
-                            CodePage = CodePageList[i];
-                            CharSet = CodePageToCharSet(CodePage);
+                            CodePage = codePage;
+                            CharSet = CodePageToCharSet(codePage);
                             break;
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
@@ -3377,7 +3377,7 @@ namespace System.Windows.Documents
 
         internal void ComputePreferredCodePage()
         {
-            ReadOnlySpan<int> CodePageList = [1252, 932, 949, 1361, 936, 950, 1253, 1254, 1258, 1255, 1256, 1257, 1251, 874, 1250, 437, 850];
+            ReadOnlySpan<int> codePageList = [1252, 932, 949, 1361, 936, 950, 1253, 1254, 1258, 1255, 1256, 1257, 1251, 874, 1250, 437, 850];
 
             CodePage = 1252;
             CharSet = 0;
@@ -3387,7 +3387,7 @@ namespace System.Windows.Documents
                 byte[] rgBytes = new byte[Name.Length * 6];
                 char[] rgChars = new char[Name.Length * 6];
 
-                foreach (int codePage in CodePageList)
+                foreach (int codePage in codePageList)
                 {
                     Encoding e = InternalEncoding.GetEncoding(codePage);
 
@@ -3396,7 +3396,7 @@ namespace System.Windows.Documents
 
                     if (cch == Name.Length)
                     {
-                        int k = 0;
+                        int k;
                         for (k = 0; k < cch; k++)
                         {
                             if (rgChars[k] != Name[k])

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlStream.cs
@@ -211,25 +211,20 @@ namespace System.Windows.Markup
         /// <param name="offset">zero base starting offset</param>
         /// <param name="count">number of bytes to read</param>
         /// <returns></returns>
-        internal int Read(byte[] buffer, int offset, int count)
+        internal int Read(Span<byte> buffer, int offset, int count)
         {
             ArgumentOutOfRangeException.ThrowIfGreaterThan(count, ReadLength - ReadPosition);
-            int bufferOffset;
-            int bufferIndex;
 
-            byte[] readBuffer = GetBufferFromFilePosition(
-                ReadPosition,true /*reader*/,
-                out bufferOffset, out bufferIndex);
+            byte[] readBuffer = GetBufferFromFilePosition(ReadPosition, reader: true, out int bufferOffset, out _);
 
-
-            Debug.Assert(bufferOffset < BufferSize,"Calculated bufferOffset is greater than buffer");
+            Debug.Assert(bufferOffset < BufferSize, "Calculated bufferOffset is greater than buffer");
 
             // see how many bytes we can read from this buffer.
-            int availableBytesInBuffer =  BufferSize - bufferOffset;
+            int availableBytesInBuffer = BufferSize - bufferOffset;
             int leftOverBytes = 0;
             int bufferReadCount = 0;
 
-            // check if ther is enough room in the write buffer to meet the
+            // check if there is enough room in the write buffer to meet the
             // request or if there will be leftOverBytes.
             if (count > availableBytesInBuffer)
             {
@@ -257,7 +252,7 @@ namespace System.Windows.Markup
 
             if (leftOverBytes > 0)
             {
-                Read(buffer,offset,(int) leftOverBytes);
+                Read(buffer, offset, leftOverBytes);
             }
 
             return count;
@@ -271,11 +266,12 @@ namespace System.Windows.Markup
         /// <returns></returns>
         internal int ReadByte()
         {
-            byte[] buffer = new byte[1];
+            byte buffer = byte.MinValue;
 
             // uses Read to validate if reading past the end of the file.
-            Read(buffer,0,1);
-            return (int) buffer[0];
+            Read(new Span<byte>(ref buffer), 0, 1);
+
+            return buffer;
         }
 
         /// <summary>
@@ -823,7 +819,7 @@ namespace System.Windows.Markup
         /// </summary>
         public override int Read(byte[] buffer, int offset, int count)
         {
-            return StreamManager.Read(buffer,offset,count);
+            return StreamManager.Read(buffer, offset, count);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/ImageProxy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/ImageProxy.cs
@@ -218,15 +218,15 @@ namespace Microsoft.Internal.AlphaFlattener
             
             Decode();
 
-            Byte[] map = new Byte[256];
-            
-            for (int i = 0; i < 256; i ++)
+            Span<byte> map = stackalloc byte[256];
+
+            for (int i = 0; i < 256; i++)
             {
-                map[i] = (Byte)(i * op / 255);
+                map[i] = (byte)(i * op / 255);
             }
 
             int count = _pixelWidth * _pixelHeight * 4;
-            
+
             for (int i = 0; i < count; i++)
             {
                 _pixels[i] = map[_pixels[i]];


### PR DESCRIPTION
## Description

Finding a few more places that are just low hanging fruit to swap from heap-allocated arrays to stack-allocated/inline-arrays.

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build.

## Risk

Low, the swaps are pretty much 1:1.
