### PR TITLE
Remove duplicated code/branch to call into Milcore in Geometry

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Geometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Geometry.cs
@@ -689,11 +689,11 @@ namespace System.Windows.Media
                     FillRule fillRule = FillRule.Nonzero;
                     PathGeometry.FigureList list = new();
 
-                    int hr; //If we don't have dashArray, we call without it (its optional)
-                    if (dashArray is null)
+                    int hr;
+                    fixed (double* ptrDashArray = dashArray)
                     {
                         hr = UnsafeNativeMethods.MilCoreApi.MilUtility_PathGeometryWiden(&penData,
-                                                                                         null,
+                                                                                         ptrDashArray,
                                                                                          &pathData.Matrix,
                                                                                          pathData.FillRule,
                                                                                          pbPathData,
@@ -702,22 +702,6 @@ namespace System.Windows.Media
                                                                                          type == ToleranceType.Relative,
                                                                                          new PathGeometry.AddFigureToListDelegate(list.AddFigureToList),
                                                                                          out fillRule);
-                    }
-                    else // Pin the dashArray and use it, if we have one.
-                    {
-                        fixed (double* ptrDashArray = dashArray)
-                        {
-                            hr = UnsafeNativeMethods.MilCoreApi.MilUtility_PathGeometryWiden(&penData,
-                                                                                             ptrDashArray,
-                                                                                             &pathData.Matrix,
-                                                                                             pathData.FillRule,
-                                                                                             pbPathData,
-                                                                                             pathData.Size,
-                                                                                             tolerance,
-                                                                                             type == ToleranceType.Relative,
-                                                                                             new PathGeometry.AddFigureToListDelegate(list.AddFigureToList),
-                                                                                             out fillRule);
-                        }
                     }
 
                     if (hr == (int)MILErrors.WGXERR_BADNUMBER)


### PR DESCRIPTION
## Description

Removes duplicate code to call `MilUtility_PathGeometryWiden`. This was overlooked in #9365 where it has previously made sense but after the change it is no longer the case.

`fixed` on a `null` array will return a `null` pointer so we may as well remove the branch altogether and let JIT do its thing. There's also no difference in perf, besides the removed the branch, that's always nice.

## Customer Impact

Cleaner codebase for developrs.

## Regression

Well, kinda, previously it made sense due to use of `GCHandle`, now its just a useless branch.

## Testing

Local build.

## Risk

Low.