### PR TITLE
Remove unused/incompatible NETFX preprocessor conditionals from base libraries

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/CoreCompatibilityPreferences.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/CoreCompatibilityPreferences.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -39,13 +39,7 @@ namespace System.Windows
         {
             get
             {
-#if NETFX && !NETCOREAPP
-                return BinaryCompatibility.TargetsAtLeast_Desktop_V4_5;
-#elif NETCOREAPP
                 return true;
-#else
-                return true;
-#endif
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/CoreCompatibilityPreferences.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/CoreCompatibilityPreferences.cs
@@ -33,18 +33,6 @@ namespace System.Windows
 
         #endregion Constructor
 
-        #region CLR compat flags
-
-        internal static bool TargetsAtLeast_Desktop_V4_5
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        #endregion CLR compat flags
-
         #region IsAltKeyRequiredInAccessKeyDefaultScope
 
         // We decided NOT to opt-in this feature by default.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemContainerGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemContainerGenerator.cs
@@ -2403,22 +2403,16 @@ namespace System.Windows.Controls
                     break;
 
                 case NotifyCollectionChangedAction.Replace:
-                    // Don't check arguments if app targets 4.0, for compat ( 726682)
-                    if (!FrameworkCompatibilityPreferences.TargetsDesktop_V4_0)
-                    {
-                        if (args.OldItems.Count != 1)
-                            throw new NotSupportedException(SR.RangeActionsNotSupported);
-                    }
+                    if (args.OldItems.Count != 1)
+                        throw new NotSupportedException(SR.RangeActionsNotSupported);
+
                     OnItemReplaced(args.OldItems[0], args.NewItems[0], args.NewStartingIndex);
                     break;
 
                 case NotifyCollectionChangedAction.Move:
-                    // Don't check arguments if app targets 4.0, for compat ( 726682)
-                    if (!FrameworkCompatibilityPreferences.TargetsDesktop_V4_0)
-                    {
-                        if (args.OldItems.Count != 1)
-                            throw new NotSupportedException(SR.RangeActionsNotSupported);
-                    }
+                    if (args.OldItems.Count != 1)
+                        throw new NotSupportedException(SR.RangeActionsNotSupported);
+
                     OnItemMoved(args.OldItems[0], args.OldStartingIndex, args.NewStartingIndex);
                     break;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/Binding.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/Binding.cs
@@ -308,8 +308,7 @@ namespace System.Windows.Data
 
                 if (_ppath != null && _ppath.StartsWithStaticProperty)
                 {
-                    if (_sourceInUse == SourceProperties.None || _sourceInUse == SourceProperties.StaticSource ||
-                        FrameworkCompatibilityPreferences.TargetsDesktop_V4_0) 
+                    if (_sourceInUse == SourceProperties.None || _sourceInUse == SourceProperties.StaticSource)
                     {
                         // net 4.5 breaks static bindings - this is for compat
                         SourceReference = StaticSourceRef;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkCompatibilityPreferences.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkCompatibilityPreferences.cs
@@ -13,18 +13,6 @@ namespace System.Windows
 
         static FrameworkCompatibilityPreferences()
         {
-#if NETFX && !NETCOREAPP
-            _targetsDesktop_V4_0 = BinaryCompatibility.AppWasBuiltForFramework == TargetFrameworkId.NetFramework
-                && !BinaryCompatibility.TargetsAtLeast_Desktop_V4_5;
-#elif NETCOREAPP
-            // When building for NETCOREAPP, set this to false
-            // to indicate that quirks should be treated as if they are running on 
-            // .NET 4.5+
-            _targetsDesktop_V4_0 = false;
-#else
-            _targetsDesktop_V4_0 = false;
-#endif
-
             // user can use config file to set preferences
             NameValueCollection appSettings = null;
             try
@@ -46,19 +34,6 @@ namespace System.Windows
         }
 
         #endregion Constructor
-
-        #region TargetsDesktop_V4_0
-
-        // CLR's BinaryCompatibility class doesn't expose a convenient way to determine
-        // if the app targets 4.0 exactly.  We use that a lot, so encapsulate it here
-        static bool _targetsDesktop_V4_0;
-
-        internal static bool TargetsDesktop_V4_0
-        {
-            get { return _targetsDesktop_V4_0; }
-        }
-
-        #endregion TargetsDesktop_V4_0
 
         #region AreInactiveSelectionHighlightBrushKeysSupported
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkCompatibilityPreferences.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkCompatibilityPreferences.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -62,13 +62,7 @@ namespace System.Windows
 
         #region AreInactiveSelectionHighlightBrushKeysSupported
 
-#if NETFX && !NETCOREAPP
-        private static bool _areInactiveSelectionHighlightBrushKeysSupported = BinaryCompatibility.TargetsAtLeast_Desktop_V4_5 ? true : false;
-#elif NETCOREAPP
         private static bool _areInactiveSelectionHighlightBrushKeysSupported = true;
-#else
-        private static bool _areInactiveSelectionHighlightBrushKeysSupported = true;
-#endif
 
         public static bool AreInactiveSelectionHighlightBrushKeysSupported
         {
@@ -98,13 +92,7 @@ namespace System.Windows
 
         #region KeepTextBoxDisplaySynchronizedWithTextProperty
 
-#if NETFX && !NETCOREAPP
-        private static bool _keepTextBoxDisplaySynchronizedWithTextProperty = BinaryCompatibility.TargetsAtLeast_Desktop_V4_5 ? true : false;
-#elif NETCOREAPP
         private static bool _keepTextBoxDisplaySynchronizedWithTextProperty = true;
-#else
-        private static bool _keepTextBoxDisplaySynchronizedWithTextProperty = true;
-#endif
 
         /// <summary>
         /// In WPF 4.0, a TextBox can reach a state where its Text property

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/PropertyPath.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/PropertyPath.cs
@@ -877,17 +877,7 @@ namespace System.Windows
             DependencyObject hostElement = context as DependencyObject;
             if (hostElement == null)
             {
-                if (FrameworkCompatibilityPreferences.TargetsDesktop_V4_0)
-                {
-                    // WPF "OneTime" Data binding can work inconsistently when running
-                    // a .NET 4 application on .NET 4.5 compared to running it on .NET 4
-                    // app targets 4.0, so return null, for compat 
-                    return null;
-                }
-                else
-                {
-                    hostElement = new DependencyObject();   // at least pick up the default namespaces
-                }
+                hostElement = new DependencyObject();   // at least pick up the default namespaces
             }
 
             var wpfSharedSchemaContext = XamlReader.BamlSharedSchemaContext;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/BaseCompatibilityPreferences.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/BaseCompatibilityPreferences.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -97,13 +97,7 @@ namespace System.Windows
             return ReuseDispatcherSynchronizationContextInstance;
         }
 
-#if NETFX && !NETCOREAPP
-        private static bool _reuseDispatcherSynchronizationContextInstance = BinaryCompatibility.TargetsAtLeast_Desktop_V4_5 ? false : true;
-#elif NETCOREAPP
         private static bool _reuseDispatcherSynchronizationContextInstance = false;
-#else
-        private static bool _reuseDispatcherSynchronizationContextInstance = false;
-#endif
 
         #endregion ReuseDispatcherSynchronizationContextInstance
 
@@ -148,13 +142,7 @@ namespace System.Windows
             return FlowDispatcherSynchronizationContextPriority;
         }
 
-#if NETFX && !NETCOREAPP
-        private static bool _flowDispatcherSynchronizationContextPriority = BinaryCompatibility.TargetsAtLeast_Desktop_V4_5 ? true : false;
-#elif NETCOREAPP
         private static bool _flowDispatcherSynchronizationContextPriority = true;
-#else
-        private static bool _flowDispatcherSynchronizationContextPriority = true;
-#endif
 
         #endregion FlowDispatcherSynchronizationContextPriority
 
@@ -198,13 +186,8 @@ namespace System.Windows
             return InlineDispatcherSynchronizationContextSend;
         }
 
-#if NETFX && !NETCOREAPP
-        private static bool _inlineDispatcherSynchronizationContextSend = BinaryCompatibility.TargetsAtLeast_Desktop_V4_5 ? true : false;
-#elif NETCOREAPP
         private static bool _inlineDispatcherSynchronizationContextSend = true;
-#else
-        private static bool _inlineDispatcherSynchronizationContextSend = true;
-#endif
+
         #endregion InlineDispatcherSynchronizationContextSend    
 
         #region MatchPackageSignatureMethodToPackagePartDigestMethod

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/ApplicationInterop.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/ApplicationInterop.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -85,8 +85,7 @@ namespace System.Windows.Forms.Integration
             // would accidentally route messages to the control even when in
             // menu mode.  So we just bail out here, but for compat reasons
             // only if the app targets 4.5+ (DevDiv #650335).
-            if (CoreCompatibilityPreferences.TargetsAtLeast_Desktop_V4_5 &&
-                System.Windows.Input.InputManager.Current.IsInMenuMode)
+            if (SWI.InputManager.Current.IsInMenuMode)
             {
                 return;
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/WindowsFormsHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/WindowsFormsHost.cs
@@ -476,14 +476,6 @@ namespace System.Windows.Forms.Integration
 
             Debug.WriteLineIf(_traceHandle.TraceVerbose, String.Format(CultureInfo.CurrentCulture, "WindowsFormsHost({0}): BuildWindowCore (parent=0x{1:x8})", this.Name, hwndParent.Handle.ToInt32()));
 
-            // for 4.0 compat, create a Winforms.NativeWindow to swallow exceptions during WndProc
-            if (!CoreCompatibilityPreferences.TargetsAtLeast_Desktop_V4_5)
-            {
-                _dummyNativeWindow?.Dispose();
-                _dummyNativeWindow = new DummyNativeWindow(this);
-                _dummyNativeWindow.AssignHandle(hwndParent.Handle);
-            }
-
             _hwndParent = hwndParent;
             //For Keyboard interop
             ApplicationInterop.ThreadWindowsFormsHostList.Add(this);    //Keep track of this control, so it can get forwarded windows messages

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/WindowsFormsHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/WindowsFormsHost.cs
@@ -441,30 +441,6 @@ namespace System.Windows.Forms.Integration
 
         #endregion Keyboarding
 
-        #region NativeWindow
-
-        // In 4.0, we spun up a WinForms.NativeWindow to listen for WM_ACTIVATEAPP
-        // messages.  This was part of a failed attempt to make focus-restoration
-        // work correctly;   in 4.5 we solved the focus problems a different way
-        // that didn't need the NativeWindow.  However, the NativeWindow had a
-        // side-effect:  it swallows all exceptions.   For compat with 4.0, we
-        // re-introduce the NativeWindow.  We don't need it to do anything - it's
-        // only purpose is to swallow exceptions during WndProc so that 4.0 apps
-        // don't crash. (Dev11 475347)
-
-        private DummyNativeWindow _dummyNativeWindow;
-        private class DummyNativeWindow : NativeWindow, IDisposable
-        {
-            WindowsFormsHost _host;
-            public DummyNativeWindow(WindowsFormsHost host)
-            { _host = host; }
-
-            public void Dispose()
-            { this.ReleaseHandle(); }
-        }
-
-        #endregion NativeWindow
-
         #region Window Handling & Misc
         /// <internalonly>
         ///     Overrides the base class implementation of BuildWindowCore to build the hosted
@@ -477,9 +453,13 @@ namespace System.Windows.Forms.Integration
             Debug.WriteLineIf(_traceHandle.TraceVerbose, String.Format(CultureInfo.CurrentCulture, "WindowsFormsHost({0}): BuildWindowCore (parent=0x{1:x8})", this.Name, hwndParent.Handle.ToInt32()));
 
             _hwndParent = hwndParent;
-            //For Keyboard interop
-            ApplicationInterop.ThreadWindowsFormsHostList.Add(this);    //Keep track of this control, so it can get forwarded windows messages
-            EnableWindowsFormsInterop();        //Start the forwarding of windows messages to all WFH controls on active windows
+
+            // For Keyboard interop
+
+            // Keep track of this control, so it can get forwarded windows messages
+            ApplicationInterop.ThreadWindowsFormsHostList.Add(this);
+            // Start the forwarding of windows messages to all WFH controls on active windows
+            EnableWindowsFormsInterop();
 
             UnsafeNativeMethods.SetParent(/* child = */ HostContainerInternal.Handle, /* parent = */ _hwndParent.Handle);
             return new HandleRef(HostContainerInternal, HostContainerInternal.Handle);
@@ -520,7 +500,6 @@ namespace System.Windows.Forms.Integration
                     {
                         try
                         {
-                            _dummyNativeWindow?.Dispose();
                             _hostContainerInternal.Dispose();
                             this.Loaded -= new RoutedEventHandler(ApplyAllProperties);
                         }


### PR DESCRIPTION
## Description

Removes bunch of conditionals that evaluate always either `true` or `false`. None of these files compile with PBT (which is the only library that multi-targets), there's no reason for those to hang around in the codebase. And `BinaryCompatibility` from `System.Runtime` was removed like 8 releases ago.

## Customer Impact

Cleaner codebase, smaller file size.

## Regression

No.

## Testing

Local build.

## Risk

None, those conditionals never be `true` (or `false`).
