### PR TITLE
Fix in .NET 8 for Inconsistent UI Issue due to incorrect localized string resources

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
@@ -4770,7 +4770,7 @@ Chcete ho nahradit?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageDown">
         <source>Page Down</source>
-        <target state="translated">Page Down</target>
+        <target state="translated">O stránku dolů</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageLeft">
@@ -4785,7 +4785,7 @@ Chcete ho nahradit?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageUp">
         <source>Page Up</source>
-        <target state="translated">Page Up</target>
+        <target state="translated">O stránku nahoru</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_RightEdge">
@@ -4820,7 +4820,7 @@ Chcete ho nahradit?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">Nahoře</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
@@ -4820,7 +4820,7 @@ Möchten Sie das Element ersetzen?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">Nach oben</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
@@ -4820,7 +4820,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">Arriba</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
@@ -4770,7 +4770,7 @@ Voulez-vous le remplacer ?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageDown">
         <source>Page Down</source>
-        <target state="translated">Page Down</target>
+        <target state="translated">Page suivante</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageLeft">
@@ -4785,7 +4785,7 @@ Voulez-vous le remplacer ?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageUp">
         <source>Page Up</source>
-        <target state="translated">Page Up</target>
+        <target state="translated">Page précédente</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_RightEdge">
@@ -4820,7 +4820,7 @@ Voulez-vous le remplacer ?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">Haut</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
@@ -4820,7 +4820,7 @@ Sostituirlo?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">In alto</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
@@ -4820,7 +4820,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">- </target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
@@ -4770,7 +4770,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageDown">
         <source>Page Down</source>
-        <target state="translated">Page Down</target>
+        <target state="translated">페이지 아래로</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageLeft">
@@ -4785,7 +4785,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageUp">
         <source>Page Up</source>
-        <target state="translated">Page Up</target>
+        <target state="translated">페이지 위로</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_RightEdge">
@@ -4820,7 +4820,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">맨 위</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
@@ -4770,7 +4770,7 @@ Czy chcesz go zastąpić?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageDown">
         <source>Page Down</source>
-        <target state="translated">Page Down</target>
+        <target state="translated">Strona w dół</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageLeft">
@@ -4785,7 +4785,7 @@ Czy chcesz go zastąpić?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageUp">
         <source>Page Up</source>
-        <target state="translated">Page Up</target>
+        <target state="translated">Strona w górę</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_RightEdge">
@@ -4820,7 +4820,7 @@ Czy chcesz go zastąpić?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">Góra</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
@@ -4820,7 +4820,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">Наверх</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
@@ -4770,7 +4770,7 @@ Değiştirmek istiyor musunuz?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageDown">
         <source>Page Down</source>
-        <target state="translated">Page Down</target>
+        <target state="translated">Aşağı</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageLeft">
@@ -4785,7 +4785,7 @@ Değiştirmek istiyor musunuz?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageUp">
         <source>Page Up</source>
-        <target state="translated">Page Up</target>
+        <target state="translated">Yukarı</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_RightEdge">
@@ -4820,7 +4820,7 @@ Değiştirmek istiyor musunuz?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">Üst</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
@@ -4770,7 +4770,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageDown">
         <source>Page Down</source>
-        <target state="translated">Page Down</target>
+        <target state="translated">向下翻页</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageLeft">
@@ -4785,7 +4785,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageUp">
         <source>Page Up</source>
-        <target state="translated">Page Up</target>
+        <target state="translated">向上翻页</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_RightEdge">
@@ -4820,7 +4820,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">顶部</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
@@ -4770,7 +4770,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageDown">
         <source>Page Down</source>
-        <target state="translated">Page Down</target>
+        <target state="translated">下一頁</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageLeft">
@@ -4785,7 +4785,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_PageUp">
         <source>Page Up</source>
-        <target state="translated">Page Up</target>
+        <target state="translated">上一頁</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_RightEdge">
@@ -4820,7 +4820,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">回到頂端</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">


### PR DESCRIPTION
Fixes #10273 

## Description

Fixed the translation state for ScrollBar_ContextMenu_Top, ScrollBar_ContextMenu_PageDown and ScrollBar_ContextMenu_PageUp resource

## Customer Impact

Context menu for users using ScrollBar will be correctly translated for different languages.

## Regression

N/A

## Testing

Locally Tested 

## Risk

Low

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10327)