### PR TITLE
Force an x64 runtime install

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "tools": {
     "dotnet": "10.0.100-alpha.1.25077.2",
     "runtimes": {
-      "dotnet": [
+      "dotnet/x64": [
         "$(VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion)"
       ]
     },

--- a/global.json
+++ b/global.json
@@ -4,6 +4,9 @@
     "runtimes": {
       "dotnet/x64": [
         "$(VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion)"
+      ],
+      "dotnet": [
+        "$(VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion)"
       ]
     },
     "vs": {

--- a/global.json
+++ b/global.json
@@ -5,7 +5,7 @@
       "dotnet/x64": [
         "$(VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion)"
       ],
-      "dotnet": [
+      "dotnet/x86": [
         "$(VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion)"
       ]
     },


### PR DESCRIPTION
Works around an issue where because WPF uses Platform globally as to mean the Target platform, and because this is a default property that arcade uses to install additional runtimes, arcade installs the arm64 runtime on an x64 machine, which breaks when we try to run msbuild in signing. It would also break things if we ever ran testing.

```
<PropertyGroup>
    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
    <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
  </PropertyGroup>
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10494)