### PR TITLE
Use ROS<char> for slicing in ClrNamespaceUriParser, reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReader.cs
@@ -349,9 +349,7 @@ namespace System.Xaml
             // First, substitute in the LocalAssembly if needed
             if (_mergedSettings.LocalAssembly is not null)
             {
-                string clrNs, assemblyName;
-                if (ClrNamespaceUriParser.TryParseUri(xmlNamespace, out clrNs, out assemblyName) &&
-                    string.IsNullOrEmpty(assemblyName))
+                if (ClrNamespaceUriParser.TryParseUri(xmlNamespace, out ReadOnlySpan<char> clrNs, out ReadOnlySpan<char> assemblyName) && assemblyName.IsEmpty)
                 {
                     assemblyName = _mergedSettings.LocalAssembly.FullName;
                     newXmlNamespace = ClrNamespaceUriParser.GetUri(clrNs, assemblyName);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -51,7 +51,7 @@ namespace System.Xaml.MS.Impl
     }
 
     /// <summary>
-    /// String compare and formating class.
+    /// String compare and formatting class.
     /// To control standards of Localization and generally keep FxCop under control.
     /// </summary>
     internal static class KS
@@ -62,27 +62,6 @@ namespace System.Xaml.MS.Impl
         public static bool Eq(string a, string b)
         {
             return string.Equals(a, b, StringComparison.Ordinal);
-        }
-
-        public static bool Eq(ReadOnlySpan<char> a, ReadOnlySpan<char> b)
-        {
-            return a.Equals(b, StringComparison.Ordinal);
-        }
-
-        /// <summary>
-        /// Standard String Index search operation.
-        /// </summary>
-        public static int IndexOf(string src, string chars)
-        {
-            return src.IndexOf(chars, StringComparison.Ordinal);
-        }
-
-        /// <summary>
-        /// Standard String Index search operation.
-        /// </summary>
-        public static int IndexOf(string src, char ch)
-        {
-            return src.IndexOf(ch, StringComparison.Ordinal);
         }
 
         public static bool EndsWith(string src, string target)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/XmlNsInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/XmlNsInfo.cs
@@ -225,7 +225,7 @@ namespace System.Xaml.MS.Impl
                 xmlNamespaceList.Add(nsDef.XmlNamespace);
             }
 
-            string assemblyName = _fullyQualifyAssemblyName ? assembly.FullName : ReflectionUtils.GetAssemblyPartialName(assembly).ToString();
+            ReadOnlySpan<char> assemblyName = _fullyQualifyAssemblyName ? assembly.FullName : ReflectionUtils.GetAssemblyPartialName(assembly);
             foreach (KeyValuePair<string, IList<string>> clrToXmlNs in result)
             {
                 // Sort namespaces in preference order

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
@@ -26,12 +26,12 @@ namespace System.Xaml.Schema
             SchemaContext = schemaContext;
         }
 
-        // This ctor is used for "clr-namespace" uri's where there is only one pair
-        public XamlNamespace(XamlSchemaContext schemaContext, string clrNs, string assemblyName)
+        // This ctor is used for "clr-namespace" URIs where there is only one pair
+        public XamlNamespace(XamlSchemaContext schemaContext, ReadOnlySpan<char> clrNs, ReadOnlySpan<char> assemblyName)
         {
             SchemaContext = schemaContext;
             _assemblyNamespaces = GetClrNamespacePair(clrNs, assemblyName);
-            // For now we just ignore failures, including swalloing assembly load exceptions.
+            // For now we just ignore failures, including swallowing assembly load exceptions.
             // Any types in this namespace will be treated as unknown. But it would be useful to
             // surface errors here through tracing or an event.
             if (_assemblyNamespaces is not null)
@@ -233,22 +233,16 @@ namespace System.Xaml.Schema
             return xamlTypeList.AsReadOnly();
         }
 
-        private List<AssemblyNamespacePair> GetClrNamespacePair(string clrNs, string assemblyName)
+        private List<AssemblyNamespacePair> GetClrNamespacePair(ReadOnlySpan<char> clrNs, ReadOnlySpan<char> assemblyName)
         {
-            Assembly asm = SchemaContext.OnAssemblyResolve(assemblyName);
-            if (asm is null)
-            {
-                return null;
-            }
+            Assembly assembly = SchemaContext.OnAssemblyResolve(assemblyName.ToString());
 
-            List<AssemblyNamespacePair> onePair = new List<AssemblyNamespacePair>();
-            onePair.Add(new AssemblyNamespacePair(asm, clrNs));
-            return onePair;
+            return assembly is null ? null : new List<AssemblyNamespacePair>(1) { new AssemblyNamespacePair(assembly, clrNs.ToString()) };
         }
 
         private Type SearchAssembliesForShortName(string shortName)
         {
-            foreach(AssemblyNamespacePair assemblyNamespacePair in _assemblyNamespaces)
+            foreach (AssemblyNamespacePair assemblyNamespacePair in _assemblyNamespaces)
             {
                 Assembly asm = assemblyNamespacePair.Assembly;
                 if (asm is null)


### PR DESCRIPTION
## Description

Builds on top of #9739 and allows a few more uses of `ReadOnlySpan<char>` where often we don't need to materialize the output to a `string` object, this time in the `ClrNamespaceUriParser`. Keeping it a small, easy to review step like #9940 that allows to save a few allocations on common paths without any substantial changes and can be built upon further.

Not really including a benchmark as its either 0 bytes allocated or the same amount when both strings need to be materialized.

## Customer Impact

Increased performance, decreased allocations.

## Regression

No.

## Testing

Local build, unit tests.

## Risk

Low.
