### PR TITLE
Gridsplitter fluent

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Dark.xaml
@@ -475,6 +475,13 @@
     <SolidColorBrush x:Key="FlyoutBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
     <SolidColorBrush x:Key="FlyoutBorderBrush" Color="{StaticResource SurfaceStrokeColorFlyout}" />
 
+    <!-- GridSplitter -->
+    <SolidColorBrush x:Key="GridsplitterBackground" Color="{StaticResource ControlAltFillColorTransparent}" />
+    <SolidColorBrush x:Key="GridsplitterBackgroundPointerOver" Color="{StaticResource ControlAltFillColorTertiary}" />
+    <SolidColorBrush x:Key="GridsplitterBackgroundPressed" Color="{StaticResource ControlAltFillColorQuarternary}" />
+    <SolidColorBrush x:Key="GridsplitterBackgroundDisabled" Color="{StaticResource ControlAltFillColorDisabled}" />
+    <SolidColorBrush x:Key="GridsplitterForeground" Color="{StaticResource ControlStrongFillColorDefault}" />
+
     <!--  HyperlinkButton  -->
     <SolidColorBrush x:Key="HyperlinkButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
@@ -350,6 +350,13 @@
     <SolidColorBrush x:Key="FlyoutBackground" Color="{StaticResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="FlyoutBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
 
+    <!-- GridSplitter -->
+    <SolidColorBrush x:Key="GridsplitterBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="GridsplitterBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="GridsplitterBackgroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="GridsplitterBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="GridsplitterForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+
     <!--  HyperlinkButton  -->
     <SolidColorBrush x:Key="HyperlinkButtonBackground" Color="Transparent" />
     <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Light.xaml
@@ -472,6 +472,13 @@
     <SolidColorBrush x:Key="FlyoutBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
     <SolidColorBrush x:Key="FlyoutBorderBrush" Color="{StaticResource SurfaceStrokeColorFlyout}" />
 
+    <!-- GridSplitter -->
+    <SolidColorBrush x:Key="GridsplitterBackground" Color="{StaticResource ControlAltFillColorTransparent}" />
+    <SolidColorBrush x:Key="GridsplitterBackgroundPointerOver" Color="{StaticResource ControlAltFillColorTertiary}" />
+    <SolidColorBrush x:Key="GridsplitterBackgroundPressed" Color="{StaticResource ControlAltFillColorQuarternary}" />
+    <SolidColorBrush x:Key="GridsplitterBackgroundDisabled" Color="{StaticResource ControlAltFillColorDisabled}" />
+    <SolidColorBrush x:Key="GridsplitterForeground" Color="{StaticResource ControlStrongFillColorDefault}" />
+
     <!--  HyperlinkButton  -->
     <SolidColorBrush x:Key="HyperlinkButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/GridSplitter.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/GridSplitter.xaml
@@ -16,14 +16,16 @@
     <system:Double x:Key="GridsplitterThumbHeight">24</system:Double>
     <system:Double x:Key="GridsplitterThumbWidth">4</system:Double>
     <system:Double x:Key="GridsplitterThumbRadius">2</system:Double>
+    <system:Double x:Key="GridsplitterMinHeight">8</system:Double>
+    <system:Double x:Key="GridsplitterMinWidth">8</system:Double>
     <Thickness x:Key="GridsplitterPadding">4</Thickness>
 
     <Style x:Key="DefaultGridSplitterStyle" TargetType="{x:Type GridSplitter}">
         <Setter Property="IsTabStop" Value="True" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
-        <Setter Property="MinHeight" Value="8" />
-        <Setter Property="MinWidth" Value="8" />
+        <Setter Property="MinHeight" Value="{DynamicResource GridsplitterMinHeight}" />
+        <Setter Property="MinWidth" Value="{DynamicResource GridsplitterMinHeight}" />
         <Setter Property="Padding" Value="{StaticResource GridsplitterPadding}" />
         <Setter Property="Foreground" Value="{DynamicResource GridsplitterForeground}" />
         <Setter Property="Background" Value="{DynamicResource GridsplitterBackground}" />
@@ -37,8 +39,8 @@
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Background="{TemplateBinding Background}">
                         <Rectangle x:Name="PART_Thumb"
-                            Width="{StaticResource GridsplitterThumbWidth}"
-                            Height="{StaticResource GridsplitterThumbHeight}"
+                            Width="{DynamicResource GridsplitterThumbWidth}"
+                            Height="{DynamicResource GridsplitterThumbHeight}"
                             Margin="{TemplateBinding Padding}"
                             Fill="{TemplateBinding Foreground}"
                             RadiusX="{StaticResource GridsplitterThumbRadius}"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/GridSplitter.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/GridSplitter.xaml
@@ -1,0 +1,69 @@
+<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+    
+    Based on Microsoft XAML for Win UI
+    Copyright (c) Microsoft Corporation. All Rights Reserved.
+-->
+
+<ResourceDictionary 
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+
+    <system:Double x:Key="GridsplitterThumbHeight">24</system:Double>
+    <system:Double x:Key="GridsplitterThumbWidth">4</system:Double>
+    <system:Double x:Key="GridsplitterThumbRadius">2</system:Double>
+    <Thickness x:Key="GridsplitterPadding">4</Thickness>
+
+    <Style x:Key="DefaultGridSplitterStyle" TargetType="{x:Type GridSplitter}">
+        <Setter Property="IsTabStop" Value="True" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="MinHeight" Value="8" />
+        <Setter Property="MinWidth" Value="8" />
+        <Setter Property="Padding" Value="{StaticResource GridsplitterPadding}" />
+        <Setter Property="Foreground" Value="{DynamicResource GridsplitterForeground}" />
+        <Setter Property="Background" Value="{DynamicResource GridsplitterBackground}" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type GridSplitter}">
+                    <Border x:Name="RootGrid" 
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}">
+                        <Rectangle x:Name="PART_Thumb"
+                            Width="{StaticResource GridsplitterThumbWidth}"
+                            Height="{StaticResource GridsplitterThumbHeight}"
+                            Margin="{TemplateBinding Padding}"
+                            Fill="{TemplateBinding Foreground}"
+                            RadiusX="{StaticResource GridsplitterThumbRadius}"
+                            RadiusY="{StaticResource GridsplitterThumbRadius}" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundPointerOver}" />
+                        </Trigger>
+                        <Trigger Property="IsDragging" Value="True">
+                                <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundPressed}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled"  Value="False">
+                                <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundDisabled}" />
+                                <Setter TargetName="PART_Thumb" Property="Opacity" Value="0.45"/>
+                        </Trigger>
+                        <Trigger Property="ResizeDirection" Value="Rows">
+                                <Setter TargetName="PART_Thumb" Property="Width" Value="{DynamicResource GridsplitterThumbHeight}"/>
+                                <Setter TargetName="PART_Thumb" Property="Height" Value="{DynamicResource GridsplitterThumbWidth}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style BasedOn="{StaticResource DefaultGridSplitterStyle}" TargetType="{x:Type GridSplitter}" />
+</ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -2661,13 +2661,15 @@
   <system:Double x:Key="GridsplitterThumbHeight">24</system:Double>
   <system:Double x:Key="GridsplitterThumbWidth">4</system:Double>
   <system:Double x:Key="GridsplitterThumbRadius">2</system:Double>
+  <system:Double x:Key="GridsplitterMinHeight">8</system:Double>
+  <system:Double x:Key="GridsplitterMinWidth">8</system:Double>
   <Thickness x:Key="GridsplitterPadding">4</Thickness>
   <Style x:Key="DefaultGridSplitterStyle" TargetType="{x:Type GridSplitter}">
     <Setter Property="IsTabStop" Value="True" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Stretch" />
-    <Setter Property="MinHeight" Value="8" />
-    <Setter Property="MinWidth" Value="8" />
+    <Setter Property="MinHeight" Value="{DynamicResource GridsplitterMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource GridsplitterMinHeight}" />
     <Setter Property="Padding" Value="{StaticResource GridsplitterPadding}" />
     <Setter Property="Foreground" Value="{DynamicResource GridsplitterForeground}" />
     <Setter Property="Background" Value="{DynamicResource GridsplitterBackground}" />
@@ -2677,7 +2679,7 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type GridSplitter}">
           <Border x:Name="RootGrid" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
-            <Rectangle x:Name="PART_Thumb" Width="{StaticResource GridsplitterThumbWidth}" Height="{StaticResource GridsplitterThumbHeight}" Margin="{TemplateBinding Padding}" Fill="{TemplateBinding Foreground}" RadiusX="{StaticResource GridsplitterThumbRadius}" RadiusY="{StaticResource GridsplitterThumbRadius}" />
+            <Rectangle x:Name="PART_Thumb" Width="{DynamicResource GridsplitterThumbWidth}" Height="{DynamicResource GridsplitterThumbHeight}" Margin="{TemplateBinding Padding}" Fill="{TemplateBinding Foreground}" RadiusX="{StaticResource GridsplitterThumbRadius}" RadiusY="{StaticResource GridsplitterThumbRadius}" />
           </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -469,6 +469,12 @@
   <!--  Flyout  -->
   <SolidColorBrush x:Key="FlyoutBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
   <SolidColorBrush x:Key="FlyoutBorderBrush" Color="{StaticResource SurfaceStrokeColorFlyout}" />
+  <!-- GridSplitter -->
+  <SolidColorBrush x:Key="GridsplitterBackground" Color="{StaticResource ControlAltFillColorTransparent}" />
+  <SolidColorBrush x:Key="GridsplitterBackgroundPointerOver" Color="{StaticResource ControlAltFillColorTertiary}" />
+  <SolidColorBrush x:Key="GridsplitterBackgroundPressed" Color="{StaticResource ControlAltFillColorQuarternary}" />
+  <SolidColorBrush x:Key="GridsplitterBackgroundDisabled" Color="{StaticResource ControlAltFillColorDisabled}" />
+  <SolidColorBrush x:Key="GridsplitterForeground" Color="{StaticResource ControlStrongFillColorDefault}" />
   <!--  HyperlinkButton  -->
   <SolidColorBrush x:Key="HyperlinkButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />
   <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
@@ -2652,6 +2658,48 @@
     <Setter Property="Focusable" Value="False" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
   </Style>
+  <system:Double x:Key="GridsplitterThumbHeight">24</system:Double>
+  <system:Double x:Key="GridsplitterThumbWidth">4</system:Double>
+  <system:Double x:Key="GridsplitterThumbRadius">2</system:Double>
+  <Thickness x:Key="GridsplitterPadding">4</Thickness>
+  <Style x:Key="DefaultGridSplitterStyle" TargetType="{x:Type GridSplitter}">
+    <Setter Property="IsTabStop" Value="True" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="MinHeight" Value="8" />
+    <Setter Property="MinWidth" Value="8" />
+    <Setter Property="Padding" Value="{StaticResource GridsplitterPadding}" />
+    <Setter Property="Foreground" Value="{DynamicResource GridsplitterForeground}" />
+    <Setter Property="Background" Value="{DynamicResource GridsplitterBackground}" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type GridSplitter}">
+          <Border x:Name="RootGrid" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
+            <Rectangle x:Name="PART_Thumb" Width="{StaticResource GridsplitterThumbWidth}" Height="{StaticResource GridsplitterThumbHeight}" Margin="{TemplateBinding Padding}" Fill="{TemplateBinding Foreground}" RadiusX="{StaticResource GridsplitterThumbRadius}" RadiusY="{StaticResource GridsplitterThumbRadius}" />
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="True">
+              <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundPressed}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundDisabled}" />
+              <Setter TargetName="PART_Thumb" Property="Opacity" Value="0.45" />
+            </Trigger>
+            <Trigger Property="ResizeDirection" Value="Rows">
+              <Setter TargetName="PART_Thumb" Property="Width" Value="{DynamicResource GridsplitterThumbHeight}" />
+              <Setter TargetName="PART_Thumb" Property="Height" Value="{DynamicResource GridsplitterThumbWidth}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultGridSplitterStyle}" TargetType="{x:Type GridSplitter}" />
   <Style x:Key="{x:Type GroupItem}" TargetType="{x:Type GroupItem}">
     <Setter Property="Template">
       <Setter.Value>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -2642,13 +2642,15 @@
   <system:Double x:Key="GridsplitterThumbHeight">24</system:Double>
   <system:Double x:Key="GridsplitterThumbWidth">4</system:Double>
   <system:Double x:Key="GridsplitterThumbRadius">2</system:Double>
+  <system:Double x:Key="GridsplitterMinHeight">8</system:Double>
+  <system:Double x:Key="GridsplitterMinWidth">8</system:Double>
   <Thickness x:Key="GridsplitterPadding">4</Thickness>
   <Style x:Key="DefaultGridSplitterStyle" TargetType="{x:Type GridSplitter}">
     <Setter Property="IsTabStop" Value="True" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Stretch" />
-    <Setter Property="MinHeight" Value="8" />
-    <Setter Property="MinWidth" Value="8" />
+    <Setter Property="MinHeight" Value="{DynamicResource GridsplitterMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource GridsplitterMinHeight}" />
     <Setter Property="Padding" Value="{StaticResource GridsplitterPadding}" />
     <Setter Property="Foreground" Value="{DynamicResource GridsplitterForeground}" />
     <Setter Property="Background" Value="{DynamicResource GridsplitterBackground}" />
@@ -2658,7 +2660,7 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type GridSplitter}">
           <Border x:Name="RootGrid" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
-            <Rectangle x:Name="PART_Thumb" Width="{StaticResource GridsplitterThumbWidth}" Height="{StaticResource GridsplitterThumbHeight}" Margin="{TemplateBinding Padding}" Fill="{TemplateBinding Foreground}" RadiusX="{StaticResource GridsplitterThumbRadius}" RadiusY="{StaticResource GridsplitterThumbRadius}" />
+            <Rectangle x:Name="PART_Thumb" Width="{DynamicResource GridsplitterThumbWidth}" Height="{DynamicResource GridsplitterThumbHeight}" Margin="{TemplateBinding Padding}" Fill="{TemplateBinding Foreground}" RadiusX="{StaticResource GridsplitterThumbRadius}" RadiusY="{StaticResource GridsplitterThumbRadius}" />
           </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -367,6 +367,12 @@
   <!--  Flyout  -->
   <SolidColorBrush x:Key="FlyoutBackground" Color="{StaticResource SystemColorWindowColor}" />
   <SolidColorBrush x:Key="FlyoutBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+  <!-- GridSplitter -->
+  <SolidColorBrush x:Key="GridsplitterBackground" Color="Transparent" />
+  <SolidColorBrush x:Key="GridsplitterBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+  <SolidColorBrush x:Key="GridsplitterBackgroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+  <SolidColorBrush x:Key="GridsplitterBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+  <SolidColorBrush x:Key="GridsplitterForeground" Color="{StaticResource SystemColorButtonTextColor}" />
   <!--  HyperlinkButton  -->
   <SolidColorBrush x:Key="HyperlinkButtonBackground" Color="Transparent" />
   <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
@@ -2633,6 +2639,48 @@
     <Setter Property="Focusable" Value="False" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
   </Style>
+  <system:Double x:Key="GridsplitterThumbHeight">24</system:Double>
+  <system:Double x:Key="GridsplitterThumbWidth">4</system:Double>
+  <system:Double x:Key="GridsplitterThumbRadius">2</system:Double>
+  <Thickness x:Key="GridsplitterPadding">4</Thickness>
+  <Style x:Key="DefaultGridSplitterStyle" TargetType="{x:Type GridSplitter}">
+    <Setter Property="IsTabStop" Value="True" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="MinHeight" Value="8" />
+    <Setter Property="MinWidth" Value="8" />
+    <Setter Property="Padding" Value="{StaticResource GridsplitterPadding}" />
+    <Setter Property="Foreground" Value="{DynamicResource GridsplitterForeground}" />
+    <Setter Property="Background" Value="{DynamicResource GridsplitterBackground}" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type GridSplitter}">
+          <Border x:Name="RootGrid" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
+            <Rectangle x:Name="PART_Thumb" Width="{StaticResource GridsplitterThumbWidth}" Height="{StaticResource GridsplitterThumbHeight}" Margin="{TemplateBinding Padding}" Fill="{TemplateBinding Foreground}" RadiusX="{StaticResource GridsplitterThumbRadius}" RadiusY="{StaticResource GridsplitterThumbRadius}" />
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="True">
+              <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundPressed}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundDisabled}" />
+              <Setter TargetName="PART_Thumb" Property="Opacity" Value="0.45" />
+            </Trigger>
+            <Trigger Property="ResizeDirection" Value="Rows">
+              <Setter TargetName="PART_Thumb" Property="Width" Value="{DynamicResource GridsplitterThumbHeight}" />
+              <Setter TargetName="PART_Thumb" Property="Height" Value="{DynamicResource GridsplitterThumbWidth}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultGridSplitterStyle}" TargetType="{x:Type GridSplitter}" />
   <Style x:Key="{x:Type GroupItem}" TargetType="{x:Type GroupItem}">
     <Setter Property="Template">
       <Setter.Value>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -2658,13 +2658,15 @@
   <system:Double x:Key="GridsplitterThumbHeight">24</system:Double>
   <system:Double x:Key="GridsplitterThumbWidth">4</system:Double>
   <system:Double x:Key="GridsplitterThumbRadius">2</system:Double>
+  <system:Double x:Key="GridsplitterMinHeight">8</system:Double>
+  <system:Double x:Key="GridsplitterMinWidth">8</system:Double>
   <Thickness x:Key="GridsplitterPadding">4</Thickness>
   <Style x:Key="DefaultGridSplitterStyle" TargetType="{x:Type GridSplitter}">
     <Setter Property="IsTabStop" Value="True" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Stretch" />
-    <Setter Property="MinHeight" Value="8" />
-    <Setter Property="MinWidth" Value="8" />
+    <Setter Property="MinHeight" Value="{DynamicResource GridsplitterMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource GridsplitterMinHeight}" />
     <Setter Property="Padding" Value="{StaticResource GridsplitterPadding}" />
     <Setter Property="Foreground" Value="{DynamicResource GridsplitterForeground}" />
     <Setter Property="Background" Value="{DynamicResource GridsplitterBackground}" />
@@ -2674,7 +2676,7 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type GridSplitter}">
           <Border x:Name="RootGrid" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
-            <Rectangle x:Name="PART_Thumb" Width="{StaticResource GridsplitterThumbWidth}" Height="{StaticResource GridsplitterThumbHeight}" Margin="{TemplateBinding Padding}" Fill="{TemplateBinding Foreground}" RadiusX="{StaticResource GridsplitterThumbRadius}" RadiusY="{StaticResource GridsplitterThumbRadius}" />
+            <Rectangle x:Name="PART_Thumb" Width="{DynamicResource GridsplitterThumbWidth}" Height="{DynamicResource GridsplitterThumbHeight}" Margin="{TemplateBinding Padding}" Fill="{TemplateBinding Foreground}" RadiusX="{StaticResource GridsplitterThumbRadius}" RadiusY="{StaticResource GridsplitterThumbRadius}" />
           </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -466,6 +466,12 @@
   <!--  Flyout  -->
   <SolidColorBrush x:Key="FlyoutBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
   <SolidColorBrush x:Key="FlyoutBorderBrush" Color="{StaticResource SurfaceStrokeColorFlyout}" />
+  <!-- GridSplitter -->
+  <SolidColorBrush x:Key="GridsplitterBackground" Color="{StaticResource ControlAltFillColorTransparent}" />
+  <SolidColorBrush x:Key="GridsplitterBackgroundPointerOver" Color="{StaticResource ControlAltFillColorTertiary}" />
+  <SolidColorBrush x:Key="GridsplitterBackgroundPressed" Color="{StaticResource ControlAltFillColorQuarternary}" />
+  <SolidColorBrush x:Key="GridsplitterBackgroundDisabled" Color="{StaticResource ControlAltFillColorDisabled}" />
+  <SolidColorBrush x:Key="GridsplitterForeground" Color="{StaticResource ControlStrongFillColorDefault}" />
   <!--  HyperlinkButton  -->
   <SolidColorBrush x:Key="HyperlinkButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />
   <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
@@ -2649,6 +2655,48 @@
     <Setter Property="Focusable" Value="False" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
   </Style>
+  <system:Double x:Key="GridsplitterThumbHeight">24</system:Double>
+  <system:Double x:Key="GridsplitterThumbWidth">4</system:Double>
+  <system:Double x:Key="GridsplitterThumbRadius">2</system:Double>
+  <Thickness x:Key="GridsplitterPadding">4</Thickness>
+  <Style x:Key="DefaultGridSplitterStyle" TargetType="{x:Type GridSplitter}">
+    <Setter Property="IsTabStop" Value="True" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="MinHeight" Value="8" />
+    <Setter Property="MinWidth" Value="8" />
+    <Setter Property="Padding" Value="{StaticResource GridsplitterPadding}" />
+    <Setter Property="Foreground" Value="{DynamicResource GridsplitterForeground}" />
+    <Setter Property="Background" Value="{DynamicResource GridsplitterBackground}" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type GridSplitter}">
+          <Border x:Name="RootGrid" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
+            <Rectangle x:Name="PART_Thumb" Width="{StaticResource GridsplitterThumbWidth}" Height="{StaticResource GridsplitterThumbHeight}" Margin="{TemplateBinding Padding}" Fill="{TemplateBinding Foreground}" RadiusX="{StaticResource GridsplitterThumbRadius}" RadiusY="{StaticResource GridsplitterThumbRadius}" />
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="True">
+              <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundPressed}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundDisabled}" />
+              <Setter TargetName="PART_Thumb" Property="Opacity" Value="0.45" />
+            </Trigger>
+            <Trigger Property="ResizeDirection" Value="Rows">
+              <Setter TargetName="PART_Thumb" Property="Width" Value="{DynamicResource GridsplitterThumbHeight}" />
+              <Setter TargetName="PART_Thumb" Property="Height" Value="{DynamicResource GridsplitterThumbWidth}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultGridSplitterStyle}" TargetType="{x:Type GridSplitter}" />
   <Style x:Key="{x:Type GroupItem}" TargetType="{x:Type GroupItem}">
     <Setter Property="Template">
       <Setter.Value>


### PR DESCRIPTION

## Description

A GridSplitter in WPF is a control that allows users to resize rows or columns in a Grid layout interactively. By dragging the splitter, users can adjust the size of adjacent grid sections. 

This pull request adds styling for this control in fluent. This style is derived from CommunityTookit SizerBase style.

## Fluent:
State:  Default
![image](https://github.com/user-attachments/assets/20a70b58-7b46-46dc-8619-86346dfb573b)<

State: PointerOver
![image](https://github.com/user-attachments/assets/54ea4cd1-64a1-4be8-8219-dd0aa37bdd33)
## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

No
## Testing

Local build pass, tested with sample applications
## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
