### PR TITLE
Remove double dictionary lookup for ctor params lookup in WpfKnownType

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfKnownType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfKnownType.cs
@@ -327,25 +327,20 @@ namespace System.Windows.Baml2006
 
         protected override IList<XamlType> LookupPositionalParameters(int paramCount)
         {
-            if (this.IsMarkupExtension)
+            if (IsMarkupExtension)
             {
-                List<XamlType> xTypes = null;
                 Baml6ConstructorInfo info = Constructors[paramCount];
-                if (Constructors.TryGetValue(paramCount, out info))
+                List<XamlType> xTypes = new(info.Types.Count);
+
+                foreach (Type type in info.Types)
                 {
-                    xTypes = new List<XamlType>();
-                    foreach (Type type in info.Types)
-                    {
-                        xTypes.Add(SchemaContext.GetXamlType(type));
-                    }
+                    xTypes.Add(SchemaContext.GetXamlType(type));
                 }
 
                 return xTypes;
             }
-            else
-            {
-                return base.LookupPositionalParameters(paramCount);
-            }
+
+            return base.LookupPositionalParameters(paramCount);
         }
 
         protected override ICustomAttributeProvider LookupCustomAttributeProvider()


### PR DESCRIPTION
## Description

Removes double dictionary lookup in `LookupPositionalParameters` for `WpfKnownType`. Also pre-allocates the type list.

I've removed the `TryGetValue` one as this it would previously already crash with `KeyNotFoundException` anyways which seems alright I guess, eitherway it doesn't change the behaviour that wasn't an issue to begin with.

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build.

## Risk

Low.
