### PR TITLE
Fix the ArtifactsPackagingDir on win-x64

### DIFF
--- a/eng/WpfArcadeSdk/tools/Packaging.props
+++ b/eng/WpfArcadeSdk/tools/Packaging.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
-    <ArtifactsPackagingDir Condition="'$(ArtifactsPackagingDir)'=='' and $(Platform.EndsWith('x64'))">$(ArtifactsDir)packaging\$(Configuration)\$(Platform)\</ArtifactsPackagingDir>
-    <ArtifactsPackagingDir Condition="'$(ArtifactsPackagingDir)'=='' and !$(Platform.EndsWith('x64'))">$(ArtifactsDir)packaging\$(Configuration)\</ArtifactsPackagingDir>
+    <ArtifactsPackagingDir Condition="'$(ArtifactsPackagingDir)'==''">$(ArtifactsDir)packaging\$(Configuration)\</ArtifactsPackagingDir>
 
     <!-- We like using RID prefix when generating nuget package names -->
     <PackageRuntimeIdentifierPrefix Condition="'$(Platform)'!='AnyCPU' and '$(Platform)'!='Win32'">runtime.win-$(Platform)</PackageRuntimeIdentifierPrefix>


### PR DESCRIPTION
Without this fix, the Microsoft.NET.Sdk.WindowsDesktop package is missing the "tools" folder when being built on win-x64.

This happens because the PresentationBuildTasks project targest AnyCPU and so the artifacts aren't present in the ArtifactsPackagingDir with the platform. This is basically a wrong expectation in packaging.props as the Platform isn't aligned between a packable project and its project dependencies.

Fixes https://github.com/dotnet/source-build/issues/4888
Unblocks https://github.com/dotnet/sdk/pull/46550