### PR TITLE
Fix conversion of FlowDocument to RTF where the source contains NavigateUri with non-ASCII characters

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
@@ -834,23 +834,7 @@ namespace System.Windows.Documents
             if (documentNode.Type == DocumentNodeType.dnHyperlink && !string.IsNullOrEmpty(documentNode.NavigateUri))
             {
                 _rtfBuilder.Append("{\\field{\\*\\fldinst { HYPERLINK \"");
-
-                // Unescape the escape sequences added in Xaml
-                documentNode.NavigateUri = BamlResourceContentUtil.UnescapeString(documentNode.NavigateUri);
-
-                // Add the additional backslash which rtf expected
-                for (int i = 0; i < documentNode.NavigateUri.Length; i++)
-                {
-                    if (documentNode.NavigateUri[i] == '\\')
-                    {
-                        _rtfBuilder.Append("\\\\");
-                    }
-                    else
-                    {
-                        _rtfBuilder.Append(documentNode.NavigateUri[i]);
-                    }
-                }
-
+                _rtfBuilder.Append(documentNode.NavigateUri);                
                 _rtfBuilder.Append("\" }}{\\fldrslt {");
             }
             else
@@ -3057,9 +3041,12 @@ namespace System.Windows.Documents
                                     case XamlAttribute.XANavigateUri:
                                         if (xamlTag == XamlTag.XTHyperlink && valueString.Length > 0)
                                         {
+                                            // Unescape the escape sequences added in Xaml
+                                            documentNode.NavigateUri = BamlResourceContentUtil.UnescapeString(valueString);
+                                            
                                             StringBuilder sb = new StringBuilder();
 
-                                            XamlParserHelper.AppendRTFText(sb, valueString, 0);
+                                            XamlParserHelper.AppendRTFText(sb, documentNode.NavigateUri, 0);
                                             documentNode.NavigateUri = sb.ToString();
                                         }
                                         break;


### PR DESCRIPTION
Fixes #7601.

## Description

Saving the content of a FlowDocument to Rich Text Format (RTF) leads to malformed RTF if the source XAML contains a NavigateUri with non-ASCII characters.  This PR addresses the issue by correcting the conversion sequence to remove any XAML escape sequences from the NavigateUri value first, thus obtaining plain text which can be correctly escaped for RTF.

## Customer Impact

Conversion between FlowDocument and RTF correctly handles Uri values containing non-ASCII characters without data corruption.

## Regression

No.

## Testing

None.

## Risk

Low.  Two existing steps in the conversion have been applied in the correct order.
