### PR TITLE
Makes Margin and Padding of ListViewItem and ListBoxItem as DynamicResource

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ListBoxItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ListBoxItem.xaml
@@ -9,6 +9,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+    <Thickness x:Key="ListBoxItemPadding">12</Thickness>
+    <Thickness x:Key="ListBoxItemMargin">0</Thickness>
+
     <Style x:Key="DefaultListBoxItemStyle" TargetType="{x:Type ListBoxItem}">
         <Setter Property="Foreground" Value="{DynamicResource ListBoxItemForeground}" />
         <Setter Property="Background" Value="Transparent" />
@@ -16,9 +19,9 @@
         <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
         <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-        <Setter Property="Margin" Value="0" />
+        <Setter Property="Margin" Value="{DynamicResource ListBoxItemMargin}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="Padding" Value="12" />
+        <Setter Property="Padding" Value="{DynamicResource ListBoxItemPadding}" />
         <Setter Property="Border.CornerRadius" Value="0" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ListViewItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ListViewItem.xaml
@@ -10,6 +10,9 @@
 
     <system:Double x:Key="ListViewItemMinHeight">40</system:Double>
     <system:Double x:Key="ListViewItemMinWidth">88</system:Double>
+    <Thickness x:Key="ListViewItemPadding">16,0,12,0</Thickness>
+    <Thickness x:Key="ListViewItemMargin">0,0,0,2</Thickness>
+
 
 
     <Style x:Key="DefaultListViewItemStyle" TargetType="{x:Type ListViewItem}">
@@ -19,8 +22,8 @@
         <Setter Property="MinHeight" Value="{StaticResource ListViewItemMinHeight}" />
         <Setter Property="MinWidth" Value="{StaticResource ListViewItemMinWidth}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="Margin" Value="0,0,0,2" />
-        <Setter Property="Padding" Value="16,0,12,0" />
+        <Setter Property="Margin" Value="{DynamicResource ListViewItemMargin}" />
+        <Setter Property="Padding" Value="{DynamicResource ListViewItemPadding}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="OverridesDefaultStyle" Value="True" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -2719,6 +2719,8 @@
     </Setter>
   </Style>
   <Style BasedOn="{StaticResource DefaultListBoxStyle}" TargetType="{x:Type ListBox}" />
+  <Thickness x:Key="ListBoxItemPadding">12</Thickness>
+  <Thickness x:Key="ListBoxItemMargin">0</Thickness>
   <Style x:Key="DefaultListBoxItemStyle" TargetType="{x:Type ListBoxItem}">
     <Setter Property="Foreground" Value="{DynamicResource ListBoxItemForeground}" />
     <Setter Property="Background" Value="Transparent" />
@@ -2726,9 +2728,9 @@
     <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-    <Setter Property="Margin" Value="0" />
+    <Setter Property="Margin" Value="{DynamicResource ListBoxItemMargin}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="Padding" Value="12" />
+    <Setter Property="Padding" Value="{DynamicResource ListBoxItemPadding}" />
     <Setter Property="Border.CornerRadius" Value="0" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -2814,6 +2816,8 @@
   <Style BasedOn="{StaticResource DefaultListViewStyle}" TargetType="{x:Type ListView}" />
   <system:Double x:Key="ListViewItemMinHeight">40</system:Double>
   <system:Double x:Key="ListViewItemMinWidth">88</system:Double>
+  <Thickness x:Key="ListViewItemPadding">16,0,12,0</Thickness>
+  <Thickness x:Key="ListViewItemMargin">0,0,0,2</Thickness>
   <Style x:Key="DefaultListViewItemStyle" TargetType="{x:Type ListViewItem}">
     <Setter Property="Foreground" Value="{DynamicResource ListViewItemForeground}" />
     <Setter Property="Background" Value="Transparent" />
@@ -2821,8 +2825,8 @@
     <Setter Property="MinHeight" Value="{StaticResource ListViewItemMinHeight}" />
     <Setter Property="MinWidth" Value="{StaticResource ListViewItemMinWidth}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="Margin" Value="0,0,0,2" />
-    <Setter Property="Padding" Value="16,0,12,0" />
+    <Setter Property="Margin" Value="{DynamicResource ListViewItemMargin}" />
+    <Setter Property="Padding" Value="{DynamicResource ListViewItemPadding}" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="OverridesDefaultStyle" Value="True" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -2700,6 +2700,8 @@
     </Setter>
   </Style>
   <Style BasedOn="{StaticResource DefaultListBoxStyle}" TargetType="{x:Type ListBox}" />
+  <Thickness x:Key="ListBoxItemPadding">12</Thickness>
+  <Thickness x:Key="ListBoxItemMargin">0</Thickness>
   <Style x:Key="DefaultListBoxItemStyle" TargetType="{x:Type ListBoxItem}">
     <Setter Property="Foreground" Value="{DynamicResource ListBoxItemForeground}" />
     <Setter Property="Background" Value="Transparent" />
@@ -2707,9 +2709,9 @@
     <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-    <Setter Property="Margin" Value="0" />
+    <Setter Property="Margin" Value="{DynamicResource ListBoxItemMargin}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="Padding" Value="12" />
+    <Setter Property="Padding" Value="{DynamicResource ListBoxItemPadding}" />
     <Setter Property="Border.CornerRadius" Value="0" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -2795,6 +2797,8 @@
   <Style BasedOn="{StaticResource DefaultListViewStyle}" TargetType="{x:Type ListView}" />
   <system:Double x:Key="ListViewItemMinHeight">40</system:Double>
   <system:Double x:Key="ListViewItemMinWidth">88</system:Double>
+  <Thickness x:Key="ListViewItemPadding">16,0,12,0</Thickness>
+  <Thickness x:Key="ListViewItemMargin">0,0,0,2</Thickness>
   <Style x:Key="DefaultListViewItemStyle" TargetType="{x:Type ListViewItem}">
     <Setter Property="Foreground" Value="{DynamicResource ListViewItemForeground}" />
     <Setter Property="Background" Value="Transparent" />
@@ -2802,8 +2806,8 @@
     <Setter Property="MinHeight" Value="{StaticResource ListViewItemMinHeight}" />
     <Setter Property="MinWidth" Value="{StaticResource ListViewItemMinWidth}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="Margin" Value="0,0,0,2" />
-    <Setter Property="Padding" Value="16,0,12,0" />
+    <Setter Property="Margin" Value="{DynamicResource ListViewItemMargin}" />
+    <Setter Property="Padding" Value="{DynamicResource ListViewItemPadding}" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="OverridesDefaultStyle" Value="True" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -2716,6 +2716,8 @@
     </Setter>
   </Style>
   <Style BasedOn="{StaticResource DefaultListBoxStyle}" TargetType="{x:Type ListBox}" />
+  <Thickness x:Key="ListBoxItemPadding">12</Thickness>
+  <Thickness x:Key="ListBoxItemMargin">0</Thickness>
   <Style x:Key="DefaultListBoxItemStyle" TargetType="{x:Type ListBoxItem}">
     <Setter Property="Foreground" Value="{DynamicResource ListBoxItemForeground}" />
     <Setter Property="Background" Value="Transparent" />
@@ -2723,9 +2725,9 @@
     <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-    <Setter Property="Margin" Value="0" />
+    <Setter Property="Margin" Value="{DynamicResource ListBoxItemMargin}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="Padding" Value="12" />
+    <Setter Property="Padding" Value="{DynamicResource ListBoxItemPadding}" />
     <Setter Property="Border.CornerRadius" Value="0" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -2811,6 +2813,8 @@
   <Style BasedOn="{StaticResource DefaultListViewStyle}" TargetType="{x:Type ListView}" />
   <system:Double x:Key="ListViewItemMinHeight">40</system:Double>
   <system:Double x:Key="ListViewItemMinWidth">88</system:Double>
+  <Thickness x:Key="ListViewItemPadding">16,0,12,0</Thickness>
+  <Thickness x:Key="ListViewItemMargin">0,0,0,2</Thickness>
   <Style x:Key="DefaultListViewItemStyle" TargetType="{x:Type ListViewItem}">
     <Setter Property="Foreground" Value="{DynamicResource ListViewItemForeground}" />
     <Setter Property="Background" Value="Transparent" />
@@ -2818,8 +2822,8 @@
     <Setter Property="MinHeight" Value="{StaticResource ListViewItemMinHeight}" />
     <Setter Property="MinWidth" Value="{StaticResource ListViewItemMinWidth}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="Margin" Value="0,0,0,2" />
-    <Setter Property="Padding" Value="16,0,12,0" />
+    <Setter Property="Margin" Value="{DynamicResource ListViewItemMargin}" />
+    <Setter Property="Padding" Value="{DynamicResource ListViewItemPadding}" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="OverridesDefaultStyle" Value="True" />


### PR DESCRIPTION

Fixes #10370


## Description

This PR makes the margin and padding of ListViewItem and ListBoxItem as Lightweight resources
## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

No
## Testing

Local build pass
## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10469)