### PR TITLE
Avoid UCEERR_RENDERTHREADFAILURE

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/hw/InteropDeviceBitmap.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/hw/InteropDeviceBitmap.cpp
@@ -845,6 +845,10 @@ CInteropDeviceBitmap::GetDisplayFromUserDevice(
     IFC(pID3DUserDevice->GetDirect3D(&pID3DUserObject));
 
     HMONITOR hMon = pID3DUserObject->GetAdapterMonitor(m_uAdapter);
+    if(hMon == NULL)
+    {
+        hMon = ::MonitorFromWindow(NULL, MONITOR_DEFAULTTOPRIMARY);
+    }
 
     g_DisplayManager.GetCurrentDisplaySet(&pDisplaySet);
     UINT uDisplayIndex;


### PR DESCRIPTION
Fixes #9042

Main PR

## Description

WPF applications with D3DImage can crash when a monitor is off or unavailable and IDirect3D9.GetAdapterMonitor returns NULL.
For example on laptops with connected HDMI external display and display setting “Extend”
and control panel “when I close the lid” = “Do nothing”, when closing the lid or on sleep / awake.

## Customer Impact

WPF applications crash.

## Regression

This bug exists in existing .NET releases like 4.8.

## Testing

Take a laptop with connected HDMI external display and set display setting “Extend”
and control panel “when I close the lid” = “Do nothing”, then close the lid and check if a WPF application with D3DImage crashes.

## Risk

Unclear.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10394)