### PR TITLE
Remove unnecessary S.R.CompilerServices.Unsafe packageref

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,7 +43,6 @@
     <SystemSecurityCryptographyXmlPackageVersion>10.0.0-preview.2.25102.2</SystemSecurityCryptographyXmlPackageVersion>
     <SystemSecurityPermissionsPackageVersion>10.0.0-preview.2.25102.2</SystemSecurityPermissionsPackageVersion>
     <SystemWindowsExtensionsPackageVersion>10.0.0-preview.2.25102.2</SystemWindowsExtensionsPackageVersion>
-    <SystemRuntimeCompilerServicesUnsafePackageVersion>6.0.0</SystemRuntimeCompilerServicesUnsafePackageVersion>
   </PropertyGroup>
   <!-- Docs / Intellisense -->
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Primitives/System.Windows.Primitives.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Primitives/System.Windows.Primitives.csproj
@@ -29,7 +29,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="$(MicrosoftWindowsCsWin32PackageVersion)" PrivateAssets="all" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
 
     <ProjectReference Include="$(WpfSourceDir)System.Windows.Primitives\ref\System.Windows.Primitives-ref.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/WindowsBase.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/WindowsBase.csproj
@@ -387,7 +387,6 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsPackageVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
All the projects that reference the S.R.CompilerServices.Unsafe package target a version of .NETCoreApp (net10.0) which already have that assembly available inbox. There's no need for the package references.