### PR TITLE
Fix DependencyProperty test

### DIFF
--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/System/Windows/DependencyPropertyTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/System/Windows/DependencyPropertyTests.cs
@@ -296,7 +296,7 @@ public class DependencyPropertyTests
 
     public static IEnumerable<object?[]> Register_String_Type_Type_ValidateFail_TestData()
     {
-        yield return new object?[] { " ", typeof(int), typeof(DependencyObjectTests), null, 0 };
+        yield return new object?[] { " ", typeof(int), typeof(DependencyObjectTest1), null, 0 };
         yield return new object?[] { " ", typeof(int), typeof(DependencyObject), new PropertyMetadata(), 0 };
         yield return new object?[] { "Register_String_Type_Type_ValidateFail_TestData1", typeof(string), typeof(DependencyObjectTests), null, null };
         yield return new object?[] { "Register_String_Type_Type_ValidateFail_TestData2", typeof(string), typeof(DependencyObject), new PropertyMetadata(), null };
@@ -1082,7 +1082,8 @@ public class DependencyPropertyTests
         Assert.NotNull(key.DependencyProperty);
         Assert.Same(key.DependencyProperty, key.DependencyProperty);
 
-        DependencyProperty property = key.DependencyProperty;        Assert.NotNull(property.DefaultMetadata);
+        DependencyProperty property = key.DependencyProperty;
+        Assert.NotNull(property.DefaultMetadata);
         Assert.Same(property.DefaultMetadata, property.DefaultMetadata);
         Assert.Null(property.DefaultMetadata.CoerceValueCallback);
         Assert.Equal(expectedDefaultValue, property.DefaultMetadata.DefaultValue);
@@ -1218,6 +1219,10 @@ public class DependencyPropertyTests
     }
 
     private class SubDispatcherObject : DispatcherObject
+    {
+    }
+
+    private sealed class DependencyObjectTest1
     {
     }
 }


### PR DESCRIPTION
## Description
Fixes the test failure seen in main currently. This was caused by the switch from xUnit test runner to VSTest test runner introduced in #10514 which changed the order in which test were ran and exposed an existing bug in the tests.

The problem is because the xUnit test runner ran the test `Register_InvokeStringTypeTypeValidateFail_Throws` before `Register_InvokeStringTypeType_Success` and VSTest test runner runs them in inverse order. This causes problem because both test registers a dependency property for the same type with the same property name, the thing is that `Register_InvokeStringTypeTypeValidateFail_Throws` expects the registration to fail and not register the dependency property in the cache while `Register_InvokeStringTypeType_Success` expects the registration to succeed and register the dependency property in the cache. 

When the order is `Register_InvokeStringTypeTypeValidateFail_Throws` -> `Register_InvokeStringTypeType_Success` it's fine because the dependency property is not in the cache for the second test.
When the order is `Register_InvokeStringTypeType_Success` -> `Register_InvokeStringTypeTypeValidateFail_Throws` it fails because  `Register_InvokeStringTypeTypeValidateFail_Throws` fails early because the property is already registered for the second test.

Here's the 2 conflicting dependency property name + type:
https://github.com/dotnet/wpf/blob/009ae5a190fcbd8f730d2f0959a96ffaebe244d5/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/System/Windows/DependencyPropertyTests.cs#L19

https://github.com/dotnet/wpf/blob/009ae5a190fcbd8f730d2f0959a96ffaebe244d5/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/System/Windows/DependencyPropertyTests.cs#L299-L300

Side note:
We should probably refactor how tests are done for DependencyProperty, this PR is just a patch to fix the current failure. IMO we should have 1 type per tests that register dependency properties, if we don't want to have a mess of types we could possibly create the types at runtime using IL emit.

## Customer Impact
None, tests only.

## Regression
WPF tests regression only.

## Testing
Running the tests locally.

## Risk
Low to none, tests only.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10522)