### PR TITLE
[StyleCleanUp] Resolve CA1507 for exception formatting arguments

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/TextProviderWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/TextProviderWrapper.cs
@@ -54,7 +54,7 @@ namespace MS.Internal.Automation
         {
             if (!(childElement is ElementProxy))
             {
-                throw new ArgumentException(SR.Format(SR.TextProvider_InvalidChild, "childElement"));
+                throw new ArgumentException(SR.Format(SR.TextProvider_InvalidChild, nameof(childElement)));
             }
 
             return (ITextRangeProvider)ElementUtil.Invoke(_peer, new DispatcherOperationCallback(RangeFromChild), childElement);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/TextRangeProviderWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/TextRangeProviderWrapper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -48,7 +48,7 @@ namespace MS.Internal.Automation
         {
             if (!(range is TextRangeProviderWrapper))
             {
-                throw new ArgumentException(SR.Format(SR.TextRangeProvider_InvalidRangeProvider, "range"));
+                throw new ArgumentException(SR.Format(SR.TextRangeProvider_InvalidRangeProvider, nameof(range)));
             }
 
             return (bool)ElementUtil.Invoke(_peer, new DispatcherOperationCallback(Compare), range);
@@ -58,7 +58,7 @@ namespace MS.Internal.Automation
         {
             if (!(targetRange is TextRangeProviderWrapper))
             {
-                throw new ArgumentException(SR.Format(SR.TextRangeProvider_InvalidRangeProvider, "targetRange"));
+                throw new ArgumentException(SR.Format(SR.TextRangeProvider_InvalidRangeProvider, nameof(targetRange)));
             }
 
             object[] args = new object[] { endpoint, targetRange, targetEndpoint };
@@ -121,7 +121,7 @@ namespace MS.Internal.Automation
         {
             if (!(targetRange is TextRangeProviderWrapper))
             {
-                throw new ArgumentException(SR.Format(SR.TextRangeProvider_InvalidRangeProvider, "targetRange"));
+                throw new ArgumentException(SR.Format(SR.TextRangeProvider_InvalidRangeProvider, nameof(targetRange)));
             }
 
             object[] args = new object[] { endpoint, targetRange, targetEndpoint };

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/IO/Packaging/ByteRangeDownloader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/IO/Packaging/ByteRangeDownloader.cs
@@ -693,14 +693,14 @@ namespace MS.Internal.IO.Packaging
             // The byteRanges should never be less; perf optimization
             if (byteRanges.Length < 2 || (byteRanges.Length % 2) != 0)
             {
-                throw new ArgumentException(SR.Format(SR.InvalidByteRanges, "byteRanges"));
+                throw new ArgumentException(SR.Format(SR.InvalidByteRanges, nameof(byteRanges)));
             }
 
             for (int i = 0; i < byteRanges.Length; i++)
             {
                 if (byteRanges[i] < 0 || byteRanges[i+1] <= 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidByteRanges, "byteRanges"));
+                    throw new ArgumentException(SR.Format(SR.InvalidByteRanges, nameof(byteRanges)));
                 }
                 i++;
             }
@@ -718,14 +718,14 @@ namespace MS.Internal.IO.Packaging
         {
             if (byteRanges.GetLength(0) <= 0 || byteRanges.GetLength(1) != 2)
             {
-                throw new ArgumentException(SR.Format(SR.InvalidByteRanges, "byteRanges"));
+                throw new ArgumentException(SR.Format(SR.InvalidByteRanges, nameof(byteRanges)));
             }
 
             for (int i = 0; i < byteRanges.GetLength(0); ++i)
             {
                 if (byteRanges[i,Offset_Index] < 0 || byteRanges[i,Length_Index] <= 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidByteRanges, "byteRanges"));
+                    throw new ArgumentException(SR.Format(SR.InvalidByteRanges, nameof(byteRanges)));
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/PartialArray.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/PartialArray.cs
@@ -138,7 +138,7 @@ namespace MS.Internal
                 throw new ArgumentException(
                     SR.Format(
                         SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, 
-                        "arrayIndex", 
+                        nameof(arrayIndex), 
                         "array"),
                         nameof(arrayIndex));
             }
@@ -148,7 +148,7 @@ namespace MS.Internal
                 throw new ArgumentException(
                     SR.Format(
                         SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength,
-                        "arrayIndex",
+                        nameof(arrayIndex),
                         "array"));
             }           
             

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/PartialArray.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/PartialArray.cs
@@ -139,7 +139,7 @@ namespace MS.Internal
                     SR.Format(
                         SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, 
                         nameof(arrayIndex), 
-                        "array"),
+                        nameof(array)),
                         nameof(arrayIndex));
             }
 
@@ -149,7 +149,7 @@ namespace MS.Internal
                     SR.Format(
                         SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength,
                         nameof(arrayIndex),
-                        "array"));
+                        nameof(array)));
             }           
             
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/ThousandthOfEmRealDoubles.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/ThousandthOfEmRealDoubles.cs
@@ -180,7 +180,7 @@ namespace MS.Internal.TextFormatting
                     SR.Format(
                         SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, 
                         nameof(arrayIndex), 
-                        "array"),
+                        nameof(array)),
                     nameof(arrayIndex));
             }
 
@@ -190,7 +190,7 @@ namespace MS.Internal.TextFormatting
                     SR.Format(
                         SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength,
                         nameof(arrayIndex),
-                        "array"));
+                        nameof(array)));
             }           
             
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/ThousandthOfEmRealDoubles.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/ThousandthOfEmRealDoubles.cs
@@ -179,7 +179,7 @@ namespace MS.Internal.TextFormatting
                 throw new ArgumentException(
                     SR.Format(
                         SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, 
-                        "arrayIndex", 
+                        nameof(arrayIndex), 
                         "array"),
                     nameof(arrayIndex));
             }
@@ -189,7 +189,7 @@ namespace MS.Internal.TextFormatting
                 throw new ArgumentException(
                     SR.Format(
                         SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength,
-                        "arrayIndex",
+                        nameof(arrayIndex),
                         "array"));
             }           
             

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/ThousandthOfEmRealPoints.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/ThousandthOfEmRealPoints.cs
@@ -124,7 +124,7 @@ namespace MS.Internal.TextFormatting
                 throw new ArgumentException(
                     SR.Format(
                         SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, 
-                        "arrayIndex", 
+                        nameof(arrayIndex), 
                         "array"),
                     nameof(arrayIndex));
             }
@@ -134,7 +134,7 @@ namespace MS.Internal.TextFormatting
                 throw new ArgumentException(
                     SR.Format(
                         SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength,
-                        "arrayIndex",
+                        nameof(arrayIndex),
                         "array"));
             }           
             

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/ThousandthOfEmRealPoints.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/ThousandthOfEmRealPoints.cs
@@ -125,7 +125,7 @@ namespace MS.Internal.TextFormatting
                     SR.Format(
                         SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, 
                         nameof(arrayIndex), 
-                        "array"),
+                        nameof(array)),
                     nameof(arrayIndex));
             }
 
@@ -135,7 +135,7 @@ namespace MS.Internal.TextFormatting
                     SR.Format(
                         SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength,
                         nameof(arrayIndex),
-                        "array"));
+                        nameof(array)));
             }           
             
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/CoreCompatibilityPreferences.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/CoreCompatibilityPreferences.cs
@@ -65,7 +65,7 @@ namespace System.Windows
                 {
                     if (_isSealed)
                     {
-                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, "IsAltKeyRequiredInAccessKeyDefaultScope", "CoreCompatibilityPreferences"));
+                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, nameof(IsAltKeyRequiredInAccessKeyDefaultScope), "CoreCompatibilityPreferences"));
                     }
 
                     _isAltKeyRequiredInAccessKeyDefaultScope = value;
@@ -105,7 +105,7 @@ namespace System.Windows
                 {
                     if (_isSealed)
                     {
-                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, "IncludeAllInkInBoundingBox", "CoreCompatibilityPreferences"));
+                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, nameof(IncludeAllInkInBoundingBox), "CoreCompatibilityPreferences"));
                     }
 
                     _includeAllInkInBoundingBox = value;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DragEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DragEventArgs.cs
@@ -145,7 +145,7 @@ namespace System.Windows
             {
                 if (!DragDrop.IsValidDragDropEffects(value))
                 {
-                    throw new ArgumentException(SR.Format(SR.DragDrop_DragDropEffectsInvalid, "value"));
+                    throw new ArgumentException(SR.Format(SR.DragDrop_DragDropEffectsInvalid, nameof(value)));
                 }
 
                 _effects = value;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/Events.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/Events.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Ink
         {
             if ( added == null && removed == null )
             {
-                throw new ArgumentException(SR.Format(SR.CannotBothBeNull, nameof(added), "removed"));
+                throw new ArgumentException(SR.Format(SR.CannotBothBeNull, nameof(added), nameof(removed)));
             }
             _added = ( added == null ) ? null : new StrokeCollection.ReadOnlyStrokeCollection(added);
             _removed = ( removed == null ) ? null : new StrokeCollection.ReadOnlyStrokeCollection(removed);
@@ -101,7 +101,7 @@ namespace System.Windows.Ink
         {
             if ( newValue == null && previousValue == null )
             {
-                throw new ArgumentException(SR.Format(SR.CannotBothBeNull, nameof(newValue), "previousValue"));
+                throw new ArgumentException(SR.Format(SR.CannotBothBeNull, nameof(newValue), nameof(previousValue)));
             }
 
             _propertyGuid = propertyGuid;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/Events.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/Events.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Ink
         {
             if ( added == null && removed == null )
             {
-                throw new ArgumentException(SR.Format(SR.CannotBothBeNull, "added", "removed"));
+                throw new ArgumentException(SR.Format(SR.CannotBothBeNull, nameof(added), "removed"));
             }
             _added = ( added == null ) ? null : new StrokeCollection.ReadOnlyStrokeCollection(added);
             _removed = ( removed == null ) ? null : new StrokeCollection.ReadOnlyStrokeCollection(removed);
@@ -101,7 +101,7 @@ namespace System.Windows.Ink
         {
             if ( newValue == null && previousValue == null )
             {
-                throw new ArgumentException(SR.Format(SR.CannotBothBeNull, "newValue", "previousValue"));
+                throw new ArgumentException(SR.Format(SR.CannotBothBeNull, nameof(newValue), "previousValue"));
             }
 
             _propertyGuid = propertyGuid;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/AccessKeyManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/AccessKeyManager.cs
@@ -123,7 +123,7 @@ namespace System.Windows.Input
 
             if (key != firstCharacter)
             {
-                throw new ArgumentException(SR.Format(SR.AccessKeyManager_NotAUnicodeCharacter, "key"));
+                throw new ArgumentException(SR.Format(SR.AccessKeyManager_NotAUnicodeCharacter, nameof(key)));
             }
 
             return firstCharacter.ToUpperInvariant();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputScope.cs
@@ -169,7 +169,7 @@ namespace System.Windows.Input
             { 
                 if (!IsValidInputScopeNameValue(value))
                 {
-                    throw new ArgumentException(SR.Format(SR.InputScope_InvalidInputScopeName, "value"));
+                    throw new ArgumentException(SR.Format(SR.InputScope_InvalidInputScopeName, nameof(value)));
                 }
                 _nameValue = value; 
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusSystemGestureEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusSystemGestureEventArgs.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Input
         {
             if (!RawStylusSystemGestureInputReport.IsValidSystemGesture(systemGesture, false, false))
             {
-                throw new InvalidEnumArgumentException(SR.Format(SR.Enum_Invalid, "systemGesture"));
+                throw new InvalidEnumArgumentException(SR.Format(SR.Enum_Invalid, nameof(systemGesture)));
             }
             
             _id        = systemGesture;
@@ -75,7 +75,7 @@ namespace System.Windows.Input
         {
             if (!RawStylusSystemGestureInputReport.IsValidSystemGesture(systemGesture, true, false))
             {
-                throw new InvalidEnumArgumentException(SR.Format(SR.Enum_Invalid, "systemGesture"));
+                throw new InvalidEnumArgumentException(SR.Format(SR.Enum_Invalid, nameof(systemGesture)));
             }
 
             _id          = systemGesture;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextCompositionManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextCompositionManager.cs
@@ -301,12 +301,12 @@ namespace System.Windows.Input
 
             if (composition._InputManager == null)
             {
-                throw new ArgumentException(SR.Format(SR.TextCompositionManager_NoInputManager, "composition"));
+                throw new ArgumentException(SR.Format(SR.TextCompositionManager_NoInputManager, nameof(composition)));
             }
 
             if (composition.Stage != TextCompositionStage.None)
             {
-                throw new ArgumentException(SR.Format(SR.TextCompositionManager_TextCompositionHasStarted, "composition"));
+                throw new ArgumentException(SR.Format(SR.TextCompositionManager_TextCompositionHasStarted, nameof(composition)));
             }
 
             composition.Stage = TextCompositionStage.Started;
@@ -324,17 +324,17 @@ namespace System.Windows.Input
 
             if (composition._InputManager == null)
             {
-                throw new ArgumentException(SR.Format(SR.TextCompositionManager_NoInputManager, "composition"));
+                throw new ArgumentException(SR.Format(SR.TextCompositionManager_NoInputManager, nameof(composition)));
             }
 
             if (composition.Stage == TextCompositionStage.None)
             {
-                throw new ArgumentException(SR.Format(SR.TextCompositionManager_TextCompositionNotStarted, "composition"));
+                throw new ArgumentException(SR.Format(SR.TextCompositionManager_TextCompositionNotStarted, nameof(composition)));
             }
 
             if (composition.Stage == TextCompositionStage.Done)
             {
-                throw new ArgumentException(SR.Format(SR.TextCompositionManager_TextCompositionHasDone, "composition"));
+                throw new ArgumentException(SR.Format(SR.TextCompositionManager_TextCompositionHasDone, nameof(composition)));
             }
 
             TextCompositionEventArgs textargs = new TextCompositionEventArgs(composition._InputDevice, composition)
@@ -351,17 +351,17 @@ namespace System.Windows.Input
 
             if (composition._InputManager == null)
             {
-                throw new ArgumentException(SR.Format(SR.TextCompositionManager_NoInputManager, "composition"));
+                throw new ArgumentException(SR.Format(SR.TextCompositionManager_NoInputManager, nameof(composition)));
             }
 
             if (composition.Stage == TextCompositionStage.None)
             {
-                throw new ArgumentException(SR.Format(SR.TextCompositionManager_TextCompositionNotStarted, "composition"));
+                throw new ArgumentException(SR.Format(SR.TextCompositionManager_TextCompositionNotStarted, nameof(composition)));
             }
 
             if (composition.Stage == TextCompositionStage.Done)
             {
-                throw new ArgumentException(SR.Format(SR.TextCompositionManager_TextCompositionHasDone, "composition"));
+                throw new ArgumentException(SR.Format(SR.TextCompositionManager_TextCompositionHasDone, nameof(composition)));
             }
 
             composition.Stage = TextCompositionStage.Done;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/KeySpline.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/KeySpline.cs
@@ -167,7 +167,7 @@ namespace System.Windows.Media.Animation
                     {
                         throw new ArgumentException(SR.Format(
                             SR.Animation_KeySpline_InvalidValue,
-                            "ControlPoint1",
+                            nameof(ControlPoint1),
                             value));
                     }
 
@@ -199,7 +199,7 @@ namespace System.Windows.Media.Animation
                     {
                         throw new ArgumentException(SR.Format(
                             SR.Animation_KeySpline_InvalidValue,
-                            "ControlPoint2",
+                            nameof(ControlPoint2),
                             value));
                     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/KeySpline.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/KeySpline.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Media.Animation
             {
                 throw new ArgumentException(SR.Format(
                     SR.Animation_KeySpline_InvalidValue,
-                    "controlPoint1",
+                    nameof(controlPoint1),
                     controlPoint1));
             }
 
@@ -65,7 +65,7 @@ namespace System.Windows.Media.Animation
             {
                 throw new ArgumentException(SR.Format(
                     SR.Animation_KeySpline_InvalidValue,
-                    "controlPoint2",
+                    nameof(controlPoint2),
                     controlPoint2));
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetricsDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetricsDictionary.cs
@@ -119,7 +119,7 @@ namespace System.Windows.Media
             ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), nameof(array)));
 
             CharacterMetrics[][] pageTable = _pageTable;
             if (pageTable != null)
@@ -137,7 +137,7 @@ namespace System.Windows.Media
                             if (metrics != null)
                             {
                                 if (k >= array.Length)
-                                    throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));
+                                    throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, nameof(array)));
 
                                 array[k++] = new KeyValuePair<int, CharacterMetrics>(
                                     (i << PageShift) | j,
@@ -176,10 +176,10 @@ namespace System.Windows.Media
             ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), nameof(array)));
 
             if (Count > array.Length - index)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, nameof(array)));
 
             SC.DictionaryEntry[] typedArray = array as SC.DictionaryEntry[];
             if (typedArray != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetricsDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetricsDictionary.cs
@@ -119,7 +119,7 @@ namespace System.Windows.Media
             ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, "index", "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
 
             CharacterMetrics[][] pageTable = _pageTable;
             if (pageTable != null)
@@ -176,7 +176,7 @@ namespace System.Windows.Media
             ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, "index", "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
 
             if (Count > array.Length - index)
                 throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CultureSpecificStringDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CultureSpecificStringDictionary.cs
@@ -111,7 +111,7 @@ namespace System.Windows.Media
             ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, "index", "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
 
             if (_innerDictionary.Count > array.Length - index)
                 throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));
@@ -145,7 +145,7 @@ namespace System.Windows.Media
             ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, "index", "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
 
             if (_innerDictionary.Count > array.Length - index)
                 throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CultureSpecificStringDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CultureSpecificStringDictionary.cs
@@ -111,10 +111,10 @@ namespace System.Windows.Media
             ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), nameof(array)));
 
             if (_innerDictionary.Count > array.Length - index)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, nameof(array)));
 
             _innerDictionary.CopyTo(array, index);
         }
@@ -145,10 +145,10 @@ namespace System.Windows.Media
             ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), nameof(array)));
 
             if (_innerDictionary.Count > array.Length - index)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, nameof(array)));
 
             SC.DictionaryEntry[] typedArray = array as SC.DictionaryEntry[];
             if (typedArray != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EllipseGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EllipseGeometry.cs
@@ -28,7 +28,7 @@ namespace System.Windows.Media
         {
             if (rect.IsEmpty) 
             {
-                throw new System.ArgumentException(SR.Format(SR.Rect_Empty, "rect"));
+                throw new System.ArgumentException(SR.Format(SR.Rect_Empty, nameof(rect)));
             }
 
             RadiusX = (rect.Right - rect.X) * (1.0 / 2.0);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyMapCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyMapCollection.cs
@@ -75,7 +75,7 @@ namespace System.Windows.Media
             ArgumentNullException.ThrowIfNull(array);
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, "index", "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
 
             if (_count > array.Length - index)
                 throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));
@@ -96,7 +96,7 @@ namespace System.Windows.Media
                 throw new ArgumentException(SR.Format(SR.CannotConvertType, typeof(FamilyTypeface), elementType));
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, "index", "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
 
             if (_count > array.Length - index)
                 throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyMapCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyMapCollection.cs
@@ -75,10 +75,10 @@ namespace System.Windows.Media
             ArgumentNullException.ThrowIfNull(array);
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), nameof(array)));
 
             if (_count > array.Length - index)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, nameof(array)));
 
             if (_count != 0)
                 Array.Copy(_items, 0, array, index, _count);
@@ -96,10 +96,10 @@ namespace System.Windows.Media
                 throw new ArgumentException(SR.Format(SR.CannotConvertType, typeof(FamilyTypeface), elementType));
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), nameof(array)));
 
             if (_count > array.Length - index)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, nameof(array)));
 
             if (_count != 0)
                 Array.Copy(_items, 0, array, index, _count);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyTypefaceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyTypefaceCollection.cs
@@ -374,7 +374,7 @@ namespace System.Windows.Media
                 throw new ArgumentException(SR.Format(SR.CannotConvertType, typeof(FamilyTypeface[]), elementType));
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, "index", "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
 
             if (_count > array.Length - index)
                 throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyTypefaceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyTypefaceCollection.cs
@@ -374,10 +374,10 @@ namespace System.Windows.Media
                 throw new ArgumentException(SR.Format(SR.CannotConvertType, typeof(FamilyTypeface[]), elementType));
 
             if (index >= array.Length)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(index), nameof(array)));
 
             if (_count > array.Length - index)
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, index, nameof(array)));
 
             if (_count != 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Fonts.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Fonts.cs
@@ -100,7 +100,7 @@ namespace System.Windows.Media
             {
                 // relative location; we need a base URI
                 if (baseUri == null)
-                    throw new ArgumentNullException(nameof(baseUri), SR.Format(SR.NullBaseUriParam, "baseUri", "location"));
+                    throw new ArgumentNullException(nameof(baseUri), SR.Format(SR.NullBaseUriParam, nameof(baseUri), "location"));
 
                 // the location part must include a path component, otherwise we'll look in windows fonts and ignore the base URI
                 if (string.IsNullOrEmpty(location))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Fonts.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Fonts.cs
@@ -100,7 +100,7 @@ namespace System.Windows.Media
             {
                 // relative location; we need a base URI
                 if (baseUri == null)
-                    throw new ArgumentNullException(nameof(baseUri), SR.Format(SR.NullBaseUriParam, nameof(baseUri), "location"));
+                    throw new ArgumentNullException(nameof(baseUri), SR.Format(SR.NullBaseUriParam, nameof(baseUri), nameof(location)));
 
                 // the location part must include a path component, otherwise we'll look in windows fonts and ignore the base URI
                 if (string.IsNullOrEmpty(location))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
@@ -1308,10 +1308,10 @@ namespace System.Windows.Media
             set
             {
                 if (value <= 0)
-                    throw new ArgumentOutOfRangeException(nameof(value), SR.Format(SR.PropertyMustBeGreaterThanZero, "MaxTextHeight"));
+                    throw new ArgumentOutOfRangeException(nameof(value), SR.Format(SR.PropertyMustBeGreaterThanZero, nameof(MaxTextHeight)));
 
                 if (double.IsNaN(value))
-                    throw new ArgumentOutOfRangeException(nameof(value), SR.Format(SR.PropertyValueCannotBeNaN, "MaxTextHeight"));
+                    throw new ArgumentOutOfRangeException(nameof(value), SR.Format(SR.PropertyValueCannotBeNaN, nameof(MaxTextHeight)));
 
                 _maxTextHeight = value;
                 InvalidateMetrics();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapEncoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapEncoder.cs
@@ -74,7 +74,7 @@ namespace System.Windows.Media.Imaging
             if (containerFormat == Guid.Empty)
             {
                 throw new ArgumentException(
-                    SR.Format(SR.Image_GuidEmpty, "containerFormat"),
+                    SR.Format(SR.Image_GuidEmpty, nameof(containerFormat)),
                     nameof(containerFormat)
                     );
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapImage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapImage.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -72,7 +72,7 @@ namespace System.Windows.Media.Imaging
 
             if (UriSource == null && StreamSource == null)
             {
-                throw new InvalidOperationException(SR.Format(SR.Image_NeitherArgument, nameof(UriSource), "StreamSource"));
+                throw new InvalidOperationException(SR.Format(SR.Image_NeitherArgument, nameof(UriSource), nameof(StreamSource)));
             }
 
             // If the Uri is relative, use delay creation as the BaseUri could be set at a later point

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapImage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapImage.cs
@@ -72,7 +72,7 @@ namespace System.Windows.Media.Imaging
 
             if (UriSource == null && StreamSource == null)
             {
-                throw new InvalidOperationException(SR.Format(SR.Image_NeitherArgument, "UriSource", "StreamSource"));
+                throw new InvalidOperationException(SR.Format(SR.Image_NeitherArgument, nameof(UriSource), "StreamSource"));
             }
 
             // If the Uri is relative, use delay creation as the BaseUri could be set at a later point

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/ColorConvertedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/ColorConvertedBitmap.cs
@@ -136,7 +136,7 @@ namespace System.Windows.Media.Imaging
             {
                 if (throwIfInvalid)
                 {
-                    throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, "Source"));
+                    throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, nameof(Source)));
                 }
                 return false;
             }
@@ -154,7 +154,7 @@ namespace System.Windows.Media.Imaging
             {
                 if (throwIfInvalid)
                 {
-                    throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, "DestinationColorContext"));
+                    throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, nameof(DestinationColorContext)));
                 }
                 return false;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/CroppedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/CroppedBitmap.cs
@@ -152,7 +152,7 @@ namespace System.Windows.Media.Imaging
             {
                 if (throwIfInvalid)
                 {
-                    throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, "Source"));
+                    throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, nameof(Source)));
                 }
                 return false;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/FormatConvertedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/FormatConvertedBitmap.cs
@@ -167,7 +167,7 @@ namespace System.Windows.Media.Imaging
             {
                 if (throwIfInvalid)
                 {
-                    throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, "Source"));
+                    throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, nameof(Source)));
                 }
                 return false;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/TransformedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/TransformedBitmap.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Media.Imaging
 
             if (newTransform == null)
             {
-                throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, "Transform"));
+                throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, nameof(Transform)));
             }
 
             if (!CheckTransform(newTransform))
@@ -275,7 +275,7 @@ namespace System.Windows.Media.Imaging
             {
                 if (throwIfInvalid)
                 {
-                    throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, "Source"));
+                    throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, nameof(Source)));
                 }
                 return false;
             }
@@ -285,7 +285,7 @@ namespace System.Windows.Media.Imaging
             {
                 if (throwIfInvalid)
                 {
-                    throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, "Transform"));
+                    throw new InvalidOperationException(SR.Format(SR.Image_NoArgument, nameof(Transform)));
                 }
                 return false;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/QueryContinueDragEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/QueryContinueDragEventArgs.cs
@@ -79,7 +79,7 @@ namespace System.Windows
             {
                 if (!DragDrop.IsValidDragAction(value))
                 {
-                    throw new ArgumentException(SR.Format(SR.DragDrop_DragActionInvalid, "value"));
+                    throw new ArgumentException(SR.Format(SR.DragDrop_DragActionInvalid, nameof(value)));
                 }
 
                 _action = value; 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/TextAnchor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/TextAnchor.cs
@@ -103,7 +103,7 @@ namespace System.Windows.Annotations
 
             if (textPointer.TextContainer != this.Start.TextContainer)
             {
-                throw new ArgumentException(SR.Format(SR.NotInAssociatedTree, "textPointer"));
+                throw new ArgumentException(SR.Format(SR.NotInAssociatedTree, nameof(textPointer)));
             }
 
             // Correct position normalization on range boundary so that

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -350,7 +350,7 @@ namespace System.Windows
             ArgumentNullException.ThrowIfNull(resourceLocator);
 
             if (resourceLocator.OriginalString == null)
-                throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull,"resourceLocator", "OriginalString"));
+                throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull,nameof(resourceLocator), "OriginalString"));
 
             if (resourceLocator.IsAbsoluteUri == true)
                 throw new ArgumentException(SR.AbsoluteUriNotAllowed);
@@ -440,7 +440,7 @@ namespace System.Windows
             ArgumentNullException.ThrowIfNull(resourceLocator);
 
             if (resourceLocator.OriginalString == null)
-                throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull,"resourceLocator", "OriginalString"));
+                throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull,nameof(resourceLocator), "OriginalString"));
 
             if (resourceLocator.IsAbsoluteUri == true)
                 throw new ArgumentException(SR.AbsoluteUriNotAllowed);
@@ -577,7 +577,7 @@ namespace System.Windows
             ArgumentNullException.ThrowIfNull(uriResource);
 
             if (uriResource.OriginalString == null)
-                throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull, "uriResource", "OriginalString"));
+                throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull, nameof(uriResource), "OriginalString"));
 
             if (uriResource.IsAbsoluteUri == true && !BaseUriHelper.IsPackApplicationUri(uriResource))
             {
@@ -609,7 +609,7 @@ namespace System.Windows
             ArgumentNullException.ThrowIfNull(uriContent);
 
             if (uriContent.OriginalString == null)
-                throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull, "uriContent", "OriginalString"));
+                throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull, nameof(uriContent), "OriginalString"));
 
             if (uriContent.IsAbsoluteUri == true && !BaseUriHelper.IsPackApplicationUri(uriContent))
             {
@@ -638,7 +638,7 @@ namespace System.Windows
             ArgumentNullException.ThrowIfNull(uriRemote);
 
             if (uriRemote.OriginalString == null)
-                throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull, "uriRemote", "OriginalString"));
+                throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull, nameof(uriRemote), "OriginalString"));
 
             if (uriRemote.IsAbsoluteUri == true)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -1093,7 +1093,7 @@ namespace System.Windows
                         }
                         else
                         {
-                            throw new InvalidOperationException(SR.Format(SR.PropertyIsImmutable, "ResourceAssembly", "Application"));
+                            throw new InvalidOperationException(SR.Format(SR.PropertyIsImmutable, nameof(ResourceAssembly), "Application"));
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ComponentResourceKeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ComponentResourceKeyConverter.cs
@@ -98,7 +98,7 @@ namespace System.Windows.Markup
             ComponentResourceKey key = value as ComponentResourceKey;
             if (key == null)
             {
-                throw new ArgumentException(SR.Format(SR.MustBeOfType, "value", "ComponentResourceKey")); 
+                throw new ArgumentException(SR.Format(SR.MustBeOfType, nameof(value), "ComponentResourceKey")); 
             }
             ArgumentNullException.ThrowIfNull(destinationType);
             return base.CanConvertTo(context, destinationType);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Condition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Condition.cs
@@ -191,7 +191,7 @@ namespace System.Windows
                 case ValueLookupType.PropertyTriggerResource:
                     if (_property == null)
                     {
-                        throw new InvalidOperationException(SR.Format(SR.NullPropertyIllegal, "Property"));
+                        throw new InvalidOperationException(SR.Format(SR.NullPropertyIllegal, nameof(Property)));
                     }
 
                     if (!_property.IsValidValue(_value))
@@ -204,7 +204,7 @@ namespace System.Windows
                 case ValueLookupType.DataTriggerResource:
                     if (_binding == null)
                     {
-                        throw new InvalidOperationException(SR.Format(SR.NullPropertyIllegal, "Binding"));
+                        throw new InvalidOperationException(SR.Format(SR.NullPropertyIllegal, nameof(Binding)));
                     }
                     break;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ColumnDefinition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ColumnDefinition.cs
@@ -80,11 +80,11 @@ namespace System.Windows.Controls
             }
             if (index < 0)
             {
-                throw new ArgumentOutOfRangeException(SR.Format(SR.GridCollection_DestArrayInvalidLowerBound, "index"));
+                throw new ArgumentOutOfRangeException(SR.Format(SR.GridCollection_DestArrayInvalidLowerBound, nameof(index)));
             }
             if (array.Length - index < _size)
             {
-                throw new ArgumentException(SR.Format(SR.GridCollection_DestArrayInvalidLength, "array"));
+                throw new ArgumentException(SR.Format(SR.GridCollection_DestArrayInvalidLength, nameof(array)));
             }
 
             if (_size > 0)
@@ -102,11 +102,11 @@ namespace System.Windows.Controls
             ArgumentNullException.ThrowIfNull(array);
             if (index < 0)
             {
-                throw new ArgumentOutOfRangeException(SR.Format(SR.GridCollection_DestArrayInvalidLowerBound, "index"));
+                throw new ArgumentOutOfRangeException(SR.Format(SR.GridCollection_DestArrayInvalidLowerBound, nameof(index)));
             }
             if (array.Length - index < _size)
             {
-                throw new ArgumentException(SR.Format(SR.GridCollection_DestArrayInvalidLength, "array"));
+                throw new ArgumentException(SR.Format(SR.GridCollection_DestArrayInvalidLength, nameof(array)));
             }
 
             if (_size > 0)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ColumnDefinition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ColumnDefinition.cs
@@ -552,7 +552,7 @@ namespace System.Windows.Controls
 
             if (item.Parent != null)
             {
-                throw new ArgumentException(SR.Format(SR.GridCollection_InOtherCollection, "value", "ColumnDefinitionCollection"));
+                throw new ArgumentException(SR.Format(SR.GridCollection_InOtherCollection, nameof(value), "ColumnDefinitionCollection"));
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PrintDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PrintDialog.cs
@@ -159,7 +159,7 @@ namespace System.Windows.Controls
             {
                 if (_minPage <= 0)
                 {
-                    throw new System.ArgumentException(SR.Format(SR.PrintDialogZeroNotAllowed, "MinPage"));
+                    throw new System.ArgumentException(SR.Format(SR.PrintDialogZeroNotAllowed, nameof(MinPage)));
                 }
 
                 _minPage = value;
@@ -179,7 +179,7 @@ namespace System.Windows.Controls
             {
                 if (_maxPage <= 0)
                 {
-                    throw new System.ArgumentException(SR.Format(SR.PrintDialogZeroNotAllowed, "MaxPage"));
+                    throw new System.ArgumentException(SR.Format(SR.PrintDialogZeroNotAllowed, nameof(MaxPage)));
                 }
 
                 _maxPage = value;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RowDefinition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RowDefinition.cs
@@ -75,11 +75,11 @@ namespace System.Windows.Controls
             }
             if (index < 0)
             {
-                throw new ArgumentOutOfRangeException(SR.Format(SR.GridCollection_DestArrayInvalidLowerBound, "index"));
+                throw new ArgumentOutOfRangeException(SR.Format(SR.GridCollection_DestArrayInvalidLowerBound, nameof(index)));
             }
             if (array.Length - index < _size)
             {
-                throw new ArgumentException(SR.Format(SR.GridCollection_DestArrayInvalidLength, "array"));
+                throw new ArgumentException(SR.Format(SR.GridCollection_DestArrayInvalidLength, nameof(array)));
             }
 
             if (_size > 0)
@@ -97,11 +97,11 @@ namespace System.Windows.Controls
             ArgumentNullException.ThrowIfNull(array);
             if (index < 0)
             {
-                throw new ArgumentOutOfRangeException(SR.Format(SR.GridCollection_DestArrayInvalidLowerBound, "index"));
+                throw new ArgumentOutOfRangeException(SR.Format(SR.GridCollection_DestArrayInvalidLowerBound, nameof(index)));
             }
             if (array.Length - index < _size)
             {
-                throw new ArgumentException(SR.Format(SR.GridCollection_DestArrayInvalidLength, "array"));
+                throw new ArgumentException(SR.Format(SR.GridCollection_DestArrayInvalidLength, nameof(array)));
             }
 
             if (_size > 0)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RowDefinition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RowDefinition.cs
@@ -547,7 +547,7 @@ namespace System.Windows.Controls
 
             if (item.Parent != null)
             {
-                throw new ArgumentException(SR.Format(SR.GridCollection_InOtherCollection, "value", "RowDefinitionCollection"));
+                throw new ArgumentException(SR.Format(SR.GridCollection_InOtherCollection, nameof(value), "RowDefinitionCollection"));
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -125,7 +125,7 @@ namespace System.Windows.Controls
 
             if (!(_complexContent.TextContainer is TextContainer))
             {
-                throw new ArgumentException(SR.Format(SR.TextPanelIllegalParaTypeForIAddChild, "value", value.GetType()));
+                throw new ArgumentException(SR.Format(SR.TextPanelIllegalParaTypeForIAddChild, nameof(value), value.GetType()));
             }
 
             // Get parent of the text container. Note that it can be not a "this" TextBlock - in case

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextRangeAdaptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextRangeAdaptor.cs
@@ -1852,7 +1852,7 @@ namespace MS.Internal.Automation
         {
             if (maxLength < 0 && maxLength != -1)
             {
-                throw new ArgumentException(SR.Format(SR.TextRangeProvider_InvalidParameterValue, maxLength, "maxLength"));
+                throw new ArgumentException(SR.Format(SR.TextRangeProvider_InvalidParameterValue, maxLength, nameof(maxLength)));
             }
 
             Normalize();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextRangeAdaptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextRangeAdaptor.cs
@@ -1749,7 +1749,7 @@ namespace MS.Internal.Automation
             ArgumentNullException.ThrowIfNull(text);
             if (text.Length == 0)
             {
-                throw new ArgumentException(SR.Format(SR.TextRangeProvider_EmptyStringParameter, "text"));
+                throw new ArgumentException(SR.Format(SR.TextRangeProvider_EmptyStringParameter, nameof(text)));
             }
 
             Normalize();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/UIElementCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/UIElementCollection.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Controls
         {
             if (visualParent == null)
             {
-                throw new ArgumentNullException(SR.Format(SR.Panel_NoNullVisualParent, "visualParent", this.GetType()));
+                throw new ArgumentNullException(SR.Format(SR.Panel_NoNullVisualParent, nameof(visualParent), this.GetType()));
             }
 
             _visualChildren = new VisualCollection(visualParent);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizationCacheLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizationCacheLength.cs
@@ -66,12 +66,12 @@ namespace System.Windows.Controls
         {
             if (double.IsNaN(cacheBeforeViewport))
             {
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, "cacheBeforeViewport"));
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, nameof(cacheBeforeViewport)));
             }
 
             if (double.IsNaN(cacheAfterViewport))
             {
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, "cacheAfterViewport"));
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, nameof(cacheAfterViewport)));
             }
 
             _cacheBeforeViewport = cacheBeforeViewport;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
@@ -210,7 +210,7 @@ namespace System.Windows.Data
 
             DependencyProperty dp = args.Property;
             if (dp == null)
-                throw new InvalidOperationException(SR.Format(SR.ArgumentPropertyMustNotBeNull, "Property", "args"));
+                throw new InvalidOperationException(SR.Format(SR.ArgumentPropertyMustNotBeNull, "Property", nameof(args)));
 
             // ignore irrelevant notifications.  This test must happen before any marshalling.
             bool relevant = !IgnoreSourcePropertyChange;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingListCollectionView.cs
@@ -1120,7 +1120,7 @@ namespace System.Windows.Data
         public bool? IsLiveSorting
         {
             get { return IsDataView ? (bool?)true : (bool?)null; }
-            set { throw new InvalidOperationException(SR.Format(SR.CannotChangeLiveShaping, nameof(IsLiveSorting), "CanChangeLiveSorting")); }
+            set { throw new InvalidOperationException(SR.Format(SR.CannotChangeLiveShaping, nameof(IsLiveSorting), nameof(CanChangeLiveSorting))); }
         }
 
         ///<summary>
@@ -1132,7 +1132,7 @@ namespace System.Windows.Data
         public bool? IsLiveFiltering
         {
             get { return IsDataView ? (bool?)true : (bool?)null; }
-            set { throw new InvalidOperationException(SR.Format(SR.CannotChangeLiveShaping, nameof(IsLiveFiltering), "CanChangeLiveFiltering")); }
+            set { throw new InvalidOperationException(SR.Format(SR.CannotChangeLiveShaping, nameof(IsLiveFiltering), nameof(CanChangeLiveFiltering))); }
         }
 
         ///<summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingListCollectionView.cs
@@ -427,7 +427,7 @@ namespace System.Windows.Data
                 VerifyRefreshNotDeferred();
 
                 if (value != _newItemPlaceholderPosition && IsAddingNew)
-                    throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringTransaction, "NewItemPlaceholderPosition", "AddNew"));
+                    throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringTransaction, nameof(NewItemPlaceholderPosition), "AddNew"));
 
                 if (value != _newItemPlaceholderPosition && _isRemoving)
                 {
@@ -1120,7 +1120,7 @@ namespace System.Windows.Data
         public bool? IsLiveSorting
         {
             get { return IsDataView ? (bool?)true : (bool?)null; }
-            set { throw new InvalidOperationException(SR.Format(SR.CannotChangeLiveShaping, "IsLiveSorting", "CanChangeLiveSorting")); }
+            set { throw new InvalidOperationException(SR.Format(SR.CannotChangeLiveShaping, nameof(IsLiveSorting), "CanChangeLiveSorting")); }
         }
 
         ///<summary>
@@ -1132,7 +1132,7 @@ namespace System.Windows.Data
         public bool? IsLiveFiltering
         {
             get { return IsDataView ? (bool?)true : (bool?)null; }
-            set { throw new InvalidOperationException(SR.Format(SR.CannotChangeLiveShaping, "IsLiveFiltering", "CanChangeLiveFiltering")); }
+            set { throw new InvalidOperationException(SR.Format(SR.CannotChangeLiveShaping, nameof(IsLiveFiltering), "CanChangeLiveFiltering")); }
         }
 
         ///<summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingListCollectionView.cs
@@ -304,7 +304,7 @@ namespace System.Windows.Data
                 if (!CanCustomFilter)
                     throw new NotSupportedException(SR.BindingListCannotCustomFilter);
                 if (IsAddingNew || IsEditingItem)
-                    throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringAddOrEdit, "CustomFilter"));
+                    throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringAddOrEdit, nameof(CustomFilter)));
                 if (AllowsCrossThreadChanges)
                     VerifyAccess();
 
@@ -367,7 +367,7 @@ namespace System.Windows.Data
                 if (!CanGroup)
                     throw new NotSupportedException();
                 if (IsAddingNew || IsEditingItem)
-                    throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringAddOrEdit, "GroupBySelector"));
+                    throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringAddOrEdit, nameof(GroupBySelector)));
 
                 _group.GroupBySelector = value;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
@@ -540,7 +540,7 @@ namespace System.Windows.Data
                 VerifyRefreshNotDeferred();
 
                 if (value != _newItemPlaceholderPosition && IsAddingNew)
-                    throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringTransaction, "NewItemPlaceholderPosition", "AddNew"));
+                    throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringTransaction, nameof(NewItemPlaceholderPosition), "AddNew"));
 
                 if (value != _newItemPlaceholderPosition && _isRemoving)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
@@ -435,7 +435,7 @@ namespace System.Windows.Data
                 if (AllowsCrossThreadChanges)
                     VerifyAccess();
                 if (IsAddingNew || IsEditingItem)
-                    throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringAddOrEdit, "Filter"));
+                    throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringAddOrEdit, nameof(Filter)));
 
                 base.Filter = value;
             }
@@ -459,7 +459,7 @@ namespace System.Windows.Data
                 if (AllowsCrossThreadChanges)
                     VerifyAccess();
                 if (IsAddingNew || IsEditingItem)
-                    throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringAddOrEdit, "CustomSort"));
+                    throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringAddOrEdit, nameof(CustomSort)));
                 _customSort = value;
 
                 SetSortDescriptions(null);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlNamespaceMapping.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlNamespaceMapping.cs
@@ -44,9 +44,9 @@ namespace System.Windows.Data
             set
             {
                 if (!_initializing)
-                    throw new InvalidOperationException(SR.Format(SR.PropertyIsInitializeOnly, "Prefix", this.GetType().Name));
+                    throw new InvalidOperationException(SR.Format(SR.PropertyIsInitializeOnly, nameof(Prefix), this.GetType().Name));
                 if (_prefix != null && _prefix != value)
-                    throw new InvalidOperationException(SR.Format(SR.PropertyIsImmutable, "Prefix", this.GetType().Name));
+                    throw new InvalidOperationException(SR.Format(SR.PropertyIsImmutable, nameof(Prefix), this.GetType().Name));
 
                 _prefix = value;
             }
@@ -63,9 +63,9 @@ namespace System.Windows.Data
             set
             {
                 if (!_initializing)
-                    throw new InvalidOperationException(SR.Format(SR.PropertyIsInitializeOnly, "Uri", this.GetType().Name));
+                    throw new InvalidOperationException(SR.Format(SR.PropertyIsInitializeOnly, nameof(Uri), this.GetType().Name));
                 if (_uri != null && _uri != value)
-                    throw new InvalidOperationException(SR.Format(SR.PropertyIsImmutable, "Uri", this.GetType().Name));
+                    throw new InvalidOperationException(SR.Format(SR.PropertyIsImmutable, nameof(Uri), this.GetType().Name));
 
                 _uri = value;
             }
@@ -135,11 +135,11 @@ namespace System.Windows.Data
         {
             if (_prefix == null)
             {
-                throw new InvalidOperationException(SR.Format(SR.PropertyMustHaveValue, "Prefix", this.GetType().Name));
+                throw new InvalidOperationException(SR.Format(SR.PropertyMustHaveValue, nameof(Prefix), this.GetType().Name));
             }
             if (_uri == null)
             {
-                throw new InvalidOperationException(SR.Format(SR.PropertyMustHaveValue, "Uri", this.GetType().Name));
+                throw new InvalidOperationException(SR.Format(SR.PropertyMustHaveValue, nameof(Uri), this.GetType().Name));
             }
 
             _initializing = false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextContainer.cs
@@ -344,13 +344,13 @@ namespace System.Windows.Documents
 
             if (position.TextContainer != this)
             {
-                throw new ArgumentException(SR.Format(SR.NotInAssociatedContainer, "position"));
+                throw new ArgumentException(SR.Format(SR.NotInAssociatedContainer, nameof(position)));
             }
 
             DocumentSequenceTextPointer tp = position as DocumentSequenceTextPointer;
             if (tp == null)
             {
-                throw new ArgumentException(SR.Format(SR.BadFixedTextPosition, "position"));
+                throw new ArgumentException(SR.Format(SR.BadFixedTextPosition, nameof(position)));
             }
 
             return tp;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextPointer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextPointer.cs
@@ -656,7 +656,7 @@ namespace System.Windows.Documents
             ArgumentNullException.ThrowIfNull(textBuffer);
             if (startIndex < 0)
             {
-                throw new ArgumentException(SR.Format(SR.NegativeValue, "startIndex"));
+                throw new ArgumentException(SR.Format(SR.NegativeValue, nameof(startIndex)));
             }
             if (startIndex > textBuffer.Length)
             {
@@ -664,7 +664,7 @@ namespace System.Windows.Documents
             }
             if (count < 0)
             {
-                throw new ArgumentException(SR.Format(SR.NegativeValue, "count"));
+                throw new ArgumentException(SR.Format(SR.NegativeValue, nameof(count)));
             }
             if (count > textBuffer.Length - startIndex)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextContainer.cs
@@ -311,14 +311,14 @@ namespace System.Windows.Documents
 
             if (position.TextContainer != this)
             {
-                throw new ArgumentException(SR.Format(SR.NotInAssociatedContainer, "position"));
+                throw new ArgumentException(SR.Format(SR.NotInAssociatedContainer, nameof(position)));
             }
 
             FixedTextPointer ftp = position as FixedTextPointer;
 
             if (ftp == null)
             {
-                throw new ArgumentException(SR.Format(SR.BadFixedTextPosition, "position"));
+                throw new ArgumentException(SR.Format(SR.BadFixedTextPosition, nameof(position)));
             }
 
             return ftp;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextPointer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextPointer.cs
@@ -126,7 +126,7 @@ namespace System.Windows.Documents
             ArgumentNullException.ThrowIfNull(textBuffer);
             if (count < 0)
             {
-                throw new ArgumentException(SR.Format(SR.NegativeValue, "count"));
+                throw new ArgumentException(SR.Format(SR.NegativeValue, nameof(count)));
             }
 
             if (_flowPosition.GetPointerContext(direction) != TextPointerContext.Text)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Span.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Span.cs
@@ -90,11 +90,11 @@ namespace System.Windows.Documents
             ArgumentNullException.ThrowIfNull(end);
             if (start.TextContainer != end.TextContainer)
             {
-                throw new ArgumentException(SR.Format(SR.InDifferentTextContainers, "start", "end"));
+                throw new ArgumentException(SR.Format(SR.InDifferentTextContainers, nameof(start), "end"));
             }
             if (start.CompareTo(end) > 0)
             {
-                throw new ArgumentException(SR.Format(SR.BadTextPositionOrder, "start", "end"));
+                throw new ArgumentException(SR.Format(SR.BadTextPositionOrder, nameof(start), "end"));
             }
 
             start.TextContainer.BeginChange();
@@ -107,7 +107,7 @@ namespace System.Windows.Documents
 
                 if (start.Paragraph != end.Paragraph)
                 {
-                    throw new ArgumentException(SR.Format(SR.InDifferentParagraphs, "start", "end"));
+                    throw new ArgumentException(SR.Format(SR.InDifferentParagraphs, nameof(start), "end"));
                 }
 
                 // If start or end positions have a Hyperlink ancestor, we cannot split them.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Span.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Span.cs
@@ -90,11 +90,11 @@ namespace System.Windows.Documents
             ArgumentNullException.ThrowIfNull(end);
             if (start.TextContainer != end.TextContainer)
             {
-                throw new ArgumentException(SR.Format(SR.InDifferentTextContainers, nameof(start), "end"));
+                throw new ArgumentException(SR.Format(SR.InDifferentTextContainers, nameof(start), nameof(end)));
             }
             if (start.CompareTo(end) > 0)
             {
-                throw new ArgumentException(SR.Format(SR.BadTextPositionOrder, nameof(start), "end"));
+                throw new ArgumentException(SR.Format(SR.BadTextPositionOrder, nameof(start), nameof(end)));
             }
 
             start.TextContainer.BeginChange();
@@ -107,7 +107,7 @@ namespace System.Windows.Documents
 
                 if (start.Paragraph != end.Paragraph)
                 {
-                    throw new ArgumentException(SR.Format(SR.InDifferentParagraphs, nameof(start), "end"));
+                    throw new ArgumentException(SR.Format(SR.InDifferentParagraphs, nameof(start), nameof(end)));
                 }
 
                 // If start or end positions have a Hyperlink ancestor, we cannot split them.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextContainer.cs
@@ -3225,7 +3225,7 @@ namespace System.Windows.Documents
 
             if (position.TextContainer != this)
             {
-                throw new InvalidOperationException(SR.Format(SR.NotInThisTree, "position"));
+                throw new InvalidOperationException(SR.Format(SR.NotInThisTree, nameof(position)));
             }
 
             position.SyncToTreeGeneration();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElement.cs
@@ -121,7 +121,7 @@ namespace System.Windows.Documents
 
                 if (startNode != endNode)
                 {
-                    throw new ArgumentException(SR.Format(SR.InDifferentScope, nameof(start), "end"));
+                    throw new ArgumentException(SR.Format(SR.InDifferentScope, nameof(start), nameof(end)));
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElement.cs
@@ -121,7 +121,7 @@ namespace System.Windows.Documents
 
                 if (startNode != endNode)
                 {
-                    throw new ArgumentException(SR.Format(SR.InDifferentScope, "start", "end"));
+                    throw new ArgumentException(SR.Format(SR.InDifferentScope, nameof(start), "end"));
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElementCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElementCollection.cs
@@ -333,7 +333,7 @@ namespace System.Windows.Documents
                     {
                         // REVIEW: It would be better design if we reviewed all elements in the range before starting an insert.
                         // Otherwise, we might insert half the elements and then throw.
-                        throw new ArgumentException(SR.Format(SR.TextElementCollection_ItemHasUnexpectedType, "range", typeof(TextElementType).Name, typeof(TextElementType).Name), "value");
+                        throw new ArgumentException(SR.Format(SR.TextElementCollection_ItemHasUnexpectedType, nameof(range), typeof(TextElementType).Name, typeof(TextElementType).Name), "value");
                     }
 
                     Add(element);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextPointer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextPointer.cs
@@ -1750,7 +1750,7 @@ namespace System.Windows.Documents
             ArgumentNullException.ThrowIfNull(textBuffer);
             if (startIndex < 0)
             {
-                throw new ArgumentException(SR.Format(SR.NegativeValue, "startIndex"));
+                throw new ArgumentException(SR.Format(SR.NegativeValue, nameof(startIndex)));
             }
             if (startIndex > textBuffer.Length)
             {
@@ -1758,7 +1758,7 @@ namespace System.Windows.Documents
             }
             if (count < 0)
             {
-                throw new ArgumentException(SR.Format(SR.NegativeValue, "count"));
+                throw new ArgumentException(SR.Format(SR.NegativeValue, nameof(count)));
             }
             if (count > textBuffer.Length - startIndex)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextPointer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextPointer.cs
@@ -1420,7 +1420,7 @@ namespace System.Windows.Documents
                 Type containerType = this.TextContainer.Parent.GetType();
                 if (!TextSchema.IsValidChildOfContainer(containerType, typeof(Paragraph)))
                 {
-                    throw new InvalidOperationException(SR.Format(SR.TextSchema_IllegalElement, "Paragraph", containerType));
+                    throw new InvalidOperationException(SR.Format(SR.TextSchema_IllegalElement, nameof(Paragraph), containerType));
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ValidationHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ValidationHelper.cs
@@ -57,11 +57,11 @@ namespace System.Windows.Documents
             ArgumentNullException.ThrowIfNull(endPosition);
             if (startPosition.TextContainer != endPosition.TextContainer)
             {
-                throw new ArgumentException(SR.Format(SR.InDifferentTextContainers, "startPosition", "endPosition"));
+                throw new ArgumentException(SR.Format(SR.InDifferentTextContainers, nameof(startPosition), "endPosition"));
             }
             if (startPosition.CompareTo(endPosition) > 0)
             {
-                throw new ArgumentException(SR.Format(SR.BadTextPositionOrder, "startPosition", "endPosition"));
+                throw new ArgumentException(SR.Format(SR.BadTextPositionOrder, nameof(startPosition), "endPosition"));
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ValidationHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ValidationHelper.cs
@@ -57,11 +57,11 @@ namespace System.Windows.Documents
             ArgumentNullException.ThrowIfNull(endPosition);
             if (startPosition.TextContainer != endPosition.TextContainer)
             {
-                throw new ArgumentException(SR.Format(SR.InDifferentTextContainers, nameof(startPosition), "endPosition"));
+                throw new ArgumentException(SR.Format(SR.InDifferentTextContainers, nameof(startPosition), nameof(endPosition)));
             }
             if (startPosition.CompareTo(endPosition) > 0)
             {
-                throw new ArgumentException(SR.Format(SR.BadTextPositionOrder, nameof(startPosition), "endPosition"));
+                throw new ArgumentException(SR.Format(SR.BadTextPositionOrder, nameof(startPosition), nameof(endPosition)));
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DynamicResourceExtensionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DynamicResourceExtensionConverter.cs
@@ -45,7 +45,7 @@ namespace System.Windows
                 DynamicResourceExtension dynamicResource = value as DynamicResourceExtension;
 
                 if (dynamicResource == null)
-                    throw new ArgumentException(SR.Format(SR.MustBeOfType, "value", "DynamicResourceExtension"), nameof(value)); 
+                    throw new ArgumentException(SR.Format(SR.MustBeOfType, nameof(value), "DynamicResourceExtension"), nameof(value)); 
 
                 return new InstanceDescriptor(typeof(DynamicResourceExtension).GetConstructor(new Type[] { typeof(object) }), 
                     new object[] { dynamicResource.ResourceKey } );

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
@@ -101,15 +101,15 @@ namespace System.Windows
 
             if (double.IsNaN(value))
             {
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, "value"));
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, nameof(value)));
             }
             if (double.IsInfinity(value))
             {
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoInfinity, "value"));
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoInfinity, nameof(value)));
             }
             if (value < 0.0)
             {
-                throw new ArgumentOutOfRangeException(SR.Format(SR.InvalidCtorParameterNoNegative, "value"));
+                throw new ArgumentOutOfRangeException(SR.Format(SR.InvalidCtorParameterNoNegative, nameof(value)));
             }
             if (    type != FigureUnitType.Auto
                 &&  type != FigureUnitType.Pixel
@@ -117,7 +117,7 @@ namespace System.Windows
                 &&  type != FigureUnitType.Content
                 &&  type != FigureUnitType.Page   )
             {
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterUnknownFigureUnitType, "type"));
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterUnknownFigureUnitType, nameof(type)));
             }
             if (type is FigureUnitType.Content or FigureUnitType.Page)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkCompatibilityPreferences.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkCompatibilityPreferences.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -79,7 +79,7 @@ namespace System.Windows
                 {
                     if (_isSealed)
                     {
-                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, "AreInactiveSelectionHighlightBrushKeysSupported", "FrameworkCompatibilityPreferences"));
+                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, nameof(AreInactiveSelectionHighlightBrushKeysSupported), "FrameworkCompatibilityPreferences"));
                     }
 
                     _areInactiveSelectionHighlightBrushKeysSupported = value;
@@ -192,7 +192,7 @@ namespace System.Windows
                 {
                     if (_isSealed)
                     {
-                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, "UseSetWindowPosForTopmostWindows", "FrameworkCompatibilityPreferences"));
+                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, nameof(UseSetWindowPosForTopmostWindows), "FrameworkCompatibilityPreferences"));
                     }
 
                     _useSetWindowPosForTopmostWindows = value;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkTemplate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkTemplate.cs
@@ -238,7 +238,7 @@ namespace System.Windows
 
                 if ( IsSealed )
                 {
-                    throw new InvalidOperationException(SR.Format(SR.CannotChangeAfterSealed, "Template"));
+                    throw new InvalidOperationException(SR.Format(SR.CannotChangeAfterSealed, nameof(Template)));
                 }
 
                 _resources = value;
@@ -427,7 +427,7 @@ namespace System.Windows
         {
             if (_sealed)
             {
-                throw new InvalidOperationException(SR.Format(SR.CannotChangeAfterSealed, "Template"));
+                throw new InvalidOperationException(SR.Format(SR.CannotChangeAfterSealed, nameof(Template)));
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/GridLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/GridLength.cs
@@ -90,17 +90,17 @@ namespace System.Windows
         {
             if (double.IsNaN(value))
             {
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, "value"));
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoNaN, nameof(value)));
             }
             if (double.IsInfinity(value))
             {
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoInfinity, "value"));
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterNoInfinity, nameof(value)));
             }
             if (    type != GridUnitType.Auto
                 &&  type != GridUnitType.Pixel
                 &&  type != GridUnitType.Star   )
             {
-                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterUnknownGridUnitType, "type"));
+                throw new ArgumentException(SR.Format(SR.InvalidCtorParameterUnknownGridUnitType, nameof(type)));
             }
 
             _unitValue = (type == GridUnitType.Auto) ? 0.0 : value;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Localizer/BamlLocalizationDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Localizer/BamlLocalizationDictionary.cs
@@ -298,12 +298,12 @@ namespace System.Windows.Markup.Localizer
 
             if (arrayIndex >= array.Length)
             {
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, "arrayIndex", "array"), nameof(arrayIndex));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(arrayIndex), "array"), nameof(arrayIndex));
             }
 
             if (Count > (array.Length - arrayIndex))
             {
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, "arrayIndex", "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, nameof(arrayIndex), "array"));
             }
 
             foreach (KeyValuePair<BamlLocalizableResourceKey, BamlLocalizableResource> pair in _dictionary)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Localizer/BamlLocalizationDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Localizer/BamlLocalizationDictionary.cs
@@ -298,12 +298,12 @@ namespace System.Windows.Markup.Localizer
 
             if (arrayIndex >= array.Length)
             {
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(arrayIndex), "array"), nameof(arrayIndex));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, nameof(arrayIndex), nameof(array)), nameof(arrayIndex));
             }
 
             if (Count > (array.Length - arrayIndex))
             {
-                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, nameof(arrayIndex), "array"));
+                throw new ArgumentException(SR.Format(SR.Collection_CopyTo_NumberOfElementsExceedsArrayLength, nameof(arrayIndex), nameof(array)));
             }
 
             foreach (KeyValuePair<BamlLocalizableResourceKey, BamlLocalizableResource> pair in _dictionary)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/BeginStoryboard.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/BeginStoryboard.cs
@@ -103,7 +103,7 @@ public sealed class BeginStoryboard : TriggerAction
             if(value != null && !System.Windows.Markup.NameValidationHelper.IsValidIdentifierName(value))
             {
                 // Duplicate the error string thrown from DependencyObject.SetValueValidateParams
-                throw new ArgumentException(SR.Format(SR.InvalidPropertyValue, value, "Name"));
+                throw new ArgumentException(SR.Format(SR.InvalidPropertyValue, value, nameof(Name)));
             }
             
             // Null is OK - it's to remove whatever name was previously set.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceExpressionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceExpressionConverter.cs
@@ -114,7 +114,7 @@ namespace System.Windows.Markup
             ResourceReferenceExpression expr = value as ResourceReferenceExpression;
             if (expr == null)
             {
-                throw new ArgumentException(SR.Format(SR.MustBeOfType, "value", "ResourceReferenceExpression"));
+                throw new ArgumentException(SR.Format(SR.MustBeOfType, nameof(value), "ResourceReferenceExpression"));
             }
             ArgumentNullException.ThrowIfNull(destinationType);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
@@ -494,7 +494,7 @@ namespace System.Windows
             //  can't be checked until Style is sealed.
             if (_targetType == null)
             {
-                throw new InvalidOperationException(SR.Format(SR.NullPropertyIllegal, "TargetType"));
+                throw new InvalidOperationException(SR.Format(SR.NullPropertyIllegal, nameof(TargetType)));
             }
 
             if (_basedOn != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemKeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemKeyConverter.cs
@@ -130,7 +130,7 @@ namespace System.Windows.Markup
                 }
                 else
                 {
-                    throw new ArgumentException(SR.Format(SR.MustBeOfType, "value", "SystemResourceKey or SystemThemeKey")); 
+                    throw new ArgumentException(SR.Format(SR.MustBeOfType, nameof(value), "SystemResourceKey or SystemThemeKey")); 
                 }
 
                 // System resource keys can be converted into a MarkupExtension (StaticExtension)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateBindingExpressionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateBindingExpressionConverter.cs
@@ -43,7 +43,7 @@ namespace System.Windows
             {
                 TemplateBindingExpression templateBindingExpression = value as TemplateBindingExpression;
                 if (templateBindingExpression == null)
-                    throw new ArgumentException(SR.Format(SR.MustBeOfType, "value", "TemplateBindingExpression"));
+                    throw new ArgumentException(SR.Format(SR.MustBeOfType, nameof(value), "TemplateBindingExpression"));
                 return templateBindingExpression.TemplateBindingExtension;
             }
             return base.ConvertTo(context, culture, value, destinationType);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateBindingExtensionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateBindingExtensionConverter.cs
@@ -49,7 +49,7 @@ namespace System.Windows
                 TemplateBindingExtension templateBinding = value as TemplateBindingExtension;
 
                 if(templateBinding == null)
-                    throw new ArgumentException(SR.Format(SR.MustBeOfType, "value", "TemplateBindingExtension"), nameof(value));
+                    throw new ArgumentException(SR.Format(SR.MustBeOfType, nameof(value), "TemplateBindingExtension"), nameof(value));
 
                 return new InstanceDescriptor(typeof(TemplateBindingExtension).GetConstructor(new Type[] { typeof(DependencyProperty) }),
                     new object[] { templateBinding.Property });

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateKey.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateKey.cs
@@ -48,7 +48,7 @@ namespace System.Windows
         {
             if (_dataType == null)
             {
-                throw new InvalidOperationException(SR.Format(SR.PropertyMustHaveValue, "DataType", this.GetType().Name));
+                throw new InvalidOperationException(SR.Format(SR.PropertyMustHaveValue, nameof(DataType), this.GetType().Name));
             }
 
             _initializing = false;
@@ -67,9 +67,9 @@ namespace System.Windows
             set
             {
                 if (!_initializing)
-                    throw new InvalidOperationException(SR.Format(SR.PropertyIsInitializeOnly, "DataType", this.GetType().Name));
+                    throw new InvalidOperationException(SR.Format(SR.PropertyIsInitializeOnly, nameof(DataType), this.GetType().Name));
                 if (_dataType != null && value != _dataType)
-                    throw new InvalidOperationException(SR.Format(SR.PropertyIsImmutable, "DataType", this.GetType().Name));
+                    throw new InvalidOperationException(SR.Format(SR.PropertyIsImmutable, nameof(DataType), this.GetType().Name));
 
                 Exception ex = ValidateDataType(value, "value");
                 if (ex != null)

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/FontTypeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/FontTypeConverter.cs
@@ -155,7 +155,7 @@ namespace System.Windows.Xps.Serialization
             GlyphRun fontGlyphRun = (GlyphRun)value;
             if (fontGlyphRun == null)
             {
-                throw new ArgumentException(SR.Format(SR.MustBeOfType, "value", "GlyphRun"));
+                throw new ArgumentException(SR.Format(SR.MustBeOfType, nameof(value), "GlyphRun"));
             }
 
             //

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ImageSourceTypeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ImageSourceTypeConverter.cs
@@ -160,7 +160,7 @@ namespace System.Windows.Xps.Serialization
             BitmapSource bitmapSource = (BitmapSource)value;
             if (bitmapSource == null)
             {
-                throw new ArgumentException(SR.Format(SR.MustBeOfType, "value", "BitmapSource"));
+                throw new ArgumentException(SR.Format(SR.MustBeOfType, nameof(value), "BitmapSource"));
             }
 
             //

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachVisualSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachVisualSerializer.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Xps.Serialization
 
             if (v == null)
             {
-                throw new ArgumentException(SR.Format(SR.MustBeOfType, "serializedObject", typeof(Visual)));
+                throw new ArgumentException(SR.Format(SR.MustBeOfType, nameof(serializedObject), typeof(Visual)));
             }
 
             //  The new class XpsOMSerializationManager now also interacts with this class
@@ -177,7 +177,7 @@ namespace System.Windows.Xps.Serialization
 
             if (v == null)
             {
-                throw new ArgumentException(SR.Format(SR.MustBeOfType, "serializedObject", typeof(Visual)));
+                throw new ArgumentException(SR.Format(SR.MustBeOfType, nameof(serializedObject), typeof(Visual)));
             }
 
             //  The new class XpsOMSerializationManager now also interacts with this class

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachVisualSerializerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachVisualSerializerAsync.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -74,7 +74,7 @@ namespace System.Windows.Xps.Serialization
 
             if (v == null)
             {
-                throw new ArgumentException(SR.Format(SR.MustBeOfType, "serializedObject", typeof(Visual)));
+                throw new ArgumentException(SR.Format(SR.MustBeOfType, nameof(serializedObject), typeof(Visual)));
             }
 
             IXpsSerializationManagerAsync manager = (IXpsSerializationManagerAsync)SerializationManager;
@@ -227,7 +227,7 @@ namespace System.Windows.Xps.Serialization
 
             if (v == null)
             {
-                throw new ArgumentException(SR.Format(SR.MustBeOfType, "serializedObject", typeof(Visual)));
+                throw new ArgumentException(SR.Format(SR.MustBeOfType, nameof(serializedObject), typeof(Visual)));
             }
 
             IXpsSerializationManagerAsync manager = (IXpsSerializationManagerAsync)SerializationManager;

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControlLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControlLength.cs
@@ -48,12 +48,12 @@ namespace Microsoft.Windows.Controls.Ribbon
         {
             if (double.IsNaN(value))
             {
-                throw new ArgumentException(Microsoft.Windows.Controls.SR.Format(Microsoft.Windows.Controls.SR.InvalidCtorParameterNoNaN, "value"));
+                throw new ArgumentException(Microsoft.Windows.Controls.SR.Format(Microsoft.Windows.Controls.SR.InvalidCtorParameterNoNaN, nameof(value)));
             }
 
             if (type == RibbonControlLengthUnitType.Star && double.IsInfinity(value))
             {
-                throw new ArgumentException(Microsoft.Windows.Controls.SR.Format(Microsoft.Windows.Controls.SR.InvalidCtorParameterNoInfinityForStarSize, "value"));
+                throw new ArgumentException(Microsoft.Windows.Controls.SR.Format(Microsoft.Windows.Controls.SR.InvalidCtorParameterNoInfinityForStarSize, nameof(value)));
             }
 
             if (type != RibbonControlLengthUnitType.Auto
@@ -61,7 +61,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                 && type != RibbonControlLengthUnitType.Item
                 && type != RibbonControlLengthUnitType.Star)
             {
-                throw new ArgumentException(Microsoft.Windows.Controls.SR.Format(Microsoft.Windows.Controls.SR.InvalidCtorParameterUnknownRibbonControlLengthUnitType, "type"));
+                throw new ArgumentException(Microsoft.Windows.Controls.SR.Format(Microsoft.Windows.Controls.SR.InvalidCtorParameterUnknownRibbonControlLengthUnitType, nameof(type)));
             }
 
             _unitValue = (type == RibbonControlLengthUnitType.Auto) ? 0.0 : value;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ServiceProviderContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ServiceProviderContext.cs
@@ -137,7 +137,7 @@ namespace MS.Internal.Xaml
                 if (property is null)
                 {
                     // we don't allow any property to be null
-                    throw new ArgumentException(SR.Format(SR.ValueInArrayIsNull, "properties"));
+                    throw new ArgumentException(SR.Format(SR.ValueInArrayIsNull, nameof(properties)));
                 }
             }
 
@@ -153,7 +153,7 @@ namespace MS.Internal.Xaml
                 if (type is null)
                 {
                     // we don't allow any type to be null
-                    throw new ArgumentException(SR.Format(SR.ValueInArrayIsNull, "types"));
+                    throw new ArgumentException(SR.Format(SR.ValueInArrayIsNull, nameof(types)));
                 }
             }
 
@@ -171,7 +171,7 @@ namespace MS.Internal.Xaml
                 if (property is null)
                 {
                     // we don't allow any property to be null
-                    throw new ArgumentException(SR.Format(SR.ValueInArrayIsNull, "properties"));
+                    throw new ArgumentException(SR.Format(SR.ValueInArrayIsNull, nameof(properties)));
                 }
             }
 
@@ -187,7 +187,7 @@ namespace MS.Internal.Xaml
                 if (type is null)
                 {
                     // we don't allow any type to be null
-                    throw new ArgumentException(SR.Format(SR.ValueInArrayIsNull, "types"));
+                    throw new ArgumentException(SR.Format(SR.ValueInArrayIsNull, nameof(types)));
                 }
             }
 
@@ -207,7 +207,7 @@ namespace MS.Internal.Xaml
                 if (property is null)
                 {
                     // we don't allow any property to be null
-                    throw new ArgumentException(SR.Format(SR.ValueInArrayIsNull, "properties"));
+                    throw new ArgumentException(SR.Format(SR.ValueInArrayIsNull, nameof(properties)));
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -317,7 +317,7 @@ namespace System.Xaml
                 {
                     if (typeArg is null)
                     {
-                        throw new ArgumentException(SR.Format(SR.CollectionCannotContainNulls, "typeArguments"));
+                        throw new ArgumentException(SR.Format(SR.CollectionCannotContainNulls, nameof(typeArguments)));
                     }
 
                     if (typeArg.UnderlyingType is null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
@@ -1585,7 +1585,7 @@ namespace System.Xaml
             {
                 if (typeArg is null)
                 {
-                    throw new ArgumentException(SR.Format(SR.CollectionCannotContainNulls, "typeArguments"));
+                    throw new ArgumentException(SR.Format(SR.CollectionCannotContainNulls, nameof(typeArguments)));
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/NativeCompoundFileAPIs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/NativeCompoundFileAPIs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -608,7 +608,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
                 if (cb < 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "cb", cb.ToString(CultureInfo.InvariantCulture)));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(cb), cb.ToString(CultureInfo.InvariantCulture)));
                 }
 
                 _unsafeStream.Read(pv, cb, out pcbRead);
@@ -619,7 +619,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
                 if (cb < 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "cb", cb.ToString(CultureInfo.InvariantCulture)));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(cb), cb.ToString(CultureInfo.InvariantCulture)));
                 }
 
                 _unsafeStream.Write(pv, cb, out pcbWritten);
@@ -632,12 +632,12 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
                 if (dwOrigin < 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "dwOrigin", dwOrigin.ToString(CultureInfo.InvariantCulture)));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(dwOrigin), dwOrigin.ToString(CultureInfo.InvariantCulture)));
                 }
 
                 if (dlibMove < 0 && dwOrigin == SafeNativeCompoundFileConstants.STREAM_SEEK_SET)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "dlibMove", dlibMove.ToString(CultureInfo.InvariantCulture)));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(dlibMove), dlibMove.ToString(CultureInfo.InvariantCulture)));
                 }
 
                 _unsafeStream.Seek(dlibMove, dwOrigin, out plibNewPosition);
@@ -648,7 +648,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
                 if (libNewSize < 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "libNewSize", libNewSize.ToString(CultureInfo.InvariantCulture)));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(libNewSize), libNewSize.ToString(CultureInfo.InvariantCulture)));
                 }
 
                 _unsafeStream.SetSize(libNewSize);
@@ -661,7 +661,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
                 if (cb < 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "cb", cb.ToString(CultureInfo.InvariantCulture)));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(cb), cb.ToString(CultureInfo.InvariantCulture)));
                 }
 
                 _unsafeStream.CopyTo(((SafeIStreamImplementation) pstm)._unsafeStream, cb, out pcbRead, out pcbWritten);
@@ -684,11 +684,11 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
                 if (libOffset < 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "libOffset", libOffset.ToString(CultureInfo.InvariantCulture)));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(libOffset), libOffset.ToString(CultureInfo.InvariantCulture)));
                 }
                 if (cb < 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "cb", cb.ToString(CultureInfo.InvariantCulture)));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(cb), cb.ToString(CultureInfo.InvariantCulture)));
                 }
 
                 _unsafeStream.LockRegion(libOffset, cb, dwLockType);
@@ -699,11 +699,11 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
                 if (libOffset < 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "libOffset", libOffset.ToString(CultureInfo.InvariantCulture)));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(libOffset), libOffset.ToString(CultureInfo.InvariantCulture)));
                 }
                 if (cb < 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "cb", cb.ToString(CultureInfo.InvariantCulture)));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(cb), cb.ToString(CultureInfo.InvariantCulture)));
                 }
 
                 _unsafeStream.UnlockRegion(libOffset, cb, dwLockType);
@@ -1142,7 +1142,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
                 if (celt != 1)
                 {
-                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "celt", celt.ToString(CultureInfo.InvariantCulture)));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(celt), celt.ToString(CultureInfo.InvariantCulture)));
                 }
                 
                 _unsafeEnumSTATSTG.Next(

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/PrivateUnsafeNativeCompoundFileMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/PrivateUnsafeNativeCompoundFileMethods.cs
@@ -176,7 +176,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
                                      SafeNativeCompoundFileConstants.STATFLAG_NOOPEN  )) != 0)
                 {
                     // validate grfStatFlag's value
-                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, "grfStatFlag", grfStatFlag.ToString(CultureInfo.InvariantCulture)));
+                    throw new ArgumentException(SR.Format(SR.InvalidArgumentValue, nameof(grfStatFlag), grfStatFlag.ToString(CultureInfo.InvariantCulture)));
                 }
 
                 System.Runtime.InteropServices.ComTypes.STATSTG returnValue = new System.Runtime.InteropServices.ComTypes.STATSTG

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/BaseCompatibilityPreferences.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/BaseCompatibilityPreferences.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -82,7 +82,7 @@ namespace System.Windows
                 {
                     if (_isSealed)
                     {
-                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, "ReuseDispatcherSynchronizationContextInstance", "BaseCompatibilityPreferences"));
+                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, nameof(ReuseDispatcherSynchronizationContextInstance), "BaseCompatibilityPreferences"));
                     }
 
                     _reuseDispatcherSynchronizationContextInstance = value;
@@ -133,7 +133,7 @@ namespace System.Windows
                 {
                     if (_isSealed)
                     {
-                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, "FlowDispatcherSynchronizationContextPriority", "BaseCompatibilityPreferences"));
+                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, nameof(FlowDispatcherSynchronizationContextPriority), "BaseCompatibilityPreferences"));
                     }
 
                     _flowDispatcherSynchronizationContextPriority = value;
@@ -183,7 +183,7 @@ namespace System.Windows
                 {
                     if (_isSealed)
                     {
-                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, "InlineDispatcherSynchronizationContextSend", "BaseCompatibilityPreferences"));
+                        throw new InvalidOperationException(SR.Format(SR.CompatibilityPreferencesSealed, nameof(InlineDispatcherSynchronizationContextSend), "BaseCompatibilityPreferences"));
                     }
 
                     _inlineDispatcherSynchronizationContextSend = value;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DesignerSerializationOptionsAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DesignerSerializationOptionsAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -25,7 +25,7 @@ namespace System.Windows.Markup
             }
             else
             {
-                throw new InvalidEnumArgumentException(SR.Format(SR.Enum_Invalid, "DesignerSerializationOptions"));
+                throw new InvalidEnumArgumentException(SR.Format(SR.Enum_Invalid, nameof(DesignerSerializationOptions)));
             }
         }
 


### PR DESCRIPTION
## Description

This resolves `CA1507` occurences after forcefully triggering `UseNameofInPlaceOfStringAnalyzer` against the `SR.Format` methods. This replaces literals with `nameof` for parameters and properties, nothing else.

Unfortunately it is not possible to trigger the analyzer against explicit interface implementations (e.g. properties), so that will have to be done manually. Likewise, type name references are not resolved in this PR.

## Customer Impact

Increased code maintainability and resilience against refactorings.

## Regression

No.

## Testing

Local build.

## Risk

Low.
