### PR TITLE
Remove DUCE.CopyBytes

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Common/Graphics/exports.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/Graphics/exports.cs
@@ -81,33 +81,6 @@ namespace System.Windows.Media.Composition
     /// </summary>
     internal partial class DUCE
     {
-        /// <summary>
-        /// CopyBytes - Poor-man's mem copy.  Copies cbData from pbFrom to pbTo.
-        /// pbFrom and pbTo must be DWORD aligned, and cbData must be a multiple of 4.
-        /// </summary>
-        /// <param name="pbTo"> byte* pointing to the "to" array.  Must be DWORD aligned. </param>
-        /// <param name="pbFrom"> byte* pointing to the "from" array.  Must be DWORD aligned. </param>
-        /// <param name="cbData"> int - count of bytes to copy.  Must be a multiple of 4. </param>
-        internal static unsafe void CopyBytes(byte* pbTo,
-                                              byte* pbFrom,
-                                              int cbData)
-        {
-            // We'd like to only handle QWORD aligned data, but the CLR can't enforce this.
-            // If there's no data to copy, it's ok if the pointers aren't aligned
-            Debug.Assert((cbData == 0) || ((Int64)(IntPtr)pbFrom) % 4 == 0);
-            Debug.Assert((cbData == 0) || ((Int64)(IntPtr)pbTo) % 4 == 0);
-            Debug.Assert(cbData % 4 == 0);
-            Debug.Assert(cbData >= 0);
-
-            Int32* pCurFrom32 = (Int32*)pbFrom;
-            Int32* pCurTo32 = (Int32*)pbTo;
-
-            for (int i = 0; i < cbData / 4; i++)
-            {
-                pCurTo32[i] = pCurFrom32[i];
-            }
-        }
-
         private static class UnsafeNativeMethods
         {
             [DllImport(DllImport.MilCore)]

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/LinearGradientBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/LinearGradientBrush.cs
@@ -153,27 +153,24 @@ namespace System.Windows.Media
                 DUCE.ResourceHandle hStartPointAnimations = GetAnimationResourceHandle(StartPointProperty, channel);
                 DUCE.ResourceHandle hEndPointAnimations = GetAnimationResourceHandle(EndPointProperty, channel);
 
+                DUCE.MILCMD_LINEARGRADIENTBRUSH data;
+                data.Type = MILCMD.MilCmdLinearGradientBrush;
+                data.Handle = _duceResource.GetHandle(channel);
+                data.Opacity = Opacity;
+                data.hOpacityAnimations = hOpacityAnimations;
+                data.hTransform = hTransform;
+                data.hRelativeTransform = hRelativeTransform;
+                data.ColorInterpolationMode = ColorInterpolationMode;
+                data.MappingMode = MappingMode;
+                data.SpreadMethod = SpreadMethod;
+
+                data.StartPoint = StartPoint;
+                data.hStartPointAnimations = hStartPointAnimations;
+                data.EndPoint = EndPoint;
+                data.hEndPointAnimations = hEndPointAnimations;
+
                 unsafe
                 {
-                    DUCE.MILCMD_LINEARGRADIENTBRUSH data;
-                    data.Type = MILCMD.MilCmdLinearGradientBrush;
-                    data.Handle = _duceResource.GetHandle(channel);
-                    double tempOpacity = Opacity;
-                    DUCE.CopyBytes((byte*)&data.Opacity, (byte*)&tempOpacity, 8);
-                    data.hOpacityAnimations = hOpacityAnimations;
-                    data.hTransform = hTransform;
-                    data.hRelativeTransform = hRelativeTransform;
-                    data.ColorInterpolationMode = ColorInterpolationMode;
-                    data.MappingMode = MappingMode;
-                    data.SpreadMethod = SpreadMethod;
-
-                    Point tempStartPoint = StartPoint;
-                    DUCE.CopyBytes((byte*)&data.StartPoint, (byte*)&tempStartPoint, 16);
-                    data.hStartPointAnimations = hStartPointAnimations;
-                    Point tempEndPoint = EndPoint;
-                    DUCE.CopyBytes((byte*)&data.EndPoint, (byte*)&tempEndPoint, 16);
-                    data.hEndPointAnimations = hEndPointAnimations;
-
                     // GradientStopCollection:  Need to enforce upper-limit of gradient stop capacity
 
                     int count = (vGradientStops == null) ? 0 : vGradientStops.Count;
@@ -190,8 +187,7 @@ namespace System.Windows.Media
                         DUCE.MIL_GRADIENTSTOP stopCmd;
                         GradientStop gradStop = vGradientStops.Internal_GetItem(i);
 
-                        double temp = gradStop.Offset;
-                        DUCE.CopyBytes((byte*)&stopCmd.Position,(byte*)&temp, sizeof(double));
+                        stopCmd.Position = gradStop.Offset;
                         stopCmd.Color = CompositionResourceManager.ColorToMilColorF(gradStop.Color);
                         
                         channel.AppendCommandData(

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RadialGradientBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RadialGradientBrush.cs
@@ -97,32 +97,27 @@ namespace System.Windows.Media
                 DUCE.ResourceHandle hGradientOriginAnimations = GetAnimationResourceHandle(GradientOriginProperty, channel);
 
                 DUCE.MILCMD_RADIALGRADIENTBRUSH data;
+                data.Type = MILCMD.MilCmdRadialGradientBrush;
+                data.Handle = _duceResource.GetHandle(channel);
+                data.Opacity = Opacity;
+                data.hOpacityAnimations = hOpacityAnimations;
+                data.hTransform = hTransform;
+                data.hRelativeTransform = hRelativeTransform;
+                data.ColorInterpolationMode = ColorInterpolationMode;
+                data.MappingMode = MappingMode;
+                data.SpreadMethod = SpreadMethod;
+
+                data.Center = Center;
+                data.hCenterAnimations = hCenterAnimations;
+                data.RadiusX = RadiusX;
+                data.hRadiusXAnimations = hRadiusXAnimations;
+                data.RadiusY = RadiusY;
+                data.hRadiusYAnimations = hRadiusYAnimations;
+                data.GradientOrigin = GradientOrigin;
+                data.hGradientOriginAnimations = hGradientOriginAnimations;
+
                 unsafe
                 {
-                    data.Type = MILCMD.MilCmdRadialGradientBrush;
-                    data.Handle = _duceResource.GetHandle(channel);
-                    double tempOpacity = Opacity;
-                    DUCE.CopyBytes((byte*)&data.Opacity, (byte*)&tempOpacity, 8);
-                    data.hOpacityAnimations = hOpacityAnimations;
-                    data.hTransform = hTransform;
-                    data.hRelativeTransform = hRelativeTransform;
-                    data.ColorInterpolationMode = ColorInterpolationMode;
-                    data.MappingMode = MappingMode;
-                    data.SpreadMethod = SpreadMethod;
-
-                    Point tempCenter = Center;
-                    DUCE.CopyBytes((byte*)&data.Center, (byte*)&tempCenter, 16);
-                    data.hCenterAnimations = hCenterAnimations;
-                    double tempRadiusX = RadiusX;
-                    DUCE.CopyBytes((byte*)&data.RadiusX, (byte*)&tempRadiusX, 8);
-                    data.hRadiusXAnimations = hRadiusXAnimations;
-                    double tempRadiusY = RadiusY;
-                    DUCE.CopyBytes((byte*)&data.RadiusY, (byte*)&tempRadiusY, 8);
-                    data.hRadiusYAnimations = hRadiusYAnimations;
-                    Point tempGradientOrigin = GradientOrigin;
-                    DUCE.CopyBytes((byte*)&data.GradientOrigin, (byte*)&tempGradientOrigin, 16);
-                    data.hGradientOriginAnimations = hGradientOriginAnimations;
-
                     // GradientStopCollection:  Need to enforce upper-limit of gradient stop capacity
 
                     int count = (vGradientStops == null) ? 0 : vGradientStops.Count;
@@ -139,8 +134,7 @@ namespace System.Windows.Media
                         DUCE.MIL_GRADIENTSTOP stopCmd;
                         GradientStop gradStop = vGradientStops.Internal_GetItem(i);
 
-                        double temp = gradStop.Offset;
-                        DUCE.CopyBytes((byte*)&stopCmd.Position,(byte*)&temp, sizeof(double));
+                        stopCmd.Position = gradStop.Offset;
                         stopCmd.Color = CompositionResourceManager.ColorToMilColorF(gradStop.Color);
                         
                         channel.AppendCommandData(


### PR DESCRIPTION
## Description
Removes DUCE.CopyBytes that was used to set struct fields. It was probably used in the past to improve performance but since then the JIT has improved and is faster than custom memcopy, thanks in part to SIMD.

LinearGradientBrush and RadialGradientBrush were the only 2 of many DUCE resources to use this method.

<details>
  <summary>Benchmark results (Copying 5 double to a struct)</summary>
  
| Method    | Mean      | Error     | StdDev    | Ratio | Code Size |
|---------- |----------:|----------:|----------:|------:|----------:|
| CopyBytes | 6.8878 ns | 0.0178 ns | 0.0158 ns |  1.00 |     150 B |
| JIT       | 0.8358 ns | 0.0050 ns | 0.0044 ns |  0.12 |      46 B |
  
</details>

## Customer Impact
Slightly better performance.

## Regression
No.

## Testing
Local testing.

## Risk
Low.