### PR TITLE
Fix InvalidCastException in Can/ConvertTo from MouseActionConverter

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseActionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseActionConverter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
 using System.Globalization;
@@ -8,12 +7,12 @@ using System.Globalization;
 namespace System.Windows.Input
 {
     /// <summary>
-    /// Converter class for converting between a <see langword="string"/> and <see cref="MouseAction"/>.
+    /// Converter class for converting between a <see cref="string"/> and <see cref="MouseAction"/>.
     /// </summary>
     public class MouseActionConverter : TypeConverter
     {
         ///<summary>
-        /// Used to check whether we can convert a <see langword="string"/> into a <see cref="MouseAction"/>.
+        /// Used to check whether we can convert a <see cref="string"/> into a <see cref="MouseAction"/>.
         ///</summary>
         ///<param name="context">ITypeDescriptorContext</param>
         ///<param name="sourceType">type to convert from</param>
@@ -25,11 +24,11 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// Used to check whether we can convert specified value to <see langword="string"/>.
+        /// Used to check whether we can convert specified value to <see cref="string"/>.
         /// </summary>
         /// <param name="context">ITypeDescriptorContext</param>
         /// <param name="destinationType">Type to convert to</param>
-        /// <returns><see langword="true"/> if conversion to <see langword="string"/> is possible, <see langword="false"/> otherwise.</returns>
+        /// <returns><see langword="true"/> if conversion to <see cref="string"/> is possible, <see langword="false"/> otherwise.</returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
             // We can convert to an InstanceDescriptor or to a string
@@ -37,20 +36,20 @@ namespace System.Windows.Input
                 return false;
 
             // When invoked by the serialization engine we can convert to string only for known type
-            if (context is null || context.Instance is null)
+            if (context?.Instance is not MouseAction mouseAction)
                 return false;
 
             // Make sure the value falls within defined set
-            return IsDefinedMouseAction((MouseAction)context.Instance);
+            return IsDefinedMouseAction(mouseAction);
         }
 
         /// <summary>
-        /// Converts <paramref name="source"/> of <see langword="string"/> type to its <see cref="MouseAction"/> represensation.
+        /// Converts <paramref name="source"/> of <see cref="string"/> type to its <see cref="MouseAction"/> representation.
         /// </summary>
         /// <param name="context">Parser Context</param>
         /// <param name="culture">Culture Info</param>
         /// <param name="source">MouseAction String</param>
-        /// <returns>A <see cref="MouseAction"/> representing the <see langword="string"/> specified by <paramref name="source"/>.</returns>
+        /// <returns>A <see cref="MouseAction"/> representing the <see cref="string"/> specified by <paramref name="source"/>.</returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object source)
         {
             if (source is not string mouseAction)
@@ -73,21 +72,20 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// Converts a <paramref name="value"/> of <see cref="MouseAction"/> to its <see langword="string"/> represensation.
+        /// Converts a <paramref name="value"/> of <see cref="MouseAction"/> to its <see cref="string"/> representation.
         /// </summary>
         /// <param name="context">Serialization Context</param>
         /// <param name="culture">Culture Info</param>
         /// <param name="value">MouseAction value </param>
         /// <param name="destinationType">Type to Convert</param>
-        /// <returns>A <see langword="string"/> representing the <see cref="MouseAction"/> specified by <paramref name="value"/>.</returns>
+        /// <returns>A <see cref="string"/> representing the <see cref="MouseAction"/> specified by <paramref name="value"/>.</returns>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
             ArgumentNullException.ThrowIfNull(destinationType);
 
-            if (value is null || destinationType != typeof(string))
+            if (value is not MouseAction mouseAction || destinationType != typeof(string))
                 throw GetConvertToException(value, destinationType);
 
-            MouseAction mouseAction = (MouseAction)value;
             return mouseAction switch
             {
                 MouseAction.None => string.Empty,

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Input/MouseActionConverter.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Input/MouseActionConverter.Tests.cs
@@ -23,7 +23,7 @@ public sealed class MouseActionConverterTests
     }
 
     [Theory]
-    [MemberData(nameof(CanConvertTo_Data))]
+    [MemberData(nameof(CanConvertTo_ReturnsExpected_Data))]
     public void CanConvertTo_ReturnsExpected(bool expected, bool passContext, object? value, Type? destinationType)
     {
         MouseActionConverter converter = new();
@@ -32,7 +32,7 @@ public sealed class MouseActionConverterTests
         Assert.Equal(expected, converter.CanConvertTo(passContext ? context : null, destinationType));
     }
 
-    public static IEnumerable<object?[]> CanConvertTo_Data
+    public static IEnumerable<object?[]> CanConvertTo_ReturnsExpected_Data
     {
         get
         {
@@ -46,6 +46,8 @@ public sealed class MouseActionConverterTests
             // Unsupported cases
             yield return new object[] { false, false, MouseAction.None, typeof(string) };
             yield return new object[] { false, false, MouseAction.MiddleDoubleClick, typeof(string) };
+            yield return new object[] { false, true, (int)MouseAction.MiddleDoubleClick, typeof(string) };
+            yield return new object[] { false, true, (short)MouseAction.LeftDoubleClick, typeof(string) };
             yield return new object?[] { false, true, null, typeof(MouseAction) };
             yield return new object?[] { false, true, null, typeof(string) };
             yield return new object?[] { false, false, MouseAction.MiddleDoubleClick, typeof(string) };
@@ -54,16 +56,6 @@ public sealed class MouseActionConverterTests
 
             yield return new object[] { false, true, MouseAction.MiddleDoubleClick + 1, typeof(string) };
         }
-    }
-
-    [Fact]
-    public void CanConvertTo_ThrowsInvalidCastException()
-    {
-        MouseActionConverter converter = new();
-        StandardContextImpl context = new() { Instance = 10 };
-
-        // TODO: CanConvert* methods should not throw but the implementation is faulty
-        Assert.Throws<InvalidCastException>(() => converter.CanConvertTo(context, typeof(string)));
     }
 
     [Theory]
@@ -156,6 +148,9 @@ public sealed class MouseActionConverterTests
     [Theory]
     // Unsupported value
     [InlineData(null, typeof(string))]
+    // Unsupported unboxing casts
+    [InlineData((int)MouseAction.RightClick, typeof(string))]
+    [InlineData((short)MouseAction.LeftDoubleClick, typeof(string))]
     // Unsupported destinationType
     [InlineData(MouseAction.None, typeof(int))]
     [InlineData(MouseAction.LeftClick, typeof(byte))]
@@ -167,20 +162,11 @@ public sealed class MouseActionConverterTests
     }
 
     [Fact]
-    public void ConvertTo_ThrowsInvalidCastException()
-    {
-        MouseActionConverter converter = new();
-
-        // TODO: This should not throw InvalidCastException but NotSupportedException
-        Assert.Throws<InvalidCastException>(() => converter.ConvertTo(null, null, (int)(MouseAction.MiddleDoubleClick), typeof(string)));
-    }
-
-    [Fact]
     public void ConvertTo_ThrowsInvalidEnumArgumentException()
     {
         MouseActionConverter converter = new();
 
-        Assert.Throws<InvalidEnumArgumentException>(() => converter.ConvertTo(null, null, (MouseAction)(MouseAction.MiddleDoubleClick + 1), typeof(string)));
+        Assert.Throws<InvalidEnumArgumentException>(() => converter.ConvertTo(null, null, MouseAction.MiddleDoubleClick + 1, typeof(string)));
     }
 
     public sealed class StandardContextImpl : ITypeDescriptorContext


### PR DESCRIPTION
Mirrors #10289 

## Description

Sending this in now when we merged and discussed #9891 as I've discovered this bug during development of #9676 but wanted to wait until I can fix the TODOs in the unit tests as well.

Fixes `InvalidCastException` thrown from `CanConvertTo` when unboxing cast is performed on value that was not `null` but was of a different type than `MouseAction` or the underlying storage (`byte`), e.g. an object or a different value type (`int`).
Can* methods should not (and converters do not intentionally) throw in them but this is simple a programmer's error, it is not documented behavior either, hence the fix for this.

https://learn.microsoft.com/en-us/dotnet/api/system.windows.input.mouseactionconverter.canconvertto?view=windowsdesktop-9.0

Fixes the same issue in `ConvertTo` by throwing the proper (NotSupported) exception.

https://learn.microsoft.com/en-us/dotnet/api/system.windows.input.mouseactionconverter.convertto?view=windowsdesktop-9.0

## Customer Impact

Less unexpected exceptions thrown.

## Regression

No.

## Testing

Local build, unit test.

## Risk

There might be a concern that a code was passing `byte` instead of `MouseAction` which is the underlying storage type, so it survives the unboxing hard cast that was being performed but not the type `is` check. We may therefore for back-compat include check for both `MouseAction` and `byte` but other converters (besides `Key` since it shares the bug) just check for their type, so in my honest opinion it would be best to unify the behaviour and mention in release notes.

**Not to mention, unlike `Key` where the backing storage is `int`, here its `byte`, even lesser chance for such occurence.**
