### PR TITLE
Fix crash if bitmapStream is null

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
@@ -1165,7 +1165,7 @@ namespace System.Windows.Media.Imaging
             }
             catch
             {
-                bitmapStream.Close();
+                bitmapStream?.Close();
 
                 decoderHandle = null;
                 throw;


### PR DESCRIPTION
Fixes #10390.

## Description

`bitmapStream` may be `null` in `SetupDecoderFromUriOrStream`; this fixes a `NullReferenceException` closing it if an exception occurs.

## Customer Impact

Potential `NullReferenceException` from `BitmapImage` when loading invalid image data.

## Regression

This fixes a regression introduced in .NET 9.0 in 3854d3238a00ceb81ad4b618686d7d5654582556.

## Testing

None.

## Risk

Low. This allows a local variable to be `null` and takes no action if it is.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10428)