### PR TITLE
Change lookup path of binaries: wpf-debug.targets

### DIFF
--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -62,6 +62,10 @@ Go to the csproj file and append this line at the bottom of it. `<Import Project
     <Import Project="$(WpfRepoRoot)\eng\wpf-debug.targets" />
 ```
 
+The default PlatformTarget of a sample application according the `wpf-debug.targets` is x64 and the default build of wpf repository using `./build.cmd` is x86. This leads to a mismatch in the binaries and may result in local binaries not getting picked up. To avoid this, either build the repo using the command `./build.cmd -plat x64` or specify the `PlatformTarget` of the sample application to x86.
+
+When building the repository, the artifacts' packaging folder does not differentiate between x64 and x86 binaries, causing one build to override the other. To prevent this, clean the repository when switching between x64 and x86 builds using the command `.\build.cmd -clean`.
+
 
 ### Testing Locally built WPF assemblies (excluding PresentationBuildTasks)
 This section of guide is intended to discuss the different approaches for ad-hoc testing of WPF assemblies,

--- a/eng/wpf-debug.targets
+++ b/eng/wpf-debug.targets
@@ -17,6 +17,11 @@
     
     <WpfArtifactsPackagesCommonPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\'))\artifacts\packaging</WpfArtifactsPackagesCommonPath>
     <WPFArtifactsPathSuffix Condition="'$(WpfConfig)'=='Debug'">.$(WpfConfig)</WPFArtifactsPathSuffix>
+    <!-- 
+    Make sure that the build binaries match the platform target.
+    The default local build using ./build.cmd is x86 and if the platform target in the application is not specified, it takes x64 by default.
+    So if you are planning to use the default Platform target, consider building wpf using ./build.cmd -plat x64.
+    -->
     <WPFArtifactsPath>$(WpfArtifactsPackagesCommonPath)\$(WpfConfig)\Microsoft.DotNet.Wpf.GitHub$(WPFArtifactsPathSuffix)</WPFArtifactsPath>
   </PropertyGroup>
 

--- a/eng/wpf-debug.targets
+++ b/eng/wpf-debug.targets
@@ -16,9 +16,8 @@
     <RuntimeIdentifier Condition="'$(PlatformTarget)' != ''">win-$(PlatformTarget)</RuntimeIdentifier>
     
     <WpfArtifactsPackagesCommonPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\'))\artifacts\packaging</WpfArtifactsPackagesCommonPath>
-    <WpfPlatformTargetArtifactsDirectory Condition="'$(PlatformTarget)'=='x64'">x64\</WpfPlatformTargetArtifactsDirectory>
     <WPFArtifactsPathSuffix Condition="'$(WpfConfig)'=='Debug'">.$(WpfConfig)</WPFArtifactsPathSuffix>
-    <WPFArtifactsPath>$(WpfArtifactsPackagesCommonPath)\$(WpfConfig)\$(WpfPlatformTargetArtifactsDirectory)Microsoft.DotNet.Wpf.GitHub$(WPFArtifactsPathSuffix)</WPFArtifactsPath>
+    <WPFArtifactsPath>$(WpfArtifactsPackagesCommonPath)\$(WpfConfig)\Microsoft.DotNet.Wpf.GitHub$(WPFArtifactsPathSuffix)</WPFArtifactsPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Debugging sample application with local binaries is currently broken due to a recent change removing the x64 folder in packaging. The change here updates the path that the binaries are copied to without the x64 folder.

## Customer Impact
Seamless debugging experience
<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
Verified using sample application
<!-- What kind of testing has been done with the fix. -->

## Risk
Low
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10478)