### PR TITLE
[ Draft ] Adding tests for Fluent theme

### DIFF
--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ControlTests/BaseControlTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ControlTests/BaseControlTests.cs
@@ -1,0 +1,230 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using PresentationFramework.Fluent.Tests.TestUtilities;
+using System.Windows.Controls;
+
+
+namespace PresentationFramework.Fluent.Tests.ControlTests;
+
+public class BaseControlTests : IDisposable
+{
+    public BaseControlTests()
+    {
+        TestWindow = SetupTestWindow();
+    }
+
+    public virtual List<FrameworkElement> GetStyleParts(Control element)
+    {
+        return new List<FrameworkElement>();
+    }
+
+    public virtual void VerifyControlProperties(FrameworkElement element, ResourceDictionary expectedProperties)
+    {
+        return;
+    }
+
+    #region Protected Methods
+
+    protected void AddControlToView(Window window, FrameworkElement fe)
+    {
+        ArgumentNullException.ThrowIfNull(window);
+
+        if (window.Content is not StackPanel panel)
+            throw new ArgumentException($"The window does not have StackPanel as it's root element.");
+        
+        panel.Children.Add(fe);
+    }
+
+    protected void RemoveControlFromView(Window window, FrameworkElement fe)
+    {
+        if (window is null)
+            return;
+
+        if (window.Content is not StackPanel panel)
+            return;
+
+        panel.Children?.Remove(fe);
+    }
+
+    protected void ClearView(Window window)
+    {
+        if (window is null)
+            return;
+
+        if (window.Content is not StackPanel panel)
+            return;
+
+        panel.Children?.Clear();
+    }
+
+    protected Window SetupTestWindow()
+    {
+        Window window = new Window() { Width = 800, Height = 600 };
+        
+        StackPanel sp = new StackPanel() { 
+            Name = "RootPanel",
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Orientation = Orientation.Vertical
+        };
+
+        window.Content = sp;
+
+        return window;
+    }
+
+    protected Window SetupTestWindow(ColorMode mode)
+    {
+        Window window = new Window() { Width = 800, Height = 600 };
+        StackPanel sp = new StackPanel() { Name = "RootPanel" };
+        SetColorMode(window, mode);
+        window.Content = sp;
+        TestWindows[mode] = window;
+        return window;
+    }
+
+    protected void ResetTestWindow(Window window)
+    {
+        if (window is null) return;
+        window.Content = null;
+        window.ThemeMode = ThemeMode.None;
+        window.Resources.Clear();
+        window.Resources.MergedDictionaries.Clear();
+        window.Close();
+    }
+
+    protected ResourceDictionary GetTestDataDictionary(ColorMode colorMode, string testDictionaryName, string baseDictionaryName = "Default")
+    {
+        TestDictionary colorDictionary = GetTestDictionary(TestDataResourceDictionary, $"{colorMode}") ??
+            throw new InvalidOperationException("colorDictionary is null");
+
+        ResourceDictionary rd = new ResourceDictionary();
+
+        TestDictionary? baseDictionary = GetTestDictionary(colorDictionary, baseDictionaryName);
+        TestDictionary? testDataDictionary = GetTestDictionary(colorDictionary, testDictionaryName);
+
+        if (baseDictionary is not null)
+        {
+            foreach (object key in baseDictionary.Keys)
+            {
+                rd.Add(key, baseDictionary[key]);
+            }
+        }
+
+        if (testDataDictionary is not null)
+        {
+            foreach (object key in testDataDictionary.Keys)
+            {
+                if (rd.Contains(key))
+                {
+                    rd[key] = testDataDictionary[key];
+                }
+                else
+                {
+                    rd.Add(key, testDataDictionary[key]);
+                }
+            }
+        }
+
+        return rd;
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private TestDictionary? GetTestDictionary(ResourceDictionary resourceDictionary, string dictionaryName)
+    {
+        if (string.IsNullOrEmpty(dictionaryName)) return null;
+
+        foreach (ResourceDictionary dictionary in resourceDictionary.MergedDictionaries)
+        {
+            if (dictionary is TestDictionary testDicitonary)
+            {
+                if (testDicitonary.Name == dictionaryName)
+                {
+                    return testDicitonary;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    protected void SetColorMode(Window window, ColorMode mode)
+    {
+        switch (mode)
+        {
+            case ColorMode.Light:
+                window.ThemeMode = ThemeMode.Light;
+                break;
+            case ColorMode.Dark:
+                window.ThemeMode = ThemeMode.Dark;
+                break;
+            case ColorMode.HC:
+                window.ThemeMode = ThemeMode.None;
+                var uri = new Uri(HighContrastThemeDictionaryUri, UriKind.RelativeOrAbsolute);
+                if (Application.LoadComponent(uri) is not ResourceDictionary rd)
+                {
+                    throw new ArgumentException("HighContrast ThemeDictionary did not load correctly.");
+                }
+                window.Resources.MergedDictionaries.Add(rd);
+                break;
+        }
+        window.ApplyTemplate();
+    }
+
+    public void Dispose()
+    {
+        foreach(ColorMode mode in Enum.GetValues(typeof(ColorMode)))
+        {
+            if (TestWindows.TryGetValue(mode, out var window))
+            {
+                ResetTestWindow(window);
+            }
+        }
+    }
+
+    #endregion
+
+    #region Test Data
+
+    public static IEnumerable<object[]> ColorModes_TestData => new List<object[]>
+    {
+        new object[] { ColorMode.Light },
+        new object[] { ColorMode.Dark },
+        new object[] { ColorMode.HC }
+    };
+
+    #endregion
+
+    #region Public Properties
+
+    public Dictionary<ColorMode, Window> TestWindows { get; private set; } = new Dictionary<ColorMode, Window>();
+    public Window TestWindow { get; set; }
+    
+    protected virtual string TestDataDictionaryPath => @"/PresentationFramework.Fluent.Tests;component/ControlTests/Data/";
+    
+    protected ResourceDictionary TestDataResourceDictionary
+    {
+        get
+        {
+            _testDataResourceDictionary ??= new ResourceDictionary
+                {
+                    Source = new Uri(TestDataDictionaryPath, uriKind: UriKind.RelativeOrAbsolute)
+                };
+
+            return _testDataResourceDictionary;
+        }
+    }
+
+    #endregion
+
+    #region Private Members
+
+    private ResourceDictionary? _testDataResourceDictionary;
+
+    private const string HighContrastThemeDictionaryUri = @"/PresentationFramework.Fluent;component/Themes/Fluent.HC.xaml";
+
+    #endregion
+}

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ControlTests/ButtonTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ControlTests/ButtonTests.cs
@@ -1,0 +1,158 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using PresentationFramework.Fluent.Tests.TestUtilities;
+using FluentAssertions.Execution;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace PresentationFramework.Fluent.Tests.ControlTests;
+
+public class ButtonTests : BaseControlTests
+{
+    public ButtonTests()
+    {
+        TestButton = SetupTestButton();
+    }
+
+    [WpfTheory]
+    [MemberData(nameof(ColorModes_TestData))]
+    public void Button_Initialization_Test(ColorMode colorMode)
+    {
+        SetColorMode(TestWindow, colorMode);
+        TestWindow.Show();
+
+        ResourceDictionary rd = GetTestDataDictionary(colorMode, "");
+        VerifyControlProperties(TestButton, rd);
+    }
+
+    [WpfTheory]
+    [MemberData(nameof(ColorModes_TestData))]
+    public void Button_IsEnabled_False_Test(ColorMode colorMode)
+    {
+        SetColorMode(TestWindow, colorMode);
+        TestButton.IsEnabled = false;
+        TestWindow.Show();
+
+        ResourceDictionary rd = GetTestDataDictionary(colorMode, "Disabled");
+        VerifyControlProperties(TestButton, rd);
+    }
+
+    #region Override Methods
+
+    #pragma warning disable CS8604
+    public override List<FrameworkElement> GetStyleParts(Control element)
+    {
+        List<FrameworkElement> templateParts = new List<FrameworkElement>();
+        templateParts.Add(element);
+
+        Border? border = element.Template.FindName("ContentBorder", element) as Border;
+        border.Should().NotBeNull();
+
+        templateParts.Add(border);
+
+        ContentPresenter? contentPresenter = element.Template.FindName("ContentPresenter", element) as ContentPresenter;
+        contentPresenter.Should().NotBeNull();
+
+        templateParts.Add(contentPresenter);
+
+        return templateParts;
+    }
+
+    #pragma warning restore CS8604
+
+    #pragma warning disable CS8602
+
+    public override void VerifyControlProperties(FrameworkElement element, ResourceDictionary expectedProperties)
+    {
+        if(element is not Button button)
+            return;
+
+        List<FrameworkElement> parts = GetStyleParts(button);
+
+        Button? part_Button = parts[0] as Button;
+        Border? part_ContentBorder = parts[1] as Border;
+        ContentPresenter? part_ContentPresenter = parts[2] as ContentPresenter;
+    
+        using(new AssertionScope())
+        {
+            part_Button.Should().NotBeNull();
+            BrushComparer.Equal(part_Button.Background, (Brush)expectedProperties["Button_Background"]).Should().BeTrue();
+            if(!BrushComparer.Equal(part_Button.Background, (Brush)expectedProperties["Button_Background"]))
+            {
+                Console.WriteLine("part_Button.Background does not match expected value");
+                BrushComparer.LogBrushDifference(part_Button.Background, (Brush)expectedProperties["Button_Background"]);
+            }
+            BrushComparer.Equal(part_Button.Foreground, (Brush)expectedProperties["Button_Foreground"]).Should().BeTrue();
+            if(!BrushComparer.Equal(part_Button.Foreground, (Brush)expectedProperties["Button_Foreground"]))
+            {
+                Console.WriteLine("part_Button.Foreground does not match expected value");
+                BrushComparer.LogBrushDifference(part_Button.Foreground, (Brush)expectedProperties["Button_Foreground"]);
+            }
+            part_Button.BorderThickness.Should().Be((Thickness)expectedProperties["Button_BorderThickness"]);
+            part_Button.IsTabStop.Should().Be((bool)expectedProperties["Button_IsTabStop"]);
+            part_Button.Padding.Should().Be(expectedProperties["Button_Padding"]);
+            part_Button.Margin.Should().Be(expectedProperties["Button_Margin"]);
+            part_Button.HorizontalAlignment.Should().Be((HorizontalAlignment)expectedProperties["Button_HorizontalAlignment"]);
+            part_Button.VerticalAlignment.Should().Be((VerticalAlignment)expectedProperties["Button_VerticalAlignment"]);
+            part_Button.HorizontalContentAlignment.Should().Be((HorizontalAlignment)expectedProperties["Button_HorizontalContentAlignment"]);
+            part_Button.VerticalContentAlignment.Should().Be((VerticalAlignment)expectedProperties["Button_VerticalContentAlignment"]);
+            part_Button.Focusable.Should().Be((bool)expectedProperties["Button_Focusable"]);
+            part_Button.Cursor.Should().Be((Cursor)expectedProperties["Button_Cursor"]);
+        
+            part_ContentBorder.Should().NotBeNull();
+            BrushComparer.Equal(part_ContentBorder.Background, (Brush)expectedProperties["ContentBorder_Background"]).Should().BeTrue();
+            if(!BrushComparer.Equal(part_ContentBorder.Background, (Brush)expectedProperties["ContentBorder_Background"]))
+            {
+                Console.WriteLine("part_ContentBorder.Background does not match expected value");
+                BrushComparer.LogBrushDifference(part_ContentBorder.Background, (Brush)expectedProperties["ContentBorder_Background"]);
+            }
+            part_ContentBorder.BorderThickness.Should().Be((Thickness)expectedProperties["ContentBorder_BorderThickness"]);
+            part_ContentBorder.CornerRadius.Should().Be((CornerRadius)expectedProperties["ContentBorder_CornerRadius"]);
+            part_ContentBorder.Margin.Should().Be((Thickness)expectedProperties["ContentBorder_Margin"]);
+            part_ContentBorder.Padding.Should().Be((Thickness)expectedProperties["ContentBorder_Padding"]);
+            part_ContentBorder.Focusable.Should().Be((bool)expectedProperties["ContentBorder_Focusable"]);
+            part_ContentBorder.HorizontalAlignment.Should().Be((HorizontalAlignment)expectedProperties["ContentBorder_HorizontalAlignment"]);
+            part_ContentBorder.VerticalAlignment.Should().Be((VerticalAlignment)expectedProperties["ContentBorder_VerticalAlignment"]);
+        
+            part_ContentPresenter.Should().NotBeNull();
+            BrushComparer.Equal(TextElement.GetForeground(part_ContentPresenter), (Brush)expectedProperties["ContentPresenter_Foreground"]).Should().BeTrue();
+            if(!BrushComparer.Equal(TextElement.GetForeground(part_ContentPresenter), (Brush)expectedProperties["ContentPresenter_Foreground"]))
+            {
+                Console.WriteLine("part_ContentPresenter.Foreground does not match expected value");
+                BrushComparer.LogBrushDifference(TextElement.GetForeground(part_ContentPresenter), (Brush)expectedProperties["ContentPresenter_Foreground"]);
+            }
+            part_ContentPresenter.RecognizesAccessKey.Should().Be((bool)expectedProperties["ContentPresenter_RecognizesAccessKey"]);
+            part_ContentPresenter.HorizontalAlignment.Should().Be((HorizontalAlignment)expectedProperties["ContentPresenter_HorizontalAlignment"]);
+            part_ContentPresenter.VerticalAlignment.Should().Be((VerticalAlignment)expectedProperties["ContentPresenter_VerticalAlignment"]);
+            part_ContentPresenter.Margin.Should().Be((Thickness)expectedProperties["ContentPresenter_Margin"]);
+            part_ContentPresenter.Focusable.Should().Be((bool)expectedProperties["ContentPresenter_Focusable"]);
+        }
+    }
+
+    #pragma warning restore CS8602
+
+    #endregion
+
+    #region Private Methods
+
+    private Button SetupTestButton()
+    {
+        Button button = new Button() { Content = "Hello" };
+        AddControlToView(TestWindow, button);
+        return button;
+    }
+
+    #endregion
+
+    #region Private Properties
+
+    private Button TestButton { get; set; }
+    protected override string TestDataDictionaryPath => @"/PresentationFramework.Fluent.Tests;component/ControlTests/Data/ButtonTests.xaml";
+
+    #endregion
+
+}
+

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ControlTests/Data/ButtonTests.xaml
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ControlTests/Data/ButtonTests.xaml
@@ -1,0 +1,197 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=System.Runtime"
+                    xmlns:ut="clr-namespace:PresentationFramework.Fluent.Tests.TestUtilities">
+    <ResourceDictionary.MergedDictionaries>
+        
+        <ut:TestDictionary Name="Light">
+            <ut:TestDictionary.MergedDictionaries>
+                <ut:TestDictionary Source="/PresentationFramework.Fluent.Tests;component/ResourceTests/Data/Light.Test.xaml" />
+
+                <ut:TestDictionary Name="Default">
+                    <!-- Button Control Properties -->
+                    <SolidColorBrush x:Key="Button_Background" Color="{StaticResource ControlFillColorDefault}" />
+                    <SolidColorBrush x:Key="Button_Foreground" Color="{StaticResource TextFillColorPrimary}" />
+                    <!--<SolidColorBrush x:Key="Button_BorderBrush" Color="" />-->
+                    <Thickness x:Key="Button_BorderThickness">1</Thickness>
+                    <!--<sys:Double x:Key="Button_FontSize">14</sys:Double>-->
+                    <sys:Boolean x:Key="Button_IsTabStop">True</sys:Boolean>
+                    <Thickness x:Key="Button_Padding">11,5,11,6</Thickness>
+                    <HorizontalAlignment x:Key="Button_HorizontalContentAlignment">Center</HorizontalAlignment>
+                    <VerticalAlignment x:Key="Button_VerticalContentAlignment">Center</VerticalAlignment>
+                    <!-- <Cursor x:Key="Button_Cursor">Arrow</Cursor> -->
+                    <HorizontalAlignment x:Key="Button_HorizontalAlignment">Left</HorizontalAlignment>
+                    <VerticalAlignment x:Key="Button_VerticalAlignment">Center</VerticalAlignment>
+                    <Thickness x:Key="Button_Margin">0</Thickness>
+                    <sys:Boolean x:Key="Button_Focusable">True</sys:Boolean>
+                    
+                    <!-- Button : ContentBorder Properties -->
+                    <SolidColorBrush x:Key="ContentBorder_Background" Color="{StaticResource ControlFillColorDefault}" />
+                    <SolidColorBrush x:Key="ContentPresenter_Foreground" Color="{StaticResource TextFillColorPrimary}" />
+                    <!--<SolidColorBrush x:Key="ContentBorder_BorderBrush" Color="" />-->
+                    <Thickness x:Key="ContentBorder_BorderThickness">1</Thickness>
+                    <Thickness x:Key="ContentBorder_Padding">11,5,11,6</Thickness>
+                    <CornerRadius x:Key="ContentBorder_CornerRadius">4</CornerRadius>
+
+                    <HorizontalAlignment x:Key="ContentBorder_HorizontalAlignment">Left</HorizontalAlignment>
+                    <VerticalAlignment x:Key="ContentBorder_VerticalAlignment">Center</VerticalAlignment>
+                    <Thickness x:Key="ContentBorder_Margin">0</Thickness>
+
+                    <sys:Boolean x:Key="ContentBorder_Focusable">False</sys:Boolean>
+
+                    
+                    
+                    <!-- Button : ContentPresenter Properties -->
+                    <sys:Boolean x:Key="ContentPresenter_RecognizesAccessKey">False</sys:Boolean>
+                    <HorizontalAlignment x:Key="ContentPresenter_HorizontalAlignment">Center</HorizontalAlignment>
+                    <VerticalAlignment x:Key="ContentPresenter_VerticalAlignment">Center</VerticalAlignment>
+                    <Thickness x:Key="ContentPresenter_Margin">0</Thickness>
+                    <sys:Boolean x:Key="ContentPresenter_Focusable">False</sys:Boolean>
+                </ut:TestDictionary>
+
+                <ut:TestDictionary Name="Disabled">
+                    <!-- Button : ContentBorder Properties -->
+                    <SolidColorBrush x:Key="ContentBorder_Background" Color="{StaticResource ControlFillColorDisabled}" />
+                    <!--<SolidColorBrush x:Key="ContentBorder_BorderBrush" Color="" />-->
+
+                    <!-- Button : ContentPresenter Properties -->
+                    <SolidColorBrush x:Key="ContentPresenter_Foreground" Color="{StaticResource TextFillColorDisabled}" />
+                    <sys:Boolean x:Key="ContentPresenter_RecognizesAccessKey">False</sys:Boolean>
+                </ut:TestDictionary>
+
+            </ut:TestDictionary.MergedDictionaries>
+        </ut:TestDictionary>
+
+        <ut:TestDictionary Name="Dark">
+            <ut:TestDictionary.MergedDictionaries>
+                <ut:TestDictionary Source="/PresentationFramework.Fluent.Tests;component/ResourceTests/Data/Dark.Test.xaml" />
+
+                <ut:TestDictionary Name="Default">
+
+                     <!--Button Control Properties--> 
+
+                    <SolidColorBrush x:Key="Button_Background" Color="{StaticResource ControlFillColorDefault}" />
+                    <SolidColorBrush x:Key="Button_Foreground" Color="{StaticResource TextFillColorPrimary}" />
+                    <!--<SolidColorBrush x:Key="Button_BorderBrush" Color="" />-->
+                    <Thickness x:Key="Button_BorderThickness">1</Thickness>
+                    <sys:Double x:Key="Button_FontSize">14</sys:Double>
+                    <sys:Boolean x:Key="Button_IsTabStop">True</sys:Boolean>
+                    <Thickness x:Key="Button_Padding">11,5,11,6</Thickness>
+                    <HorizontalAlignment x:Key="Button_HorizontalContentAlignment">Center</HorizontalAlignment>
+                    <VerticalAlignment x:Key="Button_VerticalContentAlignment">Center</VerticalAlignment>
+
+                    <Cursor x:Key="Button_Curson">Arrow</Cursor>
+                    <HorizontalAlignment x:Key="Button_HorizontalAlignment">Left</HorizontalAlignment>
+                    <VerticalAlignment x:Key="Button_VerticalAlignment">Center</VerticalAlignment>
+                    <Thickness x:Key="Button_Margin">0</Thickness>
+
+                    <sys:Boolean x:Key="Button_Focusable">True</sys:Boolean>
+
+
+
+                     <!--Button : ContentBorder Properties--> 
+
+                    <SolidColorBrush x:Key="ContentBorder_Background" Color="{StaticResource ControlFillColorDefault}" />
+                    <SolidColorBrush x:Key="ContentPresenter_Foreground" Color="{StaticResource TextFillColorPrimary}" />
+                    <!--<SolidColorBrush x:Key="ContentBorder_BorderBrush" Color="" />-->
+                    <Thickness x:Key="ContentBorder_BorderThickness">1</Thickness>
+                    <Thickness x:Key="ContentBorder_Padding">11,5,11,6</Thickness>
+                    <CornerRadius x:Key="ContentBorder_CornerRadius">4</CornerRadius>
+
+                    <HorizontalAlignment x:Key="ContentBorder_HorizontalAlignment">Left</HorizontalAlignment>
+                    <VerticalAlignment x:Key="ContentBorder_VerticalAlignment">Center</VerticalAlignment>
+                    <Thickness x:Key="ContentBorder_Margin">0</Thickness>
+
+                    <sys:Boolean x:Key="ContentBorder_Focusable">False</sys:Boolean>
+
+
+
+                     <!--Button : ContentPresenter Properties--> 
+
+                    <sys:Boolean x:Key="ContentPresenter_RecognizesAccessKey">False</sys:Boolean>
+                    <HorizontalAlignment x:Key="ContentPresenter_HorizontalAlignment">Center</HorizontalAlignment>
+                    <VerticalAlignment x:Key="ContentPresenter_VerticalAlignment">Center</VerticalAlignment>
+                    <Thickness x:Key="ContentPresenter_Margin">0</Thickness>
+                    <sys:Boolean x:Key="ContentPresenter_Focusable">False</sys:Boolean>
+
+                </ut:TestDictionary>
+
+                <ut:TestDictionary Name="Disabled">
+
+                    <!--Button : ContentBorder Properties-->
+                    <SolidColorBrush x:Key="ContentBorder_Background" Color="{StaticResource ControlFillColorDisabled}" />
+                    <SolidColorBrush x:Key="ContentPresenter_Foreground" Color="{StaticResource TextFillColorDisabled}" />
+                    <!--<SolidColorBrush x:Key="ContentBorder_BorderBrush" Color="" />-->
+
+
+                     <!--Button : ContentPresenter Properties--> 
+                    <sys:Boolean x:Key="ContentPresenter_RecognizesAccessKey">False</sys:Boolean>
+
+                </ut:TestDictionary>
+
+            </ut:TestDictionary.MergedDictionaries>
+        </ut:TestDictionary>
+
+        <ut:TestDictionary Name="HC">
+            <ut:TestDictionary.MergedDictionaries>
+                <ut:TestDictionary Source="/PresentationFramework.Fluent.Tests;component/ResourceTests/Data/HC.Test.xaml" />
+
+                <ut:TestDictionary Name="Default">
+
+                    <!--Button Control Properties-->
+
+                    <SolidColorBrush x:Key="Button_Background" Color="{StaticResource SystemColorButtonFaceColor}" />
+                    <SolidColorBrush x:Key="Button_Foreground" Color="{StaticResource SystemColorButtonTextColor}" />
+                    <!--<SolidColorBrush x:Key="Button_BorderBrush" Color="" />-->
+                    <Thickness x:Key="Button_BorderThickness">1</Thickness>
+                    <sys:Double x:Key="Button_FontSize">14</sys:Double>
+                    <sys:Boolean x:Key="Button_IsTabStop">True</sys:Boolean>
+                    <Thickness x:Key="Button_Padding">11,5,11,6</Thickness>
+                    <HorizontalAlignment x:Key="Button_HorizontalContentAlignment">Center</HorizontalAlignment>
+                    <VerticalAlignment x:Key="Button_VerticalContentAlignment">Center</VerticalAlignment>
+
+                    <Cursor x:Key="Button_Curson">Arrow</Cursor>
+                    <HorizontalAlignment x:Key="Button_HorizontalAlignment">Left</HorizontalAlignment>
+                    <VerticalAlignment x:Key="Button_VerticalAlignment">Center</VerticalAlignment>
+                    <Thickness x:Key="Button_Margin">0</Thickness>
+
+                    <sys:Boolean x:Key="Button_Focusable">True</sys:Boolean>
+
+
+                    <!--Button : ContentBorder Properties-->
+                    <SolidColorBrush x:Key="ContentBorder_Background" Color="{StaticResource SystemColorButtonFaceColor}" />
+                    <SolidColorBrush x:Key="ContentPresenter_Foreground" Color="{StaticResource SystemColorButtonTextColor}" />
+                    <!--<SolidColorBrush x:Key="ContentBorder_BorderBrush" Color="" />-->
+                    <Thickness x:Key="ContentBorder_BorderThickness">1</Thickness>
+                    <Thickness x:Key="ContentBorder_Padding">11,5,11,6</Thickness>
+                    <CornerRadius x:Key="ContentBorder_CornerRadius">4</CornerRadius>
+
+                    <HorizontalAlignment x:Key="ContentBorder_HorizontalAlignment">Left</HorizontalAlignment>
+                    <VerticalAlignment x:Key="ContentBorder_VerticalAlignment">Center</VerticalAlignment>
+                    <Thickness x:Key="ContentBorder_Margin">0</Thickness>
+
+                    <sys:Boolean x:Key="ContentBorder_Focusable">False</sys:Boolean>
+
+                    <!--Button : ContentPresenter Properties-->
+                    <sys:Boolean x:Key="ContentPresenter_RecognizesAccessKey">False</sys:Boolean>
+                    <HorizontalAlignment x:Key="ContentPresenter_HorizontalAlignment">Center</HorizontalAlignment>
+                    <VerticalAlignment x:Key="ContentPresenter_VerticalAlignment">Center</VerticalAlignment>
+                    <Thickness x:Key="ContentPresenter_Margin">0</Thickness>
+                    <sys:Boolean x:Key="ContentPresenter_Focusable">False</sys:Boolean>
+
+                </ut:TestDictionary>
+
+                <ut:TestDictionary Name="Disabled">
+                    <!--Button : ContentBorder Properties-->
+                    <SolidColorBrush x:Key="ContentBorder_Background" Color="{StaticResource SystemColorWindowColor}" />
+                    <SolidColorBrush x:Key="ContentPresenter_Foreground" Color="{StaticResource SystemColorGrayTextColor}" />
+                    <!--<SolidColorBrush x:Key="ContentBorder_BorderBrush" Color="" />-->
+
+                    <!--Button : ContentPresenter Properties-->
+                    <sys:Boolean x:Key="ContentPresenter_RecognizesAccessKey">False</sys:Boolean>
+                </ut:TestDictionary>
+
+            </ut:TestDictionary.MergedDictionaries>
+        </ut:TestDictionary>
+    </ResourceDictionary.MergedDictionaries>
+</ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/GlobalUsings.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/GlobalUsings.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+global using System;
+global using System.Windows;
+global using System.Collections.Generic;
 global using Xunit;
 #pragma warning disable IDE0005 // Using directive is unnecessary. New project, this will be used.
 global using FluentAssertions;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/PresentationFramework.Fluent.Tests.csproj
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/PresentationFramework.Fluent.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
+    <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,16 +21,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
-    <ProjectReference Include="$(WpfSourceDir)System.Windows.Primitives\System.Windows.Primitives.csproj" />
-
-    <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
     <ProjectReference Include="$(WpfSourceDir)DirectWriteForwarder\DirectWriteForwarder.vcxproj">
       <UndefineProperties>TargetFramework;TargetFrameworks</UndefineProperties>
     </ProjectReference>
-    <ProjectReference Include="$(WpfSourceDir)System.Xaml\System.Xaml.csproj" />
-    <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
+
+    <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)PresentationFramework\PresentationFramework.csproj" />
     <ProjectReference Include="$(WpfSourceDir)UIAutomation\UIAutomationTypes\UIAutomationTypes.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)System.Xaml\System.Xaml.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)System.Windows.Primitives\System.Windows.Primitives.csproj" />
+
     <ProjectReference Include="$(WpfSourceDir)UIAutomation\UIAutomationProvider\UIAutomationProvider.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)Themes\PresentationFramework.Fluent\PresentationFramework.Fluent.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/PresentationFramework.Fluent.Tests.csproj
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/PresentationFramework.Fluent.Tests.csproj
@@ -6,8 +6,17 @@
     <RootNamespace />
     <TargetFramework Condition="!$(TargetFramework.Contains('windows'))">$(TargetFramework)-windows</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+    <GenerateProgramFile>true</GenerateProgramFile>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Remove="ControlTests\Data\ButtonTests.xaml" />
+    <None Remove="ResourceTests\Data\Dark.Test.xaml" />
+    <None Remove="ResourceTests\Data\HC.Test.xaml" />
+    <None Remove="ResourceTests\Data\Light.Test.xaml" />
+  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />
@@ -21,6 +30,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Page Include="ResourceTests\Data\Dark.Test.xaml" />
+    <Page Include="ResourceTests\Data\HC.Test.xaml" />
+    <Page Include="ResourceTests\Data\Light.Test.xaml" />
+    <Page Include="ControlTests\Data\ButtonTests.xaml" />
+  </ItemGroup>
+  
+  <ItemGroup>    
     <ProjectReference Include="$(WpfSourceDir)DirectWriteForwarder\DirectWriteForwarder.vcxproj">
       <UndefineProperties>TargetFramework;TargetFrameworks</UndefineProperties>
     </ProjectReference>
@@ -36,3 +52,4 @@
     <ProjectReference Include="$(WpfSourceDir)Themes\PresentationFramework.Fluent\PresentationFramework.Fluent.csproj" />
   </ItemGroup>
 </Project>
+

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ResourceTests/Data/Dark.Test.xaml
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ResourceTests/Data/Dark.Test.xaml
@@ -1,0 +1,151 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="ApplicationBackgroundColor">#FF202020</Color>
+    <SolidColorBrush x:Key="ApplicationBackgroundBrush" Color="{StaticResource ApplicationBackgroundColor}" />
+
+    <Color x:Key="KeyboardFocusBorderColor">#87FFFFFF</Color>
+    <SolidColorBrush x:Key="KeyboardFocusBorderColorBrush" Color="{StaticResource KeyboardFocusBorderColor}" />
+
+    <!--  Colors  -->
+
+    <Color x:Key="TextFillColorPrimary">#FFFFFF</Color>
+    <Color x:Key="TextFillColorSecondary">#C5FFFFFF</Color>
+    <Color x:Key="TextFillColorTertiary">#87FFFFFF</Color>
+    <Color x:Key="TextFillColorDisabled">#5DFFFFFF</Color>
+    <Color x:Key="TextFillColorInverse">#E4000000</Color>
+
+    <Color x:Key="AccentTextFillColorDisabled">#5DFFFFFF</Color>
+    <Color x:Key="TextOnAccentFillColorSelectedText">#FFFFFF</Color>
+    <Color x:Key="TextOnAccentFillColorPrimary">#000000</Color>
+    <Color x:Key="TextOnAccentFillColorSecondary">#80000000</Color>
+    <Color x:Key="TextOnAccentFillColorDisabled">#87FFFFFF</Color>
+
+    <Color x:Key="ControlFillColorDefault">#0FFFFFFF</Color>
+    <Color x:Key="ControlFillColorSecondary">#15FFFFFF</Color>
+    <Color x:Key="ControlFillColorTertiary">#08FFFFFF</Color>
+    <Color x:Key="ControlFillColorDisabled">#0BFFFFFF</Color>
+    <Color x:Key="ControlFillColorTransparent">#00FFFFFF</Color>
+    <Color x:Key="ControlFillColorInputActive">#B31E1E1E</Color>
+
+    <Color x:Key="ControlStrongFillColorDefault">#8BFFFFFF</Color>
+    <Color x:Key="ControlStrongFillColorDisabled">#3FFFFFFF</Color>
+
+    <Color x:Key="ControlSolidFillColorDefault">#454545</Color>
+
+    <Color x:Key="SubtleFillColorTransparent">#00FFFFFF</Color>
+    <Color x:Key="SubtleFillColorSecondary">#0FFFFFFF</Color>
+    <Color x:Key="SubtleFillColorTertiary">#0AFFFFFF</Color>
+    <Color x:Key="SubtleFillColorDisabled">#00FFFFFF</Color>
+
+    <Color x:Key="ControlAltFillColorTransparent">#00FFFFFF</Color>
+    <Color x:Key="ControlAltFillColorSecondary">#19000000</Color>
+    <Color x:Key="ControlAltFillColorTertiary">#0BFFFFFF</Color>
+    <Color x:Key="ControlAltFillColorQuarternary">#12FFFFFF</Color>
+    <Color x:Key="ControlAltFillColorDisabled">#00FFFFFF</Color>
+
+    <Color x:Key="ControlOnImageFillColorDefault">#B31C1C1C</Color>
+    <Color x:Key="ControlOnImageFillColorSecondary">#1A1A1A</Color>
+    <Color x:Key="ControlOnImageFillColorTertiary">#131313</Color>
+    <Color x:Key="ControlOnImageFillColorDisabled">#1E1E1E</Color>
+
+    <Color x:Key="AccentFillColorDisabled">#28FFFFFF</Color>
+
+    <Color x:Key="ControlStrokeColorDefault">#12FFFFFF</Color>
+    <Color x:Key="ControlStrokeColorSecondary">#18FFFFFF</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDefault">#14FFFFFF</Color>
+    <Color x:Key="ControlStrokeColorOnAccentSecondary">#23000000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentTertiary">#37000000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDisabled">#33000000</Color>
+
+    <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#6B000000</Color>
+
+    <Color x:Key="CardStrokeColorDefault">#19000000</Color>
+    <Color x:Key="CardStrokeColorDefaultSolid">#1C1C1C</Color>
+
+    <Color x:Key="ControlStrongStrokeColorDefault">#8BFFFFFF</Color>
+    <Color x:Key="ControlStrongStrokeColorDisabled">#28FFFFFF</Color>
+
+    <Color x:Key="SurfaceStrokeColorDefault">#66757575</Color>
+    <Color x:Key="SurfaceStrokeColorFlyout">#33000000</Color>
+    <Color x:Key="SurfaceStrokeColorInverse">#0F000000</Color>
+
+    <Color x:Key="DividerStrokeColorDefault">#15FFFFFF</Color>
+
+    <Color x:Key="FocusStrokeColorOuter">#FFFFFF</Color>
+    <Color x:Key="FocusStrokeColorInner">#B3000000</Color>
+
+    <Color x:Key="CardBackgroundFillColorDefault">#0DFFFFFF</Color>
+    <Color x:Key="CardBackgroundFillColorSecondary">#08FFFFFF</Color>
+
+    <Color x:Key="SmokeFillColorDefault">#4D000000</Color>
+
+    <Color x:Key="LayerFillColorDefault">#4C3A3A3A</Color>
+    <Color x:Key="LayerFillColorAlt">#0DFFFFFF</Color>
+    <Color x:Key="LayerOnAcrylicFillColorDefault">#09FFFFFF</Color>
+    <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#09FFFFFF</Color>
+
+    <!--  Fallback color for missing Acrylic used for e.g. Flyouts  -->
+    <Color x:Key="AcrylicBackgroundFillColorDefault">#2C2C2C</Color>
+
+    <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#733A3A3A</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#0FFFFFFF</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#2C2C2C</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#00FFFFFF</Color>
+
+    <Color x:Key="SolidBackgroundFillColorBase">#202020</Color>
+    <Color x:Key="SolidBackgroundFillColorSecondary">#1C1C1C</Color>
+    <Color x:Key="SolidBackgroundFillColorTertiary">#282828</Color>
+    <Color x:Key="SolidBackgroundFillColorQuarternary">#2C2C2C</Color>
+    <Color x:Key="SolidBackgroundFillColorTransparent">#00202020</Color>
+    <Color x:Key="SolidBackgroundFillColorBaseAlt">#0A0A0A</Color>
+
+    <Color x:Key="SystemFillColorSuccess">#6CCB5F</Color>
+    <Color x:Key="SystemFillColorCaution">#FCE100</Color>
+    <Color x:Key="SystemFillColorCritical">#FF99A4</Color>
+    <Color x:Key="SystemFillColorNeutral">#8BFFFFFF</Color>
+    <Color x:Key="SystemFillColorSolidNeutral">#9D9D9D</Color>
+    <Color x:Key="SystemFillColorAttentionBackground">#08FFFFFF</Color>
+    <Color x:Key="SystemFillColorSuccessBackground">#393D1B</Color>
+    <Color x:Key="SystemFillColorCautionBackground">#433519</Color>
+    <Color x:Key="SystemFillColorCriticalBackground">#442726</Color>
+    <Color x:Key="SystemFillColorNeutralBackground">#08FFFFFF</Color>
+    <Color x:Key="SystemFillColorSolidAttentionBackground">#2E2E2E</Color>
+    <Color x:Key="SystemFillColorSolidNeutralBackground">#2E2E2E</Color>
+
+    <!-- AccentColor Brushes -->
+
+    <DynamicResource x:Key="SystemAccentColor" ResourceKey="{x:Static SystemColors.AccentColorKey}" />
+    <DynamicResource x:Key="SystemAccentColorLight1" ResourceKey="{x:Static SystemColors.AccentColorLight1Key}" />
+    <DynamicResource x:Key="SystemAccentColorLight2" ResourceKey="{x:Static SystemColors.AccentColorLight2Key}" />
+    <DynamicResource x:Key="SystemAccentColorLight3" ResourceKey="{x:Static SystemColors.AccentColorLight3Key}" />
+    <DynamicResource x:Key="SystemAccentColorDark1" ResourceKey="{x:Static SystemColors.AccentColorDark1Key}" />
+    <DynamicResource x:Key="SystemAccentColorDark2" ResourceKey="{x:Static SystemColors.AccentColorDark2Key}" />
+    <DynamicResource x:Key="SystemAccentColorDark3" ResourceKey="{x:Static SystemColors.AccentColorDark3Key}" />
+
+    <SolidColorBrush x:Key="AccentTextFillColorPrimaryBrush" Color="{StaticResource SystemAccentColorLight3}" />
+    <SolidColorBrush x:Key="AccentTextFillColorSecondaryBrush" Color="{StaticResource SystemAccentColorLight3}" />
+    <SolidColorBrush x:Key="AccentTextFillColorTertiaryBrush" Color="{StaticResource SystemAccentColorLight2}" />
+    <SolidColorBrush x:Key="AccentTextFillColorDisabledBrush" Color="{StaticResource AccentTextFillColorDisabled}" />
+
+    <SolidColorBrush x:Key="TextOnAccentFillColorSelectedTextBrush" Color="{StaticResource TextOnAccentFillColorSelectedText}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush" Color="{StaticResource TextOnAccentFillColorPrimary}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorSecondaryBrush" Color="{StaticResource TextOnAccentFillColorSecondary}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorDisabledBrush" Color="{StaticResource TextOnAccentFillColorDisabled}" />
+
+    <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{StaticResource SystemAccentColor}" />
+    <SolidColorBrush x:Key="AccentFillColorDefaultBrush" Color="{StaticResource SystemAccentColorLight2}" />
+    <SolidColorBrush x:Key="AccentFillColorSecondaryBrush" Opacity="0.9" Color="{StaticResource SystemAccentColorLight2}" />
+    <SolidColorBrush x:Key="AccentFillColorTertiaryBrush" Opacity="0.8" Color="{StaticResource SystemAccentColorLight2}" />
+    <SolidColorBrush x:Key="AccentFillColorDisabledBrush" Color="{StaticResource AccentFillColorDisabled}" />
+
+    <SolidColorBrush x:Key="SystemFillColorAttentionBrush" Color="{StaticResource SystemAccentColor}" />
+
+    <Color x:Key="SystemColorWindowTextColor">#FF00FF</Color>
+    <Color x:Key="SystemColorWindowColor">#FF00FF</Color>
+    <Color x:Key="SystemColorButtonFaceColor">#FF00FF</Color>
+    <Color x:Key="SystemColorButtonTextColor">#FF00FF</Color>
+    <Color x:Key="SystemColorHighlightColor">#FF00FF</Color>
+    <Color x:Key="SystemColorHighlightTextColor">#FF00FF</Color>
+    <Color x:Key="SystemColorHotlightColor">#FF00FF</Color>
+    <Color x:Key="SystemColorGrayTextColor">#FF00FF</Color>
+</ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ResourceTests/Data/HC.Test.xaml
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ResourceTests/Data/HC.Test.xaml
@@ -1,0 +1,151 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="TextFillColorPrimary">#FFFFFF</Color>
+    <Color x:Key="TextFillColorSecondary">#FFFFFF</Color>
+    <Color x:Key="TextFillColorTertiary">#FFFFFF</Color>
+    <Color x:Key="TextFillColorDisabled">#A6A6A6</Color>
+    <Color x:Key="TextFillColorInverse">#FFFFFF</Color>
+
+    <Color x:Key="AccentTextFillColorDisabled">#A6A6A6</Color>
+    <Color x:Key="TextOnAccentFillColorSelectedText">#FFFFFF</Color>
+    <Color x:Key="TextOnAccentFillColorPrimary">#FFFFFF</Color>
+    <Color x:Key="TextOnAccentFillColorSecondary">#FFFFFF</Color>
+    <Color x:Key="TextOnAccentFillColorDisabled">#A6A6A6</Color>
+
+    <Color x:Key="ControlFillColorDefault">#2D3236</Color>
+    <Color x:Key="ControlFillColorSecondary">#2D3236</Color>
+    <Color x:Key="ControlFillColorTertiary">#2D3236</Color>
+    <Color x:Key="ControlFillColorDisabled">#2D3236</Color>
+    <Color x:Key="ControlFillColorTransparent">Transparent</Color>
+    <Color x:Key="ControlFillColorInputActive">#2D3236</Color>
+
+    <Color x:Key="ControlStrongFillColorDefault">#2D3236</Color>
+    <Color x:Key="ControlStrongFillColorDisabled">#2D3236</Color>
+
+    <Color x:Key="ControlSolidFillColorDefault">#2D3236</Color>
+
+    <Color x:Key="SubtleFillColorTransparent">#2D3236</Color>
+    <Color x:Key="SubtleFillColorSecondary">#2D3236</Color>
+    <Color x:Key="SubtleFillColorTertiary">#2D3236</Color>
+    <Color x:Key="SubtleFillColorDisabled">#2D3236</Color>
+
+    <Color x:Key="ControlAltFillColorTransparent">Transparent</Color>
+    <Color x:Key="ControlAltFillColorSecondary">#2D3236</Color>
+    <Color x:Key="ControlAltFillColorTertiary">#2D3236</Color>
+    <Color x:Key="ControlAltFillColorQuarternary">#2D3236</Color>
+    <Color x:Key="ControlAltFillColorDisabled">#2D3236</Color>
+
+    <Color x:Key="ControlOnImageFillColorDefault">#2D3236</Color>
+    <Color x:Key="ControlOnImageFillColorSecondary">#2D3236</Color>
+    <Color x:Key="ControlOnImageFillColorTertiary">#2D3236</Color>
+    <Color x:Key="ControlOnImageFillColorDisabled">#2D3236</Color>
+
+    <Color x:Key="AccentFillColorDisabled">#2D3236</Color>
+
+    <Color x:Key="ControlStrokeColorDefault">#B6F6F0</Color>
+    <Color x:Key="ControlStrokeColorSecondary">#B6F6F0</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDefault">#B6F6F0</Color>
+    <Color x:Key="ControlStrokeColorOnAccentSecondary">#B6F6F0</Color>
+    <Color x:Key="ControlStrokeColorOnAccentTertiary">#B6F6F0</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDisabled">#A6A6A6</Color>
+
+    <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#B6F6F0</Color>
+
+    <Color x:Key="CardStrokeColorDefault">#FFFFFF</Color>
+    <Color x:Key="CardStrokeColorDefaultSolid">#FFFFFF</Color>
+
+    <Color x:Key="ControlStrongStrokeColorDefault">#B6F6F0</Color>
+    <Color x:Key="ControlStrongStrokeColorDisabled">#B6F6F0</Color>
+
+    <Color x:Key="SurfaceStrokeColorDefault">#FFFFFF</Color>
+    <Color x:Key="SurfaceStrokeColorFlyout">#FFFFFF</Color>
+    <Color x:Key="SurfaceStrokeColorInverse">#FFFFFF</Color>
+
+    <Color x:Key="DividerStrokeColorDefault">#FFFFFF</Color>
+
+    <Color x:Key="FocusStrokeColorOuter">#FFFFFF</Color>
+    <Color x:Key="FocusStrokeColorInner">#2D3236</Color>
+
+    <Color x:Key="CardBackgroundFillColorDefault">#2D3236</Color>
+    <Color x:Key="CardBackgroundFillColorSecondary">#2D3236</Color>
+
+    <Color x:Key="SmokeFillColorDefault">#2D3236</Color>
+
+    <Color x:Key="LayerFillColorDefault">#2D3236</Color>
+    <Color x:Key="LayerFillColorAlt">#2D3236</Color>
+    <Color x:Key="LayerOnAcrylicFillColorDefault">#2D3236</Color>
+    <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#2D3236</Color>
+
+    <!--  Fallback color for missing Acrylic used for e.g. Flyouts  -->
+    <Color x:Key="AcrylicBackgroundFillColorDefault">#2D3236</Color>
+
+    <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FF0000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FF0000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#FF0000</Color>
+
+    <Color x:Key="SolidBackgroundFillColorBase">#2D3236</Color>
+    <Color x:Key="SolidBackgroundFillColorSecondary">#2D3236</Color>
+    <Color x:Key="SolidBackgroundFillColorTertiary">#2D3236</Color>
+    <Color x:Key="SolidBackgroundFillColorQuarternary">#2D3236</Color>
+    <Color x:Key="SolidBackgroundFillColorTransparent">Transparent</Color>
+    <Color x:Key="SolidBackgroundFillColorBaseAlt">#2D3236</Color>
+
+    <Color x:Key="SystemFillColorSuccess">#FFFFFF</Color>
+    <Color x:Key="SystemFillColorCaution">#FFFFFF</Color>
+    <Color x:Key="SystemFillColorCritical">#FFFFFF</Color>
+    <Color x:Key="SystemFillColorNeutral">#FFFFFF</Color>
+    <Color x:Key="SystemFillColorSolidNeutral">#FF0000</Color>
+    <Color x:Key="SystemFillColorAttentionBackground">#2D3236</Color>
+    <Color x:Key="SystemFillColorSuccessBackground">#2D3236</Color>
+    <Color x:Key="SystemFillColorCautionBackground">#2D3236</Color>
+    <Color x:Key="SystemFillColorCriticalBackground">#2D3236</Color>
+    <Color x:Key="SystemFillColorNeutralBackground">#2D3236</Color>
+    <Color x:Key="SystemFillColorSolidAttentionBackground">#2D3236</Color>
+    <Color x:Key="SystemFillColorSolidNeutralBackground">#FF0000</Color>
+
+    <DynamicResource x:Key="SystemColorWindowTextColor" ResourceKey="{x:Static SystemColors.WindowTextColorKey}" />
+    <DynamicResource x:Key="SystemColorWindowColor" ResourceKey="{x:Static SystemColors.WindowColorKey}" />
+    <DynamicResource x:Key="SystemColorHighlightTextColor" ResourceKey="{x:Static SystemColors.HighlightTextColorKey}" />
+    <DynamicResource x:Key="SystemColorHighlightColor" ResourceKey="{x:Static SystemColors.HighlightColorKey}" />
+    <DynamicResource x:Key="SystemColorButtonTextColor" ResourceKey="{x:Static SystemColors.ControlTextColorKey}" />
+    <DynamicResource x:Key="SystemColorButtonFaceColor" ResourceKey="{x:Static SystemColors.ControlColorKey}" />
+    <DynamicResource x:Key="SystemColorHotlightColor" ResourceKey="{x:Static SystemColors.HotTrackColorKey}" />
+    <DynamicResource x:Key="SystemColorGrayTextColor" ResourceKey="{x:Static SystemColors.GrayTextColorKey}" />
+
+    <Color x:Key="ApplicationBackgroundColor">#2D3236</Color>
+    <!--  Same as SystemColorWindowColor  -->
+    <SolidColorBrush x:Key="ApplicationBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <Color x:Key="KeyboardFocusBorderColor">#FFFFFF</Color>
+    <!--  Same as SystemColorWindowTextColor  -->
+    <SolidColorBrush x:Key="KeyboardFocusBorderColorBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!-- Accent Colors and Brushes -->
+
+    <DynamicResource x:Key="SystemAccentColor" ResourceKey="{x:Static SystemColors.AccentColorKey}" />
+    <DynamicResource x:Key="SystemAccentColorLight1" ResourceKey="{x:Static SystemColors.AccentColorLight1Key}" />
+    <DynamicResource x:Key="SystemAccentColorLight2" ResourceKey="{x:Static SystemColors.AccentColorLight2Key}" />
+    <DynamicResource x:Key="SystemAccentColorLight3" ResourceKey="{x:Static SystemColors.AccentColorLight3Key}" />
+    <DynamicResource x:Key="SystemAccentColorDark1" ResourceKey="{x:Static SystemColors.AccentColorDark1Key}" />
+    <DynamicResource x:Key="SystemAccentColorDark2" ResourceKey="{x:Static SystemColors.AccentColorDark2Key}" />
+    <DynamicResource x:Key="SystemAccentColorDark3" ResourceKey="{x:Static SystemColors.AccentColorDark3Key}" />
+
+    <SolidColorBrush x:Key="AccentTextFillColorPrimaryBrush" Color="{StaticResource SystemAccentColorDark2}" />
+    <SolidColorBrush x:Key="AccentTextFillColorSecondaryBrush" Color="{StaticResource SystemAccentColorDark3}" />
+    <SolidColorBrush x:Key="AccentTextFillColorTertiaryBrush" Color="{StaticResource SystemAccentColorDark1}" />
+    <SolidColorBrush x:Key="AccentTextFillColorDisabledBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="TextOnAccentFillColorSelectedTextBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorDisabledBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{StaticResource SystemAccentColor}" />
+    <SolidColorBrush x:Key="AccentFillColorDefaultBrush" Color="{StaticResource SystemAccentColorDark1}" />
+    <SolidColorBrush x:Key="AccentFillColorSecondaryBrush" Opacity="0.9" Color="{StaticResource SystemAccentColorDark1}" />
+    <SolidColorBrush x:Key="AccentFillColorTertiaryBrush" Opacity="0.8" Color="{StaticResource SystemAccentColorDark1}" />
+    <SolidColorBrush x:Key="AccentFillColorDisabledBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="SystemFillColorAttentionBrush" Color="{StaticResource SystemAccentColor}" />
+</ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ResourceTests/Data/Light.Test.xaml
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ResourceTests/Data/Light.Test.xaml
@@ -1,0 +1,147 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="ApplicationBackgroundColor">#FFFAFAFA</Color>
+    <SolidColorBrush x:Key="ApplicationBackgroundBrush" Color="{StaticResource ApplicationBackgroundColor}" />
+
+    <Color x:Key="KeyboardFocusBorderColor">#BE000000</Color>
+    <SolidColorBrush x:Key="KeyboardFocusBorderColorBrush" Color="{StaticResource KeyboardFocusBorderColor}" />
+
+    <Color x:Key="TextFillColorPrimary">#E4000000</Color>
+    <Color x:Key="TextFillColorSecondary">#9E000000</Color>
+    <Color x:Key="TextFillColorTertiary">#72000000</Color>
+    <Color x:Key="TextFillColorDisabled">#5C000000</Color>
+    <Color x:Key="TextFillColorInverse">#FFFFFF</Color>
+
+    <Color x:Key="AccentTextFillColorDisabled">#5C000000</Color>
+    <Color x:Key="TextOnAccentFillColorSelectedText">#FFFFFF</Color>
+    <Color x:Key="TextOnAccentFillColorPrimary">#FFFFFF</Color>
+    <Color x:Key="TextOnAccentFillColorSecondary">#B3FFFFFF</Color>
+    <Color x:Key="TextOnAccentFillColorDisabled">#FFFFFF</Color>
+
+    <Color x:Key="ControlFillColorDefault">#B3FFFFFF</Color>
+    <Color x:Key="ControlFillColorSecondary">#80F9F9F9</Color>
+    <Color x:Key="ControlFillColorTertiary">#4DF9F9F9</Color>
+    <Color x:Key="ControlFillColorDisabled">#4DF9F9F9</Color>
+    <Color x:Key="ControlFillColorTransparent">#00FFFFFF</Color>
+    <Color x:Key="ControlFillColorInputActive">#FFFFFF</Color>
+
+    <Color x:Key="ControlStrongFillColorDefault">#72000000</Color>
+    <Color x:Key="ControlStrongFillColorDisabled">#51000000</Color>
+
+    <Color x:Key="ControlSolidFillColorDefault">#FFFFFF</Color>
+
+    <Color x:Key="SubtleFillColorTransparent">#00FFFFFF</Color>
+    <Color x:Key="SubtleFillColorSecondary">#09000000</Color>
+    <Color x:Key="SubtleFillColorTertiary">#06000000</Color>
+    <Color x:Key="SubtleFillColorDisabled">#00FFFFFF</Color>
+
+    <Color x:Key="ControlAltFillColorTransparent">#00FFFFFF</Color>
+    <Color x:Key="ControlAltFillColorSecondary">#06000000</Color>
+    <Color x:Key="ControlAltFillColorTertiary">#0F000000</Color>
+    <Color x:Key="ControlAltFillColorQuarternary">#18000000</Color>
+    <Color x:Key="ControlAltFillColorDisabled">#00FFFFFF</Color>
+
+    <Color x:Key="ControlOnImageFillColorDefault">#C9FFFFFF</Color>
+    <Color x:Key="ControlOnImageFillColorSecondary">#F3F3F3</Color>
+    <Color x:Key="ControlOnImageFillColorTertiary">#EBEBEB</Color>
+    <Color x:Key="ControlOnImageFillColorDisabled">#00FFFFFF</Color>
+
+    <Color x:Key="AccentFillColorDisabled">#37000000</Color>
+
+    <Color x:Key="ControlStrokeColorDefault">#0F000000</Color>
+    <Color x:Key="ControlStrokeColorSecondary">#29000000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDefault">#14FFFFFF</Color>
+    <Color x:Key="ControlStrokeColorOnAccentSecondary">#66000000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentTertiary">#37000000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDisabled">#0F000000</Color>
+
+    <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#59FFFFFF</Color>
+
+    <Color x:Key="CardStrokeColorDefault">#0F000000</Color>
+    <Color x:Key="CardStrokeColorDefaultSolid">#EBEBEB</Color>
+
+    <Color x:Key="ControlStrongStrokeColorDefault">#72000000</Color>
+    <Color x:Key="ControlStrongStrokeColorDisabled">#37000000</Color>
+
+    <Color x:Key="SurfaceStrokeColorDefault">#66757575</Color>
+    <Color x:Key="SurfaceStrokeColorFlyout">#0F000000</Color>
+    <Color x:Key="SurfaceStrokeColorInverse">#15FFFFFF</Color>
+
+    <Color x:Key="DividerStrokeColorDefault">#0F000000</Color>
+
+    <Color x:Key="FocusStrokeColorOuter">#E4000000</Color>
+    <Color x:Key="FocusStrokeColorInner">#B3FFFFFF</Color>
+
+    <Color x:Key="CardBackgroundFillColorDefault">#B3FFFFFF</Color>
+    <Color x:Key="CardBackgroundFillColorSecondary">#80F6F6F6</Color>
+
+    <Color x:Key="SmokeFillColorDefault">#4D000000</Color>
+
+    <Color x:Key="LayerFillColorDefault">#80FFFFFF</Color>
+    <Color x:Key="LayerFillColorAlt">#FFFFFF</Color>
+    <Color x:Key="LayerOnAcrylicFillColorDefault">#40FFFFFF</Color>
+    <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#40FFFFFF</Color>
+
+    <!--  Fallback color for missing Acrylic used for e.g. Flyouts  -->
+    <Color x:Key="AcrylicBackgroundFillColorDefault">#F9F9F9</Color>
+
+    <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#B3FFFFFF</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#0A000000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#F9F9F9</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#00000000</Color>
+
+    <Color x:Key="SolidBackgroundFillColorBase">#F3F3F3</Color>
+    <Color x:Key="SolidBackgroundFillColorSecondary">#EEEEEE</Color>
+    <Color x:Key="SolidBackgroundFillColorTertiary">#F9F9F9</Color>
+    <Color x:Key="SolidBackgroundFillColorQuarternary">#FFFFFF</Color>
+    <Color x:Key="SolidBackgroundFillColorTransparent">#00F3F3F3</Color>
+    <Color x:Key="SolidBackgroundFillColorBaseAlt">#DADADA</Color>
+
+    <Color x:Key="SystemFillColorSuccess">#0F7B0F</Color>
+    <Color x:Key="SystemFillColorCaution">#9D5D00</Color>
+    <Color x:Key="SystemFillColorCritical">#C42B1C</Color>
+    <Color x:Key="SystemFillColorNeutral">#72000000</Color>
+    <Color x:Key="SystemFillColorSolidNeutral">#8A8A8A</Color>
+    <Color x:Key="SystemFillColorAttentionBackground">#80F6F6F6</Color>
+    <Color x:Key="SystemFillColorSuccessBackground">#DFF6DD</Color>
+    <Color x:Key="SystemFillColorCautionBackground">#FFF4CE</Color>
+    <Color x:Key="SystemFillColorCriticalBackground">#FDE7E9</Color>
+    <Color x:Key="SystemFillColorNeutralBackground">#06000000</Color>
+    <Color x:Key="SystemFillColorSolidAttentionBackground">#F7F7F7</Color>
+    <Color x:Key="SystemFillColorSolidNeutralBackground">#F3F3F3</Color>
+
+    <DynamicResource x:Key="SystemAccentColor" ResourceKey="{x:Static SystemColors.AccentColorKey}" />
+    <DynamicResource x:Key="SystemAccentColorLight1" ResourceKey="{x:Static SystemColors.AccentColorLight1Key}" />
+    <DynamicResource x:Key="SystemAccentColorLight2" ResourceKey="{x:Static SystemColors.AccentColorLight2Key}" />
+    <DynamicResource x:Key="SystemAccentColorLight3" ResourceKey="{x:Static SystemColors.AccentColorLight3Key}" />
+    <DynamicResource x:Key="SystemAccentColorDark1" ResourceKey="{x:Static SystemColors.AccentColorDark1Key}" />
+    <DynamicResource x:Key="SystemAccentColorDark2" ResourceKey="{x:Static SystemColors.AccentColorDark2Key}" />
+    <DynamicResource x:Key="SystemAccentColorDark3" ResourceKey="{x:Static SystemColors.AccentColorDark3Key}" />
+
+    <SolidColorBrush x:Key="AccentTextFillColorPrimaryBrush" Color="{StaticResource SystemAccentColorDark2}" />
+    <SolidColorBrush x:Key="AccentTextFillColorSecondaryBrush" Color="{StaticResource SystemAccentColorDark3}" />
+    <SolidColorBrush x:Key="AccentTextFillColorTertiaryBrush" Color="{StaticResource SystemAccentColorDark1}" />
+    <SolidColorBrush x:Key="AccentTextFillColorDisabledBrush" Color="{StaticResource AccentTextFillColorDisabled}" />
+
+    <SolidColorBrush x:Key="TextOnAccentFillColorSelectedTextBrush" Color="{StaticResource TextOnAccentFillColorSelectedText}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush" Color="{StaticResource TextOnAccentFillColorPrimary}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorSecondaryBrush" Color="{StaticResource TextOnAccentFillColorSecondary}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorDisabledBrush" Color="{StaticResource TextOnAccentFillColorDisabled}" />
+
+    <SolidColorBrush x:Key="AccentFillColorSelectedTextBackgroundBrush" Color="{StaticResource SystemAccentColor}" />
+    <SolidColorBrush x:Key="AccentFillColorDefaultBrush" Color="{StaticResource SystemAccentColorDark1}" />
+    <SolidColorBrush x:Key="AccentFillColorSecondaryBrush" Opacity="0.9" Color="{StaticResource SystemAccentColorDark1}" />
+    <SolidColorBrush x:Key="AccentFillColorTertiaryBrush" Opacity="0.8" Color="{StaticResource SystemAccentColorDark1}" />
+    <SolidColorBrush x:Key="AccentFillColorDisabledBrush" Color="{StaticResource AccentFillColorDisabled}" />
+
+    <SolidColorBrush x:Key="SystemFillColorAttentionBrush" Color="{StaticResource SystemAccentColor}" />
+
+    <Color x:Key="SystemColorWindowTextColor">#FF00FF</Color>
+    <Color x:Key="SystemColorWindowColor">#FF00FF</Color>
+    <Color x:Key="SystemColorButtonFaceColor">#FF00FF</Color>
+    <Color x:Key="SystemColorButtonTextColor">#FF00FF</Color>
+    <Color x:Key="SystemColorHighlightColor">#FF00FF</Color>
+    <Color x:Key="SystemColorHighlightTextColor">#FF00FF</Color>
+    <Color x:Key="SystemColorHotlightColor">#FF00FF</Color>
+    <Color x:Key="SystemColorGrayTextColor">#FF00FF</Color>
+</ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ResourceTests/FluentColorResourceTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ResourceTests/FluentColorResourceTests.cs
@@ -1,0 +1,155 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions.Execution;
+using System.Windows.Media;
+using Application = System.Windows.Application;
+
+namespace PresentationFramework.Fluent.Tests.ResourceTests;
+public class FluentColorResourceTests
+{
+
+    [WpfTheory]
+    [MemberData(nameof(ColorDictionary_Validate_TestData))]
+    public void Fluent_ColorDictionary_ValidateTest(string testSource, string actualSource)
+    {
+        ResourceDictionary dictionary1 = LoadResourceDictionary(testSource);
+        ResourceDictionary dictionary2 = LoadResourceDictionary(actualSource);
+
+        using (new AssertionScope())
+        {
+            List<object> missingKeys = new List<object>();
+            foreach (object key in dictionary1.Keys)
+            {
+                if (dictionary2.Contains(key))
+                {
+                    if (dictionary1[key] is Color)
+                    {
+                        dictionary2[key].Should().BeOfType<Color>();
+                        dictionary1[key].Should().Be(dictionary2[key]);
+                    }
+                }
+                else
+                {
+                    missingKeys.Add(key);
+                }
+            }
+
+            missingKeys.Should().BeEmpty();
+        }
+    }
+
+    [WpfTheory]
+    [MemberData(nameof(ThemeDictionary_Validate_TestData))]
+    public void ThemeDictionary_FluentColor_ValidateTest(string testSource, string actualSource)
+    {
+        actualSource.Should().NotBeNull();
+        ResourceDictionary dictionary1 = LoadResourceDictionary(testSource);
+        ResourceDictionary dictionary2 = LoadResourceDictionary(actualSource);
+
+        using (new AssertionScope())
+        {
+            List<object> missingKeys = new List<object>();
+            foreach (object key in dictionary1.Keys)
+            {
+                if (dictionary2.Contains(key))
+                {
+                    if (dictionary1[key] is Color)
+                    {
+                        dictionary2[key].Should().BeOfType<Color>();
+                        dictionary1[key].Should().Be(dictionary2[key]);
+                    }
+                }
+                else
+                {
+                    missingKeys.Add(key);
+                }
+            }
+
+            missingKeys.Should().BeEmpty();
+        }
+    }
+
+
+    #region Helper Methods
+
+    private static ResourceDictionary LoadResourceDictionary(string source)
+    {
+        var uri = new Uri(source, UriKind.RelativeOrAbsolute);
+
+        if (Application.LoadComponent(uri) is not ResourceDictionary resourceDictionary)
+        {
+            throw new ArgumentException($"The source : {source} can not be loaded.");
+        }
+
+        return resourceDictionary;
+    }
+
+    // private static ResourceDictionary LoadTestDictionary(string resourceName)
+    // {
+    //     var assembly = Assembly.GetExecutingAssembly();
+    //     using Stream stream = assembly.GetManifestResourceStream(resourceName) ?? throw new ArgumentException($"The resource : {resourceName} can not be loaded.");
+
+    //     if (XamlReader.Load(stream) is not ResourceDictionary dictionary)
+    //     {
+    //         throw new ArgumentException($"The resource : {resourceName} can not be loaded.");
+    //     }
+
+    //     return dictionary;
+    // }
+
+    #endregion
+
+
+    #region Test Data
+
+    public static IEnumerable<object[]> ColorDictionary_Validate_TestData()
+    {
+        int count = s_colorDictionarySourceList.Count;
+        for (int i = 0; i < count; i++)
+        {
+            yield return new object[] { s_testColorDictionarySourceList[i], s_colorDictionarySourceList[i] };
+        }
+    }
+
+    public static IEnumerable<object[]> ThemeDictionary_Validate_TestData()
+    {
+        int count = s_themeDictionarySourceList.Count;
+        for (int i = 1; i < count; i++)
+        {
+            yield return new object[] { s_testColorDictionarySourceList[i - 1], (string)s_themeDictionarySourceList[i][0] };
+        }
+    }
+
+    public static readonly IList<object[]> s_themeDictionarySourceList
+        = new List<object[]>
+            {
+                new object[] { $"{ThemeDictionaryPath}/Fluent.xaml" },
+                new object[] { $"{ThemeDictionaryPath}/Fluent.Light.xaml" },
+                new object[] { $"{ThemeDictionaryPath}/Fluent.Dark.xaml" },
+                new object[] { $"{ThemeDictionaryPath}/Fluent.HC.xaml" },
+            };
+
+    public static readonly IList<string> s_colorDictionarySourceList
+        = new List<string>
+        {
+            $"{ColorDictionaryPath}/Light.xaml",
+            $"{ColorDictionaryPath}/Dark.xaml",
+            $"{ColorDictionaryPath}/HC.xaml"
+        };
+
+    public static readonly IList<string> s_testColorDictionarySourceList
+        = new List<string>
+        {
+            $"{TestColorDictionaryPath}/Light.Test.xaml",
+            $"{TestColorDictionaryPath}/Dark.Test.xaml",
+            $"{TestColorDictionaryPath}/HC.Test.xaml"
+        };
+
+    private const string ThemeDictionaryPath = @"/PresentationFramework.Fluent;component/Themes";
+    private const string ColorDictionaryPath = @"/PresentationFramework.Fluent;component/Resources/Theme";
+    private const string TestColorDictionaryPath = @"/PresentationFramework.Fluent.Tests;component/ResourceTests/Data";
+
+    #endregion
+
+}

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ResourceTests/ResourceDictionaryTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/ResourceTests/ResourceDictionaryTests.cs
@@ -1,0 +1,143 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using FluentAssertions.Execution;
+using Application = System.Windows.Application;
+
+namespace PresentationFramework.Fluent.Tests.ResourceTests;
+public class ResourceDictionaryTests
+{
+    [WpfTheory]
+    [MemberData(nameof(s_themeDictionarySourceList))]
+    public void Fluent_ResourceDictionary_LoadTests(string source)
+    {
+        LoadFluentResourceDictionary(source);
+    }
+
+    [WpfTheory]
+    [MemberData(nameof(GetColorDictionary_MatchKeys_TestData))]
+    public void Fluent_ColorDictionary_MatchKeysTest(string firstSource, string secondSource)
+    {
+        ResourceDictionary dictionary1 = LoadFluentResourceDictionary(firstSource);
+        ResourceDictionary dictionary2 = LoadFluentResourceDictionary(secondSource);
+
+        GetResourceKeysFromResourceDictionary(dictionary1,
+            out List<string> dictionary1StringKeys, out List<object> dictionary1ObjectKeys);
+
+        GetResourceKeysFromResourceDictionary(dictionary2,
+            out List<string> dictionary2StringKeys, out List<object> dictionary2ObjectKeys);
+
+        List<string> dictionary1ExtraStringKeys = dictionary1StringKeys.Except(dictionary2StringKeys).ToList();
+        List<string> dictionary2ExtraStringKeys = dictionary2StringKeys.Except(dictionary1StringKeys).ToList();
+
+        List<object> dictionary1ExtraObjectKeys = dictionary1ObjectKeys.Except(dictionary2ExtraStringKeys).ToList();
+        List<object> dictionary2ExtraObjectKeys = dictionary2ObjectKeys.Except(dictionary1ObjectKeys).ToList();
+
+        Log_ExtraKeys(dictionary1ExtraStringKeys, $"Dictionary 1 : {firstSource} extra keys");
+        Log_ExtraKeys(dictionary2ExtraStringKeys, $"Dictionary 2 : {secondSource} extra keys");
+
+        using (new AssertionScope())
+        {
+            dictionary1ExtraStringKeys.Should().BeEmpty();
+            dictionary2ExtraStringKeys.Should().BeEmpty();
+            dictionary1ExtraObjectKeys.Should().BeEmpty();
+            dictionary2ExtraObjectKeys.Should().BeEmpty();
+        }
+    }
+
+    #region Helper Methods
+
+    private static void Log_ExtraKeys(List<string> dictionary1ExtraStringKeys, string v)
+    {
+        Console.WriteLine(v);
+        if (dictionary1ExtraStringKeys.Count == 0)
+        {
+            Console.WriteLine("None\n");
+            return;
+        }
+
+        foreach (string key in dictionary1ExtraStringKeys)
+        {
+            Console.WriteLine(key);
+        }
+        Console.WriteLine();
+    }
+
+    private static ResourceDictionary LoadFluentResourceDictionary(string source)
+    {
+        var uri = new Uri(source, UriKind.RelativeOrAbsolute);
+
+        if(Application.LoadComponent(uri) is not ResourceDictionary resourceDictionary)
+        {
+            throw new ArgumentException($"The source : {source} can not be loaded.");
+        }
+
+        return resourceDictionary;
+    }
+
+    private static int GetResourceKeysFromResourceDictionary(ResourceDictionary resourceDictionary,
+        out List<string> stringResourceKeys,
+        out List<object> objectResourceKeys)
+    {
+        ArgumentNullException.ThrowIfNull(resourceDictionary, nameof(resourceDictionary));
+        stringResourceKeys = new List<string>();
+        objectResourceKeys = new List<object>();
+
+        int resourceDictionaryKeysCount = resourceDictionary.Count;
+
+        foreach (object key in resourceDictionary.Keys)
+        {
+            if (key is string skey)
+            {
+                stringResourceKeys.Add(skey);
+            }
+            else
+            {
+                objectResourceKeys.Add(key);
+            }
+        }
+
+        return resourceDictionaryKeysCount;
+    }
+
+    #endregion
+
+
+    #region Test Data
+
+    public static IEnumerable<object[]> GetColorDictionary_MatchKeys_TestData()
+    {
+        int count = s_colorDictionarySourceList.Count;
+        for (int i = 0; i < count; i++)
+        {
+            for (int j = i + 1; j < count; j++)
+            {
+                yield return new object[] { s_colorDictionarySourceList[i], s_colorDictionarySourceList[j] };
+            }
+        }
+    }
+
+    public static readonly IList<object[]> s_themeDictionarySourceList
+        = new List<object[]>
+            {
+                new object[] { $"{ThemeDictionaryPath}/Fluent.xaml" },
+                new object[] { $"{ThemeDictionaryPath}/Fluent.Light.xaml" },
+                new object[] { $"{ThemeDictionaryPath}/Fluent.Dark.xaml" },
+                new object[] { $"{ThemeDictionaryPath}/Fluent.HC.xaml" },
+            };
+
+    public static readonly IList<string> s_colorDictionarySourceList
+        = new List<string>
+        {
+            $"{ColorDictionaryPath}/Light.xaml",
+            $"{ColorDictionaryPath}/Dark.xaml",
+            $"{ColorDictionaryPath}/HC.xaml"
+        };
+
+    private const string ThemeDictionaryPath = @"/PresentationFramework.Fluent;component/Themes";
+    private const string ColorDictionaryPath = @"/PresentationFramework.Fluent;component/Resources/Theme";
+
+    #endregion
+
+}

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/System/Windows/WindowThemeModeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/System/Windows/WindowThemeModeTests.cs
@@ -1,0 +1,139 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Windows.Media;
+
+namespace Fluent.UITests.ThemeModeTests;
+
+public class WindowThemeModeTests
+{
+    [WpfTheory]
+    [MemberData(nameof(ThemeModes))]
+    public void Window_ThemeMode_Initialization(ThemeMode themeMode)
+    {
+        if (themeMode == ThemeMode.None) return;
+
+        Window window = new Window() { ThemeMode = themeMode };
+        window.ApplyTemplate();
+
+        Verify_WindowProperties(window, themeMode);
+    }
+
+    [WpfFact]
+    public void Window_ThemeMode_Default()
+    {
+        Window window = new Window();
+        window.ApplyTemplate();
+
+        window.ThemeMode.Value.Should().Be("None");
+        window.Background.Should().BeNull();
+        window.Resources.MergedDictionaries.Should().HaveCount(0);
+    }
+
+    [WpfTheory]
+    [MemberData(nameof(ThemeModePairs))]
+    public void Window_ThemeMode_Switch(ThemeMode themeMode, ThemeMode newThemeMode)
+    {
+        if (themeMode == newThemeMode) return;
+
+        Window window = new Window();
+        window.Show();
+        window.ThemeMode = themeMode;
+        Verify_WindowProperties(window, themeMode);
+        Verify_WindowResources(window, themeMode);
+
+        window.ThemeMode = newThemeMode;
+        Verify_WindowProperties(window, newThemeMode);
+        Verify_WindowResources(window, newThemeMode);
+
+        window.Close();
+    }
+
+    #region Helper Methods
+
+    private void Verify_WindowProperties(Window window, ThemeMode themeMode)
+    {
+        if (themeMode == ThemeMode.None)
+        {
+            window.Background.Should().BeNull();
+            window.Foreground.ToString().Should().Be(Brushes.Black.ToString());
+            window.Resources.MergedDictionaries.Should().HaveCount(0);
+            return;
+        }
+
+        window.Background.Should().Be(Brushes.Transparent);
+
+    }
+
+    // private void Verify_ApplicationResources(Application application, ThemeMode themeMode)
+    // {
+    //     if (themeMode == ThemeMode.None)
+    //     {
+    //         application.Resources.MergedDictionaries.Should().BeEmpty();
+    //         return;
+    //     }
+
+    //     application.Resources.MergedDictionaries.Should().HaveCount(1);
+    //     Uri source = application.Resources.MergedDictionaries[0].Source;
+    //     source.AbsoluteUri.ToString()
+    //         .Should().EndWith(s_fluentThemeResourceDictionaryMap[themeMode]);
+    // }
+
+    private void Verify_WindowResources(Window window, ThemeMode themeMode)
+    {
+        if (themeMode == ThemeMode.None)
+        {
+            window.Resources.MergedDictionaries.Should().BeEmpty();
+            return;
+        }
+
+        window.Resources.MergedDictionaries.Should().HaveCount(1);
+
+        Uri source = window.Resources.MergedDictionaries[0].Source;
+        source.AbsoluteUri.ToString()
+            .Should().Be(s_fluentThemeResourceDictionaryMap[themeMode]);
+    }
+
+    #endregion
+
+    #region Test Data
+
+    public static IEnumerable<object[]> ThemeModes => new List<object[]>
+    {
+        new object[] { ThemeMode.None },
+        new object[] { ThemeMode.System },
+        new object[] { ThemeMode.Light },
+        new object[] { ThemeMode.Dark }
+    };
+
+    public static IEnumerable<object[]> ThemeModePairs => new List<object[]>
+    {
+        new object[] { ThemeMode.None, ThemeMode.None },
+        new object[] { ThemeMode.None, ThemeMode.Light },
+        new object[] { ThemeMode.None, ThemeMode.Dark },
+        new object[] { ThemeMode.None, ThemeMode.System },
+        new object[] { ThemeMode.Light, ThemeMode.None },
+        new object[] { ThemeMode.Light, ThemeMode.Light },
+        new object[] { ThemeMode.Light, ThemeMode.Dark },
+        new object[] { ThemeMode.Light, ThemeMode.System },
+        new object[] { ThemeMode.Dark, ThemeMode.None },
+        new object[] { ThemeMode.Dark, ThemeMode.Light },
+        new object[] { ThemeMode.Dark, ThemeMode.Dark },
+        new object[] { ThemeMode.Dark, ThemeMode.System },
+        new object[] { ThemeMode.System, ThemeMode.None },
+        new object[] { ThemeMode.System, ThemeMode.Light },
+        new object[] { ThemeMode.System, ThemeMode.Dark },
+        new object[] { ThemeMode.System, ThemeMode.System }
+    };
+
+    private static readonly Dictionary<ThemeMode, string> s_fluentThemeResourceDictionaryMap
+        = new Dictionary<ThemeMode, string>
+            {
+                { ThemeMode.None, ""},
+                { ThemeMode.System, "pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.xaml"},
+                { ThemeMode.Light, "pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.Light.xaml"},
+                { ThemeMode.Dark, "pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.Dark.xaml"},
+            };
+
+    #endregion
+}

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/System/Windows/WindowThemeModeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/System/Windows/WindowThemeModeTests.cs
@@ -3,7 +3,7 @@
 
 using System.Windows.Media;
 
-namespace Fluent.UITests.ThemeModeTests;
+namespace PresentationFramework.Fluent.Tests.ThemeModeTests;
 
 public class WindowThemeModeTests
 {

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/TestUtilities/BrushComparer.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/TestUtilities/BrushComparer.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Windows.Media;
+
+namespace PresentationFramework.Fluent.Tests.TestUtilities;
+
+public static class BrushComparer
+{
+    public static bool Equal(Brush brush1, Brush brush2)
+    {
+        if(brush1 is null || brush2 is null)
+        {
+            return brush1 is null && brush2 is null;
+        }
+
+        if(brush1.GetType() != brush2.GetType())
+        {
+            return false;
+        }
+
+        return brush1 switch
+        {
+            SolidColorBrush => CompareSolidColorBrushes((SolidColorBrush)brush1, (SolidColorBrush)brush2),
+            _ => false,
+        };
+    }
+
+    public static bool CompareSolidColorBrushes(SolidColorBrush brush1, SolidColorBrush brush2)
+    {
+        if (brush1 is null || brush2 is null)
+        {
+            return brush1 is null && brush2 is null;
+        }
+
+        return brush1.Color == brush2.Color && brush1.Opacity == brush2.Opacity;
+    }
+
+    public static void LogBrushDifference(Brush brush1, Brush brush2)
+    {
+        if (brush1 is null || brush2 is null)
+        {
+            if(brush1 is null && brush2 is null)
+            {
+
+            }
+            else
+            {
+                Console.WriteLine($"brush1 is null : {brush1 is null} , brush2 is null : {brush2 is null}");
+            }
+            return;
+        }
+
+        if (brush1.GetType() != brush2.GetType())
+        {
+            Console.WriteLine($"brush1 is of type : {brush1.GetType()} , brush2 is of type : {brush2.GetType()}");
+            return;
+        }
+
+        switch (brush1)
+        {
+            case SolidColorBrush:
+                LogSolidColorBrushDifference((SolidColorBrush)brush1, (SolidColorBrush)brush2);
+                return;
+            default:
+                return;
+        }
+    }
+
+    private static void LogSolidColorBrushDifference(SolidColorBrush brush1, SolidColorBrush brush2)
+    {
+        if (brush1 is null || brush2 is null)
+        {
+            if (brush1 is null && brush2 is null)
+            {
+
+            }
+            else
+            {
+                Console.WriteLine($"brush1 is null : {brush1 is null} , brush2 is null : {brush2 is null}");
+            }
+            return;
+        }
+
+        Console.WriteLine($"brush1: Color = {brush1.Color}, Opacity = {brush1.Opacity}");
+        Console.WriteLine($"brush2: Color = {brush2.Color}, Opacity = {brush2.Opacity}");
+        return; 
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/TestUtilities/ColorMode.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/TestUtilities/ColorMode.cs
@@ -1,0 +1,12 @@
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace PresentationFramework.Fluent.Tests.TestUtilities;
+
+public enum ColorMode
+{
+    Light,
+    Dark,
+    HC
+};

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/TestUtilities/FluentAssertionExtensions.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/TestUtilities/FluentAssertionExtensions.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions.Primitives;
+using System.Windows.Media;
+using Xunit.Abstractions;
+
+namespace PresentationFramework.Fluent.Tests.TestUtilities;
+
+public static class FluentAssertionExtensions
+{
+    public static AndConstraint<ObjectAssertions> BeEquivalentToBrush(
+        this ObjectAssertions assertions,
+        Brush expectedBrush,
+        ITestOutputHelper outputHelper,
+        string because="",
+        params object[] becauseArgs)
+    {
+        var actualBrush = assertions.Subject as Brush;
+        actualBrush.Should().NotBeNull(because, becauseArgs);
+
+        if(!BrushComparer.Equal(actualBrush!, expectedBrush))
+        {
+            if (actualBrush is SolidColorBrush scb1 && expectedBrush is SolidColorBrush scb2)
+            {
+                outputHelper.WriteLine($"Brush Comparison Failed:");
+                outputHelper.WriteLine($"  Actual Color: {scb1.Color}");
+                outputHelper.WriteLine($"  Expected Color: {scb2.Color}");
+            }
+            else
+            {
+                outputHelper.WriteLine($"Brush Comparison Failed: Brushes are not SolidColorBrush.");
+            }
+        }
+
+        BrushComparer.Equal(actualBrush!, expectedBrush).Should().BeTrue(because, becauseArgs);
+
+        return new AndConstraint<ObjectAssertions>(assertions);
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/TestUtilities/TestDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Fluent.Tests/TestUtilities/TestDictionary.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace PresentationFramework.Fluent.Tests.TestUtilities;
+
+public class TestDictionary : ResourceDictionary
+{
+    public string? Name { get; set; } 
+}


### PR DESCRIPTION
Issue Link : #8552

### Description

Hello community members, we are working on writing tests for Fluent UI and ThemeMode property, and here is a basic structure of how I am planning to do this and would like to have your suggestions on how we can make this better. It is okay, if there is a completely different approach that should be taken up.

The tests that are present in this PR, can be divided into three parts : 
1. **ThemeMode Property Tests** : In this set of tests, the main aim is to test the initialization of ThemeMode properties on Window and Application classes. It will include initialization of Application and Window, switching ThemeMode, combination Application and Window ThemeMode properties.
2. **Fluent ResourceDictionary Tests** : In this set of tests, the main aim is to check the correctness of Fluent colors and brushes ( not control brushes ), loading of different Fluent ResourceDictionary, etc.
3. **Control Styles UI Tests** : These set of tests are meant to test the behavior and default property values of controls when Fluent this is applied. Here are more details on this : 
    - First, I have created a copy of all the Fluent colors and brushes, which will be used as the source of truth.
    - In each test, we launch a window with a control ( can have custom values set for the different properties )
    - For each test there is a dictionary, which corresponds to what values all the properties of controls and and different elements in the template of the control should have, and we verify these values by matching them with the values specified in the dictionary.
    - To avoid redundancy, there is a base ( default ) dictionary for a control, where the property values correspond to Fluent default values for that control. 
    - For subsequent tests ( like disabled button, mouse over, Background = Red ) we have separate dictionaries which have a subset of the values defined in the base dictionary. We combine the base dictionary with the dictionary for the current test and use that to verify the different properties of the control in that state.

From the approach that we have followed here, it may be better to put these tests under Integration Tests, but before that, I want your opinions on what limitations we can face with the above approach, or if there is some other approach that we can take to write these tests in a better fashion. 

/cc @h3xds1nz @hughbe @JeremyKuhne @ThomasGoulet73 @miloush @lindexi @batzen 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10385)