### PR TITLE
Make Dynamic Resource Optmization as Opt-Int

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
@@ -32,6 +32,7 @@ namespace System
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.KeyboardNavigationFromHyperlinkInItemsControlIsNotRelativeToFocusedElementSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.ItemAutomationPeerKeepsItsItemAliveSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableFluentThemeWindowBackdropSwitchName, false);
+            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableDynamicResourceOptimizationSwitchName, true);
 
 #pragma warning restore CS0436 // Type conflicts with imported type
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/10491

## Description
As in .NET 9, the changes here makes DynamicResource Optimization as opt-in. As observed in some of the SyncFusion based sample applications, the optimized resources, causes crashing apps. The reason we are keeping this as opt-in is to accommodate fixes in the optimized approach. We will look into other options if we are unable to fix it at a later point.

## Regression
Yes
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
Sample application testing
<!-- What kind of testing has been done with the fix. -->

## Risk
Low, changing things back to pre .NET 9 behavior
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

cc:/ @batzen 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10516)