### PR TITLE
Sets the FontWeight of ToolTip as Normal

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ToolTip.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ToolTip.xaml
@@ -21,6 +21,7 @@
         <Setter Property="TextBlock.TextAlignment" Value="Justify" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource ToolTipForeground}" />
         <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
+        <Setter Property="FontWeight" Value="Normal"/>
         <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}"/>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ToolTip.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ToolTip.xaml
@@ -21,7 +21,9 @@
         <Setter Property="TextBlock.TextAlignment" Value="Justify" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource ToolTipForeground}" />
         <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
-        <Setter Property="FontWeight" Value="Normal"/>
+        <Setter Property="FontFamily" Value="{DynamicResource {x:Static SystemFonts.StatusFontFamilyKey}}"/>
+        <Setter Property="FontSize" Value="{DynamicResource {x:Static SystemFonts.StatusFontSizeKey}}"/>
+        <Setter Property="FontStyle" Value="{DynamicResource {x:Static SystemFonts.StatusFontStyleKey}}"/>
         <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}"/>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -4798,7 +4798,9 @@
     <Setter Property="TextBlock.TextAlignment" Value="Justify" />
     <Setter Property="TextElement.Foreground" Value="{DynamicResource ToolTipForeground}" />
     <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
-    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="FontFamily" Value="{DynamicResource {x:Static SystemFonts.StatusFontFamilyKey}}" />
+    <Setter Property="FontSize" Value="{DynamicResource {x:Static SystemFonts.StatusFontSizeKey}}" />
+    <Setter Property="FontStyle" Value="{DynamicResource {x:Static SystemFonts.StatusFontStyleKey}}" />
     <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
     <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -4798,6 +4798,7 @@
     <Setter Property="TextBlock.TextAlignment" Value="Justify" />
     <Setter Property="TextElement.Foreground" Value="{DynamicResource ToolTipForeground}" />
     <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
+    <Setter Property="FontWeight" Value="Normal" />
     <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
     <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -4779,6 +4779,7 @@
     <Setter Property="TextBlock.TextAlignment" Value="Justify" />
     <Setter Property="TextElement.Foreground" Value="{DynamicResource ToolTipForeground}" />
     <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
+    <Setter Property="FontWeight" Value="Normal" />
     <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
     <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -4779,7 +4779,9 @@
     <Setter Property="TextBlock.TextAlignment" Value="Justify" />
     <Setter Property="TextElement.Foreground" Value="{DynamicResource ToolTipForeground}" />
     <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
-    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="FontFamily" Value="{DynamicResource {x:Static SystemFonts.StatusFontFamilyKey}}" />
+    <Setter Property="FontSize" Value="{DynamicResource {x:Static SystemFonts.StatusFontSizeKey}}" />
+    <Setter Property="FontStyle" Value="{DynamicResource {x:Static SystemFonts.StatusFontStyleKey}}" />
     <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
     <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -4795,6 +4795,7 @@
     <Setter Property="TextBlock.TextAlignment" Value="Justify" />
     <Setter Property="TextElement.Foreground" Value="{DynamicResource ToolTipForeground}" />
     <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
+    <Setter Property="FontWeight" Value="Normal" />
     <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
     <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -4795,7 +4795,9 @@
     <Setter Property="TextBlock.TextAlignment" Value="Justify" />
     <Setter Property="TextElement.Foreground" Value="{DynamicResource ToolTipForeground}" />
     <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
-    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="FontFamily" Value="{DynamicResource {x:Static SystemFonts.StatusFontFamilyKey}}" />
+    <Setter Property="FontSize" Value="{DynamicResource {x:Static SystemFonts.StatusFontSizeKey}}" />
+    <Setter Property="FontStyle" Value="{DynamicResource {x:Static SystemFonts.StatusFontStyleKey}}" />
     <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
     <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}" />


### PR DESCRIPTION
Fixes #9973 

## Description

Sets the FontWeight of ToolTip as Normal in Fluent
## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

No
## Testing

Local build pass, tested with sample applications
## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10546)