### PR TITLE
Disable code analysis for generated code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2284,3 +2284,6 @@ dotnet_diagnostic.IDE0251.severity = suggestion
 
 # IDE1006: Naming Styles
 dotnet_diagnostic.IDE1006.severity = suggestion
+
+[**/Generated/*.*]
+generated_code = true


### PR DESCRIPTION
## Description
Disables code analysis for generated code. Code analysis for generated code does not make sense since generated code will never be perfectly formatted and it prevents doing auto formatting to generated code without modifying the code generator.

We'll probably want to format the generated code someday but it should probably be done only when dotnet/wpf#6135 is merged and we can modify the code generator instead of modifying the generated code manually.

## Customer Impact
None.

## Regression
No.

## Testing
Local build + CI.

## Risk
None.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10337)