### PR TITLE
Fix unit tests native dependencies

### DIFF
--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/Directory.Build.props
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/Directory.Build.props
@@ -6,4 +6,9 @@
   <PropertyGroup>
     <WpfTestsDir>$(MsBuildThisFileDirectory)</WpfTestsDir>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Shared\ModuleInitializer.cs" />  
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/Shared/ModuleInitializer.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/Shared/ModuleInitializer.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Loader;
+
+internal static class ModuleInitializer
+{
+    /// <summary>
+    /// Module initializer used as a workaround for https://github.com/dotnet/runtime/issues/111825.
+    /// </summary>
+#pragma warning disable CA2255
+    [ModuleInitializer]
+#pragma warning restore CA2255
+    public static void Initialize()
+    {
+        // When a native dll fails to resolve, try loading it from the directory of the assembly loading the dll.
+        AssemblyLoadContext.Default.ResolvingUnmanagedDll += static (assembly, name) =>
+        {
+            return NativeLibrary.TryLoad(name, assembly, DllImportSearchPath.AssemblyDirectory, out nint handle) ? handle : 0;
+        };
+    }
+}


### PR DESCRIPTION
This is a workaround for dotnet/runtime#111825

## Description
Fixes errors in unit tests when trying to load wpfgfx_cor3.dll which depends on D3DCompiler_47_cor3.dll which can't be found at runtime which seems to be caused by a bug in the runtime when using `DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32` as the search path. 

This search path is the default search path used by all projects in this repo and it's configured here:
https://github.com/dotnet/wpf/blob/81019fc2492bfc15620ef14053f4f3f22eeeac6c/eng/WpfArcadeSdk/tools/ExtendedAssemblyInfo.props#L16-L20

We can't just set `IncludeDllSafeSearchPathAttribute` to false in the test projects since the attribute is used to configure the search path used by default for each assembly. We would need to set it to false for all assemblies trying to load wpfgfx_cor3.dll.

**This problem does not occur for apps using WPF, see the issue for more info**

## Customer Impact
None, test only.

## Regression
No.

## Testing
Local build + CI + local test.

## Risk
None, test only.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10338)