### PR TITLE
Remove deprecated .Net runtime

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,6 @@
     "dotnet": "10.0.100-alpha.1.25077.2",
     "runtimes": {
       "dotnet": [
-        "2.1.7",
         "$(VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion)"
       ]
     },


### PR DESCRIPTION
## Description
Removes .Net Core 2.1.7 which is EOL since 2021. I cannot find a use for it anywhere in this repo and if it does break something we should fix it instead of relying on an EOL runtime.

It's downloaded on each build (Though locally cached) so it should improve the build speed a little bit, especially in CI.

## Customer Impact
None, build only.

## Regression
No.

## Testing
Local build + CI.

## Risk
Low, it would only break the WPF build and can always be reverted (Though we really shouldn't keep using .Net Core 2.1.7 since it's EOL).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10423)