### PR TITLE
Use shared DataFormats code

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/GlobalSuppressions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/GlobalSuppressions.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.Text")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.UnicodeText")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.Dib")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.Bitmap")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.EnhancedMetafile")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.CommaSeparatedValue")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.Dif")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.FileDrop")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.Html")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.Locale")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.MetafilePicture")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.OemText")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.Palette")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.PenData")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.Riff")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.Rtf")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.Serializable")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.StringFormat")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.SymbolicLink")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.Tiff")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.WaveAudio")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.Xaml")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.DataFormats.XamlPackage")]

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/GlobalUsings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/GlobalUsings.cs
@@ -1,10 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 global using System;
 global using System.Collections.Generic;
 global using System.Diagnostics;
+
+global using DataFormatsCore = System.Private.Windows.Ole.DataFormatsCore<
+    System.Windows.DataFormat>;
 
 global using SR = MS.Internal.PresentationCore.SR;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="$(WpfCommonDir)\src\System\LocalAppContext.cs" />
     <Compile Include="$(WpfCommonDir)\src\System\AppContextDefaultValues.cs" />
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="GlobalUsings.cs" />
     <Compile Include="System\AppContextDefaultValues.cs" />
   </ItemGroup>
@@ -1436,6 +1437,10 @@
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\ref\PresentationCore-ref.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <MicrosoftPrivateWinFormsReference Include="System.Private.Windows.Core" />
   </ItemGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormat.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormat.cs
@@ -1,102 +1,40 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
-//
-// 
-// Description: Manage the data format.
-//
-// See spec at http://avalon/uis/Data%20Transfer%20clipboard%20dragdrop/Avalon%20Data%20Transfer%20Object.htm 
-// 
-//
+using System.Private.Windows.Ole;
 
-using MS.Internal.PresentationCore;
+namespace System.Windows;
 
-namespace System.Windows
+/// <summary>
+///  Represents a data format type.
+/// </summary>
+public sealed class DataFormat : IDataFormat<DataFormat>
 {
-    #region DataFormat Class
-
     /// <summary>
-    /// Represents a data format type.
+    ///  Initializes a new instance of the DataFormat class and specifies format name and id.
     /// </summary>
-    public sealed class DataFormat
+    public DataFormat(string name, int id)
     {
-        //------------------------------------------------------
-        //
-        //  Constructors
-        //
-        //------------------------------------------------------
+        ArgumentNullException.ThrowIfNull(name);
 
-        #region Constructors
-
-        /// <summary>
-        /// Initializes a new instance of the DataFormat class and specifies format name and id.
-        /// </summary>
-        public DataFormat(string name, int id)
+        if (name.Length == 0)
         {
-            ArgumentNullException.ThrowIfNull(name);
-
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.DataObject_EmptyFormatNotAllowed); 
-            }
-
-            this._name = name;
-            this._id = id;
+            throw new ArgumentException(SR.DataObject_EmptyFormatNotAllowed); 
         }
 
-        #endregion Constructors
-
-        //------------------------------------------------------
-        //
-        //  Public Properties
-        //
-        //------------------------------------------------------
-
-        #region Public Properties
-
-        /// <summary>
-        /// Specifies the name of this format. 
-        /// This field is read-only.
-        /// </summary>
-        public string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
-
-        /// <summary>
-        /// Specifies the Id number for this format. 
-        /// This field is read-only.
-        /// </summary>
-        public int Id
-        {
-            get
-            {
-                return _id;
-            }
-        }
-
-        #endregion Public Properties
-
-        //------------------------------------------------------
-        //
-        //  Private Fields
-        //
-        //------------------------------------------------------
-
-        #region Private Fields
-
-        // The registered clipboard format name string.
-        readonly string _name;
-
-        // The registered clipboard format id.
-        readonly int _id;
-
-        #endregion Private Fields
+        Name = name;
+        Id = id;
     }
 
-    #endregion DataFormat Class
+    /// <summary>
+    ///  Specifies the name of this format.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    ///  Specifies the Id number for this format.
+    /// </summary>
+    public int Id { get; }
+
+    static DataFormat IDataFormat<DataFormat>.Create(string name, int id) => new(name, id);
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
@@ -1,472 +1,190 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
-//
-//
-// Description: Manage the data formats.
-//
-// See spec at http://avalon/uis/Data%20Transfer%20clipboard%20dragdrop/Avalon%20Data%20Transfer%20Object.htm
-//
-//
+using System.Private.Windows.Ole;
 
-using MS.Win32;
-using System.Collections;
-using System.Text;
-using MS.Internal.PresentationCore;
+namespace System.Windows;
 
-namespace System.Windows
+/// <summary>
+///  Translates between Windows Design text-based formats and 32-bit signed integer-based clipboard formats.
+/// </summary>
+public static class DataFormats
 {
-    #region DataFormats class
+    private static bool s_initialized;
 
     /// <summary>
-    /// Translates between Windows Design text-based formats and
-    /// 32-bit signed integer-based clipboard formats.
+    ///  Gets an object with the Windows Clipboard numeric ID and name for the specified ID.
     /// </summary>
-    public static class DataFormats
+    public static DataFormat GetDataFormat(int id) => DataFormatsCore.GetOrAddFormat(id);
+
+    /// <summary>
+    ///  Gets the data format with the Windows Clipboard numeric ID and name for the specified data format.
+    /// </summary>
+    public static DataFormat GetDataFormat(string format)
     {
-        //------------------------------------------------------
-        //
-        //  Public Methods
-        //
-        //------------------------------------------------------
+        ArgumentNullException.ThrowIfNull(format);
 
-        #region Public Methods
-
-        /// <summary>
-        /// Gets an object with the Windows Clipboard numeric
-        /// ID and name for the specified ID.
-        /// </summary>
-        public static DataFormat GetDataFormat(int id)
+        if (format == string.Empty)
         {
-            return InternalGetDataFormat(id);
+            throw new ArgumentException(SR.DataObject_EmptyFormatNotAllowed);
         }
 
-        /// <summary>
-        /// Gets the data format with the Windows Clipboard numeric ID and name for the specified data format.
-        /// </summary>
-        /// <remarks>
-        ///     Callers must have UnmanagedCode permission to call this API.
-        /// </remarks>
-        public static DataFormat GetDataFormat(string format)
-        {
-            ArgumentNullException.ThrowIfNull(format);
+        // Ensures the predefined Win32 data formats into our format list.
+        EnsurePredefined();
 
-            if (format == string.Empty)
-            {
-                throw new ArgumentException(SR.DataObject_EmptyFormatNotAllowed);
-            }
-
-            // Ensures the predefined Win32 data formats into our format list.
-            EnsurePredefined();
-
-            // Lock the data format list to obtains the mutual-exclusion.
-            lock (_formatListlock)
-            {
-                int formatId;
-                int index;
-
-                // It is much faster to do a case sensitive search here.  So do
-                // the case sensitive compare first, then the expensive one.
-                //
-                for (int n = 0; n < _formatList.Count; n++)
-                {
-                    DataFormat formatItem;
-
-                    formatItem = (DataFormat)_formatList[n];
-
-                    if (formatItem.Name.Equals(format))
-                    {
-                        return formatItem;
-                    }
-                }
-
-                for (int n = 0; n < _formatList.Count; n++)
-                {
-                    DataFormat formatItem;
-
-                    formatItem = (DataFormat)_formatList[n];
-
-                    if (string.Equals(formatItem.Name, format, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return formatItem;
-                    }
-                }
-
-                // Reigster the this format string.
-                formatId = UnsafeNativeMethods.RegisterClipboardFormat(format);
-
-                if (formatId == 0)
-                {
-                    throw new System.ComponentModel.Win32Exception();
-                }
-
-                index = _formatList.Add(new DataFormat(format, formatId));
-
-                return (DataFormat)_formatList[index];
-            }
-        }
-
-        #endregion Public Methods
-
-        //------------------------------------------------------
-        //
-        //  Public Fields
-        //
-        //------------------------------------------------------
-
-        #region Public Fields
-
-        /// <summary>
-        /// Specifies the standard ANSI text format. This field is read-only.
-        /// </summary>
-        public static readonly string Text = "Text";
-
-        /// <summary>
-        /// Specifies the standard Windows Unicode text format. This
-        /// field is read-only.
-        /// </summary>
-        public static readonly string UnicodeText = "UnicodeText";
-
-        /// <summary>
-        /// Specifies the Windows Device Independent Bitmap (DIB)
-        /// format. This field is read-only.
-        /// </summary>
-        public static readonly string Dib = "DeviceIndependentBitmap";
-
-        /// <summary>
-        /// Specifies a Windows bitmap format. This field is read-only.
-        /// </summary>
-        public static readonly string Bitmap = "Bitmap";
-
-        /// <summary>
-        /// Specifies the Windows enhanced metafile format. This
-        /// field is read-only.
-        /// </summary>
-        public static readonly string EnhancedMetafile = "EnhancedMetafile";
-
-        /// <summary>
-        /// Specifies the Windows metafile format. This field is read-only.
-        /// </summary>
-        public static readonly string MetafilePicture = "MetaFilePict";
-
-        /// <summary>
-        /// Specifies the Windows symbolic link format. This
-        /// field is read-only.
-        /// </summary>
-        public static readonly string SymbolicLink = "SymbolicLink";
-
-        /// <summary>
-        /// Specifies the Windows data interchange format. This
-        /// field is read-only.
-        /// </summary>
-        public static readonly string Dif = "DataInterchangeFormat";
-
-        /// <summary>
-        /// Specifies the Tagged Image File Format (TIFF). This
-        /// field is read-only.
-        /// </summary>
-        public static readonly string Tiff = "TaggedImageFileFormat";
-
-        /// <summary>
-        /// Specifies the standard Windows original equipment
-        /// manufacturer (OEM) text format. This field is read-only.
-        /// </summary>
-        public static readonly string OemText = "OEMText";
-
-        /// <summary>
-        /// Specifies the Windows palette format. This
-        /// field is read-only.
-        /// </summary>
-        public static readonly string Palette = "Palette";
-
-        /// <summary>
-        /// Specifies the Windows pen data format, which consists of
-        /// pen strokes for handwriting software; This field is read-only.
-        /// </summary>
-        public static readonly string PenData = "PenData";
-
-        /// <summary>
-        /// Specifies the Resource Interchange File Format (RIFF)
-        /// audio format. This field is read-only.
-        /// </summary>
-        public static readonly string Riff = "RiffAudio";
-
-        /// <summary>
-        /// Specifies the wave audio format, which Windows Design does not
-        /// directly use. This field is read-only.
-        /// </summary>
-        public static readonly string WaveAudio = "WaveAudio";
-
-        /// <summary>
-        /// Specifies the Windows file drop format, which Windows Design
-        /// does not directly use. This field is read-only.
-        /// </summary>
-        public static readonly string FileDrop = "FileDrop";
-
-        /// <summary>
-        /// Specifies the Windows culture format, which Windows Design does
-        /// not directly use. This field is read-only.
-        /// </summary>
-        public static readonly string Locale = "Locale";
-
-        /// <summary>
-        /// Specifies text consisting of HTML data. This
-        /// field is read-only.
-        /// </summary>
-        public static readonly string Html = "HTML Format";
-
-        /// <summary>
-        /// Specifies text consisting of Rich Text Format (RTF) data. This
-        /// field is read-only.
-        /// </summary>
-        public static readonly string Rtf = "Rich Text Format";
-
-        /// <summary>
-        /// Specifies a comma-separated value (CSV) format, which is a
-        /// common interchange format used by spreadsheets. This format is not used directly
-        /// by Windows Design. This field is read-only.
-        /// </summary>
-        public static readonly string CommaSeparatedValue = "CSV";
-
-        /// <summary>
-        /// Specifies the Windows Design string class format, which Win
-        /// Forms uses to store string objects. This
-        /// field is read-only.
-        /// </summary>
-        public static readonly string StringFormat = typeof(string).FullName;
-
-        /// <summary>
-        /// Specifies a format that encapsulates any type of Windows Design
-        /// object. This field is read-only.
-        /// </summary>
-        public static readonly string Serializable = "PersistentObject";
-
-
-        /// <summary>
-        /// Specifies a data format as Xaml. This field is read-only.
-        /// </summary>
-        public static readonly string Xaml = "Xaml";
-
-        /// <summary>
-        /// Specifies a data format as Xaml Package. This field is read-only.
-        /// </summary>
-        public static readonly string XamlPackage = "XamlPackage";
-        #endregion Public Fields
-
-        //------------------------------------------------------
-        //
-        //  Internal Fields
-        //
-        //------------------------------------------------------
-
-        #region Internal Fields
-        /// <summary>
-        /// Specifies a data format as ApplicationTrust which is used to block
-        /// paste from partial trust to full trust applications. The intent of this 
-        /// format is to store the permission set of the source application where the content came from.
-        /// This is then compared at paste time
-        /// </summary>
-        internal const string ApplicationTrust = "ApplicationTrust";
-
-        internal const string FileName = "FileName";
-        internal const string FileNameW = "FileNameW";
-
-        #endregion  Internal Fields
-
-        //------------------------------------------------------
-        //
-        //  Internal Methods
-        //
-        //------------------------------------------------------
-
-        #region Internal Methods
-
-        /// <summary>
-        /// Convert TextDataFormat to Dataformats.
-        /// </summary>
-        internal static string ConvertToDataFormats(TextDataFormat textDataformat)
-        {
-            string dataFormat = DataFormats.UnicodeText;
-
-            switch (textDataformat)
-            {
-                case TextDataFormat.Text:
-                    dataFormat = DataFormats.Text;
-                    break;
-
-                case TextDataFormat.UnicodeText:
-                    dataFormat = DataFormats.UnicodeText;
-                    break;
-
-                case TextDataFormat.Rtf:
-                    dataFormat = DataFormats.Rtf;
-                    break;
-
-                case TextDataFormat.Html:
-                    dataFormat = DataFormats.Html;
-                    break;
-
-                case TextDataFormat.CommaSeparatedValue:
-                    dataFormat = DataFormats.CommaSeparatedValue;
-                    break;
-
-                case TextDataFormat.Xaml:
-                    dataFormat = DataFormats.Xaml;
-                    break;
-            }
-
-            return dataFormat;
-        }
-
-        /// <summary>
-        /// Validate the text data format.
-        /// </summary>
-        internal static bool IsValidTextDataFormat(TextDataFormat textDataFormat)
-        {
-            if (textDataFormat == TextDataFormat.Text ||
-                textDataFormat == TextDataFormat.UnicodeText ||
-                textDataFormat == TextDataFormat.Rtf ||
-                textDataFormat == TextDataFormat.Html ||
-                textDataFormat == TextDataFormat.CommaSeparatedValue ||
-                textDataFormat == TextDataFormat.Xaml)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        #endregion Internal Methods
-
-        //------------------------------------------------------
-        //
-        //  Private Methods
-        //
-        //------------------------------------------------------
-
-        #region Private Methods
-
-        /// <summary>
-        /// Allows a the new format name to be specified if the requested format is not
-        /// in the list
-        /// </summary>
-        private static DataFormat InternalGetDataFormat(int id)
-        {
-            // Ensures the predefined Win32 data formats into our format list.
-            EnsurePredefined();
-
-            // Lock the data format list to obtains the mutual-exclusion.
-            lock (_formatListlock)
-            {
-                DataFormat formatItem;
-                StringBuilder sb;
-                int index;
-
-                for (int n = 0; n < _formatList.Count; n++)
-                {
-                    formatItem = (DataFormat)_formatList[n];
-
-                    // OLE FORMATETC defined CLIPFORMAT as the unsigned short, so we should ignore
-                    // high 2bytes to find the matched CLIPFORMAT ID. 
-                    if ((formatItem.Id & 0x0000ffff) == (id & 0x0000ffff))
-                    {
-                        return formatItem;
-                    }
-                }
-
-                sb = new StringBuilder(NativeMethods.MAX_PATH);
-
-                // This can happen if windows adds a standard format that we don't know about,
-                // so we should play it safe.
-                if (UnsafeNativeMethods.GetClipboardFormatName(id, sb, sb.Capacity) == 0)
-                {
-                    sb.Length = 0;
-                    sb.Append("Format").Append(id);
-                }
-
-                index = _formatList.Add(new DataFormat(sb.ToString(), id));
-
-                return (DataFormat)_formatList[index];
-            }
-        }
-
-        /// <summary>
-        /// Ensures that the Win32 predefined formats are setup in our format list.  This
-        /// is called anytime we need to search the list
-        /// </summary>
-        private static void EnsurePredefined()
-        {
-            // Lock the data format list to obtains the mutual-exclusion.
-            lock (_formatListlock)
-            {
-                if (_formatList == null)
-                {
-                    // Create format list for the default formats.
-                    _formatList = new ArrayList(19);
-
-                    _formatList.Add(new DataFormat(UnicodeText, NativeMethods.CF_UNICODETEXT));
-                    _formatList.Add(new DataFormat(Text, NativeMethods.CF_TEXT));
-                    _formatList.Add(new DataFormat(Bitmap, NativeMethods.CF_BITMAP));
-                    _formatList.Add(new DataFormat(MetafilePicture, NativeMethods.CF_METAFILEPICT));
-                    _formatList.Add(new DataFormat(EnhancedMetafile, NativeMethods.CF_ENHMETAFILE));
-                    _formatList.Add(new DataFormat(Dif, NativeMethods.CF_DIF));
-                    _formatList.Add(new DataFormat(Tiff, NativeMethods.CF_TIFF));
-                    _formatList.Add(new DataFormat(OemText, NativeMethods.CF_OEMTEXT));
-                    _formatList.Add(new DataFormat(Dib, NativeMethods.CF_DIB));
-                    _formatList.Add(new DataFormat(Palette, NativeMethods.CF_PALETTE));
-                    _formatList.Add(new DataFormat(PenData, NativeMethods.CF_PENDATA));
-                    _formatList.Add(new DataFormat(Riff, NativeMethods.CF_RIFF));
-                    _formatList.Add(new DataFormat(WaveAudio, NativeMethods.CF_WAVE));
-                    _formatList.Add(new DataFormat(SymbolicLink, NativeMethods.CF_SYLK));
-                    _formatList.Add(new DataFormat(FileDrop, NativeMethods.CF_HDROP));
-                    _formatList.Add(new DataFormat(Locale, NativeMethods.CF_LOCALE));
-                    int xamlFormatId = UnsafeNativeMethods.RegisterClipboardFormat(Xaml);
-                    if (xamlFormatId != 0)
-                    {
-                        _formatList.Add(new DataFormat(Xaml,xamlFormatId));
-                    }
-
-                    // This is the format to store trust boundary information. Essentially this is accompalished by storing 
-                    // the permission set of the source application where the content comes from. During paste we compare this to
-                    // the permissio set of the target application.
-                    int applicationTrustFormatId = UnsafeNativeMethods.RegisterClipboardFormat(DataFormats.ApplicationTrust);
-                    if (applicationTrustFormatId != 0)
-                    {
-                        _formatList.Add(new DataFormat(ApplicationTrust, applicationTrustFormatId));
-                    }
-                    // RegisterClipboardFormat returns 0 on failure
-                    int inkServicesFrameworkFormatId = UnsafeNativeMethods.RegisterClipboardFormat(System.Windows.Ink.StrokeCollection.InkSerializedFormat);
-
-                    if (inkServicesFrameworkFormatId != 0)
-                    {
-                        _formatList.Add(new DataFormat(System.Windows.Ink.StrokeCollection.InkSerializedFormat,
-                                                        inkServicesFrameworkFormatId));
-                    }
-}
-            }
-        }
-
-        #endregion Private Methods
-
-        //------------------------------------------------------
-        //
-        //  Private Fields
-        //
-        //------------------------------------------------------
-
-        #region Private Fields
-
-        // The registered data format list.
-        private static ArrayList _formatList;
-
-        // This object is for locking the _formatList to access safe in the multi-thread.
-        private static readonly Object _formatListlock = new Object();
-
-        #endregion Private Fields
+        return DataFormatsCore.GetOrAddFormat(format);
     }
 
-    #endregion DataFormats class
+    /// <summary>
+    ///  Specifies the standard ANSI text format.
+    /// </summary>
+    public static readonly string Text = DataFormatNames.Text;
+
+    /// <summary>
+    ///  Specifies the standard Windows Unicode text format.
+    /// </summary>
+    public static readonly string UnicodeText = DataFormatNames.UnicodeText;
+
+    /// <summary>
+    ///  Specifies the Windows Device Independent Bitmap (DIB) format.
+    /// </summary>
+    public static readonly string Dib = DataFormatNames.Dib;
+
+    /// <summary>
+    ///  Specifies a Windows bitmap format.
+    /// </summary>
+    public static readonly string Bitmap = DataFormatNames.Bitmap;
+
+    /// <summary>
+    ///  Specifies the Windows enhanced metafile format.
+    /// </summary>
+    public static readonly string EnhancedMetafile = DataFormatNames.Emf;
+
+    /// <summary>
+    ///  Specifies the Windows metafile format.
+    /// </summary>
+    public static readonly string MetafilePicture = DataFormatNames.Wmf;
+
+    /// <summary>
+    ///  Specifies the Windows symbolic link format.
+    /// </summary>
+    public static readonly string SymbolicLink = DataFormatNames.SymbolicLink;
+
+    /// <summary>
+    ///  Specifies the Windows data interchange format.
+    /// </summary>
+    public static readonly string Dif = DataFormatNames.Dif;
+
+    /// <summary>
+    ///  Specifies the Tagged Image File Format (TIFF).
+    /// </summary>
+    public static readonly string Tiff = DataFormatNames.Tiff;
+
+    /// <summary>
+    ///  Specifies the standard Windows original equipment manufacturer (OEM) text format.
+    /// </summary>
+    public static readonly string OemText = DataFormatNames.OemText;
+
+    /// <summary>
+    ///  Specifies the Windows palette format.
+    /// </summary>
+    public static readonly string Palette = DataFormatNames.Palette;
+
+    /// <summary>
+    ///  Specifies the Windows pen data format, which consists of pen strokes for handwriting software.
+    /// </summary>
+    public static readonly string PenData = DataFormatNames.PenData;
+
+    /// <summary>
+    ///  Specifies the Resource Interchange File Format (RIFF) audio format.
+    /// </summary>
+    public static readonly string Riff = DataFormatNames.Riff;
+
+    /// <summary>
+    ///  Specifies the wave audio format, which Windows Design does not directly use.
+    /// </summary>
+    public static readonly string WaveAudio = DataFormatNames.WaveAudio;
+
+    /// <summary>
+    ///  Specifies the Windows file drop format, which Windows Design does not directly use.
+    /// </summary>
+    public static readonly string FileDrop = DataFormatNames.FileDrop;
+
+    /// <summary>
+    ///  Specifies the Windows culture format, which Windows Design does not directly use.
+    /// </summary>
+    public static readonly string Locale = DataFormatNames.Locale;
+
+    /// <summary>
+    ///  Specifies text consisting of HTML data.
+    /// </summary>
+    public static readonly string Html = DataFormatNames.Html;
+
+    /// <summary>
+    ///  Specifies text consisting of Rich Text Format (RTF) data. This
+    /// </summary>
+    public static readonly string Rtf = DataFormatNames.Rtf;
+
+    /// <summary>
+    ///  Specifies a comma-separated value (CSV) format, which is a common interchange format used by spreadsheets.
+    ///  This format is not used directly by Windows Design.
+    /// </summary>
+    public static readonly string CommaSeparatedValue = DataFormatNames.Csv;
+
+    /// <summary>
+    ///  Specifies the Windows Design string class format, which WinForms uses to store string objects.
+    /// </summary>
+    public static readonly string StringFormat = DataFormatNames.String;
+
+    /// <summary>
+    ///  Specifies a format that encapsulates any type of Windows Design object.
+    /// </summary>
+    public static readonly string Serializable = DataFormatNames.Serializable;
+
+    /// <summary>
+    ///  Specifies a data format as Xaml.
+    /// </summary>
+    public static readonly string Xaml = DataFormatNames.Xaml;
+
+    /// <summary>
+    ///  Specifies a data format as Xaml Package.
+    /// </summary>
+    public static readonly string XamlPackage = DataFormatNames.XamlPackage;
+
+    /// <summary>
+    ///  Convert TextDataFormat to Dataformats.
+    /// </summary>
+    internal static string ConvertToDataFormats(TextDataFormat textDataformat) => textDataformat switch
+    {
+        TextDataFormat.Text => DataFormatNames.Text,
+        TextDataFormat.UnicodeText => DataFormatNames.UnicodeText,
+        TextDataFormat.Rtf => DataFormatNames.Rtf,
+        TextDataFormat.Html => DataFormatNames.Html,
+        TextDataFormat.CommaSeparatedValue => DataFormatNames.Csv,
+        TextDataFormat.Xaml => DataFormatNames.Xaml,
+        _ => DataFormatNames.UnicodeText,
+    };
+
+    /// <summary>
+    ///  Validate the text data format.
+    /// </summary>
+    internal static bool IsValidTextDataFormat(TextDataFormat textDataFormat) =>
+        textDataFormat is TextDataFormat.Text
+            or TextDataFormat.UnicodeText
+            or TextDataFormat.Rtf
+            or TextDataFormat.Html
+            or TextDataFormat.CommaSeparatedValue
+            or TextDataFormat.Xaml;
+
+    private static void EnsurePredefined()
+    {
+        if (!s_initialized)
+        {
+            s_initialized = true;
+
+            // Add the WPF specific data formats by getting the ids for each.
+            DataFormatsCore.GetOrAddFormat(DataFormatNames.Xaml);
+            DataFormatsCore.GetOrAddFormat(DataFormatNames.InkSerializedFormat);
+        }
+    }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -8,6 +8,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Formats.Nrbf;
 using System.IO;
+using System.Private.Windows.Ole;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
@@ -1181,13 +1182,13 @@ namespace System.Windows
             }
 
             if (IsFormatEqual(format, DataFormats.FileDrop)
-                || IsFormatEqual(format, DataFormats.FileName)
-                || IsFormatEqual(format, DataFormats.FileNameW))
+                || IsFormatEqual(format, DataFormatNames.FileNameAnsi)
+                || IsFormatEqual(format, DataFormatNames.FileNameUnicode))
             {
                 return new string[] {
                                         DataFormats.FileDrop,
-                                        DataFormats.FileNameW,
-                                        DataFormats.FileName,
+                                        DataFormatNames.FileNameUnicode,
+                                        DataFormatNames.FileNameAnsi,
                 };
             }
 
@@ -1469,8 +1470,7 @@ namespace System.Windows
             {
                 hr = SaveStringToHandle(medium.unionmember, data.ToString(), false /* unicode */, doNotReallocate);
             }
-            else if (IsFormatEqual(format, DataFormats.UnicodeText)||
-                     IsFormatEqual(format, DataFormats.ApplicationTrust))
+            else if (IsFormatEqual(format, DataFormats.UnicodeText))
             {
                 hr = SaveStringToHandle(medium.unionmember, data.ToString(), true /* unicode */, doNotReallocate);
             }
@@ -1478,14 +1478,14 @@ namespace System.Windows
             {
                 hr = SaveFileListToHandle(medium.unionmember, (string[])data, doNotReallocate);
             }
-            else if (IsFormatEqual(format, DataFormats.FileName))
+            else if (IsFormatEqual(format, DataFormatNames.FileNameAnsi))
             {
                 string[] filelist;
 
                 filelist = (string[])data;
                 hr = SaveStringToHandle(medium.unionmember, filelist[0], false /* unicode */, doNotReallocate);
             }
-            else if (IsFormatEqual(format, DataFormats.FileNameW))
+            else if (IsFormatEqual(format, DataFormatNames.FileNameUnicode))
             {
                 string[] filelist;
 
@@ -2732,8 +2732,7 @@ namespace System.Windows
                     {
                         data = ReadStringFromHandle(hglobal, false);
                     }
-                    else if (IsFormatEqual(format, DataFormats.UnicodeText) ||
-                             IsFormatEqual(format, DataFormats.ApplicationTrust))
+                    else if (IsFormatEqual(format, DataFormats.UnicodeText))
                     {
                         data = ReadStringFromHandle(hglobal, true);
                     }
@@ -2741,11 +2740,11 @@ namespace System.Windows
                     {
                         data = (object)ReadFileListFromHandle(hglobal);
                     }
-                    else if (IsFormatEqual(format, DataFormats.FileName))
+                    else if (IsFormatEqual(format, DataFormatNames.FileNameAnsi))
                     {
                         data = new string[] { ReadStringFromHandle(hglobal, false) };
                     }
-                    else if (IsFormatEqual(format, DataFormats.FileNameW))
+                    else if (IsFormatEqual(format, DataFormatNames.FileNameUnicode))
                     {
                         data = new string[] { ReadStringFromHandle(hglobal, true) };
                     }

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/PresentationCore.Tests.csproj
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/PresentationCore.Tests.csproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <MicrosoftPrivateWinFormsReference Include="System.Private.Windows.Core" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="coverlet.msbuild" Version="$(CoverletMSBuildPackageVersion)" />
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />


### PR DESCRIPTION
This uses the shared DataFormats code from System.Private.Windows.Core.

Note that locking is handled by the shared code so there is no need to do so when adding the WPF specific types. The only reason they need added is that casing will stick with whatever the first request is. That is, if you ask for "XAML" that will be the string Windows gives back, not "Xaml".
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10391)