### PR TITLE
Run DesignTimeMarkupCompilation when DesignTimeBuild is set.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -79,7 +79,7 @@
   <PropertyGroup>
         <!-- Add Markup compilation to the CoreCompileDependsOn so that the IDE inproc compilers (particularly VB)
              can "see" the generated source files. -->
-      <CoreCompileDependsOn Condition="'$(BuildingInsideVisualStudio)' == 'true' ">
+      <CoreCompileDependsOn Condition="'$(BuildingInsideVisualStudio)' == 'true' Or '$(DesignTimeBuild)' == 'true'">
           DesignTimeMarkupCompilation;
           $(CoreCompileDependsOn)
       </CoreCompileDependsOn>
@@ -88,7 +88,7 @@
 
   <Target Name="DesignTimeMarkupCompilation">
         <!-- Only if we are not actually performing a compile i.e. we are in design mode -->
-        <CallTarget Condition="'$(BuildingProject)' != 'true' Or $(DesignTimeBuild) == 'true'"
+        <CallTarget Condition="'$(BuildingProject)' != 'true' Or '$(DesignTimeBuild)' == 'true'"
                 Targets="MarkupCompilePass1" />
   </Target>
 


### PR DESCRIPTION
Fixes # <!-- Issue Number --> https://github.com/microsoft/vscode-dotnettools/issues/1018, https://github.com/dotnet/vscode-csharp/issues/5958

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->
Roslyn's MSBuildWorkspace, Roslyn LSP ProjectSystem, and (possibly) CPS used in C# DevKit do not want to set BuildingInsideVisualStudio because of all the unknown compatibility issues that might create. By adding the 
DesignTimeMarkupCompilation to CoreCompile when a DesignTimeBuild is being performed we will be able to provide our users the ability to open WPF projects and have a good editing experience.

Looks like a previous PR (https://github.com/dotnet/wpf/pull/1895) enabled this for CPS within VisualStudio and this hopes to do the same for project systems outside VS.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
https://github.com/microsoft/vscode-dotnettools/issues/1018, https://github.com/dotnet/vscode-csharp/issues/5958

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->
MSBuildWorkspace has been basically running with this fix for a year ([see PR](https://github.com/dotnet/roslyn/commit/20ba0dd7e8ff0352e6ab21ccd3b60f0022354a4d)) as it checks whether the DesignTimeMarkupCompilation target exists and runs it. We have not gotten any negative feedback from that change.

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
For command line build scenarios the DesignTimeBuild property wouldn't be set, so there should be no change in behavior. For VS design-time builds, BuildingInsideVisualStudio was already being passed, so there should be no change in behavior. This really just changes the way design time builds work outside VS, by including the DesignTimeMarkupCompilation target. Based on an equivalent change being in Roslyn for a year. I would think the risk was low.

Would love to see this back ported to .NET 8 and 9 as it would enable users on those SDK to open WPF projects.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10489)