### PR TITLE
Remove allocations in BaseUriHelper, improve resource resolution performance

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontResourceCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontResourceCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -59,11 +59,7 @@ namespace MS.Internal.FontCache
             // Perform a sanity check to make sure the assumption stays the same.
             Debug.Assert(uri.IsAbsoluteUri && uri.Scheme == PackUriHelper.UriSchemePack && BaseUriHelper.IsPackApplicationUri(uri));
 
-            Assembly uriAssembly;
-            string escapedPath;
-
-            BaseUriHelper.GetAssemblyAndPartNameFromPackAppUri(uri, out uriAssembly, out escapedPath);
-
+            BaseUriHelper.GetAssemblyAndPartNameFromPackAppUri(uri, out Assembly uriAssembly, out ReadOnlySpan<char> escapedPath);
             if (uriAssembly == null)
                 return null;
 
@@ -71,7 +67,7 @@ namespace MS.Internal.FontCache
             if (isFolder)
             {
                 Debug.Assert(escapedPath.EndsWith(FakeFileName, StringComparison.OrdinalIgnoreCase));
-                escapedPath = escapedPath.Substring(0, escapedPath.Length - FakeFileName.Length);
+                escapedPath = escapedPath.Slice(0, escapedPath.Length - FakeFileName.Length);
             }
 
             Dictionary<string, List<string>> folderResourceMap;
@@ -86,8 +82,7 @@ namespace MS.Internal.FontCache
                 }
             }
 
-            List<string> ret;
-            folderResourceMap.TryGetValue(escapedPath, out ret);
+            folderResourceMap.GetAlternateLookup<ReadOnlySpan<char>>().TryGetValue(escapedPath, out List<string> ret);
             return ret;
         }
 
@@ -143,9 +138,8 @@ namespace MS.Internal.FontCache
             folderResourceMap[resourceFullName].Add(String.Empty);
         }
 
-        private static Dictionary<Assembly, Dictionary<string, List<string>>> _assemblyCaches
-            = new Dictionary<Assembly, Dictionary<string, List<string>>>(1);
         // Set the initial capacity to 1 because a single entry assembly is the most common case.
+        private static readonly Dictionary<Assembly, Dictionary<string, List<string>>> _assemblyCaches = new(1);
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Resources/ContentFileHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Resources/ContentFileHelper.cs
@@ -17,16 +17,12 @@ namespace MS.Internal.Resources
     // </summary>
     internal static class ContentFileHelper
     {
-        internal static bool IsContentFile(string partName)
+        internal static bool IsContentFile(ReadOnlySpan<char> partName)
         {
-            if (_contentFiles == null)
+            s_contentFiles ??= GetContentFiles(BaseUriHelper.ResourceAssembly);
+            if (s_contentFiles is not null && s_contentFiles.Count > 0)
             {
-                _contentFiles = GetContentFiles(BaseUriHelper.ResourceAssembly);
-            }
-
-            if (_contentFiles != null && _contentFiles.Count > 0)
-            {                
-                if (_contentFiles.Contains(partName))
+                if (s_contentFiles.GetAlternateLookup<ReadOnlySpan<char>>().Contains(partName))
                 {
                     return true;
                 }
@@ -75,6 +71,6 @@ namespace MS.Internal.Resources
             return contentFiles;
         }
 
-        private static HashSet<string> _contentFiles;
+        private static HashSet<string> s_contentFiles;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -344,6 +344,7 @@
     <Compile Include="System\Windows\BinaryFormat\ListConverterHelper.cs" />
     <Compile Include="System\Windows\BinaryFormat\FormatterConverterStub.cs" />
     <Compile Include="System\Windows\BinaryFormat\SerializationExtensions.cs" />
+    <Compile Include="System\Windows\Navigation\AssemblyPackageInfo.cs" />
     <Compile Include="System\Windows\Nrbf\SerializationRecordExtensions.cs" />
     <Compile Include="System\Windows\BinaryFormat\MessageEnd.cs" />
     <Compile Include="System\Windows\BinaryFormat\Record.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/PixelShader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/PixelShader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -76,7 +76,7 @@ namespace System.Windows.Media.Effects
                 {
                     if (!newUri.IsAbsoluteUri)
                     {
-                         newUri = BaseUriHelper.GetResolvedUri(BaseUriHelper.BaseUri, newUri);
+                         newUri = BaseUriHelper.GetResolvedUri(BaseUriHelper.PackAppBaseUri, newUri);
                     }
 
                     Debug.Assert(newUri.IsAbsoluteUri);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamilyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamilyConverter.cs
@@ -91,14 +91,14 @@ namespace System.Windows.Media
 
                             if (!baseUri.IsAbsoluteUri)
                             {
-                                baseUri = new Uri(BaseUriHelper.BaseUri, baseUri);
+                                baseUri = new Uri(BaseUriHelper.PackAppBaseUri, baseUri);
                             }
                         }
                         else
                         {
                             // If we reach here, the base uri we got from IUriContext is "".
                             // Here we resolve it to application's base
-                            baseUri = BaseUriHelper.BaseUri;
+                            baseUri = BaseUriHelper.PackAppBaseUri;
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/AssemblyPackageInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/AssemblyPackageInfo.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Navigation
+{
+    /// <summary>
+    /// Holds slices of pack/application URIs and exposes each slice through a property.
+    /// </summary>
+    /// <remarks>This should be dissected from relative URIs in format /AssemblyShortName{;Version]{;PublicKey];component/PackagePartName</remarks>
+    internal ref struct AssemblyPackageInfo
+    {
+        /// <summary>
+        /// Specifies the name of the package/resource.
+        /// </summary>
+        internal ReadOnlySpan<char> PackagePartName { get; set; }
+
+        /// <summary>
+        /// Holds Assembly.Name-like slice if specified, may be empty.
+        /// </summary>
+        /// <remarks>The slice is without leading forward slash ('/').</remarks>
+        internal ReadOnlySpan<char> AssemblyName { get; set; }
+        /// <summary>
+        /// Holds Assembly.Version if specified, may be empty.
+        /// </summary>
+        /// <remarks>The slice is without 'v' prefix.</remarks>
+        internal ReadOnlySpan<char> AssemblyVersion { get; set; }
+        /// <summary>
+        /// Holds Assembly.PublicKeyToken if specified, often is empty.
+        /// </summary>
+        internal ReadOnlySpan<char> AssemblyToken { get; set; }
+
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+
+using PackUriHelper = System.IO.Packaging.PackUriHelper;
 
 using System.Globalization;
 using System.Text;
@@ -13,8 +14,6 @@ using MS.Internal.AppModel;
 using MS.Internal.IO.Packaging;
 using MS.Internal.PresentationCore;
 
-using PackUriHelper = System.IO.Packaging.PackUriHelper;
-
 namespace System.Windows.Navigation
 {
     /// <summary>
@@ -22,29 +21,26 @@ namespace System.Windows.Navigation
     /// </summary>
     public static class BaseUriHelper
     {
-        private const string SOOBASE = "SiteOfOrigin://";
-        private static readonly Uri _siteOfOriginBaseUri = PackUriHelper.Create(new Uri(SOOBASE));
-        private const string APPBASE = "application://";
-        private static readonly Uri _packAppBaseUri = PackUriHelper.Create(new Uri(APPBASE));
+        private static readonly Uri s_siteOfOriginBaseUri = PackUriHelper.Create(new Uri("SiteOfOrigin://"));
+        private static readonly Uri s_packAppBaseUri = PackUriHelper.Create(new Uri("application://"));
 
-        private static Uri _baseUri;
+        private const string COMPONENT = ";component";
+        private const string VERSION = "v";
+        private const char COMPONENT_DELIMITER = ';';
 
-        // Cached result of calling
-        // PackUriHelper.GetPackageUri(BaseUriHelper.PackAppBaseUri).GetComponents(
-        // UriComponents.AbsoluteUri,
-        // UriFormat.UriEscaped);
-        private const string _packageApplicationBaseUriEscaped = "application:///";
-        private const string _packageSiteOfOriginBaseUriEscaped = "siteoforigin:///";
+        private static Assembly s_resourceAssembly;
+
+        // Cached result of calling the following:
+        // PackUriHelper.GetPackageUri(BaseUriHelper.PackAppBaseUri).GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped);
+        private const string PackageApplicationBaseUriEscaped = "application:///";
+        private const string PackageSiteOfOriginBaseUriEscaped = "siteoforigin:///";
 
         static BaseUriHelper()
         {
-            _baseUri = _packAppBaseUri;
             // Add an instance of the ResourceContainer to PreloadedPackages so that PackWebRequestFactory can find it
             // and mark it as thread-safe so PackWebResponse won't protect returned streams with a synchronizing wrapper
             PreloadedPackages.AddPackage(PackUriHelper.GetPackageUri(SiteOfOriginBaseUri), new SiteOfOriginContainer(), true);
         }
-
-        #region public property and method
 
         /// <summary>
         ///     The DependencyProperty for BaseUri of current Element.
@@ -52,23 +48,13 @@ namespace System.Windows.Navigation
         ///     Flags: None
         ///     Default Value: null.
         /// </summary>
-        public static readonly DependencyProperty BaseUriProperty =
-                    DependencyProperty.RegisterAttached(
-                                "BaseUri",
-                                typeof(Uri),
-                                typeof(BaseUriHelper),
-                                new PropertyMetadata((object)null));
-
+        public static readonly DependencyProperty BaseUriProperty = DependencyProperty.RegisterAttached("BaseUri", typeof(Uri), typeof(BaseUriHelper), new PropertyMetadata(null));
 
         /// <summary>
         /// Get BaseUri for a dependency object inside a tree.
-        ///
         /// </summary>
         /// <param name="element">Dependency Object</param>
-        /// <returns>BaseUri for the element</returns>
-        /// <remarks>
-        ///     Callers must have FileIOPermission(FileIOPermissionAccess.PathDiscovery) for the given Uri to call this API.
-        /// </remarks>
+        /// <returns>BaseUri for the <paramref name="element"/>.</returns>
         public static Uri GetBaseUri(DependencyObject element)
         {
             Uri baseUri = GetBaseUriCore(element);
@@ -77,17 +63,17 @@ namespace System.Windows.Navigation
             // Manipulate BaseUri after tree searching is done.
             //
 
-            if (baseUri == null)
+            if (baseUri is null)
             {
                 // If no BaseUri information is found from the current tree,
                 // just take the Application's BaseUri.
                 // Application's BaseUri must be an absolute Uri.
 
-                baseUri = BaseUriHelper.BaseUri;
+                baseUri = PackAppBaseUri;
             }
             else
             {
-                if (baseUri.IsAbsoluteUri == false)
+                if (!baseUri.IsAbsoluteUri)
                 {
                     // Most likely the BaseUriDP in element or IUriContext.BaseUri
                     // is set to a relative Uri programmatically in user's code.
@@ -100,49 +86,50 @@ namespace System.Windows.Navigation
                     // code path would not run for parser-loaded tree.
                     //
 
-                    baseUri = new Uri(BaseUriHelper.BaseUri, baseUri);
+                    baseUri = new Uri(PackAppBaseUri, baseUri);
                 }
             }
 
             return baseUri;
         }
 
-
-       #endregion public property and method
-
-        #region internal properties and methods
-
-        static internal Uri SiteOfOriginBaseUri
+        internal static Uri SiteOfOriginBaseUri
         {
-            get
-            {
-                return _siteOfOriginBaseUri;
-            }
+            get => s_siteOfOriginBaseUri;
         }
 
-        static internal Uri PackAppBaseUri
+        internal static Uri PackAppBaseUri
+        {
+            get => s_packAppBaseUri;
+        }
+
+        internal static Assembly ResourceAssembly
         {
             get
             {
-                return _packAppBaseUri;
+                s_resourceAssembly ??= Assembly.GetEntryAssembly();
+
+                return s_resourceAssembly;
             }
+            // This should only be called from Framework through Application.ResourceAssembly setter.
+            set => s_resourceAssembly = value;
         }
 
         /// <summary>
         /// Checks whether the input uri is in the "pack://application:,,," form
         /// </summary>
         internal static bool IsPackApplicationUri(Uri uri)
-        {        
-            return 
+        {
+            return
                 // Is the "outer" URI absolute?
-                uri.IsAbsoluteUri && 
+                uri.IsAbsoluteUri &&
 
                 // Does the "outer" URI have the pack: scheme?
                 string.Equals(uri.Scheme, PackUriHelper.UriSchemePack, StringComparison.OrdinalIgnoreCase) &&
 
                 // Does the "inner" URI have the application: scheme
                 string.Equals(PackUriHelper.GetPackageUri(uri).GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped),
-                              _packageApplicationBaseUriEscaped,
+                              PackageApplicationBaseUriEscaped,
                               StringComparison.OrdinalIgnoreCase);
         }
 
@@ -155,7 +142,7 @@ namespace System.Windows.Navigation
         // assembly name matches the text string in the first segment. otherwise, this method
         // would return EntryAssembly in the AppDomain.
         //
-        internal static void GetAssemblyAndPartNameFromPackAppUri(Uri uri, out Assembly assembly, out string partName)
+        internal static void GetAssemblyAndPartNameFromPackAppUri(Uri uri, out Assembly assembly, out ReadOnlySpan<char> partName)
         {
             // The input Uri is assumed to be a valid absolute pack application Uri.
             // The caller should guarantee that.
@@ -163,225 +150,182 @@ namespace System.Windows.Navigation
             Debug.Assert(uri is not null && uri.IsAbsoluteUri && string.Equals(uri.Scheme, PackUriHelper.UriSchemePack, StringComparison.OrdinalIgnoreCase) && IsPackApplicationUri(uri));
 
             // Generate a relative Uri which gets rid of the pack://application:,,, authority part.
-            Uri partUri = new Uri(uri.AbsolutePath, UriKind.Relative);
+            Uri partUri = new(uri.AbsolutePath, UriKind.Relative);
 
-            string assemblyName;
-            string assemblyVersion;
-            string assemblyKey;
+            GetAssemblyNameAndPart(partUri, out AssemblyPackageInfo assemblyInfo);
+            partName = assemblyInfo.PackagePartName;
 
-            GetAssemblyNameAndPart(partUri, out partName, out assemblyName, out assemblyVersion, out assemblyKey);
-
-            if (string.IsNullOrEmpty(assemblyName))
+            if (assemblyInfo.AssemblyName.IsEmpty)
             {
-                // The uri doesn't contain ";component". it should map to the enty application assembly.
+                // The uri doesn't contain ";component". it should map to the entry application assembly.
                 assembly = ResourceAssembly;
 
                 // The partName returned from GetAssemblyNameAndPart should be escaped.
-                Debug.Assert(string.Equals(partName, uri.GetComponents(UriComponents.Path, UriFormat.UriEscaped), StringComparison.OrdinalIgnoreCase));
+                Debug.Assert(assemblyInfo.PackagePartName.Equals(uri.GetComponents(UriComponents.Path, UriFormat.UriEscaped), StringComparison.OrdinalIgnoreCase));
             }
             else
             {
-                assembly = GetLoadedAssembly(assemblyName, assemblyVersion, assemblyKey);
+                assembly = GetLoadedAssembly(assemblyInfo.AssemblyName, assemblyInfo.AssemblyVersion, assemblyInfo.AssemblyToken);
             }
         }
 
-
-        //
-        //
-        internal static Assembly GetLoadedAssembly(string assemblyName, string assemblyVersion, string assemblyKey)
+        /// <summary>
+        /// Retrieves <see cref="Assembly"/> using AssemblyName, AssemblyVersion and AssemblyToken from the loaded assemblies pool, or loads it on demand.
+        /// </summary>
+        /// <param name="assemblyName"></param>
+        /// <param name="assemblyVersion"></param>
+        /// <param name="assemblyToken"></param>
+        /// <returns></returns>
+        internal static Assembly GetLoadedAssembly(ReadOnlySpan<char> assemblyName, ReadOnlySpan<char> assemblyVersion, ReadOnlySpan<char> assemblyToken)
         {
-            Assembly assembly;
-            AssemblyName asmName = new AssemblyName(assemblyName)
-            {
-                // We always use the primary assembly (culture neutral) for resource manager.
-                // if the required resource lives in satellite assembly, ResourceManager can find
-                // the right satellite assembly later.
-                CultureInfo = new CultureInfo(String.Empty)
-            };
+            // We always use the primary assembly (culture neutral) for resource manager.
+            // If the required resource lives in satellite assembly, ResourceManager can find the right satellite assembly later.
+            AssemblyName asmName = new(assemblyName.ToString()) { CultureInfo = CultureInfo.InvariantCulture };
 
-            if (!String.IsNullOrEmpty(assemblyVersion))
-            {
-                asmName.Version = new Version(assemblyVersion);
-            }
+            // Parse Version
+            if (!assemblyVersion.IsEmpty)
+                asmName.Version = Version.Parse(assemblyVersion);
 
-            byte[] keyToken = ParseAssemblyKey(assemblyKey);
+            // Parse Key
+            if (!assemblyToken.IsEmpty)
+                asmName.SetPublicKeyToken(Convert.FromHexString(assemblyToken));
 
-            if (keyToken != null)
-            {
-                asmName.SetPublicKeyToken(keyToken);
-            }
-
-            assembly = SafeSecurityHelper.GetLoadedAssembly(asmName);
-
-            if (assembly == null)
-            {
-                // The assembly is not yet loaded to the AppDomain, try to load it with information specified in resource Uri.
-                assembly = Assembly.Load(asmName);
-            }
-
-            return assembly;
+            // If assembly is not yet loaded to the AppDomain, try to load it with information specified in resource Uri,
+            // otherwise let Assembly.Load throw an exception in case the method couldn't find the assembly
+            return SafeSecurityHelper.GetLoadedAssembly(asmName) ?? Assembly.Load(asmName);
         }
 
-        //
-        // Return assembly Name, Version, Key and package Part from a relative Uri.
-        //
-        internal static void GetAssemblyNameAndPart(Uri uri, out string partName, out string assemblyName, out string assemblyVersion, out string assemblyKey)
+        /// <summary>
+        /// Returns AssemblyName, AssemblyVersion, PublicKeyToken and package Part from a relative <see cref="Uri"/>.
+        /// </summary>
+        /// <param name="uri">A relative <see cref="Uri"/> in /AssemblyShortName{;Version]{;PublicKey];component/PackagePartName format.</param>
+        /// <param name="assemblyInfo">The sliced out information from the current <see cref="Uri"/>.</param>
+        /// <exception cref="UriFormatException"></exception>
+        /// <remarks>See more info on <seealso href="https://learn.microsoft.com/en-us/dotnet/desktop/wpf/app-development/pack-uris-in-wpf"/>.</remarks>
+        internal static void GetAssemblyNameAndPart(Uri uri, out AssemblyPackageInfo assemblyInfo)
         {
-            Invariant.Assert(uri != null && uri.IsAbsoluteUri == false, "This method accepts relative uri only.");
+            Invariant.Assert(uri is not null && !uri.IsAbsoluteUri, "This method accepts relative uri only.");
 
-            string original = uri.ToString(); // only relative Uri here (enforced by Package)
+            ReadOnlySpan<char> original = uri.ToString(); // only relative Uri here (enforced by Package)
 
             // Start and end points for the first segment in the Uri.
-            int start = 0;
-            int end;
+            int segmentStart = original[0] == '/' ? 1 : 0;
+            int segmentEnd;
 
-            if (original[0] == '/')
+            assemblyInfo = new AssemblyPackageInfo { PackagePartName = original.Slice(segmentStart) };
+            segmentEnd = assemblyInfo.PackagePartName.IndexOf('/');
+
+            if (segmentEnd == -1)
+                return;
+
+            // Get the first uri section
+            ReadOnlySpan<char> referencedAssemblySegment = original.Slice(segmentStart, segmentEnd);
+
+            // If false, the resource does not come from the current assembly but likely from the entry assembly.
+            if (!referencedAssemblySegment.EndsWith(COMPONENT, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            assemblyInfo.PackagePartName = original.Slice(segmentStart + segmentEnd + 1);
+
+            Span<Range> segments = stackalloc Range[5];
+            int count = referencedAssemblySegment.Split(segments, COMPONENT_DELIMITER);
+
+            // Valid values are 2; 3; 4 as we optionally can also include Version and PublicKeyToken
+            if (count is < 2 or > 4)
+                throw new UriFormatException(SR.WrongFirstSegment);
+
+            assemblyInfo.AssemblyName = referencedAssemblySegment[segments[0]];
+
+            // If the uri contains escaping character, convert it back to normal unicode string
+            // so that the string as assembly name can be recognized by Assembly.Load(...) later.
+            if (IsUriUnescapeRequired(assemblyInfo.AssemblyName))
+                assemblyInfo.AssemblyName = Uri.UnescapeDataString(assemblyInfo.AssemblyName);
+
+            for (int i = 1; i < count - 1; i++)
             {
-                start = 1;
-            }
-
-            partName = original.Substring(start);
-
-            assemblyName = string.Empty;
-            assemblyVersion = string.Empty;
-            assemblyKey = string.Empty;
-
-            end = original.IndexOf('/', start);
-
-            string firstSegment = String.Empty;
-            bool fHasComponent = false;
-
-            if (end > 0)
-            {
-                // get the first section
-                firstSegment = original.Substring(start, end - start);
-
-                // The resource comes from dll
-                if (firstSegment.EndsWith(COMPONENT, StringComparison.OrdinalIgnoreCase))
+                if (referencedAssemblySegment[segments[i]].StartsWith(VERSION, StringComparison.OrdinalIgnoreCase))
                 {
-                    partName = original.Substring(end + 1);
-                    fHasComponent = true;
-                }
-            }
-
-            if (fHasComponent)
-            {
-                string[] assemblyInfo = firstSegment.Split(COMPONENT_DELIMITER);
-
-                int count = assemblyInfo.Length;
-
-                if ((count > 4) || (count < 2))
-                {
-                    throw new UriFormatException(SR.WrongFirstSegment);
-                }
-
-                //
-                // if the uri contains escaping character,
-                // Convert it back to normal unicode string
-                // so that the string as assembly name can be
-                // recognized by Assembly.Load later.
-                //
-                assemblyName = Uri.UnescapeDataString(assemblyInfo[0]);
-
-                for (int i = 1; i < count - 1; i++)
-                {
-                    if (assemblyInfo[i].StartsWith(VERSION, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (string.IsNullOrEmpty(assemblyVersion))
-                        {
-                            assemblyVersion = assemblyInfo[i].Substring(1);  // Get rid of the leading "v"
-                        }
-                        else
-                        {
-                            throw new UriFormatException(SR.WrongFirstSegment);
-                        }
-                    }
+                    if (assemblyInfo.AssemblyVersion.IsEmpty)
+                        assemblyInfo.AssemblyVersion = referencedAssemblySegment[segments[i]].Slice(1);  // Get rid of the leading "v"
                     else
-                    {
-                        if (string.IsNullOrEmpty(assemblyKey))
-                        {
-                            assemblyKey = assemblyInfo[i];
-                        }
-                        else
-                        {
-                            throw new UriFormatException(SR.WrongFirstSegment);
-                        }
-                    }
-                } // end of for loop
-
-            } // end of if fHasComponent
+                        throw new UriFormatException(SR.WrongFirstSegment);
+                }
+                else
+                {
+                    if (assemblyInfo.AssemblyToken.IsEmpty)
+                        assemblyInfo.AssemblyToken = referencedAssemblySegment[segments[i]];
+                    else
+                        throw new UriFormatException(SR.WrongFirstSegment);
+                }
+            }
         }
 
-        static internal bool IsComponentEntryAssembly(string component)
+        internal static bool IsComponentEntryAssembly(ReadOnlySpan<char> component)
         {
-            if (component.EndsWith(COMPONENT, StringComparison.OrdinalIgnoreCase))
+            if (!component.EndsWith(COMPONENT, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            Span<Range> segments = stackalloc Range[5];
+            int count = component.Split(segments, COMPONENT_DELIMITER) - 2;
+
+            // Check whether the assembly name is the same as the EntryAssembly.
+            if (count <= 2)
             {
-                string[] assemblyInfo = component.Split(COMPONENT_DELIMITER);
-                // Check whether the assembly name is the same as the EntryAssembly.
-                int count = assemblyInfo.Length;
-                if ((count >= 2) && (count <= 4))
+                ReadOnlySpan<char> assemblyName = component[segments[0]];
+                Assembly assembly = ResourceAssembly;
+
+                if (IsUriUnescapeRequired(assemblyName))
+                    assemblyName = Uri.UnescapeDataString(component[segments[0]]);
+
+                if (assembly is not null)
                 {
-                    string assemblyName = Uri.UnescapeDataString(assemblyInfo[0]);
-
-                    Assembly assembly = ResourceAssembly;
-
-                    if (assembly != null)
-                    {
-                        return ReflectionUtils.GetAssemblyPartialName(assembly).Equals(assemblyName, StringComparison.OrdinalIgnoreCase);
-                    }
-                    else
-                    {
-                        return false;
-                    }
+                    return ReflectionUtils.GetAssemblyPartialName(assembly).Equals(assemblyName, StringComparison.OrdinalIgnoreCase);
                 }
             }
+
             return false;
         }
-                
-        static internal Uri GetResolvedUri(Uri baseUri, Uri orgUri)
+
+        internal static Uri GetResolvedUri(Uri baseUri, Uri orgUri)
         {
             return new Uri(baseUri, orgUri);
         }
 
-        static internal Uri MakeRelativeToSiteOfOriginIfPossible(Uri sUri)
+        internal static Uri MakeRelativeToSiteOfOriginIfPossible(Uri sUri)
         {
             if (Uri.Compare(sUri, SiteOfOriginBaseUri, UriComponents.Scheme, UriFormat.UriEscaped, StringComparison.OrdinalIgnoreCase) == 0)
-            {                
+            {
                 Uri packageUri = PackUriHelper.GetPackageUri(sUri);
-                if (string.Equals(packageUri.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped), _packageSiteOfOriginBaseUriEscaped, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(packageUri.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped), PackageSiteOfOriginBaseUriEscaped, StringComparison.OrdinalIgnoreCase))
                 {
-                    return (new Uri(sUri.GetComponents(UriComponents.SchemeAndServer, UriFormat.UriEscaped))).MakeRelativeUri(sUri);
+                    return new Uri(sUri.GetComponents(UriComponents.SchemeAndServer, UriFormat.UriEscaped)).MakeRelativeUri(sUri);
                 }
             }
 
             return sUri;
         }
 
-        static internal Uri ConvertPackUriToAbsoluteExternallyVisibleUri(Uri packUri)
+        internal static Uri ConvertPackUriToAbsoluteExternallyVisibleUri(Uri packUri)
         {
             Invariant.Assert(packUri.IsAbsoluteUri && string.Equals(packUri.Scheme, PackAppBaseUri.Scheme, StringComparison.OrdinalIgnoreCase));
 
             Uri relative = MakeRelativeToSiteOfOriginIfPossible(packUri);
 
-            if (! relative.IsAbsoluteUri)
-            {
+            if (!relative.IsAbsoluteUri)
                 return new Uri(SiteOfOriginContainer.SiteOfOrigin, relative);
-            }
-            else
-            {
-               throw new InvalidOperationException(SR.Format(SR.CannotNavigateToApplicationResourcesInWebBrowser, packUri));
-            }
+
+            throw new InvalidOperationException(SR.Format(SR.CannotNavigateToApplicationResourcesInWebBrowser, packUri));
         }
 
         // If a Uri is constructed with a legacy path such as c:\foo\bar then the Uri
         // object will not correctly resolve relative Uris in some cases.  This method
         // detects and fixes this by constructing a new Uri with an original string
         // that contains the scheme file://.
-        static internal Uri FixFileUri(Uri uri)
+        internal static Uri FixFileUri(Uri uri)
         {
             if (uri is not null && uri.IsAbsoluteUri &&
                 string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase) &&
-                string.Compare(uri.OriginalString, 0, Uri.UriSchemeFile, 0, Uri.UriSchemeFile.Length, StringComparison.OrdinalIgnoreCase) != 0)
+                !uri.OriginalString.StartsWith(Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
             {
                 return new Uri(uri.AbsoluteUri);
             }
@@ -389,52 +333,21 @@ namespace System.Windows.Navigation
             return uri;
         }
 
-        static internal Uri BaseUri
-        {
-            get
-            {
-                return _baseUri;
-            }
-            set
-            {
-                // This setter should only be called from Framework through
-                // BindUriHelper.set_BaseUri.
-                _baseUri = value;
-            }
-        }
-
-        static internal Assembly ResourceAssembly
-        {
-            get
-            {
-                if (_resourceAssembly == null)
-                {
-                    _resourceAssembly = Assembly.GetEntryAssembly();
-                }
-                return _resourceAssembly;
-            }
-            set
-            {
-                // This should only be called from Framework through Application.ResourceAssembly setter.
-                _resourceAssembly = value;
-            }
-        }
-        
         // If the Uri provided is a pack Uri calling out an assembly and the assembly name matches that from assemblyInfo
         // this method will append the version taken from assemblyInfo, provided the Uri does not already have a version,
         // if the Uri provided the public Key token we must also verify that it matches the one in assemblyInfo.
         // We only add the version if the Uri is missing both the version and the key, otherwise returns null.
         // If the Uri is not a pack Uri, or we can't extract the information we need this method returns null.
-        static internal Uri AppendAssemblyVersion(Uri uri, Assembly assemblyInfo)
+        internal static Uri AppendAssemblyVersion(Uri uri, Assembly assembly)
         {
             Uri source = null;
             Uri baseUri = null;
 
             // assemblyInfo.GetName does not work in PartialTrust, so do this instead.
-            AssemblyName currAssemblyName = new AssemblyName(assemblyInfo.FullName);
+            AssemblyName currAssemblyName = new AssemblyName(assembly.FullName);
             string version = currAssemblyName.Version?.ToString();
-            
-            if (uri != null && !string.IsNullOrEmpty(version))
+
+            if (uri is not null && !string.IsNullOrEmpty(version))
             {
                 if (uri.IsAbsoluteUri)
                 {
@@ -451,186 +364,130 @@ namespace System.Windows.Navigation
                     source = uri;
                 }
 
-
-                if (source != null)
+                if (source is not null)
                 {
-                    string appendedUri;
-                    string assemblyName;
-                    string assemblyVersion;
-                    string assemblyKey;
-                    string partName;
+                    GetAssemblyNameAndPart(source, out AssemblyPackageInfo assemblyInfo);
 
-                    BaseUriHelper.GetAssemblyNameAndPart(source, out partName, out assemblyName, out assemblyVersion, out assemblyKey);
-
-                    bool assemblyKeyProvided = !string.IsNullOrEmpty(assemblyKey);
+                    bool assemblyKeyProvided = !assemblyInfo.AssemblyToken.IsEmpty;
 
                     // Make sure we:
                     //      1) Successfully extracted the assemblyName from the Uri.
                     //      2) No assembly version was already provided in the Uri.
-                    //      3) The assembly short name matches the name in assemblyInfo.
+                    //      3) The assembly short name matches the name in assembly.
                     //      4) If a public key token was provided in the Uri, verify
-                    //          that it matches the token in asssemblyInfo.
-                    if (!string.IsNullOrEmpty(assemblyName) && string.IsNullOrEmpty(assemblyVersion) &&
-                        assemblyName.Equals(currAssemblyName.Name, StringComparison.Ordinal) &&
-                        (!assemblyKeyProvided || AssemblyMatchesKeyString(currAssemblyName, assemblyKey)))
+                    //          that it matches the token in assemblyInfo.
+                    if (!assemblyInfo.AssemblyName.IsEmpty && assemblyInfo.AssemblyVersion.IsEmpty &&
+                        assemblyInfo.AssemblyName.Equals(currAssemblyName.Name, StringComparison.Ordinal) &&
+                        (!assemblyKeyProvided || ComparePublicKeyTokens(currAssemblyName, assemblyInfo.AssemblyToken)))
                     {
-                        StringBuilder uriStringBuilder = new StringBuilder();
+                        StringBuilder uriStringBuilder = new(assemblyInfo.AssemblyName.Length + assemblyInfo.PackagePartName.Length + 32);
 
                         uriStringBuilder.Append('/');
-                        uriStringBuilder.Append(assemblyName);
+                        uriStringBuilder.Append(assemblyInfo.AssemblyName);
                         uriStringBuilder.Append(COMPONENT_DELIMITER);
                         uriStringBuilder.Append(VERSION);
                         uriStringBuilder.Append(version);
                         if (assemblyKeyProvided)
                         {
                             uriStringBuilder.Append(COMPONENT_DELIMITER);
-                            uriStringBuilder.Append(assemblyKey);
+                            uriStringBuilder.Append(assemblyInfo.AssemblyToken);
                         }
                         uriStringBuilder.Append(COMPONENT);
                         uriStringBuilder.Append('/');
-                        uriStringBuilder.Append(partName);
+                        uriStringBuilder.Append(assemblyInfo.PackagePartName);
 
-                        appendedUri = uriStringBuilder.ToString();
+                        string appendedUri = uriStringBuilder.ToString();
 
-                        if (baseUri != null)
-                        {
-                            return new Uri(baseUri, appendedUri);
-                        }
-
-                        return new Uri(appendedUri, UriKind.Relative);
+                        return baseUri is not null ? new Uri(baseUri, appendedUri) : new Uri(appendedUri, UriKind.Relative);
                     }
                 }
 
             }
-            
+
             return null;
         }
 
-        #endregion internal properties and methods
-
-        #region private methods
-
         /// <summary>
-        /// Get BaseUri for a dependency object inside a tree.
-        ///
+        /// Get <see cref="BaseUriProperty"/> for a <see cref="DependencyObject"/> inside a tree.
         /// </summary>
-        /// <param name="element">Dependency Object</param>
-        /// <returns>BaseUri for the element</returns>
-        /// <remarks>
-        ///     Callers must have FileIOPermission(FileIOPermissionAccess.PathDiscovery) for the given Uri to call this API.
-        /// </remarks>
+        /// <param name="element">A <see cref="DependencyObject"/> to perform search in.</param>
+        /// <returns>BaseUri for the element.</returns>
         internal static Uri GetBaseUriCore(DependencyObject element)
         {
-            Uri baseUri = null;
-            DependencyObject doCurrent;
-
             ArgumentNullException.ThrowIfNull(element);
 
-            //
             // Search the tree to find the closest parent which implements
             // IUriContext or have set value for BaseUri property.
-            //
-            doCurrent = element;
+            Uri baseUri = null;
+            DependencyObject doCurrent = element;
 
-                while (doCurrent != null)
+            while (doCurrent is not null)
+            {
+                // Try to get BaseUri property value from current node.
+                baseUri = doCurrent.GetValue(BaseUriProperty) as Uri;
+
+                if (baseUri is not null)
                 {
-                    // Try to get BaseUri property value from current node.
-                    baseUri = doCurrent.GetValue(BaseUriProperty) as Uri;
-
-                    if (baseUri != null)
-                    {
-                        // Got the right node which is the closest to original element.
-                        // Stop searching here.
-                        break;
-                    }
-
-                    IUriContext uriContext = doCurrent as IUriContext;
-
-                    if (uriContext != null)
-                    {
-                        // If the element implements IUriContext, and if the BaseUri
-                        // is not null, just take the BaseUri from there.
-                        // and stop the search loop.
-                        baseUri = uriContext.BaseUri;
-
-                        if (baseUri != null)
-                            break;
-                    }
-
-                    //
-                    // The current node doesn't contain BaseUri value,
-                    // try its parent node in the tree.
-
-                    UIElement uie = doCurrent as UIElement;
-
-                    if (uie != null)
-                    {
-                        // Do the tree walk up
-                        doCurrent = uie.GetUIParent(true);
-                    }
-                    else
-                    {
-                        ContentElement ce = doCurrent as ContentElement;
-
-                        if (ce != null)
-                        {
-                            doCurrent = ce.Parent;
-                        }
-                        else
-                        {
-                            Visual vis = doCurrent as Visual;
-
-                            if (vis != null)
-                            {
-                                // Try the Visual tree search
-                                doCurrent = VisualTreeHelper.GetParent(vis);
-                            }
-                            else
-                            {
-                                // Not a Visual.
-                                // Stop here for the tree searching to aviod an infinite loop.
-                                break;
-                            }
-                        }
-                    }
+                    // Got the right node which is the closest to original element.
+                    // Stop searching here.
+                    break;
                 }
+
+                if (doCurrent is IUriContext uriContext)
+                {
+                    // If the element implements IUriContext, and if the BaseUri
+                    // is not null, just take the BaseUri from there and stop the search loop.
+                    baseUri = uriContext.BaseUri;
+
+                    if (baseUri is not null)
+                        break;
+                }
+
+                // The current node doesn't contain BaseUri value, try its parent node in the tree.
+
+                if (doCurrent is UIElement uie)
+                {
+                    // Do the tree walk up
+                    doCurrent = uie.GetUIParent(true);
+                    continue;
+                }
+
+                if (doCurrent is ContentElement ce)
+                {
+                    doCurrent = ce.Parent;
+                    continue;
+                }
+
+                // Try the Visual tree search
+                if (doCurrent is Visual vis)
+                {
+                    doCurrent = VisualTreeHelper.GetParent(vis);
+                    continue;
+                }
+
+                // Not even a Visual, break here to avoid an infinite loop
+                break;
+            }
 
             return baseUri;
         }
-        
-        private static bool AssemblyMatchesKeyString(AssemblyName asmName, string assemblyKey)
-        {
-            byte[] parsedKeyToken = ParseAssemblyKey(assemblyKey);
-            byte[] assemblyKeyToken = asmName.GetPublicKeyToken();
 
-            return SafeSecurityHelper.IsSameKeyToken(assemblyKeyToken, parsedKeyToken);
+        private static bool ComparePublicKeyTokens(AssemblyName asmName, ReadOnlySpan<char> assemblyKey)
+        {
+            Span<byte> parsedKeyToken = assemblyKey.IsEmpty ? null : stackalloc byte[8];
+            Convert.FromHexString(assemblyKey, parsedKeyToken, out _, out _);
+
+            return ReflectionUtils.IsSamePublicKeyToken(asmName.GetPublicKeyToken(), parsedKeyToken);
         }
 
-        private static byte[] ParseAssemblyKey(string assemblyKey)
+        /// <summary>
+        /// Generally we do need to unescape pack uris, hence checking twice won't hurt so we don't end up allocating a <see cref="string"/>.
+        /// </summary>
+        /// <param name="uri">The uri to verify.</param>
+        /// <returns><see langword="true"/> if <paramref name="uri"/> needs unescaping, <see langword="false"/> otherwise.</returns>
+        private static bool IsUriUnescapeRequired(ReadOnlySpan<char> uri)
         {
-            if (!string.IsNullOrEmpty(assemblyKey))
-            {
-                int byteCount = assemblyKey.Length / 2;
-                byte[] keyToken = new byte[byteCount];
-                for (int i = 0; i < byteCount; i++)
-                {
-                    keyToken[i] = byte.Parse(assemblyKey.AsSpan(i * 2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-                }
-
-                return keyToken;
-            }
-
-            return null;
+            return uri.Contains('%');
         }
-
-        #endregion
-
-        private const string COMPONENT = ";component";
-        private const string VERSION = "v";
-        private const char COMPONENT_DELIMITER = ';';
-       
-        private static Assembly _resourceAssembly;
     }
 }
-
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppModelKnownContentFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppModelKnownContentFactory.cs
@@ -45,10 +45,8 @@ namespace MS.Internal.AppModel
             }
 
             // If this stream comes from a content file also throw
-            Uri partUri = PackUriHelper.GetPartUri(baseUri);
-            string partName, assemblyName, assemblyVersion, assemblyKey;
-            BaseUriHelper.GetAssemblyNameAndPart(partUri, out partName, out assemblyName, out assemblyVersion, out assemblyKey);
-            if (ContentFileHelper.IsContentFile(partName))
+            BaseUriHelper.GetAssemblyNameAndPart(PackUriHelper.GetPartUri(baseUri), out AssemblyPackageInfo assemblyInfo);
+            if (ContentFileHelper.IsContentFile(assemblyInfo.PackagePartName))
             {
                 throw new InvalidOperationException(SR.BamlIsNotSupportedOutsideOfApplicationResources);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ContentFilePart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ContentFilePart.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -55,18 +55,15 @@ namespace MS.Internal.AppModel
                 //   for deployed files the <Content> files are deployed with the application.
                 string location = GetEntryAssemblyLocation();
 
-                string assemblyName, assemblyVersion, assemblyKey;
-                string filePath;
-
                 // For now, only Application assembly supports content files, 
                 // so we can simply ignore the assemblyname etc.
                 // In the future, we may extend this support for regular library assembly,
                 // assemblyName will be used to predict the right file path.
 
-                BaseUriHelper.GetAssemblyNameAndPart(Uri, out filePath, out assemblyName, out assemblyVersion, out assemblyKey);
+                BaseUriHelper.GetAssemblyNameAndPart(Uri, out AssemblyPackageInfo assemblyInfo);
 
-                // filePath should not have leading slash.  GetAssemblyNameAndPart( ) can guarantee it.
-                _fullPath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(location), filePath);
+                // filePath should not have leading slash. GetAssemblyNameAndPart() will guarantee it.
+                _fullPath = Path.Join(Path.GetDirectoryName(location.AsSpan()), assemblyInfo.PackagePartName);
             }
 
             stream = CriticalOpenFile(_fullPath);
@@ -119,9 +116,9 @@ namespace MS.Internal.AppModel
             return entryLocation;
         }
 
-        private Stream CriticalOpenFile(string filename)
+        private static Stream CriticalOpenFile(string filename)
         {
-            return System.IO.File.Open(filename, FileMode.Open, FileAccess.Read, ResourceContainer.FileShare);
+            return File.Open(filename, FileMode.Open, FileAccess.Read, ResourceContainer.FileShareMode);
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 //
 //
@@ -12,24 +11,23 @@
 // the NotSupportedException.
 // 
 
-using System.IO.Packaging;
-using System.IO;
-using System.Reflection;
-using System.Globalization;
-using System.Windows;
 using System.Windows.Navigation;
 using MS.Internal.Resources;
+using System.IO.Packaging;
+using System.Reflection;
+using System.Windows;
+using System.IO;
 
 namespace MS.Internal.AppModel
 {
-    // <summary>
-    // ResourceContainer is an implementation of the abstract Package class. 
-    // It contains nontrivial overrides for GetPartCore and Exists.
-    // Many of the methods on Package are not applicable to loading application 
-    // resources, so the ResourceContainer implementations of these methods throw 
-    // the NotSupportedException.
-    // </summary>
-    internal class ResourceContainer : System.IO.Packaging.Package
+    /// <summary>
+    /// ResourceContainer is an implementation of the abstract Package class. 
+    /// It contains nontrivial overrides for GetPartCore and Exists.
+    /// Many of the methods on Package are not applicable to loading application 
+    /// resources, so the ResourceContainer implementations of these methods throw 
+    /// the NotSupportedException.
+    /// </summary>
+    internal sealed class ResourceContainer : Package
     {
         //------------------------------------------------------
         //
@@ -39,36 +37,34 @@ namespace MS.Internal.AppModel
 
         #region Static Methods
 
-
         internal static ResourceManagerWrapper ApplicationResourceManagerWrapper
         {
             get
             {
-                if (_applicationResourceManagerWrapper == null)
+                if (s_applicationResourceManagerWrapper == null)
                 {
-                    // load main excutable assembly
+                    // load main executable assembly
                     Assembly asmApplication = Application.ResourceAssembly;
 
                     if (asmApplication != null)
                     {
-                        _applicationResourceManagerWrapper = new ResourceManagerWrapper(asmApplication);
+                        s_applicationResourceManagerWrapper = new ResourceManagerWrapper(asmApplication);
                     }
                 }
 
-                return _applicationResourceManagerWrapper;
+                return s_applicationResourceManagerWrapper;
             }
         }
 
-        // <summary>
-        //  The FileShare mode to use for opening loose files.  Currently this defaults to FileShare.Read
-        //  Today it is not changed.  If we decide that this should change in the future we can easily add
-        //  a seter here.
-        // </summary>
+        /// <summary>
+        /// The FileShare mode to use for opening loose files. Currently this defaults to <see cref="FileShare.Read"/>
+        /// Today it is not changed. If we decide that this should change in the future we can easily add a setter here.
+        /// </summary>
         internal static FileShare FileShare
         {
             get
             {
-                return _fileShare;
+                return s_fileShare;
             }
         }
 
@@ -82,41 +78,32 @@ namespace MS.Internal.AppModel
 
         #region Public Constructors
 
-        // <summary>
-        // Default Constructor
-        // </summary>
-        internal ResourceContainer() : base(FileAccess.Read)
-        {
-        }
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        internal ResourceContainer() : base(FileAccess.Read) { }
 
-        #endregion
-
-        //------------------------------------------------------
-        //
-        //  Public Properties
-        //
-        //------------------------------------------------------
-        // None  
+        #endregion     
 
         //------------------------------------------------------
         //
         //  Public Methods
         //
-        //------------------------------------------------------        
+        //------------------------------------------------------
 
         #region Public Methods
 
-        // <summary>
-        // This method always returns true.  This is because ResourceManager does not have a
-        // simple way to check if a resource exists without loading the resource stream (or failing to)
-        // so checking if a resource exists would be a very expensive task.
-        // A part will later be constructed and returned by GetPart().  This part class contains
-        // a ResourceManager which may or may not contain the requested resource.  When someone 
-        // calls GetStream() on PackagePart then we will attempt to get the stream for the named resource 
-        // and potentially fail.
-        // </summary>
-        // <param name="uri"></param>
-        // <returns></returns>
+        /// <summary>
+        /// This method always returns true.  This is because ResourceManager does not have a
+        /// simple way to check if a resource exists without loading the resource stream (or failing to)
+        /// so checking if a resource exists would be a very expensive task.
+        /// A part will later be constructed and returned by GetPart().  This part class contains
+        /// a ResourceManager which may or may not contain the requested resource.  When someone 
+        /// calls GetStream() on PackagePart then we will attempt to get the stream for the named resource 
+        /// and potentially fail.
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <returns></returns>
         public override bool PartExists(Uri uri)
         {
             return true;
@@ -126,52 +113,16 @@ namespace MS.Internal.AppModel
 
         //------------------------------------------------------
         //
-        //  Public Events
-        //
-        //------------------------------------------------------
-        // None
-
-        //------------------------------------------------------
-        //
-        //  Internal Constructors
-        //
-        //------------------------------------------------------
-        // None
-
-        //------------------------------------------------------
-        //
-        //  Internal Properties
+        //  Internal Constants
         //
         //------------------------------------------------------
 
-        #region Internal Members
+        #region Internal Constants
 
         internal const string XamlExt = ".xaml";
         internal const string BamlExt = ".baml";
 
         #endregion
-
-
-        //------------------------------------------------------
-        //
-        //  Internal Methods
-        //
-        //------------------------------------------------------
-        // None
-
-        //------------------------------------------------------
-        //
-        //  Internal Events
-        //
-        //------------------------------------------------------
-        // None
-
-        //------------------------------------------------------
-        //
-        //  Protected Constructors
-        //
-        //------------------------------------------------------
-        // None
 
         //------------------------------------------------------
         //
@@ -181,42 +132,38 @@ namespace MS.Internal.AppModel
 
         #region Protected Methods
 
-        // <summary>
-        // This method creates a part containing the name of the resource and 
-        // the resource manager that should contain it.  If the resource manager 
-        // does not contain the requested part then when GetStream() is called on
-        // the part it will return null.
-        // </summary>
-        // <param name="uri"></param>
-        // <returns></returns>
-
+        /// <summary>
+        /// This method creates a part containing the name of the resource and 
+        /// the resource manager that should contain it.  If the resource manager 
+        /// does not contain the requested part then when GetStream() is called on
+        /// the part it will return null.
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <returns></returns>
         protected override PackagePart GetPartCore(Uri uri)
         {
-            string partName;
-            bool isContentFile;
-
             // AppDomain.AssemblyLoad event handler for standalone apps. This is added specifically for designer (Sparkle) scenario.
             // We use the assembly name to fetch the cached resource manager. With this mechanism we will still get resource from the 
             // old version dll when a newer one is loaded. So whenever the AssemblyLoad event is fired, we will need to update the cache 
             // with the newly loaded assembly. This is currently only for designer so not needed for browser hosted apps. 
             // Attach the event handler before the first time we get the ResourceManagerWrapper.
-            if (!assemblyLoadhandlerAttached)
+            if (!s_assemblyLoadHandlerAttached)
             {
                 AppDomain.CurrentDomain.AssemblyLoad += new AssemblyLoadEventHandler(OnAssemblyLoadEventHandler);
-                assemblyLoadhandlerAttached = true;
+                s_assemblyLoadHandlerAttached = true;
             }
 
-            ResourceManagerWrapper rmWrapper = GetResourceManagerWrapper(uri, out partName, out isContentFile);
+            ResourceManagerWrapper rmWrapper = GetResourceManagerWrapper(uri, out string partName, out bool isContentFile);
 
             // If the part name was specified as Content at compile time then we will try to load
-            // the file directly.  Otherwise we assume the user is looking for a resource.
+            // the file directly. Otherwise we assume the user is looking for a resource.
             if (isContentFile)
             {
                 return new ContentFilePart(this, uri);
             }
             else
             {
-                // Uri mapps to a resource stream.
+                // Uri maps to a resource stream.
 
                 // Make sure the resource id is exactly same as the one we used to create Resource 
                 // at compile time.
@@ -236,111 +183,99 @@ namespace MS.Internal.AppModel
 
         #region Private Methods
 
-        // AppDomain.AssemblyLoad event handler. Check whether the assembly's resourcemanager has
+        // AppDomain.AssemblyLoad event handler. Check whether the assembly's ResourceManager has
         // been added to the cache. If it has, we need to update the cache with the newly loaded dll.
         private void OnAssemblyLoadEventHandler(object sender, AssemblyLoadEventArgs args)
         {
             Assembly assembly = args.LoadedAssembly;
             // This is specific for designer (Sparkle) scenario: rebuild and reload dll using Load(Byte[]).
-            // We do not care about assemblies loaded into the reflection-only context or the Gaced assemblies.
+            // We do not care about assemblies loaded into the reflection-only context or the GACed assemblies.
             // For example, in Sparkle whenever a project is built all dependent assemblies will be loaded reflection only.
             // We do no care about those. Only when a assembly is loaded into the execution context, we will need to update the cache. 
-            if ((!assembly.ReflectionOnly))
+            if (!assembly.ReflectionOnly)
             {
-                AssemblyName assemblyInfo = new AssemblyName(assembly.FullName);
+                ReadOnlySpan<char> assemblyName = ReflectionUtils.GetAssemblyPartialName(assembly);
+                ReflectionUtils.GetAssemblyVersionPlusToken(assembly, out ReadOnlySpan<char> assemblyVersion, out ReadOnlySpan<char> assemblyToken);
+                int totalLength = assemblyName.Length + assemblyVersion.Length + assemblyToken.Length;
 
-                string assemblyName = assemblyInfo.Name.ToLowerInvariant();
-                string assemblyKey = string.Empty;
-                string key = assemblyName;
+                Span<char> key = totalLength <= 256 ? stackalloc char[totalLength] : new char[totalLength];
+                assemblyName.ToLowerInvariant(key);
 
                 // Check if this newly loaded assembly is in the cache. If so, update the cache.
                 // If it is not in cache, do not do anything. It will be added on demand.
                 // The key could be Name, Name + Version, Name + PublicKeyToken, or Name + Version + PublicKeyToken.  
                 // Otherwise, update the cache with the newly loaded dll.
 
-                // First check Name. 
-                UpdateCachedRMW(key, args.LoadedAssembly);
+                // Firstly, check the Name
+                UpdateCachedRMW(key.Slice(0, assemblyName.Length), assembly);
 
-                string assemblyVersion = assemblyInfo.Version.ToString();
-
-                if (!String.IsNullOrEmpty(assemblyVersion))
+                // Check Name + Version
+                if (!assemblyVersion.IsEmpty)
                 {
-                    key = key + assemblyVersion;
-
-                    // Check Name + Version
-                    UpdateCachedRMW(key, args.LoadedAssembly);
+                    assemblyVersion.CopyTo(key.Slice(assemblyName.Length));
+                    UpdateCachedRMW(key.Slice(0, assemblyName.Length + assemblyVersion.Length), assembly);
                 }
 
-                byte[] reqKeyToken = assemblyInfo.GetPublicKeyToken();
-                for (int i = 0; i < reqKeyToken.Length; i++)
+                if (!assemblyToken.IsEmpty)
                 {
-                    assemblyKey += reqKeyToken[i].ToString("x", NumberFormatInfo.InvariantInfo);
-                }
-
-                if (!String.IsNullOrEmpty(assemblyKey))
-                {
-                    key = key + assemblyKey;
-
                     // Check Name + Version + KeyToken
-                    UpdateCachedRMW(key, args.LoadedAssembly);
-
-                    key = assemblyName + assemblyKey;
+                    if (!assemblyVersion.IsEmpty)
+                    {
+                        assemblyToken.CopyTo(key.Slice(assemblyName.Length + assemblyVersion.Length));
+                        UpdateCachedRMW(key.Slice(0, totalLength), assembly);
+                    }
 
                     // Check Name + KeyToken
-                    UpdateCachedRMW(key, args.LoadedAssembly);
+                    assemblyToken.CopyTo(key.Slice(assemblyName.Length));
+                    UpdateCachedRMW(key.Slice(0, assemblyName.Length + assemblyToken.Length), assembly);
                 }
             }
         }
 
-        private void UpdateCachedRMW(string key, Assembly assembly)
+        private static void UpdateCachedRMW(ReadOnlySpan<char> key, Assembly assembly)
         {
-            if (_registeredResourceManagers.ContainsKey(key))
+            if (s_registeredResourceManagersLookup.TryGetValue(key, out ResourceManagerWrapper value))
             {
                 // Update the ResourceManagerWrapper with the new assembly. 
                 // Note Package caches Part and Part holds on to ResourceManagerWrapper. Package does not provide a way for 
                 // us to update their cache, so we update the assembly that the ResourceManagerWrapper holds on to. This way the 
                 // Part cached in the Package class can reference the new dll too. 
-                _registeredResourceManagers[key].Assembly = assembly;
+                value.Assembly = assembly;
             }
         }
 
-        // <summary>
-        // Searches the available ResourceManagerWrapper list for one that matches the given Uri.
-        // It could be either ResourceManagerWrapper for specific libary assembly or Application
-        // main assembly. Package enforces that all Uri will be correctly formated.
-        // </summary>
-        // <param name="uri">Assumed to be relative</param>
-        // <param name="partName">The name of the file in the resource manager</param>
-        // <param name="isContentFile">A flag to indicate that this path is a known loose file at compile time</param>
-        // <returns></returns>
-        private ResourceManagerWrapper GetResourceManagerWrapper(Uri uri, out string partName, out bool isContentFile)
+        /// <summary>
+        /// Searches the available ResourceManagerWrapper list for one that matches the given Uri.
+        /// It could be either ResourceManagerWrapper for specific library assembly or Application
+        /// main assembly. Package enforces that all Uri will be correctly formatted.
+        /// </summary>
+        /// <param name="uri">Assumed to be relative</param>
+        /// <param name="partName">The name of the file in the resource manager</param>
+        /// <param name="isContentFile">A flag to indicate that this path is a known loose file at compile time</param>
+        /// <returns></returns>
+        private static ResourceManagerWrapper GetResourceManagerWrapper(Uri uri, out string partName, out bool isContentFile)
         {
-            string assemblyName;
-            string assemblyVersion;
-            string assemblyKey;
             ResourceManagerWrapper rmwResult = ApplicationResourceManagerWrapper;
-
             isContentFile = false;
 
-            BaseUriHelper.GetAssemblyNameAndPart(uri, out partName, out assemblyName, out assemblyVersion, out assemblyKey);
+            BaseUriHelper.GetAssemblyNameAndPart(uri, out partName, out string assemblyName, out string assemblyVersion, out string assemblyToken);
 
-            if (!String.IsNullOrEmpty(assemblyName))
+            if (!string.IsNullOrEmpty(assemblyName))
             {
-                string key = assemblyName + assemblyVersion + assemblyKey;
+                // Create the key, in format of $"{assemblyName}{assemblyVersion}{assemblyToken}"
+                int totalLength = assemblyName.Length + assemblyVersion.Length + assemblyToken.Length;
+                Span<char> key = totalLength <= 256 ? stackalloc char[totalLength] : new char[totalLength];
+                assemblyName.AsSpan().ToLowerInvariant(key);
+                assemblyVersion.CopyTo(key.Slice(assemblyName.Length));
+                assemblyToken.CopyTo(key.Slice(assemblyName.Length + assemblyVersion.Length));
 
-                _registeredResourceManagers.TryGetValue(key.ToLowerInvariant(), out rmwResult);
-
-                // first time. Add this to the hash table
-                if (rmwResult == null)
+                // First time; add this to the dictionary and create the wrapper if its not the application entry assembly
+                if (!s_registeredResourceManagersLookup.TryGetValue(key.Slice(0, totalLength), out rmwResult))
                 {
-                    Assembly assembly;
-
-                    assembly = BaseUriHelper.GetLoadedAssembly(assemblyName, assemblyVersion, assemblyKey);
-
+                    Assembly assembly = BaseUriHelper.GetLoadedAssembly(assemblyName, assemblyVersion, assemblyToken);
                     if (assembly.Equals(Application.ResourceAssembly))
                     {
                         // This Uri maps to Application Entry assembly even though it has ";component".
-
                         rmwResult = ApplicationResourceManagerWrapper;
                     }
                     else
@@ -348,11 +283,11 @@ namespace MS.Internal.AppModel
                         rmwResult = new ResourceManagerWrapper(assembly);
                     }
 
-                    _registeredResourceManagers[key.ToLowerInvariant()] = rmwResult;
+                    s_registeredResourceManagersLookup[key.Slice(0, totalLength)] = rmwResult;
                 }
             }
 
-            if ((rmwResult == ApplicationResourceManagerWrapper))
+            if (rmwResult == ApplicationResourceManagerWrapper)
             {
                 if (rmwResult != null)
                 {
@@ -384,10 +319,12 @@ namespace MS.Internal.AppModel
 
         #region Private Members
 
-        private static Dictionary<string, ResourceManagerWrapper> _registeredResourceManagers = new Dictionary<string, ResourceManagerWrapper>();
-        private static ResourceManagerWrapper _applicationResourceManagerWrapper = null;
-        private static FileShare _fileShare = FileShare.Read;
-        private static bool assemblyLoadhandlerAttached = false;
+        private static readonly Dictionary<string, ResourceManagerWrapper> s_registeredResourceManagers = new(StringComparer.Ordinal);
+        private static readonly Dictionary<string, ResourceManagerWrapper>.AlternateLookup<ReadOnlySpan<char>> s_registeredResourceManagersLookup = s_registeredResourceManagers.GetAlternateLookup<ReadOnlySpan<char>>();
+        private static readonly FileShare s_fileShare = FileShare.Read;
+
+        private static ResourceManagerWrapper s_applicationResourceManagerWrapper = null;
+        private static bool s_assemblyLoadHandlerAttached = false;
 
         #endregion Private Members
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DefaultValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DefaultValueConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -759,7 +759,7 @@ namespace MS.Internal.Data
                     }
                     else
                     {
-                        _cachedBaseUri = BaseUriHelper.BaseUri;
+                        _cachedBaseUri = BaseUriHelper.PackAppBaseUri;
                     }
                 }
                 return _cachedBaseUri;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
@@ -497,21 +497,6 @@ namespace MS.Internal
             return (xdc != null) ? xdc.ParentXmlDataProvider : null;
         }
 
-#if CF_Envelope_Activation_Enabled
-        /// <summary>
-        /// Indicates whether our content is inside an old-style container
-        /// </summary>
-        /// <value></value>
-
-        internal static bool IsContainer
-        {
-            get
-            {
-                return BindUriHelper.Container != null;
-            }
-        }
-#endif
-
         /// <summary>
         /// Measure a simple element with a single child.
         /// </summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -1952,10 +1952,7 @@ namespace System.Windows
         {
             get
             {
-                if (_applicationMarkupBaseUri == null)
-                {
-                    _applicationMarkupBaseUri = BaseUriHelper.BaseUri;
-                }
+                _applicationMarkupBaseUri ??= BaseUriHelper.PackAppBaseUri;
 
                 return _applicationMarkupBaseUri;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/SoundPlayerAction.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/SoundPlayerAction.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -89,8 +89,7 @@ namespace System.Windows.Controls
            {
                // When we are given a relative Uri path, expand to an absolute Uri by resolving
                // it against the Application's base Uri.  This would typically return a Pack Uri.
-               m_lastRequestedAbsoluteUri =
-                   BaseUriHelper.GetResolvedUri(BaseUriHelper.BaseUri, newValue);
+               m_lastRequestedAbsoluteUri = BaseUriHelper.GetResolvedUri(BaseUriHelper.PackAppBaseUri, newValue);
            }
 
            // Invalidate items that depend on the Source uri

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlDataProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlDataProvider.cs
@@ -23,6 +23,7 @@ using System.Windows.Markup; // IUriContext, [XamlDesignerSerializer]
 using MS.Internal;                  // CriticalExceptions
 using MS.Internal.Utility;          // BindUriHelper
 using MS.Internal.Data;             // XmlDataCollection
+using System.Windows.Navigation;
 
 namespace System.Windows.Data
 {
@@ -350,9 +351,9 @@ namespace System.Windows.Data
         {
             // convert the Source into an absolute URI
             Uri sourceUri = this.Source;
-            if (sourceUri.IsAbsoluteUri == false)
+            if (!sourceUri.IsAbsoluteUri)
             {
-                Uri baseUri = _baseUri ?? BindUriHelper.BaseUri;
+                Uri baseUri = _baseUri ?? BaseUriHelper.PackAppBaseUri;
                 sourceUri = BindUriHelper.GetResolvedUri(baseUri, sourceUri);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006SchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006SchemaContext.cs
@@ -2,9 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Xaml.Schema;
 using System.Reflection;
 using System.Xaml;
-using System.Xaml.Schema;
+using MS.Internal;
 
 namespace System.Windows.Baml2006
 {
@@ -520,8 +521,8 @@ namespace System.Windows.Baml2006
             {
                 return true;
             }
-            return MS.Internal.PresentationFramework.SafeSecurityHelper.IsSameKeyToken(
-                publicKeyToken, localAssemblyName.GetPublicKeyToken());
+
+            return ReflectionUtils.IsSamePublicKeyToken(publicKeyToken, localAssemblyName.GetPublicKeyToken());
         }
 
         private Type ResolveBamlTypeToType(BamlType bamlType)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -4352,18 +4352,18 @@ namespace System.Windows.Markup
         // Get BaseUri for the right elements.
         Uri GetBaseUri( )
         {
-            Uri baseuri = ParserContext.BaseUri;
+            Uri baseUri = ParserContext.BaseUri;
 
-            if (baseuri == null)
+            if (baseUri is null)
             {
-                baseuri = BindUriHelper.BaseUri;
+                baseUri = BaseUriHelper.PackAppBaseUri;
             }
-            else if (baseuri.IsAbsoluteUri == false)
+            else if (!baseUri.IsAbsoluteUri)
             {
-                baseuri = new Uri(BindUriHelper.BaseUri, baseuri);
+                baseUri = new Uri(BaseUriHelper.PackAppBaseUri, baseUri);
             }
 
-            return baseuri;
+            return baseUri;
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
@@ -1137,15 +1137,15 @@ namespace System.Windows.Markup
             return (root);
         }
 
-        static Uri GetBaseUri(Uri uri)
+        private static Uri GetBaseUri(Uri uri)
         {
-            if (uri == null)
+            if (uri is null)
             {
-                return MS.Internal.Utility.BindUriHelper.BaseUri;
+                return BaseUriHelper.PackAppBaseUri;
             }
-            else if (uri.IsAbsoluteUri == false)
+            else if (!uri.IsAbsoluteUri)
             {
-                return new Uri(MS.Internal.Utility.BindUriHelper.BaseUri, uri);
+                return new Uri(BaseUriHelper.PackAppBaseUri, uri);
             }
 
             return uri;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/JournalEntry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/JournalEntry.cs
@@ -336,11 +336,11 @@ namespace System.Windows.Navigation
                 else
                 {
                     string relativeUri = uri.AbsolutePath + uri.Query + uri.Fragment;
-                    string part, assy, assyVers, assyKey;
-                    BaseUriHelper.GetAssemblyNameAndPart(new Uri(relativeUri, UriKind.Relative), out part, out assy, out assyVers, out assyKey);
-                    if (!string.IsNullOrEmpty(assy))
+
+                    BaseUriHelper.GetAssemblyNameAndPart(new Uri(relativeUri, UriKind.Relative), out AssemblyPackageInfo assemblyInfo);
+                    if (!assemblyInfo.AssemblyName.IsEmpty)
                     {
-                        displayName = part;
+                        displayName = assemblyInfo.PackagePartName.ToString();
                     }
                     else
                     {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
@@ -5,10 +5,9 @@
 
 using System.Runtime.CompilerServices;
 using System.Reflection.Metadata;
-using System.Reflection;
-using System.Text;
-using System;
 using System.Diagnostics;
+using System.Reflection;
+using System;
 
 namespace MS.Internal
 {
@@ -124,6 +123,20 @@ namespace MS.Internal
                 if (assemblyToken.Length != 16)
                     assemblyToken = ReadOnlySpan<char>.Empty;
             }
+        }
+
+        /// <summary>
+        /// Compares whether two PublicKeyTokens are the same.
+        /// If both <paramref name="reqToken"/> and <paramref name="curToken"/> are <see langword="null"/>, <see langword="true"/> is returned.
+        /// </summary>
+        /// <param name="reqToken">First PublicKeyToken to compare.</param>
+        /// <param name="curToken">Second PublicKeyToken to compare.</param>
+        /// <returns><see langword="true"/> if both parameters are <see langword="null"/> or equal in sequence, <see langword="false"/> otherwise.</returns>
+        internal static bool IsSamePublicKeyToken(byte[] reqToken, byte[] curToken)
+        {
+            Debug.Assert((reqToken is null || reqToken.Length is 0 or 8) && (curToken is null || curToken.Length is 0 or 8), "Provided PublicKeyToken has invalid length");
+
+            return (reqToken is null && curToken is null) || (curToken is not null && reqToken is not null && reqToken.AsSpan().SequenceEqual(curToken));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
@@ -1,13 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #nullable enable
 
 using System.Runtime.CompilerServices;
 using System.Reflection.Metadata;
 using System.Reflection;
+using System.Text;
 using System;
+using System.Diagnostics;
 
 namespace MS.Internal
 {
@@ -17,9 +18,12 @@ namespace MS.Internal
     internal static class ReflectionUtils
     {
 #if !NETFX
+        private const string Version = ", Version=";
+        private const string PublicKeyToken = ", PublicKeyToken=";
+
         /// <summary>
-        ///  Retrieves the full assembly name by combining the <paramref name="partialName"/> passed in
-        ///  with everything else from <paramref name="assembly"/>.
+        /// Retrieves the full assembly name by combining the <paramref name="partialName"/> passed in
+        /// with everything else from <paramref name="assembly"/>.
         /// </summary>
         internal static string GetFullAssemblyNameFromPartialName(Assembly assembly, string partialName)
         {
@@ -33,7 +37,7 @@ namespace MS.Internal
 #endif
 
         /// <summary>
-        ///  Given an <paramref name="assembly"/>, returns the partial/simple name of the assembly.
+        /// Given an <paramref name="assembly"/>, returns the partial/simple name of the assembly.
         /// </summary>
 #if !NETFX
         internal static ReadOnlySpan<char> GetAssemblyPartialName(Assembly assembly)
@@ -80,5 +84,61 @@ namespace MS.Internal
             return name.Name ?? string.Empty;
 #endif
         }
+
+#if !NETFX
+        /// <summary>
+        /// Parses <see cref="Assembly.FullName"/> and retrieves "Version" and "PublicKeyToken" values from the original string.
+        /// This should only be passed a RuntimeAssembly to ensure proper functionality.
+        /// </summary>
+        /// <param name="assembly">The RuntimeAssembly which will provide properly formatted full name.</param>
+        /// <param name="version">If present, returns the value of Version portion, otherwise Empty result.</param>
+        /// <param name="token">If present, returns the value of PublicKeyToken portion. Empty result is returned when the value is "null" or not present.</param>
+        internal static void GetAssemblyVersionPlusToken(Assembly assembly, out ReadOnlySpan<char> assemblyVersion, out ReadOnlySpan<char> assemblyToken)
+        {
+            ArgumentNullException.ThrowIfNull(assembly, nameof(assembly));
+            ReadOnlySpan<char> assemblyName = assembly.FullName;
+
+            assemblyVersion = ReadOnlySpan<char>.Empty;
+            assemblyToken = ReadOnlySpan<char>.Empty;
+
+            // Parse Version section
+            int versionIndex = assemblyName.IndexOf(Version);
+            if (versionIndex != -1)
+            {
+                int tokenEnding = assemblyName.Slice(versionIndex + 1).IndexOf(',') + 1;
+                int tokenLength = tokenEnding == 0 ? assemblyName.Slice(versionIndex).Length : tokenEnding;
+
+                assemblyVersion = assemblyName.Slice(versionIndex + Version.Length, tokenLength - Version.Length);
+            }
+
+            // Parse PublicKeyToken section
+            int tokenIndex = assemblyName.IndexOf(PublicKeyToken);
+            if (tokenIndex != -1)
+            {
+                int tokenEnding = assemblyName.Slice(tokenIndex + 1).IndexOf(',') + 1;
+                int tokenLength = tokenEnding == 0 ? assemblyName.Slice(tokenIndex).Length : tokenEnding;
+
+                // PublicKeyToken is always 8 bytes (16 chars in HEX), in other cases it is gonna be "null",
+                // however it is simply faster to match it via Length as original parser does it than anything else
+                assemblyToken = assemblyName.Slice(tokenIndex + PublicKeyToken.Length, tokenLength - PublicKeyToken.Length);
+                if (assemblyToken.Length != 16)
+                    assemblyToken = ReadOnlySpan<char>.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Compares whether two PublicKeyTokens are the same.
+        /// If both <paramref name="reqToken"/> and <paramref name="curToken"/> are <see cref="ReadOnlySpan{byte}.Empty"/>, <see langword="true"/> is returned.
+        /// </summary>
+        /// <param name="reqToken">First PublicKeyToken to compare.</param>
+        /// <param name="curToken">Second PublicKeyToken to compare.</param>
+        /// <returns><see langword="true"/> if both parameters are <see cref="ReadOnlySpan{byte}.Empty"/> or equal in sequence, <see langword="false"/> otherwise.</returns>
+        internal static bool IsSamePublicKeyToken(ReadOnlySpan<byte> reqToken, ReadOnlySpan<byte> curToken)
+        {
+            Debug.Assert((reqToken.IsEmpty || reqToken.Length == 8) && (curToken.IsEmpty || curToken.Length == 8), "Provided PublicKeyToken has invalid length");
+
+            return reqToken.SequenceEqual(curToken);
+        }
+#endif
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
@@ -10,6 +10,8 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
+using MS.Internal;
+
 #if SYSTEM_XAML
 using TypeConverterHelper = System.Xaml.TypeConverterHelper;
 #else
@@ -116,7 +118,7 @@ namespace System.Xaml
                 if (string.Equals(curAsmName.Name, assemblyName.Name, StringComparison.InvariantCultureIgnoreCase) &&
                      (reqVersion is null || reqVersion.Equals(curVersion)) &&
                      (reqCulture is null || reqCulture.Equals(curCulture)) &&
-                     (reqKeyToken is null || IsSameKeyToken(reqKeyToken, curKeyToken)))
+                     (reqKeyToken is null || ReflectionUtils.IsSamePublicKeyToken(reqKeyToken, curKeyToken)))
                 {
                     return assemblies[i];
                 }
@@ -213,46 +215,6 @@ namespace System.Xaml
         }
 
 #endif  // WINDOWS_BASE || PRESENTATION_CORE || SYSTEM_XAML
-
-        //
-        // Determine if two Public Key Tokens are the same.
-        //
-#if !REACHFRAMEWORK
-#if PRESENTATIONFRAMEWORK || SYSTEM_XAML || PRESENTATION_CORE
-        internal
-#else
-        private
-#endif
-        static bool IsSameKeyToken(byte[] reqKeyToken, byte[] curKeyToken)
-        {
-           bool isSame = false;
-
-           if (reqKeyToken is null && curKeyToken is null)
-           {
-               // Both Key Tokens are not set, treat them as same.
-               isSame = true;
-           }
-           else if (reqKeyToken is not null && curKeyToken is not null)
-           {
-               // Both KeyTokens are set.
-               if (reqKeyToken.Length == curKeyToken.Length)
-               {
-                   isSame = true;
-
-                   for (int i = 0; i < reqKeyToken.Length; i++)
-                   {
-                      if (reqKeyToken[i] != curKeyToken[i])
-                      {
-                         isSame = false;
-                         break;
-                      }
-                   }
-               }
-           }
-
-           return isSame;
-        }
-#endif //!REACHFRAMEWORK
 
         internal const string IMAGE = "image";
     }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -12,6 +12,7 @@ using System.Security;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using Microsoft.Win32;
+using System.Windows;
 
 #if !PBTCOMPILER
 using MS.Win32;
@@ -22,22 +23,8 @@ using System.IO.Packaging;
 using MS.Internal.AppModel;
 #endif
 
-#if PRESENTATIONFRAMEWORK_ONLY
-using System.Diagnostics;
-using System.Windows;
-using MS.Internal.Utility;      // BindUriHelper
-using MS.Internal.AppModel;
-#endif
-
 #if REACHFRAMEWORK
 using MS.Internal.Utility;
-#endif
-#if WINDOWS_BASE
-// This existed originally to allow FontCache service to 
-// see the WindowsBase variant of this class. We no longer have
-// a FontCache service, but over time other parts of WPF might
-// have started to depend on this, so we leave it as-is for 
-// compat. 
 #endif
 
 // The SecurityHelper class differs between assemblies and could not actually be

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/BindUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/BindUriHelper.cs
@@ -1,44 +1,29 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Text;
-using System.Windows.Navigation; // BaseUriHelper
 
-#if !PBTCOMPILER
-#endif
-
-// The functionality in this class is shared across framework and core. The functionality in core
-// is a subset of the functionality in framework, so rather than create a dependency from core to
-// framework we have choses to duplicate this chunk of  code.
 #if PRESENTATION_CORE
+using System.Windows.Navigation;
+
 namespace MS.Internal.PresentationCore
 #elif PRESENTATIONFRAMEWORK
-using MS.Internal.PresentationFramework;
-
-namespace MS.Internal.Utility
-#elif PBTCOMPILER
-using MS.Internal.PresentationBuildTasks
+using System.Windows.Navigation;
 
 namespace MS.Internal.Utility
 #elif REACHFRAMEWORK
-using MS.Internal.ReachFramework;
-
 namespace MS.Internal.Utility
 #else
 #error Class is being used from an unknown assembly.
 #endif
 {
-    // 
-    // Methods in this partial class are shared by PresentationFramework and PresentationBuildTasks.
-    // See also WpfWebRequestHelper.
-    //
-    internal static  partial class BindUriHelper
+    // Methods in this partial class are shared by PresentationFramework. See also WpfWebRequestHelper.
+    internal static partial class BindUriHelper
    {
         private const int MAX_PATH_LENGTH = 2048 ;
         private const int MAX_SCHEME_LENGTH = 32;
         public const int MAX_URL_LENGTH = MAX_PATH_LENGTH + MAX_SCHEME_LENGTH + 3; /*=sizeof("://")*/
- 
+
         //
         // Uri-toString does 3 things over the standard .toString()
         //
@@ -60,22 +45,9 @@ namespace MS.Internal.Utility
                     uri.IsAbsoluteUri ? UriComponents.AbsoluteUri : UriComponents.SerializationInfoString, 
                     UriFormat.SafeUnescaped), 
                 MAX_URL_LENGTH).ToString();
-        }        
-        
-#if PRESENTATION_CORE || PRESENTATIONFRAMEWORK
-        // Base Uri.
-        static internal Uri BaseUri
-        {
-            get
-            {
-                return BaseUriHelper.BaseUri;
-            }
-            set
-            {
-                 BaseUriHelper.BaseUri = BaseUriHelper.FixFileUri(value);
-            }
         }
 
+#if PRESENTATION_CORE || PRESENTATIONFRAMEWORK
         static internal bool DoSchemeAndHostMatch(Uri first, Uri second)
         {
             // Check that both the scheme and the host match. 
@@ -90,7 +62,7 @@ namespace MS.Internal.Utility
             {
                 newUri = null;
             }
-            else if (orgUri.IsAbsoluteUri == false)
+            else if (!orgUri.IsAbsoluteUri)
             {
                 // if the orgUri is an absolute Uri, don't need to resolve it again.
                 newUri = new Uri(baseUri ?? BaseUriHelper.PackAppBaseUri, orgUri);
@@ -102,9 +74,6 @@ namespace MS.Internal.Utility
 
             return newUri;
         }
-
-
-
 
 #endif // PRESENTATION_CORE || PRESENTATIONFRAMEWORK
     }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/BindUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/BindUriHelper.cs
@@ -93,42 +93,7 @@ namespace MS.Internal.Utility
             else if (orgUri.IsAbsoluteUri == false)
             {
                 // if the orgUri is an absolute Uri, don't need to resolve it again.
-                
-                Uri baseuri = baseUri ?? BindUriHelper.BaseUri;
-
-#if CF_Envelope_Activation_Enabled
-                bool isContainer = false ;
-
-                //
-                // if the BaseUri starts with pack://application we know that we're not in a container. 
-                //
-                // By deferring the registration of the container scheme - we avoid registering the ssres protocol. 
-                // and enable less code that requires elevation. 
-                // 
-                // Note that when container moves to pack: ( PS 25616) - we won't need this check anyway. 
-                // 
-
-                if (  // Check that the baseuri starts with pack://application:,,,/
-                       ! DoSchemeAndHostMatch(baseuri, BaseUriHelper.PackAppBaseUri))
-                {
-                    isContainer = String.Compare(baseuri.Scheme, CompoundFileUri.UriSchemeContainer, StringComparison.OrdinalIgnoreCase) == 0;
-                }           
-
-                Debug.Assert(baseuri.OriginalString == BaseUriHelper.FixFileUri(baseuri).OriginalString, "Base Uri is legacy file Uri and may not resolve relative uris correctly. This method should be updated");
-
-                // Once we move to PackUri, we don't need a special way
-                //  of resolving Uri. We can use the regurlar one.
-                if (isContainer)
-                {
-                    newUri = ResolveContainerUri(baseuri, orgUri);
-                }
-                else
-                {
-#endif
-                    newUri = new Uri(baseuri, orgUri);
-#if CF_Envelope_Activation_Enabled
-                }
-#endif
+                newUri = new Uri(baseUri ?? BaseUriHelper.PackAppBaseUri, orgUri);
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Media/TypeConverterHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Media/TypeConverterHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -89,7 +89,7 @@ namespace System.Windows.Media
 
                             if (!uriHolder.BaseUri.IsAbsoluteUri)
                             {
-                                uriHolder.BaseUri = new Uri(BaseUriHelper.BaseUri, uriHolder.BaseUri);
+                                uriHolder.BaseUri = new Uri(BaseUriHelper.PackAppBaseUri, uriHolder.BaseUri);
                             }
                         } // uriHolder.BaseUriString != ""
                         else
@@ -97,7 +97,7 @@ namespace System.Windows.Media
                             // if we reach here, the base uri we got from IUriContext is ""
                             // and the inputString is a relative uri.  Here we resolve it to
                             // application's base
-                            uriHolder.BaseUri = BaseUriHelper.BaseUri;
+                            uriHolder.BaseUri = BaseUriHelper.PackAppBaseUri;
                         }
                     } // iuc != null
                 } // context!= null

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/RefOnly/LooseTypeExtensions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/RefOnly/LooseTypeExtensions.cs
@@ -6,6 +6,7 @@
 
 using System.Reflection;
 using System.Windows.Markup;
+using MS.Internal;
 
 namespace System.Xaml
 {
@@ -42,8 +43,7 @@ namespace System.Xaml
             AssemblyName t2name = new AssemblyName(t2.Assembly.FullName);
             if (t1name.Name == t2name.Name)
             {
-                return t1name.CultureInfo.Equals(t2name.CultureInfo) &&
-                    SafeSecurityHelper.IsSameKeyToken(t1name.GetPublicKeyToken(), t2name.GetPublicKeyToken());
+                return t1name.CultureInfo.Equals(t2name.CultureInfo) && ReflectionUtils.IsSamePublicKeyToken(t1name.GetPublicKeyToken(), t2name.GetPublicKeyToken());
             }
 
             return IsWindowsBaseToSystemXamlComparison(t1.Assembly, t2.Assembly, t1name, t2name);
@@ -64,7 +64,7 @@ namespace System.Xaml
                 windowsBaseName = name2;
             }
 
-            return (windowsBaseName is not null && SafeSecurityHelper.IsSameKeyToken(windowsBaseName.GetPublicKeyToken(), WindowsBaseToken));
+            return (windowsBaseName is not null && ReflectionUtils.IsSamePublicKeyToken(windowsBaseName.GetPublicKeyToken(), WindowsBaseToken));
         }
 
         internal static bool IsAssemblyQualifiedNameAssignableFrom(Type t1, Type t2)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -801,7 +801,7 @@ namespace System.Xaml
                     }
 
                     byte[] actualToken = toAssemblyName.GetPublicKeyToken();
-                    return SafeSecurityHelper.IsSameKeyToken(expectedToken, actualToken);
+                    return ReflectionUtils.IsSamePublicKeyToken(expectedToken, actualToken);
                 }
             }
 
@@ -1310,7 +1310,7 @@ namespace System.Xaml
             if (requiredToken is not null)
             {
                 byte[] actualToken = assemblyName.GetPublicKeyToken();
-                if (!SafeSecurityHelper.IsSameKeyToken(requiredToken, actualToken))
+                if (!ReflectionUtils.IsSamePublicKeyToken(requiredToken, actualToken))
                 {
                     return false;
                 }


### PR DESCRIPTION
Currently blocked by #9822, hence draft.

## Description

Optimizes methods in `BaseUriHelper`, removes most of the allocations directly in this class and opens up more optimization possibilities; directly builds upon #9739 and #9822.

- Removes `IsSameKeyToken` from SecurityHelper in favour of `ReflectionUtils.IsSamePublicKeyToken`.
- `BaseUriHelper.GetAssemblyNameAndPart` is now fully allocation free.
    - This allows for more optimizations in the future and already makes some paths without any allocations.
    - Instead of returning 3 strings, we return slices in `AssemblyPackageInfo` `ref struct`.
- In `FontResourceCache`, we can now use `AlternateLookup` to benefit from this change as well.
- `BaseUriHelper.BaseUri` was never set outside static constructor, where it was initialized to the `s_packAppBaseUri` value,
hence I've removed the property altogether, which also led to removal of `BindUriHelper.BaseUri` which was just proxy.
- Code under `CF_Envelope_Activation_Enabled` macro was removed, most of the code is already missing in .NET Core than what was in reference files for .NET 3.5 and it is never compiled on NetFX nor on .NET Core.
- Changes in `GetLoadedAssembly` bring a bit of an improvement but there's more benchmarking needed on how to handle this chain most efficiently, so keeping as it is right now.

Cherry-picking some cases:

### GetAssemblyNameAndPart

| Method   | someUri             | Mean [ns] | Error [ns] | StdDev [ns] |  Gen0   | Allocated [B] |
|--------- |-------------------- |----------:|-----------:|------------:|---------:|--------------:|
| Original | /Mic(...)xaml [103] | 104.95 ns |   2.274 ns |    6.706 ns |     0.0448 |         752 B |
| PR__EDIT | /Mic(...)xaml [103] |  45.42 ns |   0.475 ns |    0.445 ns |         - |             - |

### AssemblyMatchesKeyString vs ComparePublicKeyTokens

| Method   | someAssembly         | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Allocated [B] |
|--------- |--------------------- |----------:|-----------:|------------:|-------:|---------------:|
| Original | Syste(...)7798e [89] | 40.755 ns |  0.3990 ns |   0.3537 ns | 0.0019 |          32 B |
| PR__EDIT | Syste(...)7798e [89] |  8.135 ns |  0.0835 ns |   0.0740 ns |      - |                 - |

## Customer Impact

Improved performance, decrased allocations.

## Regression

No.

## Testing

Local build, some assert testing; I'll provide tests before this goes out of draft.

## Risk

Low to medium, there are quite a few changes but most of them are rather straightforward.
