### PR TITLE
[Cleanup] Use named arguments in PresentationCore

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/AnimatedTypeHelpers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/AnimatedTypeHelpers.cs
@@ -130,7 +130,7 @@ namespace MS.Internal.PresentationCore
 
         internal static Rotation3D InterpolateRotation3D(Rotation3D from, Rotation3D to, Double progress)
         {
-            return new QuaternionRotation3D(InterpolateQuaternion(from.InternalQuaternion, to.InternalQuaternion, progress, /* useShortestPath = */ true));
+            return new QuaternionRotation3D(InterpolateQuaternion(from.InternalQuaternion, to.InternalQuaternion, progress, useShortestPath: true));
         }
         
         internal static Single InterpolateSingle(Single from, Single to, Double progress)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/AppModel/CookieHandler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/AppModel/CookieHandler.cs
@@ -32,7 +32,7 @@ namespace MS.Internal.AppModel
         {
             try
             {
-                string cookies = GetCookie(httpRequest.RequestUri, false/*throwIfNoCookie*/);
+                string cookies = GetCookie(httpRequest.RequestUri, throwIfNoCookie: false);
                 if(!string.IsNullOrEmpty(cookies))
                 {
                     if (httpRequest.CookieContainer == null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/ElementUtil.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/ElementUtil.cs
@@ -77,7 +77,7 @@ namespace MS.Internal.Automation
             {
                 return null;
             }
-            return FindVisibleSibling ( parent, el, true /* Next */);
+            return FindVisibleSibling ( parent, el, searchForwards: true);
         }
 
         // Warning: Method is O(N). See FindVisibleSibling function for more information.
@@ -92,7 +92,7 @@ namespace MS.Internal.Automation
                 return null;
             }
 
-            return FindVisibleSibling ( parent, el, false /* Previous */);
+            return FindVisibleSibling ( parent, el, searchForwards: false);
         }
 
         internal static Visual GetRoot( Visual el )

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/CachedFontFace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/CachedFontFace.cs
@@ -151,7 +151,7 @@ namespace MS.Internal.FontCache
                 return new GlyphTypeface(
                     _familyCollection.GetFontUri(CachedPhysicalFace),
                     CachedPhysicalFace->styleSimulations,
-                    /* fromPublic = */ false
+                    fromPublic: false
                 );
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/IListConverters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/IListConverters.cs
@@ -93,7 +93,7 @@ namespace System.Windows.Media.Converters
     {
         internal sealed override object ConvertFromCore(ITypeDescriptorContext td, CultureInfo ci, string value)
         {
-            _tokenizer = new TokenizerHelper(value, '\0' /* quote char */, DelimiterChar);
+            _tokenizer = new TokenizerHelper(value, quoteChar: '\0', DelimiterChar);
             
             // Estimate the output list's capacity from length of the input string. 
             List<double> list = new List<double>(Math.Min(256, value.Length / EstimatedCharCountPerItem + 1));
@@ -138,7 +138,7 @@ namespace System.Windows.Media.Converters
     {
         internal override object ConvertFromCore(ITypeDescriptorContext td, CultureInfo ci, string value)
         {
-            _tokenizer = new TokenizerHelper(value, '\0' /* quote char */, DelimiterChar);
+            _tokenizer = new TokenizerHelper(value, quoteChar: '\0', DelimiterChar);
             List<ushort> list = new List<ushort>(Math.Min(256, value.Length / EstimatedCharCountPerItem + 1));
             while (_tokenizer.NextToken())
             {
@@ -179,7 +179,7 @@ namespace System.Windows.Media.Converters
     {
         internal override object ConvertFromCore(ITypeDescriptorContext td, CultureInfo ci, string value)
         {
-             _tokenizer = new TokenizerHelper(value, '\0' /* quote char */, DelimiterChar);            
+             _tokenizer = new TokenizerHelper(value, quoteChar: '\0', DelimiterChar);            
             List<bool> list = new List<bool>(Math.Min(256, value.Length / EstimatedCharCountPerItem + 1));
             while (_tokenizer.NextToken())
             {
@@ -220,7 +220,7 @@ namespace System.Windows.Media.Converters
     {
         internal override object ConvertFromCore(ITypeDescriptorContext td, CultureInfo ci, string value)
         {
-            _tokenizer = new TokenizerHelper(value, '\0' /* quote char */, DelimiterChar);
+            _tokenizer = new TokenizerHelper(value, quoteChar: '\0', DelimiterChar);
             
             List<Point> list = new List<Point>(Math.Min(256, value.Length / EstimatedCharCountPerItem + 1));
             while (_tokenizer.NextToken())

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Lasso.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Lasso.cs
@@ -786,10 +786,12 @@ namespace MS.Internal.Ink
                     continue;
                 }
 
-                double s = FindIntersection(points[count-1] - points[i],            /*hitBegin*/
-                                                    point - points[i],              /*hitEnd*/
-                                                    new Vector(0, 0),               /*orgBegin*/
-                                                    points[i+1] - points[i]         /*orgEnd*/);
+                double s = FindIntersection(
+                    hitBegin: points[count-1] - points[i],
+                    hitEnd: point - points[i],
+                    orgBegin: new Vector(0, 0),
+                    orgEnd: points[i+1] - points[i]);
+
                 if (s >=0 && s <= 1)
                 {
                     // Intersection found, adjust the fIndex

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Lasso.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Lasso.cs
@@ -729,7 +729,7 @@ namespace MS.Internal.Ink
                 // points[i-1] should be removed
                 if (i > 0)
                 {
-                    points.RemoveRange(0, i /*count*/);   // Remove points[0] to points[i-1]
+                    points.RemoveRange(0, count: i);   // Remove points[0] to points[i-1]
                     IsIncrementalLassoDirty = true;
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Renderer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Renderer.cs
@@ -256,7 +256,7 @@ namespace System.Windows.Ink
                     StartListeningOnStrokeEvents(visual.Stroke);
 
                     // Attach it to the visual tree
-                    AttachVisual(visual, true/*buildingStrokeCollection*/);
+                    AttachVisual(visual, buildingStrokeCollection: true);
                 }
 
                 // Start listening on events from the stroke collection.
@@ -445,7 +445,7 @@ namespace System.Windows.Ink
                 StartListeningOnStrokeEvents(visual.Stroke);
 
                 // Attach it to the visual tree
-                AttachVisual(visual, false/*buildingStrokeCollection*/);
+                AttachVisual(visual, buildingStrokeCollection: false);
             }
 
             // Deal with removed strokes first
@@ -492,7 +492,7 @@ namespace System.Windows.Ink
             {
                 // The change requires reparenting the visual in the tree.
                 DetachVisual(visual);
-                AttachVisual(visual, false/*buildingStrokeCollection*/);
+                AttachVisual(visual, buildingStrokeCollection: false);
 
                 // Update the cached values
                 visual.CachedIsHighlighter = stroke.DrawingAttributes.IsHighlighter;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeEnumerator.cs
@@ -216,7 +216,7 @@ namespace MS.Internal.Ink
                 }
 
                 //we use previousIndex+1 because index can skip ahead
-                return new StrokeNode(_operations, previousIndex + 1, nodeData, lastNodeData, index == _stylusPoints.Count - 1 /*Is this the last node?*/);
+                return new StrokeNode(_operations, previousIndex + 1, nodeData, lastNodeData, isLastNode: index == _stylusPoints.Count - 1);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeRenderer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeRenderer.cs
@@ -867,21 +867,21 @@ namespace MS.Internal.Ink
             Debug.Assert(points != null);
             Debug.Assert(points.Count > 0);
 
-            context.BeginFigure(points[points.Count - 1], //start point
-                                        true,   //isFilled
-                                        true);  //IsClosed
+            context.BeginFigure(startPoint: points[points.Count - 1],
+                                isFilled: true,
+                                isClosed: true);
 
             if (isBezierFigure)
             {
                 context.PolyBezierTo(points,
-                                     true,      //isStroked
-                                     true);     //isSmoothJoin
+                                     isStroked: true,
+                                     isSmoothJoin: true);
             }
             else
             {
                 context.PolyLineTo(points,
-                                     true,      //isStroked
-                                     true);     //isSmoothJoin
+                                   isStroked: true,
+                                   isSmoothJoin: true);
             }
         }
 
@@ -895,18 +895,18 @@ namespace MS.Internal.Ink
             Debug.Assert(abPoints != null && dcPoints != null);
             Debug.Assert(abPoints.Count > 0 && dcPoints.Count > 0);
 
-            context.BeginFigure(abPoints[0], //start point
-                                        true,   //isFilled
-                                        true);  //IsClosed
+            context.BeginFigure(startPoint: abPoints[0],
+                                isFilled: true,
+                                isClosed: true);
 
             context.PolyLineTo(abPoints,
-                                 true,      //isStroked
-                                 true);     //isSmoothJoin
+                               isStroked: true,
+                               isSmoothJoin: true);
 
             context.PolyLineTo(dcPoints,
-                                 true,      //isStroked
-                                 true);     //isSmoothJoin
-}
+                               isStroked: true,
+                               isSmoothJoin: true);
+        }
 
         /// <summary>
         /// Private helper to render a path figure to the SGC
@@ -922,9 +922,9 @@ namespace MS.Internal.Ink
                 return;
             }
 
-            context.BeginFigure(abPoints[0], //start point
-                                        true,   //isFilled
-                                        true);  //IsClosed
+            context.BeginFigure(startPoint: abPoints[0],
+                                isFilled: true,
+                                isClosed: true);
 
             for (int j = 0; j < 2; j++)
             {
@@ -938,9 +938,9 @@ namespace MS.Internal.Ink
                         if (polyLinePoints.Count > 0)
                         {
                             //polyline first
-                            context.PolyLineTo(  polyLinePoints,
-                                                 true,      //isStroked
-                                                 true);     //isSmoothJoin
+                            context.PolyLineTo(polyLinePoints,
+                                               isStroked: true,
+                                               isSmoothJoin: true);
                             polyLinePoints.Clear();
                         }
                         //we're arcing, pull out height, width and the arc to point
@@ -948,18 +948,18 @@ namespace MS.Internal.Ink
                         if (i + 2 < points.Count)
                         {
                             Point sizePoint = points[i + 1];
-                            Size ellipseSize = new Size(sizePoint.X / 2/*width*/, sizePoint.Y / 2/*height*/);
+                            Size ellipseSize = new Size(width: sizePoint.X / 2, height: sizePoint.Y / 2);
                             Point arcToPoint = points[i + 2];
 
                             bool isLargeArc = false; //>= 180
 
-                            context.ArcTo(  arcToPoint,
-                                            ellipseSize,
-                                            0d,             //rotation
-                                            isLargeArc,     //isLargeArc
-                                            SweepDirection.Clockwise,
-                                            true,           //isStroked
-                                            true);          //isSmoothJoin
+                            context.ArcTo(arcToPoint,
+                                          ellipseSize,
+                                          rotationAngle: 0d,
+                                          isLargeArc: isLargeArc,
+                                          SweepDirection.Clockwise,
+                                          isStroked: true,
+                                          isSmoothJoin: true);
                         }
                         i += 3; //advance past this arcTo block
                     }
@@ -974,8 +974,8 @@ namespace MS.Internal.Ink
                 {
                     //polyline
                     context.PolyLineTo(polyLinePoints,
-                                         true,      //isStroked
-                                         true);     //isSmoothJoin
+                                       isStroked: true,
+                                       isSmoothJoin: true);
                     polyLinePoints.Clear();
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeRenderer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeRenderer.cs
@@ -122,7 +122,7 @@ namespace MS.Internal.Ink
                             //insert a stroke node for the previous node
                             strokeNodePoints.Clear();
                             strokeNode.GetPreviousContourPoints(strokeNodePoints);
-                            AddFigureToStreamGeometryContext(context, strokeNodePoints, strokeNode.IsEllipse/*isBezierFigure*/);
+                            AddFigureToStreamGeometryContext(context, strokeNodePoints, isBezierFigure: strokeNode.IsEllipse);
 
                             previousPreviousNodeRendered = true;
                         }
@@ -130,7 +130,7 @@ namespace MS.Internal.Ink
                         //render the stroke node
                         strokeNodePoints.Clear();
                         strokeNode.GetContourPoints(strokeNodePoints);
-                        AddFigureToStreamGeometryContext(context, strokeNodePoints, strokeNode.IsEllipse/*isBezierFigure*/);
+                        AddFigureToStreamGeometryContext(context, strokeNodePoints, isBezierFigure: strokeNode.IsEllipse);
                     }
 
                     if (!directionChanged)
@@ -176,7 +176,7 @@ namespace MS.Internal.Ink
                             }
 
                             //now render away!
-                            AddFigureToStreamGeometryContext(context, connectingQuadPoints, false/*isBezierFigure*/);
+                            AddFigureToStreamGeometryContext(context, connectingQuadPoints, isBezierFigure: false);
                         }
                     }
                 }
@@ -490,7 +490,7 @@ namespace MS.Internal.Ink
                             {
                                 //render a complete first stroke node or we can get artifacts
                                 prevPrevStrokeNode.GetContourPoints(polyLinePoints);
-                                AddFigureToStreamGeometryContext(context, polyLinePoints, prevPrevStrokeNode.IsEllipse/*isBezierFigure*/);
+                                AddFigureToStreamGeometryContext(context, polyLinePoints, isBezierFigure: prevPrevStrokeNode.IsEllipse);
                                 polyLinePoints.Clear();
                             }
 
@@ -565,7 +565,7 @@ namespace MS.Internal.Ink
                                 {
                                     //render a complete stroke node or we can get artifacts
                                     prevStrokeNode.GetContourPoints(polyLinePoints);
-                                    AddFigureToStreamGeometryContext(context, polyLinePoints, prevStrokeNode.IsEllipse/*isBezierFigure*/);
+                                    AddFigureToStreamGeometryContext(context, polyLinePoints, isBezierFigure: prevStrokeNode.IsEllipse);
                                     polyLinePoints.Clear();
                                 }
                             }
@@ -672,7 +672,7 @@ namespace MS.Internal.Ink
                             // we only have a single point to render
                             Debug.Assert(pathFigureABSide.Count == 0);
                             prevPrevStrokeNode.GetContourPoints(pathFigureABSide);
-                            AddFigureToStreamGeometryContext(context, pathFigureABSide, prevPrevStrokeNode.IsEllipse/*isBezierFigure*/);
+                            AddFigureToStreamGeometryContext(context, pathFigureABSide, isBezierFigure: prevPrevStrokeNode.IsEllipse);
 }
                     }
                     else if (prevStrokeNode.IsValid && strokeNode.IsValid)
@@ -700,7 +700,7 @@ namespace MS.Internal.Ink
                             {
                                 //render a complete stroke node or we can get artifacts
                                 strokeNode.GetContourPoints(polyLinePoints);
-                                AddFigureToStreamGeometryContext(context, polyLinePoints, strokeNode.IsEllipse/*isBezierFigure*/);
+                                AddFigureToStreamGeometryContext(context, polyLinePoints, isBezierFigure: strokeNode.IsEllipse);
                             }
                         }
                         else
@@ -763,7 +763,7 @@ namespace MS.Internal.Ink
                 //we're between 100% and 70% overlapped
                 //just render two distinct figures with a connecting quad (if needed)
                 strokeNodePrevious.GetContourPoints(pointBuffer1);
-                AddFigureToStreamGeometryContext(context, pointBuffer1, strokeNodePrevious.IsEllipse/*isBezierFigure*/);
+                AddFigureToStreamGeometryContext(context, pointBuffer1, isBezierFigure: strokeNodePrevious.IsEllipse);
 
                 Quad quad = strokeNodeCurrent.GetConnectingQuad();
                 if (!quad.IsEmpty)
@@ -772,11 +772,11 @@ namespace MS.Internal.Ink
                     pointBuffer3.Add(quad.B);
                     pointBuffer3.Add(quad.C);
                     pointBuffer3.Add(quad.D);
-                    AddFigureToStreamGeometryContext(context, pointBuffer3, false/*isBezierFigure*/);
+                    AddFigureToStreamGeometryContext(context, pointBuffer3, isBezierFigure: false);
                 }
 
                 strokeNodeCurrent.GetContourPoints(pointBuffer2);
-                AddFigureToStreamGeometryContext(context, pointBuffer2, strokeNodeCurrent.IsEllipse/*isBezierFigure*/);
+                AddFigureToStreamGeometryContext(context, pointBuffer2, isBezierFigure: strokeNodeCurrent.IsEllipse);
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media/VisualTreeUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media/VisualTreeUtils.cs
@@ -186,7 +186,7 @@ namespace MS.Internal.Media
         /// </summary>
         internal static void EnsureNonNullVisual(DependencyObject element)
         {
-            EnsureVisual(element, /* allowNull = */ false);
+            EnsureVisual(element, allowNull: false);
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace MS.Internal.Media
         /// </summary>
         internal static void EnsureVisual(DependencyObject element)
         {
-            EnsureVisual(element, /* allowNull = */ true);
+            EnsureVisual(element, allowNull: true);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/ContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/ContentElement.cs
@@ -892,7 +892,7 @@ namespace System.Windows
         {
             get
             {
-                return TouchDevice.GetCapturedTouches(this, /* includeWithin = */ false);
+                return TouchDevice.GetCapturedTouches(this, includeWithin: false);
             }
         }
 
@@ -903,7 +903,7 @@ namespace System.Windows
         {
             get
             {
-                return TouchDevice.GetCapturedTouches(this, /* includeWithin = */ true);
+                return TouchDevice.GetCapturedTouches(this, includeWithin: true);
             }
         }
 
@@ -915,7 +915,7 @@ namespace System.Windows
         {
             get
             {
-                return TouchDevice.GetTouchesOver(this, /* includeWithin = */ true);
+                return TouchDevice.GetTouchesOver(this, includeWithin: true);
             }
         }
 
@@ -927,7 +927,7 @@ namespace System.Windows
         {
             get
             {
-                return TouchDevice.GetTouchesOver(this, /* includeWithin = */ false);
+                return TouchDevice.GetTouchesOver(this, includeWithin: false);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataObjectPastingEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataObjectPastingEventArgs.cs
@@ -123,7 +123,7 @@ namespace System.Windows
 
                 ArgumentNullException.ThrowIfNull(value);
 
-                availableFormats = value.GetFormats(/*autoConvert:*/false);
+                availableFormats = value.GetFormats(autoConvert: false);
                 if (availableFormats == null || availableFormats.Length == 0)
                 {
                     throw new ArgumentException(SR.DataObject_DataObjectMustHaveAtLeastOneFormat);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataObjectSettingDataEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataObjectSettingDataEventArgs.cs
@@ -38,7 +38,7 @@ namespace System.Windows
         /// Format which is going to be added to the DataObject.
         /// </param>
         public DataObjectSettingDataEventArgs(IDataObject dataObject, string format) //
-            : base(System.Windows.DataObject.SettingDataEvent, /*isDragDrop:*/false)
+            : base(System.Windows.DataObject.SettingDataEvent, isDragDrop: false)
         {
             ArgumentNullException.ThrowIfNull(dataObject);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DragDrop.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DragDrop.cs
@@ -670,7 +670,7 @@ namespace System.Windows
             GiveFeedbackEventArgs args;
 
             // Create GiveFeedback event arguments.
-            args = new GiveFeedbackEventArgs((DragDropEffects)effect, /*UseDefaultCursors*/ false);
+            args = new GiveFeedbackEventArgs((DragDropEffects)effect, useDefaultCursors: false);
 
             // Raise the give feedback event for both Tunnel(Preview) and Bubble.
             RaiseGiveFeedbackEvent(args);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/FreezableCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/FreezableCollection.cs
@@ -82,7 +82,7 @@ namespace System.Windows
                     throw new System.ArgumentException(SR.Collection_NoNull);
                 }
 
-                OnFreezablePropertyChanged(/* oldValue = */ null, item);
+                OnFreezablePropertyChanged(oldValue: null, item);
 
                 _collection.Add(item);
             }
@@ -151,7 +151,7 @@ namespace System.Windows
 
             for (int i = _collection.Count - 1; i >= 0; i--)
             {
-                OnFreezablePropertyChanged(/* oldValue = */ _collection[i], /* newValue = */ null);
+                OnFreezablePropertyChanged(oldValue: _collection[i], newValue: null);
             }
 
             _collection.Clear();
@@ -198,7 +198,7 @@ namespace System.Windows
 
             WritePreamble();
 
-            OnFreezablePropertyChanged(/* oldValue = */ null, /* newValue = */ value);
+            OnFreezablePropertyChanged(oldValue: null, newValue: value);
 
             _collection.Insert(index, value);
 
@@ -697,7 +697,7 @@ namespace System.Windows
             }
             WritePreamble();
             T newValue = value;
-            OnFreezablePropertyChanged(/* oldValue = */ null, newValue);
+            OnFreezablePropertyChanged(oldValue: null, newValue);
             _collection.Add(value);
 
 
@@ -828,7 +828,7 @@ namespace System.Windows
                     }
                 }
 
-                OnFreezablePropertyChanged(/* oldValue = */ null, newValue);
+                OnFreezablePropertyChanged(oldValue: null, newValue);
                 _collection.Add(newValue);
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollection.cs
@@ -282,7 +282,7 @@ namespace System.Windows.Ink
 
                 base.ClearItems();
 
-                RaiseStrokesChanged(null /*added*/, removed, -1);
+                RaiseStrokesChanged(addedStrokes: null, removed, -1);
             }
         }
 
@@ -296,7 +296,7 @@ namespace System.Windows.Ink
 
             StrokeCollection removed = new StrokeCollection();
             ( (List<Stroke>)removed.Items ).Add(removedStroke);
-            RaiseStrokesChanged(null /*added*/, removed, index);
+            RaiseStrokesChanged(addedStrokes: null, removed, index);
         }
 
         /// <summary>
@@ -314,7 +314,7 @@ namespace System.Windows.Ink
 
             StrokeCollection addedStrokes = new StrokeCollection();
             ( (List<Stroke>)addedStrokes.Items ).Add(stroke);
-            RaiseStrokesChanged(addedStrokes, null /*removed*/, index);
+            RaiseStrokesChanged(addedStrokes, removedStrokes: null, index);
         }
 
         /// <summary>
@@ -398,7 +398,7 @@ namespace System.Windows.Ink
                 ( (List<Stroke>)this.Items ).RemoveAt(indexes[x]);
             }
 
-            RaiseStrokesChanged(null /*added*/, strokes, indexes[0]);
+            RaiseStrokesChanged(addedStrokes: null, strokes, indexes[0]);
         }
 
         /// <summary>
@@ -434,7 +434,7 @@ namespace System.Windows.Ink
             //and call our protected List<Stroke> directly
             ( (List<Stroke>)this.Items ).AddRange(strokes);
 
-            RaiseStrokesChanged(strokes, null /*removed*/, index);
+            RaiseStrokesChanged(strokes, removedStrokes: null, index);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollection2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollection2.cs
@@ -383,7 +383,7 @@ namespace System.Windows.Ink
                     foreach (Stroke stroke in strokes)
                     {
                         stroke.DrawInternal(context, StrokeRenderer.GetHighlighterAttributes(stroke, stroke.DrawingAttributes),
-                                            false /*Don't draw selected stroke as hollow*/);
+                                            drawAsHollow: false);
                     }
                 }
                 finally
@@ -394,7 +394,7 @@ namespace System.Windows.Ink
 
             foreach(Stroke stroke in solidStrokes)
             {
-                stroke.DrawInternal(context, stroke.DrawingAttributes, false/*Don't draw selected stroke as hollow*/);
+                stroke.DrawInternal(context, stroke.DrawingAttributes, drawAsHollow: false);
             }
         }
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollectionConverter.cs
@@ -133,7 +133,7 @@ namespace System.Windows
                     // in this case, we can't call Dispose since it will also close the underlying stream
                     // which strokecollection needs open to read in the constructor
                     MemoryStream stream = new MemoryStream();
-                    strokes.Save(stream, true/*compress*/);
+                    strokes.Save(stream, compress: true);
                     stream.Position = 0;
                     return new InstanceDescriptor(ci, new object[] { stream });
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/AccessKeyManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/AccessKeyManager.cs
@@ -292,7 +292,7 @@ namespace System.Windows.Input
 
             if ((text != null) && (text.Length > 0))
             {
-                if (ProcessKeyForSender(e.OriginalSource, text, false /* existsElsewhere */,e.UserInitiated) != ProcessKeyResult.NoMatch)
+                if (ProcessKeyForSender(e.OriginalSource, text, existsElsewhere: false,e.UserInitiated) != ProcessKeyResult.NoMatch)
                 {
                     e.Handled = true;
                 }
@@ -317,7 +317,7 @@ namespace System.Windows.Input
 
             if (text != null)
             {
-                if (ProcessKeyForSender(e.OriginalSource, text, false /* existsElsewhere */,e.UserInitiated) != ProcessKeyResult.NoMatch)
+                if (ProcessKeyForSender(e.OriginalSource, text, existsElsewhere: false,e.UserInitiated) != ProcessKeyResult.NoMatch)
                 {
                     e.Handled = true;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/AccessKeyManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/AccessKeyManager.cs
@@ -264,7 +264,7 @@ namespace System.Windows.Input
 
                 if (invokeUIElement != null)
                 {
-                    AccessKeyEventArgs args = new AccessKeyEventArgs(key, !oneUIElement || existsElsewhere /* == isMultiple */,userInitiated);
+                    AccessKeyEventArgs args = new AccessKeyEventArgs(key, isMultiple: !oneUIElement || existsElsewhere, userInitiated);
                     try
                     {
                         invokeUIElement.InvokeAccessKey(args);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CommandManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CommandManager.cs
@@ -401,7 +401,7 @@ namespace System.Windows.Input
                 {
                     if (routedCommand.CriticalCanExecute(parameter,
                                                     target,
-                                                    inputEventArgs.UserInitiated /*trusted*/,
+                                                    trusted: inputEventArgs.UserInitiated,
                                                     out continueRouting))
                     {
                         // If the command can be executed, we never continue to route the
@@ -506,7 +506,7 @@ namespace System.Windows.Input
         {
             if ((sender != null) && (e != null) && (e.Command != null))
             {
-                CanExecuteRoutedEventArgs canExecuteArgs = new CanExecuteRoutedEventArgs(e.Command, null /* parameter */)
+                CanExecuteRoutedEventArgs canExecuteArgs = new CanExecuteRoutedEventArgs(e.Command, parameter: null)
                 {
                     RoutedEvent = CommandManager.CanExecuteEvent,
                     Source = sender
@@ -515,7 +515,7 @@ namespace System.Windows.Input
 
                 if (canExecuteArgs.CanExecute)
                 {
-                    ExecutedRoutedEventArgs executedArgs = new ExecutedRoutedEventArgs(e.Command, null /* parameter */)
+                    ExecutedRoutedEventArgs executedArgs = new ExecutedRoutedEventArgs(e.Command, parameter: null)
                     {
                         RoutedEvent = CommandManager.ExecutedEvent,
                         Source = sender

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyBinding.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyBinding.cs
@@ -188,7 +188,7 @@ namespace System.Windows.Input
                 _settingGesture = true;
                 try
                 {
-                    Gesture = new KeyGesture(key, modifiers, /*validateGesture = */ false);
+                    Gesture = new KeyGesture(key, modifiers, validateGesture: false);
                 }
                 finally
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Cursor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Cursor.cs
@@ -231,13 +231,13 @@ namespace System.Windows.Input
                         // If the buffer is filled up, then write those bytes out and read more bytes up to BUFFERSIZE
                         for (dataSize = cursorData.Length;
                              dataSize >= BUFFERSIZE;
-                             dataSize = reader.Read(cursorData, 0 /*index in array*/, BUFFERSIZE /*bytes to read*/))
+                             dataSize = reader.Read(cursorData, index: 0, count: BUFFERSIZE))
                         {
-                            fileStream.Write(cursorData, 0 /*index in array*/, BUFFERSIZE /*bytes to write*/);
+                            fileStream.Write(cursorData, offset: 0, count: BUFFERSIZE);
                         }
 
                         // Write any remaining bytes
-                        fileStream.Write(cursorData, 0 /*index in array*/, dataSize /*bytes to write*/);
+                        fileStream.Write(cursorData, offset: 0, count: dataSize);
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputElement.cs
@@ -237,7 +237,7 @@ namespace System.Windows.Input
 
                 bool isUpSimple = false;
                 isUpSimple = vFrom.TrySimpleTransformToAncestor(rootFrom,
-                                                                false, /* do not apply inverse */
+                                                                inverse: false,
                                                                 out gUp,
                                                                 out mUp);               
                 if (isUpSimple)
@@ -306,7 +306,7 @@ namespace System.Windows.Input
                         }
 
                         bool isDownSimple = vToAsVisual.TrySimpleTransformToAncestor(rootTo,
-                                                                                     true, /* apply inverse */
+                                                                                     inverse: true,
                                                                                      out gDown,
                                                                                      out mDown);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputElement.cs
@@ -180,7 +180,7 @@ namespace System.Windows.Input
         // Returns the root visual of the containing element.
         internal static DependencyObject GetRootVisual(DependencyObject o)
         {
-            return GetRootVisual(o, true /* enable2DTo3DTransition */);
+            return GetRootVisual(o, enable2DTo3DTransition: true);
         }
         
         internal static DependencyObject GetRootVisual(DependencyObject o, bool enable2DTo3DTransition)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
@@ -641,7 +641,7 @@ namespace System.Windows.Input
                     moveFocusTo = _activeSource.RootVisual;
                 }
 
-                Focus(moveFocusTo, /*askOld=*/ false, /*askNew=*/ true, /*forceToNullIfFailed=*/ true);
+                Focus(moveFocusTo, askOld: false, askNew: true, forceToNullIfFailed: true);
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Manipulation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Manipulation.cs
@@ -59,7 +59,7 @@ namespace System.Windows.Input
             ArgumentNullException.ThrowIfNull(element);
 
             ManipulationDevice device = ManipulationDevice.GetManipulationDevice(element);
-            device?.CompleteManipulation(/* withInertia = */ true);
+            device?.CompleteManipulation(withInertia: true);
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace System.Windows.Input
             ManipulationDevice device = ManipulationDevice.GetManipulationDevice(element);
             if (device != null)
             {
-                device.CompleteManipulation(/* withInertia = */ false);
+                device.CompleteManipulation(withInertia: false);
                 return true;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/ManipulationDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/ManipulationDevice.cs
@@ -340,7 +340,7 @@ namespace System.Windows.Input
                         // If a Complete is requested, then pass it along to the manipulation processor
                         if (deltaEventArgs.RequestedComplete)
                         {
-                            _manipulationLogic.Complete(/* withInertia = */ deltaEventArgs.RequestedInertia);
+                            _manipulationLogic.Complete(withInertia: deltaEventArgs.RequestedInertia);
                             _manipulationLogic.PushEventsToDevice();
                         }
                         else if (deltaEventArgs.RequestedCancel)
@@ -366,7 +366,7 @@ namespace System.Windows.Input
                         if (startedEventArgs.RequestedComplete)
                         {
                             // If a Complete is requested, pass it along to the manipulation processor
-                            _manipulationLogic.Complete(/* withInertia = */ false);
+                            _manipulationLogic.Complete(withInertia: false);
                             _manipulationLogic.PushEventsToDevice();
                         }
                         else if (startedEventArgs.RequestedCancel)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPoint.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPoint.cs
@@ -134,7 +134,7 @@ namespace System.Windows.Input
                         // use SetPropertyValue, it validates buttons, but does not copy the 
                         // int[] on writes (since we pass the bool flag)
                         //
-                        SetPropertyValue(properties[i], additionalValues[j], false/*copy on write*/);
+                        SetPropertyValue(properties[i], additionalValues[j], copyBeforeWrite: false);
                     }
                 }
             } 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPointCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPointCollection.cs
@@ -500,7 +500,7 @@ namespace System.Windows.Input
                 for (int x = StylusPointDescription.RequiredCountOfProperties/*3*/; x < properties.Count; x++)
                 {
                     int value = stylusPoint.GetPropertyValue(properties[x]);
-                    newStylusPoint.SetPropertyValue(properties[x], value, false/*copy on write*/);
+                    newStylusPoint.SetPropertyValue(properties[x], value, copyBeforeWrite: false);
                 }
                 //bypass validation
                 ((List<StylusPoint>)newCollection.Items).Add(newStylusPoint);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusTouchDeviceBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusTouchDeviceBase.cs
@@ -63,8 +63,8 @@ namespace System.Windows.Input
             GeneralTransform rootToElement)
         {
             // Get width and heith in pixel value
-            double width = GetStylusPointWidthOrHeight(stylusPoint, /*isWidth*/ true);
-            double height = GetStylusPointWidthOrHeight(stylusPoint, /*isWidth*/ false);
+            double width = GetStylusPointWidthOrHeight(stylusPoint, isWidth: true);
+            double height = GetStylusPointWidthOrHeight(stylusPoint, isWidth: false);
 
             // Get the position with respect to root
             Point rootPoint;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesCompartment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesCompartment.cs
@@ -207,7 +207,7 @@ namespace System.Windows.Input
                 if (compartment == null)
                     return;
 
-                compartment.SetValue(0 /* clientid */, ref value);
+                compartment.SetValue(tid: 0, ref value);
                 Marshal.ReleaseComObject(compartment);
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesContext.cs
@@ -465,7 +465,7 @@ namespace System.Windows.Input
             internal override void OnShutDown(object target, object sender, EventArgs e)
             {
                 TextServicesContext textServicesContext = (TextServicesContext)target;
-                textServicesContext.Uninitialize(!(sender is Dispatcher) /*appDomainShutdown*/);
+                textServicesContext.Uninitialize(appDomainShutdown: !(sender is Dispatcher));
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesContext.cs
@@ -212,7 +212,7 @@ namespace System.Windows.Input
 
                 // Create a TSF document.
                 threadManager.CreateDocumentMgr(out doc);
-                doc.CreateContext(_clientId, 0 /* flags */, _defaultTextStore, out context, out editCookie);
+                doc.CreateContext(_clientId, flags: 0, _defaultTextStore, out context, out editCookie);
                 doc.Push(context);
 
                 // Release any native resources we're done with.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesManager.cs
@@ -149,7 +149,7 @@ namespace System.Windows.Input
 
                 if (context != null)
                 {
-                    if (TextServicesKeystroke(context, keyArgs, true /* test */))
+                    if (TextServicesKeystroke(context, keyArgs, test: true))
                     {
                         keyArgs.MarkImeProcessed();
                     }
@@ -192,7 +192,7 @@ namespace System.Windows.Input
 
                     if (context != null)
                     {
-                        if (TextServicesKeystroke(context, keyArgs, false /* test */))
+                        if (TextServicesKeystroke(context, keyArgs, test: false))
                         {
                             keyArgs.Handled = true;
                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TouchDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TouchDevice.cs
@@ -382,13 +382,13 @@ namespace System.Windows.Input
                         uiElement3D.IsHitTestVisibleChanged += OnReevaluateCapture;
                     }
 
-                    UpdateReverseInheritedProperty(/* capture = */ true, oldCapture, _captured);
+                    UpdateReverseInheritedProperty(capture: true, oldCapture, _captured);
 
                     if (oldCapture != null)
                     {
                         DependencyObject o = oldCapture as DependencyObject;
                         o.SetValue(UIElement.AreAnyTouchesCapturedPropertyKey,
-                            BooleanBoxes.Box(AreAnyTouchesCapturedOrDirectlyOver(oldCapture, /* isCapture = */ true)));
+                            BooleanBoxes.Box(AreAnyTouchesCapturedOrDirectlyOver(oldCapture, isCapture: true)));
                     }
                     if (_captured != null)
                     {
@@ -557,7 +557,7 @@ namespace System.Windows.Input
             // Refresh AreAnyTouchCapturesWithinProperty so that ReverseInherited flags are updated.
             if ((_capturedWithinTreeState != null) && !_capturedWithinTreeState.IsEmpty)
             {
-                UpdateReverseInheritedProperty(/* capture = */ true, _captured, _captured);
+                UpdateReverseInheritedProperty(capture: true, _captured, _captured);
             }
         }
 
@@ -633,7 +633,7 @@ namespace System.Windows.Input
             EventTrace.EasyTraceEvent(EventTrace.Keyword.KeywordInput | EventTrace.Keyword.KeywordPerf, EventTrace.Level.Info, EventTrace.Event.TouchDownReported, _deviceId);
 
             _isDown = true;
-            UpdateDirectlyOver(/* isSynchronize = */ false);
+            UpdateDirectlyOver(isSynchronize: false);
             bool handled = RaiseTouchDown();
             OnUpdated();
 
@@ -645,7 +645,7 @@ namespace System.Windows.Input
         {
             EventTrace.EasyTraceEvent(EventTrace.Keyword.KeywordInput | EventTrace.Keyword.KeywordPerf, EventTrace.Level.Info, EventTrace.Event.TouchMoveReported, _deviceId);
 
-            UpdateDirectlyOver(/* isSynchronize = */ false);
+            UpdateDirectlyOver(isSynchronize: false);
             bool handled = RaiseTouchMove();
             OnUpdated();
 
@@ -681,7 +681,7 @@ namespace System.Windows.Input
 
             bool handled = RaiseTouchUp();
             _isDown = false;
-            UpdateDirectlyOver(/* isSynchronize = */ false);
+            UpdateDirectlyOver(isSynchronize: false);
             OnUpdated();
 
             Touch.ReportFrame();
@@ -743,7 +743,7 @@ namespace System.Windows.Input
                 _activeSource.CompositionTarget != null &&
                 !_activeSource.CompositionTarget.IsDisposed)
             {
-                if (UpdateDirectlyOver(/* isSynchronize = */ true))
+                if (UpdateDirectlyOver(isSynchronize: true))
                 {
                     OnUpdated();
                     Touch.ReportFrame();
@@ -771,7 +771,7 @@ namespace System.Windows.Input
 
             if ((_directlyOverTreeState != null) && !_directlyOverTreeState.IsEmpty)
             {
-                UpdateReverseInheritedProperty(/* capture = */ false, _directlyOver, _directlyOver);
+                UpdateReverseInheritedProperty(capture: false, _directlyOver, _directlyOver);
             }
         }
 
@@ -893,13 +893,13 @@ namespace System.Windows.Input
                 newUIElement3D.IsHitTestVisibleChanged += OnReevaluateDirectlyOver;
             }
 
-            UpdateReverseInheritedProperty(/* capture = */ false, oldDirectlyOver, newDirectlyOver);
+            UpdateReverseInheritedProperty(capture: false, oldDirectlyOver, newDirectlyOver);
 
             if (oldDirectlyOver != null)
             {
                 DependencyObject o = oldDirectlyOver as DependencyObject;
                 o.SetValue(UIElement.AreAnyTouchesDirectlyOverPropertyKey,
-                            BooleanBoxes.Box(AreAnyTouchesCapturedOrDirectlyOver(oldDirectlyOver, /* isCapture = */ false)));
+                            BooleanBoxes.Box(AreAnyTouchesCapturedOrDirectlyOver(oldDirectlyOver, isCapture: false)));
             }
             if (newDirectlyOver != null)
             {
@@ -1183,12 +1183,12 @@ namespace System.Windows.Input
 
         internal static IEnumerable<TouchDevice> GetCapturedTouches(IInputElement element, bool includeWithin)
         {
-            return GetCapturedOrOverTouches(element, includeWithin, /* isCapture = */ true);
+            return GetCapturedOrOverTouches(element, includeWithin, isCapture: true);
         }
 
         internal static IEnumerable<TouchDevice> GetTouchesOver(IInputElement element, bool includeWithin)
         {
-            return GetCapturedOrOverTouches(element, includeWithin, /* isCapture = */ false);
+            return GetCapturedOrOverTouches(element, includeWithin, isCapture: false);
         }
 
         private static bool IsWithin(IInputElement parent, IInputElement child)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
@@ -717,8 +717,7 @@ namespace System.Windows.Interop
                 channel.SendCommand(
                     (byte*)&data,
                     sizeof(DUCE.MILCMD_D3DIMAGE_PRESENT),
-                    true /* sendInSeparateBatch */
-                    );
+                    sendInSeparateBatch: true);
             }
 
             _isDirty = false;
@@ -805,8 +804,7 @@ namespace System.Windows.Interop
                     channel.SendCommand(
                         (byte*)&data,
                         sizeof(DUCE.MILCMD_D3DIMAGE),
-                        false /* sendInSeparateBatch */
-                        );
+                        sendInSeparateBatch: false);
                 }
 
                 // Presents only happen on the async channel so don't let RTB flip this bit

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
@@ -822,7 +822,7 @@ namespace System.Windows.Interop
             {
                 AddRefOnChannelAnimations(channel);
 
-                UpdateResource(channel, true /* skip "on channel" check - we already know that we're on channel */ );
+                UpdateResource(channel, skipOnChannelCheck: true /* We already know that we're on channel */ );
                 
                 // If we are being put onto the asynchronous compositor channel in
                 // a dirty state, we need to subscribe to the commit batch event.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -1301,7 +1301,7 @@ namespace System.Windows.Interop
 
         private void OnMonitorPowerEvent(object sender, MonitorPowerEventArgs eventArgs)
         {
-            OnMonitorPowerEvent(sender, eventArgs.PowerOn, /*paintOnWake*/true);
+            OnMonitorPowerEvent(sender, eventArgs.PowerOn, paintOnWake: true);
         }
 
         private void OnMonitorPowerEvent(object sender, bool powerOn, bool paintOnWake)
@@ -2588,7 +2588,7 @@ namespace System.Windows.Interop
                     // behavior. It is too early for the hwnd to paint, hence
                     // pass paintOnWake=false assuming that it will soon get
                     // a WM_PAINT message.
-                    hwndTarget.OnMonitorPowerEvent(null, _monitorOn, /*paintOnWake*/ false);
+                    hwndTarget.OnMonitorPowerEvent(null, _monitorOn, paintOnWake: false);
                 }
                 _hwndTargetCount++;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Markup/XmlLanguage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Markup/XmlLanguage.cs
@@ -715,10 +715,10 @@ namespace System.Windows.Markup
                 {
                     int i;
 
-                    i = ParseSubtag(ietfLanguageTag, reader, /* isPrimary */ true);
+                    i = ParseSubtag(ietfLanguageTag, reader, isPrimary: true);
                     while (i != -1)
                     {
-                        i = ParseSubtag(ietfLanguageTag, reader, /* isPrimary */ false);
+                        i = ParseSubtag(ietfLanguageTag, reader, isPrimary: false);
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/AnimationStorage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/AnimationStorage.cs
@@ -444,8 +444,8 @@ namespace System.Windows.Media.Animation
                                 metadata,
                                 oldEntry,
                                 ref newEntry,
-                                false /* coerceWithDeferredReference */,
-                                false /* coerceWithCurrentValue */,
+                                coerceWithDeferredReference: false,
+                                coerceWithCurrentValue: false,
                                 OperationType.Unknown);
 
                         if (_hadValidationError)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/EasingQuaternionKeyFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/EasingQuaternionKeyFrame.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Media.Animation
                     "UseShortestPath",
                     typeof(bool),
                     typeof(EasingQuaternionKeyFrame),
-                    new PropertyMetadata(/* defaultValue = */ BooleanBoxes.TrueBox));
+                    new PropertyMetadata(defaultValue: BooleanBoxes.TrueBox));
 
         /// <summary>
         /// If true, the animation will automatically flip the sign of the destination

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/LinearQuaternionKeyFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/LinearQuaternionKeyFrame.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Media.Animation
                     "UseShortestPath",
                     typeof(bool),
                     typeof(LinearQuaternionKeyFrame),
-                    new PropertyMetadata(/* defaultValue = */ BooleanBoxes.TrueBox));
+                    new PropertyMetadata(defaultValue: BooleanBoxes.TrueBox));
 
         /// <summary>
         /// If true, the animation will automatically flip the sign of the destination

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/QuaternionAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/QuaternionAnimation.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Media.Animation
                     "UseShortestPath",
                     typeof(bool),
                     typeof(QuaternionAnimation),
-                    new PropertyMetadata(/* defaultValue = */ BooleanBoxes.TrueBox));
+                    new PropertyMetadata(defaultValue: BooleanBoxes.TrueBox));
 
         /// <summary>
         /// If true, the animation will automatically flip the sign of the destination

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/SplineQuaternionKeyFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/SplineQuaternionKeyFrame.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Media.Animation
                     "UseShortestPath",
                     typeof(bool),
                     typeof(SplineQuaternionKeyFrame),
-                    new PropertyMetadata(/* defaultValue = */ BooleanBoxes.TrueBox));
+                    new PropertyMetadata(defaultValue: BooleanBoxes.TrueBox));
 
         /// <summary>
         /// If true, the animation will automatically flip the sign of the destination

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/BitmapCacheBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/BitmapCacheBrush.cs
@@ -376,9 +376,9 @@ namespace System.Windows.Media
 
         private static void StaticInitialize(Type typeofThis)
         {             
-            OpacityProperty.OverrideMetadata(typeofThis, new IndependentlyAnimatedPropertyMetadata(1.0, /* PropertyChangedHandle */ null, CoerceOpacity));
-            TransformProperty.OverrideMetadata(typeofThis, new UIPropertyMetadata(null, /* PropertyChangedHandle */ null, CoerceTransform));
-            RelativeTransformProperty.OverrideMetadata(typeofThis, new UIPropertyMetadata(null, /* PropertyChangedHandle */ null, CoerceRelativeTransform));
+            OpacityProperty.OverrideMetadata(typeofThis, new IndependentlyAnimatedPropertyMetadata(1.0, propertyChangedCallback: null, CoerceOpacity));
+            TransformProperty.OverrideMetadata(typeofThis, new UIPropertyMetadata(null, propertyChangedCallback: null, CoerceTransform));
+            RelativeTransformProperty.OverrideMetadata(typeofThis, new UIPropertyMetadata(null, propertyChangedCallback: null, CoerceRelativeTransform));
         }
 
         private ContainerVisual _dummyVisual;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/BoundsDrawingContextWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/BoundsDrawingContextWalker.cs
@@ -358,12 +358,12 @@ namespace System.Windows.Media
                 if (!_haveClip)
                 {
                     _haveClip = true;
-                    _clip = clipGeometry.GetBoundsInternal(null /* pen */, _transform);
+                    _clip = clipGeometry.GetBoundsInternal(pen: null, _transform);
                 }
                 else
                 {
                     // update current clip
-                    _clip.Intersect(clipGeometry.GetBoundsInternal(null /* pen */, _transform));
+                    _clip.Intersect(clipGeometry.GetBoundsInternal(pen: null, _transform));
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ByteStreamGeometryContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ByteStreamGeometryContext.cs
@@ -96,7 +96,7 @@ namespace System.Windows.Media
                 Point* scratchForLine = stackalloc Point[1];
                 scratchForLine[0] = point;
                 GenericPolyTo(scratchForLine,
-                              1 /* count */,
+                              count: 1,
                               isStroked,
                               isSmoothJoin,
                               false /* does not have curves */,
@@ -117,7 +117,7 @@ namespace System.Windows.Media
                 scratchForQuadraticBezier[0] = point1;
                 scratchForQuadraticBezier[1] = point2;
                 GenericPolyTo(scratchForQuadraticBezier,
-                              2 /* count */,
+                              count: 2,
                               isStroked,
                               isSmoothJoin,
                               true /* has curves */,
@@ -139,7 +139,7 @@ namespace System.Windows.Media
                 scratchForBezier[1] = point2;
                 scratchForBezier[2] = point3;
                 GenericPolyTo(scratchForBezier,
-                              3 /* count */,
+                              count: 3,
                               isStroked,
                               isSmoothJoin,
                               true /* has curves */,
@@ -158,7 +158,7 @@ namespace System.Windows.Media
                           isStroked, 
                           isSmoothJoin, 
                           false /* does not have curves */,
-                          1 /* pointCountMultiple */,
+                          pointCountMultiple: 1,
                           MIL_SEGMENT_TYPE.MilSegmentPolyLine);
         }
 
@@ -173,7 +173,7 @@ namespace System.Windows.Media
                           isStroked, 
                           isSmoothJoin, 
                           true /* has curves */,
-                          2 /* pointCountMultiple */,
+                          pointCountMultiple: 2,
                           MIL_SEGMENT_TYPE.MilSegmentPolyQuadraticBezier);
         }
 
@@ -188,7 +188,7 @@ namespace System.Windows.Media
                           isStroked, 
                           isSmoothJoin, 
                           true /* has curves */,
-                          3 /* pointCountMultiple */,
+                          pointCountMultiple: 3,
                           MIL_SEGMENT_TYPE.MilSegmentPolyBezier);
         }
 
@@ -353,7 +353,7 @@ namespace System.Windows.Media
                 Invariant.Assert(_currOffset >= bufferOffset+cbDataSize);
             }
 
-            ReadWriteData(true /* reading */, pbData, cbDataSize, 0, ref bufferOffset);
+            ReadWriteData(reading: true, pbData, cbDataSize, 0, ref bufferOffset);
         }
         
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ByteStreamGeometryContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ByteStreamGeometryContext.cs
@@ -99,7 +99,7 @@ namespace System.Windows.Media
                               count: 1,
                               isStroked,
                               isSmoothJoin,
-                              false /* does not have curves */,
+                              hasCurves: false,
                               MIL_SEGMENT_TYPE.MilSegmentPolyLine);
             }
         }
@@ -120,7 +120,7 @@ namespace System.Windows.Media
                               count: 2,
                               isStroked,
                               isSmoothJoin,
-                              true /* has curves */,
+                              hasCurves: true,
                               MIL_SEGMENT_TYPE.MilSegmentPolyQuadraticBezier);
             }
         }
@@ -142,7 +142,7 @@ namespace System.Windows.Media
                               count: 3,
                               isStroked,
                               isSmoothJoin,
-                              true /* has curves */,
+                              hasCurves: true,
                               MIL_SEGMENT_TYPE.MilSegmentPolyBezier);
             }
         }
@@ -157,7 +157,7 @@ namespace System.Windows.Media
             GenericPolyTo(points, 
                           isStroked, 
                           isSmoothJoin, 
-                          false /* does not have curves */,
+                          hasCurves: false,
                           pointCountMultiple: 1,
                           MIL_SEGMENT_TYPE.MilSegmentPolyLine);
         }
@@ -172,7 +172,7 @@ namespace System.Windows.Media
             GenericPolyTo(points, 
                           isStroked, 
                           isSmoothJoin, 
-                          true /* has curves */,
+                          hasCurves: true,
                           pointCountMultiple: 2,
                           MIL_SEGMENT_TYPE.MilSegmentPolyQuadraticBezier);
         }
@@ -187,7 +187,7 @@ namespace System.Windows.Media
             GenericPolyTo(points, 
                           isStroked, 
                           isSmoothJoin, 
-                          true /* has curves */,
+                          hasCurves: true,
                           pointCountMultiple: 3,
                           MIL_SEGMENT_TYPE.MilSegmentPolyBezier);
         }
@@ -377,7 +377,7 @@ namespace System.Windows.Media
                 Invariant.Assert(newOffset <= _currOffset);
             }
 
-            ReadWriteData(false /* writing */, pbData, cbDataSize, 0, ref bufferOffset);
+            ReadWriteData(reading: false, pbData, cbDataSize, 0, ref bufferOffset);
         }
         
         /// <summary>
@@ -405,7 +405,7 @@ namespace System.Windows.Media
                 _chunkList.Add(chunk);
             }
 
-            ReadWriteData(false /* writing */, pbData, cbDataSize, _chunkList.Count-1, ref _currChunkOffset);
+            ReadWriteData(reading: false, pbData, cbDataSize, _chunkList.Count-1, ref _currChunkOffset);
 
             _currOffset = newOffset;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetricsDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetricsDictionary.cs
@@ -217,7 +217,7 @@ namespace System.Windows.Media
         /// </summary>
         public void Add(int key, CharacterMetrics value)
         {
-            SetValue(key, value, /* failIfExists = */ true);
+            SetValue(key, value, failIfExists: true);
         }
 
         /// <summary>
@@ -242,7 +242,7 @@ namespace System.Windows.Media
         public CharacterMetrics this[int key]
         {
             get { return GetValue(key); }
-            set { SetValue(key, value, /* failIfExists = */ false); }
+            set { SetValue(key, value, failIfExists: false); }
         }
 
         /// <summary>
@@ -277,7 +277,7 @@ namespace System.Windows.Media
 
             set
             {
-                SetValue(ConvertKey(key), ConvertValue(value), /* failIfExists = */ false);
+                SetValue(ConvertKey(key), ConvertValue(value), failIfExists: false);
             }
         }
 
@@ -293,7 +293,7 @@ namespace System.Windows.Media
 
         void SC.IDictionary.Add(object key, object value)
         {
-            SetValue(ConvertKey(key), ConvertValue(value), /* failIfExists = */ false);
+            SetValue(ConvertKey(key), ConvertValue(value), failIfExists: false);
         }
 
         bool SC.IDictionary.Contains(object key)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorContext.cs
@@ -59,7 +59,7 @@ namespace System.Windows.Media
                             return;
                         }
                         
-                        FromRawBytes(profileData, (int)cbProfileActual, /* dontThrowException = */ true);
+                        FromRawBytes(profileData, (int)cbProfileActual, dontThrowException: true);
                     }
 
                     break;
@@ -129,7 +129,7 @@ namespace System.Windows.Media
                         }
 
                         // Finally, fill in _colorContextHelper
-                        FromRawBytes(sRGBProfile, sRGBProfile.Length, /* dontThrowException = */ true);
+                        FromRawBytes(sRGBProfile, sRGBProfile.Length, dontThrowException: true);
                     }
                     else if (Invariant.Strict)
                     {
@@ -156,7 +156,7 @@ namespace System.Windows.Media
         /// <param name="profileUri">Specifies the URI of a color profile used by the newly created ColorContext.</param>
         public ColorContext(Uri profileUri)
         {
-            Initialize(profileUri, /* isStandardProfileUriNotFromUser = */ false);
+            Initialize(profileUri, isStandardProfileUriNotFromUser: false);
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace System.Windows.Media
                 case PixelFormatEnum.Bgra32:
                 case PixelFormatEnum.Pbgra32:
                 default:
-                    Initialize(GetStandardColorSpaceProfile(), /* isStandardProfileUriNotFromUser = */ true);
+                    Initialize(GetStandardColorSpaceProfile(), isStandardProfileUriNotFromUser: true);
                     break;
 
                 case PixelFormatEnum.Rgba64:
@@ -592,7 +592,7 @@ namespace System.Windows.Media
 
                 if (numBytesRead < bufferSize)
                 {
-                    FromRawBytes(rawBytes, numBytesRead, /* dontThrowException = */ false);
+                    FromRawBytes(rawBytes, numBytesRead, dontThrowException: false);
 
                     using (FactoryMaker factoryMaker = new FactoryMaker())
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/DrawingVisual.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/DrawingVisual.cs
@@ -92,7 +92,7 @@ namespace System.Windows.Media
                 // Remove the notification handlers.
                 //
 
-                oldContent.PropagateChangedHandler(ContentsChangedHandler, false /* remove */);
+                oldContent.PropagateChangedHandler(ContentsChangedHandler, adding: false);
 
 
                 //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/DrawingVisual.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/DrawingVisual.cs
@@ -110,7 +110,7 @@ namespace System.Windows.Media
             // 
 
             // Propagate notification handlers.
-            newContent?.PropagateChangedHandler(ContentsChangedHandler, true /* adding */);
+            newContent?.PropagateChangedHandler(ContentsChangedHandler, adding: true);
 
             _content = newContent;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/ShaderEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/ShaderEffect.cs
@@ -775,7 +775,7 @@ namespace System.Windows.Media.Effects
                 AddRefOnChannelAnimations(channel);
 
 
-                UpdateResource(channel, true /* skip "on channel" check - we already know that we're on channel */ );
+                UpdateResource(channel, skipOnChannelCheck: true /* We already know that we're on channel */ );
             }
 
             return _duceResource.GetHandle(channel);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EllipseGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EllipseGeometry.cs
@@ -102,7 +102,7 @@ namespace System.Windows.Media
                     Transform.GetTransformValue(transform, out geometryMatrix);
 
                     boundsRect = EllipseGeometry.GetBoundsHelper(
-                        null /* no pen */,
+                        pen: null,
                         Matrix.Identity,
                         Center,
                         RadiusX,
@@ -310,12 +310,12 @@ namespace System.Windows.Media
 
             ByteStreamGeometryContext ctx = new ByteStreamGeometryContext();
 
-            ctx.BeginFigure(points[0], true /* is filled */, true /* is closed */);
+            ctx.BeginFigure(points[0], isFilled: true, isClosed: true);
 
             // i == 0, 3, 6, 9
             for (int i = 0; i < 12; i += 3)
             {
-                ctx.BezierTo(points[i + 1], points[i + 2], points[i + 3], true /* is stroked */, true /* is smooth join */);
+                ctx.BezierTo(points[i + 1], points[i + 2], points[i + 3], isStroked: true, isSmoothJoin: true);
             }
 
             ctx.Close();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Geometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Geometry.cs
@@ -136,7 +136,7 @@ namespace System.Windows.Media
                 matrix,
                 tolerance,
                 type,
-                true); /* skip hollows */
+                skipHollows: true);
         }
         
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphCache.cs
@@ -96,7 +96,7 @@ namespace System.Windows.Media
             UnsafeNativeMethods.MILUnknown.AddRef(_reversePInvokeWrapper);
             cmd.CallbackPointer = (UInt64)_reversePInvokeWrapper.DangerousGetHandle();
 
-            _channel.SendCommand((byte*)&cmd, sizeof(DUCE.MILCMD_GLYPHCACHE_SETCALLBACK), false /* sendInSeparateBatch */);
+            _channel.SendCommand((byte*)&cmd, sizeof(DUCE.MILCMD_GLYPHCACHE_SETCALLBACK), sendInSeparateBatch: false);
         }
 
         private CreateGlyphsCallbackDelegate _createGlyphBitmapsCallbackDelegate;                

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HitTestDrawingContextWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HitTestDrawingContextWalker.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Media
             Point point1)
         {
             // PERF: Consider ways to reduce the allocation of Geometries during managed hit test and bounds passes.
-            DrawGeometry(null /* brush */, pen, new LineGeometry(point0, point1));
+            DrawGeometry(brush: null, pen, new LineGeometry(point0, point1));
         }
 
         /// <summary>
@@ -169,7 +169,7 @@ namespace System.Windows.Media
                 ImageSource = imageSource
             };
 
-            DrawGeometry(imageBrush, null /* pen */, new RectangleGeometry(rectangle));
+            DrawGeometry(imageBrush, pen: null, new RectangleGeometry(rectangle));
         }
 
         /// <summary>
@@ -188,10 +188,10 @@ namespace System.Windows.Media
             Rect rectangle)
         {
             // Hit test a rect with a VideoBrush once it exists.
-            // DrawGeometry(new VideoBrush(video), null /* pen */, new RectangleGeometry(rectangle));
+            // DrawGeometry(new VideoBrush(video), pen: null, new RectangleGeometry(rectangle));
 
             // PERF: Consider ways to reduce the allocation of Geometries during managed hit test and bounds passes.
-            DrawGeometry(Brushes.Black, null /* pen */, new RectangleGeometry(rectangle));
+            DrawGeometry(Brushes.Black, pen: null, new RectangleGeometry(rectangle));
         }
 
         #endregion Static Drawing Context Methods

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HitTestWithGeometryDrawingContextWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HitTestWithGeometryDrawingContextWalker.cs
@@ -168,7 +168,7 @@ namespace System.Windows.Media
                 if (!rectangle.IsEmpty)
                 {
                     rectangle.Offset((Vector)glyphRun.BaselineOrigin);
-                    DrawGeometry(Brushes.Black, null /* pen */, new RectangleGeometry(rectangle));
+                    DrawGeometry(Brushes.Black, pen: null, new RectangleGeometry(rectangle));
                 }
             }
         }   

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HostVisual.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HostVisual.cs
@@ -116,7 +116,7 @@ namespace System.Windows.Media
                 {
                     DisconnectHostedVisual(
                         channel,
-                        /* removeChannelFromCollection */ true);
+                        removeChannelFromCollection: true);
                 }
             }
 
@@ -367,7 +367,7 @@ namespace System.Windows.Media
             {
                 DisconnectHostedVisual(
                     (DUCE.Channel)ide.Key,
-                    /* removeChannelFromCollection */ false);
+                    removeChannelFromCollection: false);
             }
 
             _connectedChannels.Clear();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDownload.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDownload.cs
@@ -123,14 +123,13 @@ namespace System.Windows.Media.Imaging
             {
                 string pathToUse = tmpFileName.ToString();
                 SafeFileHandle fileHandle = MS.Win32.UnsafeNativeMethods.CreateFile(
-                    pathToUse, 
-                    NativeMethods.GENERIC_READ | NativeMethods.GENERIC_WRITE, /* dwDesiredAccess */
-                    0,                                                        /* dwShare */
-                    null,                                                     /* lpSecurityAttributes */
-                    NativeMethods.CREATE_ALWAYS,                              /* dwCreationDisposition */
-                    NativeMethods.FILE_ATTRIBUTE_TEMPORARY | 
-                    NativeMethods.FILE_FLAG_DELETE_ON_CLOSE,                  /* dwFlagsAndAttributes */
-                    IntPtr.Zero                                               /* hTemplateFile */
+                    pathToUse,
+                    dwDesiredAccess: NativeMethods.GENERIC_READ | NativeMethods.GENERIC_WRITE,
+                    dwShareMode: 0,
+                    lpSecurityAttributes: null,
+                    dwCreationDisposition: NativeMethods.CREATE_ALWAYS,
+                    dwFlagsAndAttributes: NativeMethods.FILE_ATTRIBUTE_TEMPORARY | NativeMethods.FILE_FLAG_DELETE_ON_CLOSE,
+                    hTemplateFile: IntPtr.Zero
                     );
 
                 if (fileHandle.IsInvalid)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
@@ -1251,7 +1251,7 @@ namespace System.Windows.Media.Imaging
                 // not set properly. Use IsValidForFinalizeCreation to validate, but don't throw
                 // if the validation fails.
                 if (_bitmapInit.IsInitAtLeastOnce &&
-                    IsValidForFinalizeCreation(/* throwIfInvalid = */ false))
+                    IsValidForFinalizeCreation(throwIfInvalid: false))
                 {
                     // FinalizeCreation() can throw because it usually makes pinvokes to things
                     // that return HRESULTs. Since firing the download events up the chain is

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/ColorConvertedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/ColorConvertedBitmap.cs
@@ -67,7 +67,7 @@ namespace System.Windows.Media.Imaging
             WritePreamble();
             _bitmapInit.EndInit();
 
-            IsValidForFinalizeCreation(/* throwIfInvalid = */ true);
+            IsValidForFinalizeCreation(throwIfInvalid: true);
             FinalizeCreation();
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/CroppedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/CroppedBitmap.cs
@@ -59,7 +59,7 @@ namespace System.Windows.Media.Imaging
             WritePreamble();
             _bitmapInit.EndInit();
 
-            IsValidForFinalizeCreation(/* throwIfInvalid = */ true);
+            IsValidForFinalizeCreation(throwIfInvalid: true);
             FinalizeCreation();
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/FormatConvertedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/FormatConvertedBitmap.cs
@@ -68,7 +68,7 @@ namespace System.Windows.Media.Imaging
             WritePreamble();
             _bitmapInit.EndInit();
 
-            IsValidForFinalizeCreation(/* throwIfInvalid = */ true);
+            IsValidForFinalizeCreation(throwIfInvalid: true);
             FinalizeCreation();
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/TransformedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/TransformedBitmap.cs
@@ -70,7 +70,7 @@ namespace System.Windows.Media.Imaging
             WritePreamble();
             _bitmapInit.EndInit();
 
-            IsValidForFinalizeCreation(/* throwIfInvalid = */ true);
+            IsValidForFinalizeCreation(throwIfInvalid: true);
             FinalizeCreation();
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
@@ -357,7 +357,7 @@ namespace System.Windows.Media.Imaging
                             sourceBufferStride, 
                             destinationX,
                             destinationY,
-                            /*backwardsCompat*/ false);
+                            backwardsCompat: false);
         }
         
         /// <summary>
@@ -385,7 +385,7 @@ namespace System.Windows.Media.Imaging
             int sourceBufferSize;
             Type elementType;
             ValidateArrayAndGetInfo(sourceBuffer,
-                                    /*backwardsCompat*/ false,
+                                    backwardsCompat: false,
                                     out elementSize,
                                     out sourceBufferSize,
                                     out elementType);
@@ -406,7 +406,7 @@ namespace System.Windows.Media.Imaging
                                     sourceBufferStride,
                                     destinationX,
                                     destinationY,
-                                    /*backwardsCompat*/ false);
+                                    backwardsCompat: false);
             }
         }
 
@@ -453,7 +453,7 @@ namespace System.Windows.Media.Imaging
                             stride,
                             destinationX,
                             destinationY,
-                            /*backwardsCompat*/ true);
+                            backwardsCompat: true);
         }
 
         /// <summary>
@@ -481,7 +481,7 @@ namespace System.Windows.Media.Imaging
             int sourceBufferSize;
             Type elementType;
             ValidateArrayAndGetInfo(pixels,
-                                    /*backwardsCompat*/ true,
+                                    backwardsCompat: true,
                                     out elementSize,
                                     out sourceBufferSize, 
                                     out elementType);
@@ -541,7 +541,7 @@ namespace System.Windows.Media.Imaging
                                         stride,
                                         destinationX,
                                         destinationY,
-                                        /*backwardsCompat*/ true);
+                                        backwardsCompat: true);
                     }
                 }
             }
@@ -1234,8 +1234,7 @@ namespace System.Windows.Media.Imaging
                     channel.SendCommand(
                         (byte*)&command,
                         sizeof(DUCE.MILCMD_DOUBLEBUFFEREDBITMAP),
-                        false /* sendInSeparateBatch */
-                        );
+                        sendInSeparateBatch: false);
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/LineGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/LineGeometry.cs
@@ -244,8 +244,8 @@ namespace System.Windows.Media
 
             ByteStreamGeometryContext ctx = new ByteStreamGeometryContext();
 
-            ctx.BeginFigure(StartPoint, true /* is filled */, false /* is closed */);
-            ctx.LineTo(EndPoint, true /* is stroked */, false /* is smooth join */);
+            ctx.BeginFigure(StartPoint, isFilled: true, isClosed: false);
+            ctx.LineTo(EndPoint, isStroked: true, isSmoothJoin: false);
             
             ctx.Close();
             data.SerializedData = ctx.GetData();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContext.cs
@@ -2403,7 +2403,7 @@ namespace System.Windows.Media
             if (_resourcesUpdatedHandlers != null)
             {
                 DUCE.ChannelSet channelSet = GetChannels();
-                _resourcesUpdatedHandlers(channelSet.Channel, false /* do not skip the "on channel" check */);
+                _resourcesUpdatedHandlers(channelSet.Channel, skipOnChannelCheck: false);
                 _resourcesUpdatedHandlers = null;
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -307,7 +307,7 @@ namespace MS.Internal
 
             AbbreviatedGeometryParser parser = new AbbreviatedGeometryParser();
 
-            parser.ParseToGeometryContext(context, pathString, 0 /* curIndex */);
+            parser.ParseToGeometryContext(context, pathString, startIndex: 0);
             
             PathGeometry pathGeometry = context.GetPathGeometry();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/PathFigure.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/PathFigure.cs
@@ -148,7 +148,7 @@ namespace System.Windows.Media
         {
             ReadPreamble();
             // Delegate to the internal method which implements all ToString calls.
-            return ConvertToString(null /* format string */, null /* format provider */);
+            return ConvertToString(format: null, provider: null);
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace System.Windows.Media
         {
             ReadPreamble();
             // Delegate to the internal method which implements all ToString calls.
-            return ConvertToString(null /* format string */, provider);
+            return ConvertToString(format: null, provider);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/PathStreamGeometryContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/PathStreamGeometryContext.cs
@@ -151,7 +151,7 @@ namespace System.Windows.Media
         public override void LineTo(Point point, bool isStroked, bool isSmoothJoin)
         {
             PrepareToAddPoints(
-                        1 /*count*/,
+                        count: 1,
                         isStroked,
                         isSmoothJoin,
                         MIL_SEGMENT_TYPE.MilSegmentPolyLine);
@@ -165,7 +165,7 @@ namespace System.Windows.Media
         public override void QuadraticBezierTo(Point point1, Point point2, bool isStroked, bool isSmoothJoin)
         {
             PrepareToAddPoints(
-                        2 /*count*/,
+                        count: 2,
                         isStroked,
                         isSmoothJoin,
                         MIL_SEGMENT_TYPE.MilSegmentPolyQuadraticBezier);
@@ -180,7 +180,7 @@ namespace System.Windows.Media
         public override void BezierTo(Point point1, Point point2, Point point3, bool isStroked, bool isSmoothJoin)
         {
             PrepareToAddPoints(
-                        3 /*count*/,
+                        count: 3,
                         isStroked,
                         isSmoothJoin,
                         MIL_SEGMENT_TYPE.MilSegmentPolyBezier);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
@@ -108,7 +108,7 @@ namespace System.Windows.Media
                         Transform.GetTransformValue(transform, out geometryMatrix);
 
                         boundsRect = RectangleGeometry.GetBoundsHelper(
-                            null /* no pen */,
+                            pen: null,
                             Matrix.Identity,
                             currentRect,
                             radiusX,
@@ -413,21 +413,21 @@ namespace System.Windows.Media
             {
                 Point[] points = GetPointList(rect, radiusX, radiusY);
 
-                ctx.BeginFigure(points[0], true /* is filled */, true /* is closed */);
-                ctx.BezierTo(points[1], points[2], points[3], true /* is stroked */, false /* is smooth join */);
-                ctx.LineTo(points[4], true /* is stroked */, false /* is smooth join */);
-                ctx.BezierTo(points[5], points[6], points[7], true /* is stroked */, false /* is smooth join */);
-                ctx.LineTo(points[8], true /* is stroked */, false /* is smooth join */);
-                ctx.BezierTo(points[9], points[10], points[11], true /* is stroked */, false /* is smooth join */);
-                ctx.LineTo(points[12], true /* is stroked */, false /* is smooth join */);
-                ctx.BezierTo(points[13], points[14], points[15], true /* is stroked */, false /* is smooth join */);
+                ctx.BeginFigure(points[0], isFilled: true, isClosed: true);
+                ctx.BezierTo(points[1], points[2], points[3], isStroked: true, isSmoothJoin: false);
+                ctx.LineTo(points[4], isStroked: true, isSmoothJoin: false);
+                ctx.BezierTo(points[5], points[6], points[7], isStroked: true, isSmoothJoin: false);
+                ctx.LineTo(points[8], isStroked: true, isSmoothJoin: false);
+                ctx.BezierTo(points[9], points[10], points[11], isStroked: true, isSmoothJoin: false);
+                ctx.LineTo(points[12], isStroked: true, isSmoothJoin: false);
+                ctx.BezierTo(points[13], points[14], points[15], isStroked: true, isSmoothJoin: false);
             }
             else
             {   
-                ctx.BeginFigure(rect.TopLeft, true /* is filled */, true /* is closed */);
-                ctx.LineTo(rect.TopRight, true /* is stroked */, false /* is smooth join */);
-                ctx.LineTo(rect.BottomRight, true /* is stroked */, false /* is smooth join */);
-                ctx.LineTo(rect.BottomLeft, true /* is stroked */, false /* is smooth join */);
+                ctx.BeginFigure(rect.TopLeft, isFilled: true, isClosed: true);
+                ctx.LineTo(rect.TopRight, isStroked: true, isSmoothJoin: false);
+                ctx.LineTo(rect.BottomRight, isStroked: true, isSmoothJoin: false);
+                ctx.LineTo(rect.BottomLeft, isStroked: true, isSmoothJoin: false);
             }
 
             ctx.Close();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RenderOptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RenderOptions.cs
@@ -166,7 +166,7 @@ namespace System.Windows.Media
                                                 typeof(double), 
                                                 typeof(RenderOptions),
                                                 new UIPropertyMetadata(0.707),
-                                                /* ValidateValueCallback */ null);
+                                                validateValueCallback: null);
         
         /// <summary>
         /// Reads the attached property CacheInvalidationThresholdMinimum from the given object.
@@ -199,7 +199,7 @@ namespace System.Windows.Media
                                                 typeof(double), 
                                                 typeof(RenderOptions),
                                                 new UIPropertyMetadata(1.414),
-                                                /* ValidateValueCallback */ null);
+                                                validateValueCallback: null);
         
         /// <summary>
         /// Reads the attached property CacheInvalidationThresholdMaximum from the given object.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamGeometry.cs
@@ -431,7 +431,7 @@ namespace System.Windows.Media
 
                 if (vTransform != null) ((DUCE.IResource)vTransform).AddRefOnChannel(channel);
 
-                UpdateResource(channel, true /* skip "on channel" check - we already know that we're on channel */ );
+                UpdateResource(channel, skipOnChannelCheck: true /* We already know that we're on channel */ );
             }
 
             return _duceResource.GetHandle(channel);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Visual.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Visual.cs
@@ -2626,7 +2626,7 @@ namespace System.Windows.Media
             }
 
             // Fire notifications
-            this.OnVisualChildrenChanged(child, null /* no removed child */);
+            this.OnVisualChildrenChanged(child, visualRemoved: null);
             child.FireOnVisualParentChanged(null);
             VisualDiagnostics.OnVisualChildChanged(this, child, true);
         }
@@ -2691,7 +2691,7 @@ namespace System.Windows.Media
 
             // Fire notifications
             child.FireOnVisualParentChanged(this);
-            OnVisualChildrenChanged(null /* no child added */, child);
+            OnVisualChildrenChanged(visualAdded: null, child);
         }
 
         /// <summary>
@@ -2849,7 +2849,7 @@ namespace System.Windows.Media
 
                 SetFlagsOnAllChannels(true, VisualProxyFlags.IsTransformDirty);
 
-                TransformChanged(/* sender */ null, /* args */ null);
+                TransformChanged(sender: null, args: null);
             }
         }
 
@@ -2961,7 +2961,7 @@ namespace System.Windows.Media
 
                 SetFlagsOnAllChannels(true, VisualProxyFlags.IsEffectDirty);
 
-                EffectChanged(/* sender */ null, /* args */ null);
+                EffectChanged(sender: null, args: null);
             }
         }
 
@@ -3059,7 +3059,7 @@ namespace System.Windows.Media
                 }
 
                 // Notify about the bitmap effect changes to configure the new emulation.
-                BitmapEffectEmulationChanged(/* sender */ null, /* args */ null);
+                BitmapEffectEmulationChanged(sender: null, args: null);
             }
         }
 
@@ -3148,7 +3148,7 @@ namespace System.Windows.Media
                 }
 
                 // Notify about the bitmap effect changes to configure the new emulation.
-                BitmapEffectEmulationChanged(/* sender */ null, /* args */ null);
+                BitmapEffectEmulationChanged(sender: null, args: null);
             }
         }
 
@@ -3158,7 +3158,7 @@ namespace System.Windows.Media
         // responsible for figuring out if a legacy effect can be emulated on the new pipeline or
         // not.
         // </summary>
-        internal void BitmapEffectEmulationChanged(object sender, EventArgs e)
+        internal void BitmapEffectEmulationChanged(object sender, EventArgs args)
         {
             BitmapEffectState bed = UserProvidedBitmapEffectData.GetValue(this);
             BitmapEffect currentBitmapEffect = bed?.BitmapEffect;
@@ -3224,7 +3224,7 @@ namespace System.Windows.Media
                     SetFlags(value, VisualFlags.BitmapEffectEmulationDisabled);
 
                     // Notify about the bitmap effect changes to configure the new emulation.
-                    BitmapEffectEmulationChanged(/* sender */ null, /* args */ null);
+                    BitmapEffectEmulationChanged(sender: null, args: null);
                 }
             }
         }
@@ -3380,7 +3380,7 @@ namespace System.Windows.Media
 
                 SetFlagsOnAllChannels(true, VisualProxyFlags.IsCacheModeDirty);
 
-                CacheModeChanged(/* sender */ null, /* args */ null);
+                CacheModeChanged(sender: null, args: null);
             }
         }
 
@@ -3407,7 +3407,7 @@ namespace System.Windows.Media
 
                     SetFlagsOnAllChannels(true, VisualProxyFlags.IsScrollableAreaClipDirty);
 
-                    ScrollableAreaClipChanged(/* sender */ null, /* args */ null);
+                    ScrollableAreaClipChanged(sender: null, args: null);
                 }
             }
         }
@@ -3479,7 +3479,7 @@ namespace System.Windows.Media
 
             SetFlagsOnAllChannels(true, VisualProxyFlags.IsClipDirty);
 
-            ClipChanged(/* sender */ null, /* args */ null);
+            ClipChanged(sender: null, args: null);
         }
 
         /// <summary>
@@ -3760,7 +3760,7 @@ namespace System.Windows.Media
 
                 SetFlagsOnAllChannels(true, VisualProxyFlags.IsOpacityMaskDirty);
 
-                OpacityMaskChanged(/* sender */ null, /* args */ null);
+                OpacityMaskChanged(sender: null, args: null);
             }
         }
 
@@ -3802,7 +3802,7 @@ namespace System.Windows.Media
 
                 GuidelinesXField.SetValue(this, newGuidelines);
 
-                GuidelinesChanged(/* sender */ null, /* args */ null);
+                GuidelinesChanged(sender: null, args: null);
             }
         }
 
@@ -3844,7 +3844,7 @@ namespace System.Windows.Media
 
                 GuidelinesYField.SetValue(this, newGuidelines);
 
-                GuidelinesChanged(/* sender */ null, /* args */ null);
+                GuidelinesChanged(sender: null, args: null);
             }
         }
 
@@ -4789,7 +4789,7 @@ namespace System.Windows.Media
             }
         }
 
-        internal void ClipChanged(object sender, EventArgs e)
+        internal void ClipChanged(object sender, EventArgs args)
         {
             PropagateChangedFlags();
         }
@@ -4802,7 +4802,7 @@ namespace System.Windows.Media
             }
         }
 
-        internal void ScrollableAreaClipChanged(object sender, EventArgs e)
+        internal void ScrollableAreaClipChanged(object sender, EventArgs args)
         {
             PropagateChangedFlags();
         }
@@ -4815,7 +4815,7 @@ namespace System.Windows.Media
             }
         }
 
-        internal void TransformChanged(object sender, EventArgs e)
+        internal void TransformChanged(object sender, EventArgs args)
         {
             PropagateChangedFlags();
         }
@@ -4829,7 +4829,7 @@ namespace System.Windows.Media
             }
         }
 
-        internal void EffectChanged(object sender, EventArgs e)
+        internal void EffectChanged(object sender, EventArgs args)
         {
             PropagateChangedFlags();
         }
@@ -4842,7 +4842,7 @@ namespace System.Windows.Media
             }
         }
 
-        internal void CacheModeChanged(object sender, EventArgs e)
+        internal void CacheModeChanged(object sender, EventArgs args)
         {
             PropagateChangedFlags();
         }
@@ -4855,7 +4855,7 @@ namespace System.Windows.Media
             }
         }
 
-        internal void GuidelinesChanged(object sender, EventArgs e)
+        internal void GuidelinesChanged(object sender, EventArgs args)
         {
             SetFlagsOnAllChannels(
                 true,
@@ -4872,7 +4872,7 @@ namespace System.Windows.Media
             }
         }
 
-        internal void OpacityMaskChanged(object sender, EventArgs e)
+        internal void OpacityMaskChanged(object sender, EventArgs args)
         {
             PropagateChangedFlags();
         }
@@ -4885,7 +4885,7 @@ namespace System.Windows.Media
             }
         }
 
-        internal virtual void ContentsChanged(object sender, EventArgs e)
+        internal virtual void ContentsChanged(object sender, EventArgs args)
         {
             PropagateChangedFlags();
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Visual.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Visual.cs
@@ -503,7 +503,7 @@ namespace System.Windows.Media
         /// </summary>
         internal Rect CalculateSubgraphBoundsOuterSpace()
         {
-            return CalculateSubgraphBoundsOuterSpace(false /* renderBounds */);
+            return CalculateSubgraphBoundsOuterSpace(renderBounds: false);
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace System.Windows.Media
         /// </summary>
         internal Rect CalculateSubgraphRenderBoundsOuterSpace()
         {
-            return CalculateSubgraphBoundsOuterSpace(true /* renderBounds */);
+            return CalculateSubgraphBoundsOuterSpace(renderBounds: true);
         }
 
         /// <summary>
@@ -3425,7 +3425,7 @@ namespace System.Windows.Media
             }
             protected set
             {
-                ChangeVisualClip(value, false /* dontSetWhenClose */);
+                ChangeVisualClip(value, dontSetWhenClose: false);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/ModelUIElement3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/ModelUIElement3D.cs
@@ -43,8 +43,8 @@ namespace System.Windows.Media.Media3D
         public static readonly DependencyProperty ModelProperty =
             DependencyProperty.Register(
                     "Model",
-                    /* propertyType = */ typeof(Model3D),
-                    /* ownerType = */ typeof(ModelUIElement3D),
+                    propertyType: typeof(Model3D),
+                    ownerType: typeof(ModelUIElement3D),
                     new PropertyMetadata(ModelPropertyChanged),
                     (ValidateValueCallback) delegate { return MediaContext.CurrentMediaContext.WriteAccessEnabled; });
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/ModelVisual3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/ModelVisual3D.cs
@@ -115,8 +115,8 @@ namespace System.Windows.Media.Media3D
         public static readonly DependencyProperty ContentProperty =
             DependencyProperty.Register(
                     "Content",
-                    /* propertyType = */ typeof(Model3D),
-                    /* ownerType = */ typeof(ModelVisual3D),
+                    propertyType: typeof(Model3D),
+                    ownerType: typeof(ModelVisual3D),
                     new PropertyMetadata(ContentPropertyChanged),
                     (ValidateValueCallback) delegate { return MediaContext.CurrentMediaContext.WriteAccessEnabled; });
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/PerspectiveCamera.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/PerspectiveCamera.cs
@@ -142,7 +142,7 @@ namespace System.Windows.Media.Media3D
             //       null for the Camera.Transform below and account for it
             //       later.
 
-            Matrix3D viewMatrix = CreateViewMatrix(/* trasform = */ null, ref position, ref lookDirection, ref upDirection);
+            Matrix3D viewMatrix = CreateViewMatrix(transform: null, ref position, ref lookDirection, ref upDirection);
             Matrix3D invView = viewMatrix;
             invView.Invert();
             invView.MultiplyVector(ref rayDirection);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Quaternion.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Quaternion.cs
@@ -448,7 +448,7 @@ namespace System.Windows.Media.Media3D
         /// <returns>SLERP-interpolated quaternion between the two given quaternions.</returns>
         public static Quaternion Slerp(Quaternion from, Quaternion to, double t)
         {
-            return Slerp(from, to, t, /* useShortestPath = */ true);
+            return Slerp(from, to, t, useShortestPath: true);
         }
         
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/RayHitTestParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/RayHitTestParameters.cs
@@ -108,7 +108,7 @@ namespace System.Windows.Media.Media3D
                                                      HitTestFilterCallback filterCallback,
                                                      HitTestResultBehavior lastResult)
         {
-            return RaiseCallback(resultCallback, filterCallback, lastResult, 0.0 /* distance adjustment */);
+            return RaiseCallback(resultCallback, filterCallback, lastResult, distanceAdjustment: 0.0);
         }
 
         internal HitTestResultBehavior RaiseCallback(HitTestResultCallback resultCallback, 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Viewport2DVisual3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Viewport2DVisual3D.cs
@@ -374,7 +374,7 @@ namespace System.Windows.Media.Media3D
             // Visual(3D).AddVisualChild for the things they propagate on adding a new child
             
             // Fire notifications
-            this.OnVisualChildrenChanged(child, null /* no removed child */);
+            this.OnVisualChildrenChanged(child, visualRemoved: null);
             child.FireOnVisualParentChanged(null);
         }
 
@@ -406,7 +406,7 @@ namespace System.Windows.Media.Media3D
             
             // Fire notifications
             child.FireOnVisualParentChanged(this);
-            OnVisualChildrenChanged(null /* no child added */, child);
+            OnVisualChildrenChanged(visualAdded: null, child);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Viewport3DVisual.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Viewport3DVisual.cs
@@ -191,8 +191,8 @@ namespace System.Windows.Media.Media3D
         public static readonly DependencyProperty CameraProperty =
             DependencyProperty.Register(
                     "Camera",
-                    /* propertyType = */ typeof(Camera),
-                    /* ownerType = */ typeof(Viewport3DVisual),
+                    propertyType: typeof(Camera),
+                    ownerType: typeof(Viewport3DVisual),
                     new PropertyMetadata(
                         FreezableOperations.GetAsFrozen(new PerspectiveCamera()),
                         CameraPropertyChanged),
@@ -214,7 +214,7 @@ namespace System.Windows.Media.Media3D
                 owner.SetFlagsOnAllChannels(true, VisualProxyFlags.Viewport3DVisual_IsCameraDirty | VisualProxyFlags.IsContentDirty);
             }
 
-            owner.ContentsChanged(/* sender = */ owner, EventArgs.Empty);
+            owner.ContentsChanged(sender: owner, EventArgs.Empty);
         }
 
         /// <summary>
@@ -239,8 +239,8 @@ namespace System.Windows.Media.Media3D
         public static readonly DependencyProperty ViewportProperty =
             DependencyProperty.Register(
                     "Viewport",
-                    /* propertyType = */ typeof(Rect),
-                    /* ownerType = */ typeof(Viewport3DVisual),
+                    propertyType: typeof(Rect),
+                    ownerType: typeof(Viewport3DVisual),
                     new PropertyMetadata(Rect.Empty, ViewportPropertyChanged),
                     (ValidateValueCallback) delegate { return MediaContext.CurrentMediaContext.WriteAccessEnabled; });
 
@@ -252,7 +252,7 @@ namespace System.Windows.Media.Media3D
                 "How are we receiving sub property changes from a struct?");
 
             owner.SetFlagsOnAllChannels(true, VisualProxyFlags.Viewport3DVisual_IsViewportDirty | VisualProxyFlags.IsContentDirty);
-            owner.ContentsChanged(/* sender = */ owner, EventArgs.Empty);
+            owner.ContentsChanged(sender: owner, EventArgs.Empty);
         }
 
         /// <summary>
@@ -352,7 +352,7 @@ namespace System.Windows.Media.Media3D
             // UIElement.PropagateResumeLayout(child);
 
             // Fire notifications
-            OnVisualChildrenChanged(child, /* visualRemoved = */ null);
+            OnVisualChildrenChanged(child, visualRemoved: null);
 
             child.FireOnVisualParentChanged(null);
             VisualDiagnostics.OnVisualChildChanged(this, child, true);
@@ -379,7 +379,7 @@ namespace System.Windows.Media.Media3D
 
             VisualDiagnostics.OnVisualChildChanged(this, child, false);
 
-            child.SetParent(/* newParent = */ (Visual) null);  // CS0121: Call is ambigious without casting null to Visual.
+            child.SetParent(newParent: (Visual) null);  // CS0121: Call is ambigious without casting null to Visual.
 
             // remove the inheritance context
             _inheritanceContextForChildren?.RemoveSelfAsInheritanceContext(child, null);
@@ -417,7 +417,7 @@ namespace System.Windows.Media.Media3D
 
             child.FireOnVisualParentChanged(this);
 
-            OnVisualChildrenChanged(/* visualAdded = */ null , child);
+            OnVisualChildrenChanged(visualAdded: null , child);
         }
 
         /// <summary>
@@ -780,7 +780,7 @@ namespace System.Windows.Media.Media3D
                                 DUCE.Visual3DNode.InsertChildAt(
                                     _proxy3D.GetHandle(channel),
                                     ((DUCE.IResource)child).GetHandle(channel),
-                                    /* iPosition = */ i,
+                                    iPosition: i,
                                     channel);
 
                                 child.SetFlags(channel, true, VisualProxyFlags.IsConnectedToParent);
@@ -832,7 +832,7 @@ namespace System.Windows.Media.Media3D
             // same extensibility point we use for "content".
             SetFlagsOnAllChannels(true, VisualProxyFlags.IsContentDirty);
 
-            ContentsChanged(/* sender = */ this, EventArgs.Empty);
+            ContentsChanged(sender: this, EventArgs.Empty);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Visual3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Visual3D.cs
@@ -143,8 +143,8 @@ namespace System.Windows.Media.Media3D
         public static readonly DependencyProperty TransformProperty =
             DependencyProperty.Register(
                     "Transform",
-                    /* propertyType = */ typeof(Transform3D),
-                    /* ownerType = */ typeof(Visual3D),
+                    propertyType: typeof(Transform3D),
+                    ownerType: typeof(Visual3D),
                     new PropertyMetadata(Transform3D.Identity, TransformPropertyChanged),
                     (ValidateValueCallback) delegate { return MediaContext.CurrentMediaContext.WriteAccessEnabled; });
 
@@ -170,7 +170,7 @@ namespace System.Windows.Media.Media3D
             // and subgraph bounds.  A better solution that would be both a 2D
             // and 3D win would be to stop invalidating _bboxSubgraph when a
             // visual’s transform changes.
-            owner.RenderChanged(/* sender = */ owner, EventArgs.Empty);
+            owner.RenderChanged(sender: owner, EventArgs.Empty);
         }
 
         /// <summary>
@@ -258,7 +258,7 @@ namespace System.Windows.Media.Media3D
             // UIElement.PropagateResumeLayout(child);
 
             // Fire notifications
-            OnVisualChildrenChanged(child, /* visualRemoved = */ null);
+            OnVisualChildrenChanged(child, visualRemoved: null);
 
             child.FireOnVisualParentChanged(null);
             VisualDiagnostics.OnVisualChildChanged(this, child, true);
@@ -290,7 +290,7 @@ namespace System.Windows.Media.Media3D
 
             VisualDiagnostics.OnVisualChildChanged(this, child, false);
 
-            child.SetParent(/* newParent = */ (Visual3D) null);  // CS0121: Call is ambigious without casting null to Visual3D.
+            child.SetParent(newParent: (Visual3D) null);  // CS0121: Call is ambigious without casting null to Visual3D.
 
             // remove the inheritance context
             RemoveSelfAsInheritanceContext(child, null);
@@ -328,7 +328,7 @@ namespace System.Windows.Media.Media3D
             // Fire notifications
             child.FireOnVisualParentChanged(this);
 
-            OnVisualChildrenChanged(/* visualAdded = */ null , child);
+            OnVisualChildrenChanged(visualAdded: null , child);
         }
 
         /// <summary>
@@ -368,7 +368,7 @@ namespace System.Windows.Media.Media3D
 
                     SetFlagsOnAllChannels(true, VisualProxyFlags.IsTransformDirty);
 
-                    RenderChanged(/* sender = */ this, EventArgs.Empty);
+                    RenderChanged(sender: this, EventArgs.Empty);
 
                     _internalIsVisible = value;
                 }
@@ -393,14 +393,14 @@ namespace System.Windows.Media.Media3D
 
             SetFlags(false, VisualFlags.Are3DContentBoundsValid);
 
-            RenderChanged(/* sender = */ this, EventArgs.Empty);
+            RenderChanged(sender: this, EventArgs.Empty);
         }
 
         private void Visual3DModelPropertyChanged(object o, EventArgs e)
         {
             // forward on to the main property changed method.  Since this method is
             // only called on subproperty chanes, oldValue is meaningless.
-            Visual3DModelPropertyChanged(null, /* isSubpropertyChange = */ true);
+            Visual3DModelPropertyChanged(null, isSubpropertyChange: true);
         }
 
         /// <summary>
@@ -428,7 +428,7 @@ namespace System.Windows.Media.Media3D
                     }
 
                     // notify of the property change
-                    Visual3DModelPropertyChanged(_visual3DModel, /* isSubpropertyChange = */ false);
+                    Visual3DModelPropertyChanged(_visual3DModel, isSubpropertyChange: false);
                     _visual3DModel = value;
 
                     // set the new one
@@ -1231,7 +1231,7 @@ namespace System.Windows.Media.Media3D
                             DUCE.Visual3DNode.InsertChildAt(
                                 handle,
                                 ((DUCE.IResource)child).GetHandle(channel),
-                                /* iPosition = */ (uint)i,
+                                iPosition: (uint)i,
                                 ctx.Channel);
 
                             child.SetFlags(channel, true, VisualProxyFlags.IsConnectedToParent);
@@ -2126,7 +2126,7 @@ namespace System.Windows.Media.Media3D
         // store the parent in an UncommonField.  Both fields must be considered when determining
         // the parent of this node.
         private static readonly UncommonField<Visual> _2DParent =
-            new UncommonField<Visual>(/* defaultValue = */ null);
+            new UncommonField<Visual>(defaultValue: null);
 
         // Sentinel value we use to differentiate between a null inheritance context stored in the
         // _inheritanceContext uncommon field and "empty", meaning use the parent as context.
@@ -2135,7 +2135,7 @@ namespace System.Windows.Media.Media3D
         // Normally the inheritance context is the same as the parent, except when we are parent to
         // a Viewport3D visual, in which case we use this uncommon field to store are alternate context.
         private static readonly UncommonField<DependencyObject> _inheritanceContext =
-            new UncommonField<DependencyObject>(/* defaultValue = */ UseParentAsContext);
+            new UncommonField<DependencyObject>(defaultValue: UseParentAsContext);
 
         private static readonly UncommonField<Visual.AncestorChangedEventHandler> AncestorChangedEventField
             = new UncommonField<Visual.AncestorChangedEventHandler>();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
@@ -528,7 +528,7 @@ namespace System.Windows
 
         internal static PresentationSource CriticalFromVisual(DependencyObject v)
         {
-            return CriticalFromVisual(v, true /* enable2DTo3DTransition */);
+            return CriticalFromVisual(v, enable2DTo3DTransition: true);
         }
 
         /// <param name="v">The dependency object to find the source for</param>
@@ -643,7 +643,7 @@ namespace System.Windows
 
         private static PresentationSource FindSource(DependencyObject o)
         {
-            return FindSource(o, true /* enable2DTo3DTransition */);
+            return FindSource(o, enable2DTo3DTransition: true);
         }
 
         /// <param name="o">The dependency object to find the source for</param>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/ReverseInheritProperty.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/ReverseInheritProperty.cs
@@ -71,21 +71,21 @@ namespace System.Windows
             for (int i = 0; i < otherCount; i++)
             {
                 // setOriginCacheFlag is false, because these flags should not be affected by other origins
-                SetCacheFlagInAncestry(otherOrigins[i], true, null, false, /*setOriginCacheFlag*/ false);
+                SetCacheFlagInAncestry(otherOrigins[i], true, null, false, setOriginCacheFlag: false);
             }
 
             // Step #3
             // Fire value changed on elements in the ancestry of the element that got turned off.
             if (oldOrigin != null)
             {
-                FirePropertyChangeInAncestry(oldOrigin, true /* oldValue */, treeStateLocalCopy, originChangedAction);
+                FirePropertyChangeInAncestry(oldOrigin, oldValue: true, treeStateLocalCopy, originChangedAction);
             }
 
             // Step #4
             // Fire value changed on elements in the ancestry of the element that got turned on.
             if (newOrigin != null)
             {
-                FirePropertyChangeInAncestry(newOrigin, false /* oldValue */, null, originChangedAction);
+                FirePropertyChangeInAncestry(newOrigin, oldValue: false, null, originChangedAction);
             }
 
             if (oldTreeState == null && treeStateLocalCopy != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
@@ -3073,7 +3073,7 @@ namespace System.Windows
                 }
             }
 
-            ChangeVisualClip(clipGeometry, true /* dontSetWhenClose */);
+            ChangeVisualClip(clipGeometry, dontSetWhenClose: true);
         }
 
         /// <summary>
@@ -3164,7 +3164,7 @@ namespace System.Windows
             //
 
             // Propagate notification handlers.
-            newContent?.PropagateChangedHandler(ContentsChangedHandler, true /* adding */);
+            newContent?.PropagateChangedHandler(ContentsChangedHandler, adding: true);
 
             _drawingContent = newContent;
 
@@ -4589,7 +4589,7 @@ namespace System.Windows
         {
             get
             {
-                return TouchDevice.GetCapturedTouches(this, /* includeWithin = */ false);
+                return TouchDevice.GetCapturedTouches(this, includeWithin: false);
             }
         }
 
@@ -4600,7 +4600,7 @@ namespace System.Windows
         {
             get
             {
-                return TouchDevice.GetCapturedTouches(this, /* includeWithin = */ true);
+                return TouchDevice.GetCapturedTouches(this, includeWithin: true);
             }
         }
 
@@ -4612,7 +4612,7 @@ namespace System.Windows
         {
             get
             {
-                return TouchDevice.GetTouchesOver(this, /* includeWithin = */ true);
+                return TouchDevice.GetTouchesOver(this, includeWithin: true);
             }
         }
 
@@ -4624,7 +4624,7 @@ namespace System.Windows
         {
             get
             {
-                return TouchDevice.GetTouchesOver(this, /* includeWithin = */ false);
+                return TouchDevice.GetTouchesOver(this, includeWithin: false);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
@@ -3146,7 +3146,7 @@ namespace System.Windows
                 // Remove the notification handlers.
                 //
 
-                oldContent.PropagateChangedHandler(ContentsChangedHandler, false /* remove */);
+                oldContent.PropagateChangedHandler(ContentsChangedHandler, adding: false);
 
 
                 //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement3D.cs
@@ -1493,7 +1493,7 @@ namespace System.Windows
         {
             get
             {
-                return TouchDevice.GetCapturedTouches(this, /* includeWithin = */ false);
+                return TouchDevice.GetCapturedTouches(this, includeWithin: false);
             }
         }
 
@@ -1504,7 +1504,7 @@ namespace System.Windows
         {
             get
             {
-                return TouchDevice.GetCapturedTouches(this, /* includeWithin = */ true);
+                return TouchDevice.GetCapturedTouches(this, includeWithin: true);
             }
         }
 
@@ -1516,7 +1516,7 @@ namespace System.Windows
         {
             get
             {
-                return TouchDevice.GetTouchesOver(this, /* includeWithin = */ true);
+                return TouchDevice.GetTouchesOver(this, includeWithin: true);
             }
         }
 
@@ -1528,7 +1528,7 @@ namespace System.Windows
         {
             get
             {
-                return TouchDevice.GetTouchesOver(this, /* includeWithin = */ false);
+                return TouchDevice.GetTouchesOver(this, includeWithin: false);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
@@ -702,7 +702,7 @@ namespace System.Windows
             dataObject = new DataObject();
             dataObject.SetData(format, data, autoConvert);
 
-            Clipboard.SetDataObject(dataObject, /*copy*/true);
+            Clipboard.SetDataObject(dataObject, copy: true);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -338,7 +338,7 @@ namespace System.Windows
         /// </summary>
         public bool ContainsAudio()
         {
-            return GetDataPresent(DataFormats.WaveAudio, /*autoConvert*/false);
+            return GetDataPresent(DataFormats.WaveAudio, autoConvert: false);
         }
 
         /// <summary>
@@ -346,7 +346,7 @@ namespace System.Windows
         /// </summary>
         public bool ContainsFileDropList()
         {
-            return GetDataPresent(DataFormats.FileDrop, /*autoConvert*/false);
+            return GetDataPresent(DataFormats.FileDrop, autoConvert: false);
         }
 
         /// <summary>
@@ -354,7 +354,7 @@ namespace System.Windows
         /// </summary>
         public bool ContainsImage()
         {
-            return GetDataPresent(DataFormats.Bitmap, /*autoConvert*/false);
+            return GetDataPresent(DataFormats.Bitmap, autoConvert: false);
         }
 
         /// <summary>
@@ -375,7 +375,7 @@ namespace System.Windows
                 throw new InvalidEnumArgumentException("format", (int)format, typeof(TextDataFormat));
             }
 
-            return GetDataPresent(DataFormats.ConvertToDataFormats(format), /*autoConvert*/false);
+            return GetDataPresent(DataFormats.ConvertToDataFormats(format), autoConvert: false);
         }
 
         /// <summary>
@@ -383,7 +383,7 @@ namespace System.Windows
         /// </summary>
         public Stream GetAudioStream()
         {
-            return GetData(DataFormats.WaveAudio, /*autoConvert*/false) as Stream;
+            return GetData(DataFormats.WaveAudio, autoConvert: false) as Stream;
         }
 
         /// <summary>
@@ -396,7 +396,7 @@ namespace System.Windows
 
             fileDropListCollection = new StringCollection();
 
-            fileDropList = GetData(DataFormats.FileDrop, /*autoConvert*/true) as string[];
+            fileDropList = GetData(DataFormats.FileDrop, autoConvert: true) as string[];
             if (fileDropList != null)
             {
                 fileDropListCollection.AddRange(fileDropList);
@@ -410,7 +410,7 @@ namespace System.Windows
         /// </summary>
         public BitmapSource GetImage()
         {
-            return GetData(DataFormats.Bitmap, /*autoConvert*/true) as BitmapSource;
+            return GetData(DataFormats.Bitmap, autoConvert: true) as BitmapSource;
         }
 
         /// <summary>
@@ -460,7 +460,7 @@ namespace System.Windows
         {
             ArgumentNullException.ThrowIfNull(audioStream);
 
-            SetData(DataFormats.WaveAudio, audioStream, /*autoConvert*/false);
+            SetData(DataFormats.WaveAudio, audioStream, autoConvert: false);
         }
 
         /// <summary>
@@ -645,7 +645,7 @@ namespace System.Windows
                                                            | NativeMethods.GMEM_ZEROINIT,
                                                           (IntPtr)1);
 
-                    hr = OleGetDataUnrestricted(ref formatetc, ref medium, false /* doNotReallocate */);
+                    hr = OleGetDataUnrestricted(ref formatetc, ref medium, doNotReallocate: false);
 
                     if (NativeMethods.Failed(hr))
                     {
@@ -663,7 +663,7 @@ namespace System.Windows
                         medium.unionmember = Marshal.GetComInterfaceForObject(istream, typeof(IStream));
                         Marshal.ReleaseComObject(istream);
 
-                        hr = OleGetDataUnrestricted(ref formatetc, ref medium, false /* doNotReallocate */);
+                        hr = OleGetDataUnrestricted(ref formatetc, ref medium, doNotReallocate: false);
 
                         if ( NativeMethods.Failed(hr) )
                         {
@@ -674,7 +674,7 @@ namespace System.Windows
                 else
                 {
                     medium.tymed = formatetc.tymed;
-                    hr = OleGetDataUnrestricted(ref formatetc, ref medium, false /* doNotReallocate */);
+                    hr = OleGetDataUnrestricted(ref formatetc, ref medium, doNotReallocate: false);
                 }
             }
 
@@ -702,7 +702,7 @@ namespace System.Windows
                 Marshal.ThrowExceptionForHR(DV_E_TYMED);
             }
 
-            int hr = OleGetDataUnrestricted(ref formatetc, ref medium, true /* doNotReallocate */);
+            int hr = OleGetDataUnrestricted(ref formatetc, ref medium, doNotReallocate: true);
             if (NativeMethods.Failed(hr))
             {
                 Marshal.ThrowExceptionForHR(hr);
@@ -1467,12 +1467,12 @@ namespace System.Windows
                 || IsFormatEqual(format, DataFormats.OemText)
                 || IsFormatEqual(format, DataFormats.CommaSeparatedValue))
             {
-                hr = SaveStringToHandle(medium.unionmember, data.ToString(), false /* unicode */, doNotReallocate);
+                hr = SaveStringToHandle(medium.unionmember, data.ToString(), unicode: false, doNotReallocate);
             }
             else if (IsFormatEqual(format, DataFormats.UnicodeText)||
                      IsFormatEqual(format, DataFormats.ApplicationTrust))
             {
-                hr = SaveStringToHandle(medium.unionmember, data.ToString(), true /* unicode */, doNotReallocate);
+                hr = SaveStringToHandle(medium.unionmember, data.ToString(), unicode: true, doNotReallocate);
             }
             else if (IsFormatEqual(format, DataFormats.FileDrop))
             {
@@ -1483,14 +1483,14 @@ namespace System.Windows
                 string[] filelist;
 
                 filelist = (string[])data;
-                hr = SaveStringToHandle(medium.unionmember, filelist[0], false /* unicode */, doNotReallocate);
+                hr = SaveStringToHandle(medium.unionmember, filelist[0], unicode: false, doNotReallocate);
             }
             else if (IsFormatEqual(format, DataFormats.FileNameW))
             {
                 string[] filelist;
 
                 filelist = (string[])data;
-                hr = SaveStringToHandle(medium.unionmember, filelist[0], true /* unicode */, doNotReallocate);
+                hr = SaveStringToHandle(medium.unionmember, filelist[0], unicode: true, doNotReallocate);
             }
             else if (IsFormatEqual(format, DataFormats.Dib)
                 && SystemDrawingHelper.IsImage(data))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -492,7 +492,7 @@ namespace System.Windows
             fileDropListStrings = new string[fileDropList.Count];
             fileDropList.CopyTo(fileDropListStrings, 0);
 
-            SetData(DataFormats.FileDrop, fileDropListStrings, /*audoConvert*/true);
+            SetData(DataFormats.FileDrop, fileDropListStrings, autoConvert: true);
         }
 
         /// <summary>
@@ -502,7 +502,7 @@ namespace System.Windows
         {
             ArgumentNullException.ThrowIfNull(image);
 
-            SetData(DataFormats.Bitmap, image, /*audoConvert*/true);
+            SetData(DataFormats.Bitmap, image, autoConvert: true);
         }
 
         /// <summary>
@@ -527,7 +527,7 @@ namespace System.Windows
                 throw new InvalidEnumArgumentException("format", (int)format, typeof(TextDataFormat));
             }
 
-            SetData(DataFormats.ConvertToDataFormats(format), textData, /*audoConvert*/false);
+            SetData(DataFormats.ConvertToDataFormats(format), textData, autoConvert: false);
         }
 
         /// <summary>
@@ -657,7 +657,7 @@ namespace System.Windows
                     medium.tymed = TYMED.TYMED_ISTREAM;
 
                     IStream istream = null;
-                    hr = Win32CreateStreamOnHGlobal(IntPtr.Zero, true /*deleteOnRelease*/, ref istream);
+                    hr = Win32CreateStreamOnHGlobal(IntPtr.Zero, fDeleteOnRelease: true, ref istream);
                     if ( NativeMethods.Succeeded(hr) )
                     {
                         medium.unionmember = Marshal.GetComInterfaceForObject(istream, typeof(IStream));
@@ -1144,7 +1144,7 @@ namespace System.Windows
         /// </summary>
         internal static int Win32WideCharToMultiByte(string wideString, int wideChars, byte[] bytes, int byteCount)
         {
-            int win32Return = UnsafeNativeMethods.WideCharToMultiByte(0 /*CP_ACP*/, 0 /*flags*/, wideString, wideChars, bytes, byteCount, IntPtr.Zero, IntPtr.Zero);
+            int win32Return = UnsafeNativeMethods.WideCharToMultiByte(0 /*CP_ACP*/, flags: 0, wideString, wideChars, bytes, byteCount, IntPtr.Zero, IntPtr.Zero);
             int win32Error = Marshal.GetLastWin32Error();
             if (win32Return == 0)
             {


### PR DESCRIPTION
Contributes to dotnet/wpf#10018

## Description
I replaced comments specifying an argument name with named arguments, which were introduced in C# 7. This improves readability and maintainability.

My changes are in 2 commits the first commit is automated changes using regexes and the second commit is manual changes where the comment is outdated or formatted differently than the parameter name.

**Note: The compiled IL is identical.**
(Except for some of the changes in Visual.cs where I renamed some parameters e -> args to better reflect the parameter and be able to remove the comment)

## Customer Impact
None.

## Regression
No.

## Testing
Local build + validated IL.

## Risk
Low to none.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10321)