### PR TITLE
Fix crash if bitmapStream is null. Fixes #10390

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
@@ -1190,7 +1190,7 @@ namespace System.Windows.Media.Imaging
             }
             catch
             {
-                bitmapStream.Close();
+                bitmapStream?.Close();
                 #pragma warning disable 6500
 
                 decoderHandle = null;


### PR DESCRIPTION
## Description

Backports https://github.com/dotnet/wpf/pull/10428 to `release/net9.0`. See https://github.com/dotnet/wpf/pull/10428#issuecomment-2644481693.

Fixes #10390.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10436)