### PR TITLE
Fix build binlog overwritten by test step

### DIFF
--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -165,6 +165,7 @@ jobs:
           $(_OfficialBuildIdArgs)
           $(_PlatformArgs)
           $(_InternalRuntimeDownloadArgs)
+          /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Test.binlog
         displayName: Run xUnit Tests
         condition: and(or(ne(variables['_HelixPipeline'], 'true'), and(eq(variables['_HelixPipeline'], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_PublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true'))), ne(variables['_Platform'], 'arm64'))
       - task: PublishTestResults@2


### PR DESCRIPTION
The Build.binlog contains the test binlog for non PR builds. This already got fixed in the -pr.yml file: https://github.com/dotnet/wpf/blob/263c65ed8daee5757fe6e779df4f0c4b76b0fb35/eng/pipeline-pr.yml#L193