### PR TITLE
Removes MappingMode from LinearGradientBrush in HasRealizationContextChanged

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/lineargradient.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/lineargradient.h
@@ -80,20 +80,20 @@ public:
         __in_ecount(1) const BrushContext *pBrushContext
         ) const
     {
-                // If a mapping mode is relative to the brush
-                // *or* or when a relative transform is used 
-                // *and* bounds have changed, then the realization context has changed            
+                    // If a mapping mode is relative to the brush
+                    // *or* or when a relative transform is used 
+                    // *and* bounds have changed, then the realization context has changed            
         return  (   ((m_data.m_MappingMode == MilBrushMappingMode::RelativeToBoundingBox) 
                     || (m_data.m_pRelativeTransform != NULL)) &&
 
-                // Return true if the brush sizing bounds have changed
-                //
-                // We use exact equality here because fuzzy checks are expensive, coming up 
-                // with a fuzzy threshold that defines the point at which visible changes
-                // occur isn't straightforward (i.e., the brush sizing bounds aren't
-                // in device space), and exact equality handles the case we need to optimize
-                // for where a brush fills the exact same geometry more than once.                
-                !(IsExactlyEqualRectD(pBrushContext->rcWorldBrushSizingBounds, m_cachedBrushSizingBounds) ));
+                    // Return true if the brush sizing bounds have changed
+                    //
+                    // We use exact equality here because fuzzy checks are expensive, coming up 
+                    // with a fuzzy threshold that defines the point at which visible changes
+                    // occur isn't straightforward (i.e., the brush sizing bounds aren't
+                    // in device space), and exact equality handles the case we need to optimize
+                    // for where a brush fills the exact same geometry more than once.                
+                    !(IsExactlyEqualRectD(pBrushContext->rcWorldBrushSizingBounds, m_cachedBrushSizingBounds) ));
 
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/lineargradient.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/lineargradient.h
@@ -80,20 +80,20 @@ public:
         __in_ecount(1) const BrushContext *pBrushContext
         ) const
     {
-        // If a mapping mode is relative to the brush
-        // *or* or when a relative transform is used 
-        // *and* bounds have changed, then the realization context has changed            
+                // If a mapping mode is relative to the brush
+                // *or* or when a relative transform is used 
+                // *and* bounds have changed, then the realization context has changed            
         return  (   ((m_data.m_MappingMode == MilBrushMappingMode::RelativeToBoundingBox) 
                     || (m_data.m_pRelativeTransform != NULL)) &&
 
-        // Return true if the brush sizing bounds have changed
-        //
-        // We use exact equality here because fuzzy checks are expensive, coming up 
-        // with a fuzzy threshold that defines the point at which visible changes
-        // occur isn't straightforward (i.e., the brush sizing bounds aren't
-        // in device space), and exact equality handles the case we need to optimize
-        // for where a brush fills the exact same geometry more than once.                
-        !(IsExactlyEqualRectD(pBrushContext->rcWorldBrushSizingBounds, m_cachedBrushSizingBounds) ));
+                // Return true if the brush sizing bounds have changed
+                //
+                // We use exact equality here because fuzzy checks are expensive, coming up 
+                // with a fuzzy threshold that defines the point at which visible changes
+                // occur isn't straightforward (i.e., the brush sizing bounds aren't
+                // in device space), and exact equality handles the case we need to optimize
+                // for where a brush fills the exact same geometry more than once.                
+                !(IsExactlyEqualRectD(pBrushContext->rcWorldBrushSizingBounds, m_cachedBrushSizingBounds) ));
 
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/lineargradient.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/lineargradient.h
@@ -80,10 +80,11 @@ public:
         __in_ecount(1) const BrushContext *pBrushContext
         ) const
     {
-        // If a mapping mode is relative to the brush sizing bounds *and* those
-        // bounds have changed, then the realization context has changed.            
-        // If a mapping mode is absolute and we perform transformation operations
-        // on the brush, even then the sizing bounds gets changed and realization context has changed.
+        // If a mapping mode is relative to the brush
+        // *or* or when a relative transform is used 
+        // *and* bounds have changed, then the realization context has changed            
+        return  (   ((m_data.m_MappingMode == MilBrushMappingMode::RelativeToBoundingBox) 
+                    || (m_data.m_pRelativeTransform != NULL)) &&
 
         // Return true if the brush sizing bounds have changed
         //
@@ -92,7 +93,7 @@ public:
         // occur isn't straightforward (i.e., the brush sizing bounds aren't
         // in device space), and exact equality handles the case we need to optimize
         // for where a brush fills the exact same geometry more than once.                
-        return  ( !(IsExactlyEqualRectD(pBrushContext->rcWorldBrushSizingBounds, m_cachedBrushSizingBounds) ));
+        !(IsExactlyEqualRectD(pBrushContext->rcWorldBrushSizingBounds, m_cachedBrushSizingBounds) ));
 
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/lineargradient.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/lineargradient.h
@@ -80,18 +80,19 @@ public:
         __in_ecount(1) const BrushContext *pBrushContext
         ) const
     {
-                    // If a mapping mode is relative to the brush sizing bounds *and* those
-                    // bounds have changed, then the realization context has changed            
-        return  (   (m_data.m_MappingMode == MilBrushMappingMode::RelativeToBoundingBox) &&
+        // If a mapping mode is relative to the brush sizing bounds *and* those
+        // bounds have changed, then the realization context has changed.            
+        // If a mapping mode is absolute and we perform transformation operations
+        // on the brush, even then the sizing bounds gets changed and realization context has changed.
 
-                    // Return true if the brush sizing bounds have changed
-                    //
-                    // We use exact equality here because fuzzy checks are expensive, coming up 
-                    // with a fuzzy threshold that defines the point at which visible changes
-                    // occur isn't straightforward (i.e., the brush sizing bounds aren't
-                    // in device space), and exact equality handles the case we need to optimize
-                    // for where a brush fills the exact same geometry more than once.                
-                    !(IsExactlyEqualRectD(pBrushContext->rcWorldBrushSizingBounds, m_cachedBrushSizingBounds) ));
+        // Return true if the brush sizing bounds have changed
+        //
+        // We use exact equality here because fuzzy checks are expensive, coming up 
+        // with a fuzzy threshold that defines the point at which visible changes
+        // occur isn't straightforward (i.e., the brush sizing bounds aren't
+        // in device space), and exact equality handles the case we need to optimize
+        // for where a brush fills the exact same geometry more than once.                
+        return  ( !(IsExactlyEqualRectD(pBrushContext->rcWorldBrushSizingBounds, m_cachedBrushSizingBounds) ));
 
     }
 


### PR DESCRIPTION
Fixes #10502 

## Description
As described in the issue description, LinearGradientBrushes ( LGB ) caches it bounds when we use Absolute MappingMode. However, when we apply transformations to the brush, the brush does not work work as expected. This PR removes the caching of the brush, thus resolving the issue.

## Customer Impact
Developers using the LGB along with MappingMode=Absolute and RelativeTransform will get the correct behavior for the brush.

## Regression
No

## Testing
Not yet.

## Risk
- It will have a performance impact on the application using LGB with Absolute mapping mode.
- Applications using LGB will get a different behavior now.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10506)