### PR TITLE
[StyleCleanUp] Fix spacing around keywords (SA1000) 

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -245,8 +245,6 @@ dotnet_diagnostic.IDE0300.severity = suggestion
 # IDE1006: Naming Styles
 dotnet_diagnostic.IDE1006.severity = suggestion
 
-# SA1000: Spacing around keywords
-dotnet_diagnostic.SA1000.severity = suggestion
 # SYSLIB1045: Convert to 'GeneratedRegexAttribute'.
 dotnet_diagnostic.SYSLIB1045.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlWrappingReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlWrappingReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -158,7 +158,7 @@ namespace System.Windows.Markup
         {
             try
             {
-                if(disposing)
+                if (disposing)
                 {
                     ((IDisposable)_reader).Dispose();
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/StaticExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/StaticExtension.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -129,7 +129,7 @@ namespace System.Windows.Markup
 
                 currentType = currentType.BaseType;
             }
-            while(currentType is not null);
+            while (currentType is not null);
 
             currentType = type;
             do
@@ -143,7 +143,7 @@ namespace System.Windows.Markup
 
                 currentType = currentType.BaseType;
             }
-            while(currentType is not null);
+            while (currentType is not null);
 
             value = null;
             return false;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
@@ -38,7 +38,7 @@ namespace MS.Internal.Xaml.Context
             BaseUri = savedContext.BaseUri;
             // If the bottom of the stack is a (no XamlType) Value (reparse) then back-up onto it.
             // Otherwise add a blank frame to isolate template use from the saved context.
-            switch(savedContext.SaveContextType)
+            switch (savedContext.SaveContextType)
             {
             case SavedContextType.Template:
                 // Templates always need a root namescope, to isolate them from the rest of the doc

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
@@ -60,7 +60,7 @@ namespace System.Xaml
         public XamlNode(XamlNodeType nodeType, object data)
         {
 #if DEBUG
-            switch(nodeType)
+            switch (nodeType)
             {
             case XamlNodeType.StartObject:
                 Debug.Assert(data is XamlType, "XamlNode ctor, StartObject data is not a XamlType");
@@ -114,7 +114,7 @@ namespace System.Xaml
         public override string ToString()
         {
             string str = string.Create(TypeConverterHelper.InvariantEnglishUS, $"{NodeType}: ");
-            switch(NodeType)
+            switch (NodeType)
             {
             case XamlNodeType.StartObject:
                 str += XamlType.Name;
@@ -133,7 +133,7 @@ namespace System.Xaml
                 break;
 
             case XamlNodeType.None:
-                switch(_internalNodeType)
+                switch (_internalNodeType)
                 {
                 case InternalNodeType.EndOfAttributes:
                     str += "End Of Attributes";

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -894,12 +894,12 @@ namespace System.Xaml
         {
             ThrowIfDisposed();
             ArgumentNullException.ThrowIfNull(namespaceDeclaration);
-            if(namespaceDeclaration.Prefix is null)
+            if (namespaceDeclaration.Prefix is null)
             {
                 throw new ArgumentException(SR.NamespaceDeclarationPrefixCannotBeNull);
             }
 
-            if(namespaceDeclaration.Namespace is null)
+            if (namespaceDeclaration.Namespace is null)
             {
                 throw new ArgumentException(SR.NamespaceDeclarationNamespaceCannotBeNull);
             }
@@ -2564,7 +2564,7 @@ namespace System.Xaml
             }
 
 #if DEBUG
-            if(token.Target.Property != token.TargetContext.ParentProperty)
+            if (token.Target.Property != token.TargetContext.ParentProperty)
             {
                 throw new XamlInternalException("Token's Target Property '{0}' != '{1}' the Token's Context parent Property");
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameScanner.cs
@@ -59,7 +59,7 @@ namespace MS.Internal.Xaml.Parser
 
             while (_token == GenericTypeNameScannerToken.NONE)
             {
-                if(IsAtEndOfInput)
+                if (IsAtEndOfInput)
                 {
                     if (_state == State.INNAME)
                     {
@@ -197,7 +197,7 @@ namespace MS.Internal.Xaml.Parser
                     break;
 
                 default:
-                    if(XamlName.IsValidNameStartChar(CurrentChar))
+                    if (XamlName.IsValidNameStartChar(CurrentChar))
                     {
                         StartMultiCharToken();
                         _state = State.INNAME;
@@ -217,14 +217,14 @@ namespace MS.Internal.Xaml.Parser
 
         private void State_InName()
         {
-            if(IsAtEndOfInput || IsWhitespaceChar(CurrentChar) || CurrentChar == OpenBracket)
+            if (IsAtEndOfInput || IsWhitespaceChar(CurrentChar) || CurrentChar == OpenBracket)
             {
                 _token = GenericTypeNameScannerToken.NAME;
                 _state = State.START;
                 return;
             }
 
-            switch(CurrentChar)
+            switch (CurrentChar)
             {
                 case OpenParen:
                     _pushedBackSymbol = GenericTypeNameScannerToken.OPEN;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MePullParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MePullParser.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -74,7 +74,7 @@ namespace MS.Internal.Xaml.Parser
 
         private bool Expect(MeTokenType token, string ruleString)
         {
-            if(_tokenizer.Token != token)
+            if (_tokenizer.Token != token)
             {
                 SetBrokenRuleString(ruleString);
                 return false;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -205,7 +205,7 @@ namespace MS.Internal.Xaml.Parser
                 break;
             }
 
-            if(readString)
+            if (readString)
             {
                 if (_context.CurrentType.IsMarkupExtension
                     && _context.CurrentBracketModeParseParameters is not null
@@ -352,12 +352,12 @@ namespace MS.Internal.Xaml.Parser
             StringBuilder sb = new StringBuilder();
             char ch;
 
-            while(!IsAtEndOfInput)
+            while (!IsAtEndOfInput)
             {
                 ch = CurrentChar;
 
                 // handle escaping and quoting first.
-                if(escaped)
+                if (escaped)
                 {
                     sb.Append(Backslash);
                     sb.Append(ch);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
@@ -47,7 +47,7 @@ namespace MS.Internal.Xaml
         private void StartObjectFrame()
         {
             _startObjectDepth += 1;
-            if(_seenStack.Count <=_startObjectDepth)
+            if (_seenStack.Count <=_startObjectDepth)
             {
                 _seenStack.Add(new SeenCtorDirectiveFlags());
             }
@@ -274,7 +274,7 @@ namespace MS.Internal.Xaml
             // then dig in and correct the stream.
             //
             // if (HaveSeenOutOfOrderCtorDirective)
-            if(_moveList is not null)
+            if (_moveList is not null)
             {
                 SortContentsOfReadAheadBuffer();
             }
@@ -613,9 +613,9 @@ namespace MS.Internal.Xaml
             end = current;
             int originalIdx = _sortingInfoArray[current].OriginalOrderIndex;
             XamlMember nextMember = _originalNodesInOrder[originalIdx].Member;
-            while(!IsInstancingMember(nextMember))
+            while (!IsInstancingMember(nextMember))
             {
-                if(!AdvanceTo(current, XamlNodeType.StartMember, depth, out end))
+                if (!AdvanceTo(current, XamlNodeType.StartMember, depth, out end))
                 {
                     return false;
                 }
@@ -705,7 +705,7 @@ namespace MS.Internal.Xaml
             {
                 XamlNodeType currentNodeType = _sortingInfoArray[idx].XamlNodeType;
                 int nodeDepth = _sortingInfoArray[idx].Depth;
-                if(nodeDepth == searchDepth)
+                if (nodeDepth == searchDepth)
                 {
                     if (currentNodeType == nodeType)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -60,7 +60,7 @@ namespace MS.Internal.Xaml.Parser
             }
             else if (Property.IsDirective)
             {
-                if(Property == XamlLanguage.Space)
+                if (Property == XamlLanguage.Space)
                 {
                     Kind = ScannerAttributeKind.XmlSpace;
                 }
@@ -79,7 +79,7 @@ namespace MS.Internal.Xaml.Parser
                     Kind = ScannerAttributeKind.Directive;
                 }
             }
-            else if(Property.IsAttachable)
+            else if (Property.IsAttachable)
             {
                 Kind = ScannerAttributeKind.AttachableProperty;
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPropertyName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPropertyName.cs
@@ -24,7 +24,7 @@ namespace MS.Internal.Xaml.Parser
 
         public static XamlPropertyName Parse(string longName)
         {
-            if(string.IsNullOrEmpty(longName))
+            if (string.IsNullOrEmpty(longName))
             {
                 return null;
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScanner.cs
@@ -661,7 +661,7 @@ namespace MS.Internal.Xaml.Parser
             // The Name attribute
             foreach (XamlAttribute attr in _attributes)
             {
-                switch(attr.Kind)
+                switch (attr.Kind)
                 {
                 case ScannerAttributeKind.Name:
                     nameAttribute = attr;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/RefOnly/LooseTypeExtensions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/RefOnly/LooseTypeExtensions.cs
@@ -136,7 +136,7 @@ namespace System.Xaml
                 return false; // strictly testing for sub-class
             }
 
-            for(Type baseType = t1.BaseType; baseType is not null; baseType = baseType.BaseType)
+            for (Type baseType = t1.BaseType; baseType is not null; baseType = baseType.BaseType)
             {
                 if (AssemblyQualifiedNameEquals(baseType, t2))
                 {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/ClrObjectRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/ClrObjectRuntime.cs
@@ -34,7 +34,7 @@ namespace MS.Internal.Xaml.Runtime
 
         private static Exception UnwrapTargetInvocationException(Exception e)
         {
-            if(e is TargetInvocationException && e.InnerException is not null)
+            if (e is TargetInvocationException && e.InnerException is not null)
             {
                 return e.InnerException;
             }
@@ -248,17 +248,17 @@ namespace MS.Internal.Xaml.Runtime
             object value;
             try
             {
-                if(property.IsDirective)
+                if (property.IsDirective)
                 {
                     value = CreateInstance(property.Type, null);
                 }
-                else if(!failIfWriteOnly)
+                else if (!failIfWriteOnly)
                 {
                     try
                     {
                         value = GetValue(property, obj);
                     }
-                    catch(NotSupportedException)
+                    catch (NotSupportedException)
                     {
                         value = null;
                     }
@@ -268,9 +268,9 @@ namespace MS.Internal.Xaml.Runtime
                     value = GetValue(property, obj);
                 }
             }
-            catch(Exception e)
+            catch (Exception e)
             {
-                if(CriticalExceptions.IsCriticalException(e))
+                if (CriticalExceptions.IsCriticalException(e))
                 {
                     throw;
                 }
@@ -290,16 +290,16 @@ namespace MS.Internal.Xaml.Runtime
         {
             try
             {
-                if(property.IsDirective)
+                if (property.IsDirective)
                 {
                     return;
                 }
 
                 SetValue(property, inst, value);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
-                if(CriticalExceptions.IsCriticalException(e))
+                if (CriticalExceptions.IsCriticalException(e))
                 {
                     throw;
                 }
@@ -319,9 +319,9 @@ namespace MS.Internal.Xaml.Runtime
             {
                 collectionType.Invoker.AddToCollection(collection, value);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
-                if(CriticalExceptions.IsCriticalException(e))
+                if (CriticalExceptions.IsCriticalException(e))
                 {
                     throw;
                 }
@@ -336,9 +336,9 @@ namespace MS.Internal.Xaml.Runtime
             {
                 dictionaryType.Invoker.AddToDictionary(collection, key, value);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
-                if(CriticalExceptions.IsCriticalException(e))
+                if (CriticalExceptions.IsCriticalException(e))
                 {
                     throw;
                 }
@@ -467,9 +467,9 @@ namespace MS.Internal.Xaml.Runtime
                     connector.Connect(connectionId, instance);
                 }
             }
-            catch(Exception e)
+            catch (Exception e)
             {
-                if(CriticalExceptions.IsCriticalException(e))
+                if (CriticalExceptions.IsCriticalException(e))
                 {
                     throw;
                 }
@@ -494,9 +494,9 @@ namespace MS.Internal.Xaml.Runtime
                     }
                 }
             }
-            catch(Exception e)
+            catch (Exception e)
             {
-                if(CriticalExceptions.IsCriticalException(e))
+                if (CriticalExceptions.IsCriticalException(e))
                 {
                     throw;
                 }
@@ -512,9 +512,9 @@ namespace MS.Internal.Xaml.Runtime
                 object val = me.ProvideValue(serviceProvider);
                 return val;
             }
-            catch(Exception e)
+            catch (Exception e)
             {
-                if(CriticalExceptions.IsCriticalException(e))
+                if (CriticalExceptions.IsCriticalException(e))
                 {
                     throw;
                 }
@@ -532,9 +532,9 @@ namespace MS.Internal.Xaml.Runtime
                     uriContext.BaseUri = baseUri;
                 }
             }
-            catch(Exception e)
+            catch (Exception e)
             {
-                if(CriticalExceptions.IsCriticalException(e))
+                if (CriticalExceptions.IsCriticalException(e))
                 {
                     throw;
                 }
@@ -562,9 +562,9 @@ namespace MS.Internal.Xaml.Runtime
             {
                 iXmlSerial.ReadXml(reader);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
-                if(CriticalExceptions.IsCriticalException(e))
+                if (CriticalExceptions.IsCriticalException(e))
                 {
                     throw;
                 }
@@ -585,7 +585,7 @@ namespace MS.Internal.Xaml.Runtime
             try
             {
                 XamlDeferringLoader converter = GetConverterInstance(deferringLoader);
-                if(converter is null)
+                if (converter is null)
                 {
                     throw new XamlObjectWriterException(SR.Format(SR.DeferringLoaderInstanceNull, deferringLoader));
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/BuiltInValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/BuiltInValueConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -187,7 +187,7 @@ namespace System.Xaml.Schema
 
             if (typeof(Uri).IsAssignableFrom(targetType))
             {
-                if(s_Uri is null)
+                if (s_Uri is null)
                 {
                     TypeConverter stdConverter = null;
                     try

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
@@ -248,7 +248,7 @@ namespace System.Xaml.Schema
 
         private Type SearchAssembliesForShortName(string shortName)
         {
-            foreach(AssemblyNamespacePair assemblyNamespacePair in _assemblyNamespaces)
+            foreach (AssemblyNamespacePair assemblyNamespacePair in _assemblyNamespaces)
             {
                 Assembly asm = assemblyNamespacePair.Assembly;
                 if (asm is null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlBackgroundReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlBackgroundReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -61,7 +61,7 @@ namespace System.Xaml
             _writer = new WriterDelegate(xamlNodeAddDelegate, lineInfoAddDelegate, _wrappedReader.SchemaContext);
 
             XamlNodeNextDelegate xamlNodeNextDelegate;
-            if(_wrappedReaderHasLineInfo)
+            if (_wrappedReaderHasLineInfo)
             {
                 xamlNodeNextDelegate = new XamlNodeNextDelegate(Next_ProcessLineInfo);
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -642,7 +642,7 @@ namespace System.Xaml
                 XamlType declaringType = xamlProperty.DeclaringType;
 
                 MemberMarkupInfo memberInfo;
-                if((xamlProperty == declaringType.GetAliasedProperty(XamlLanguage.Lang)) && (propertyValue is string))
+                if ((xamlProperty == declaringType.GetAliasedProperty(XamlLanguage.Lang)) && (propertyValue is string))
                 {
                     memberInfo = new MemberMarkupInfo()
                     {
@@ -725,7 +725,7 @@ namespace System.Xaml
 
                 bool isPreviousItemValue = false;
                 IList<object> itemsList = context.Runtime.GetCollectionItems(propertyValue, xamlType);
-                for(int i = 0; i < itemsList.Count; i++)
+                for (int i = 0; i < itemsList.Count; i++)
                 {
                     var itemValue = itemsList[i];
 
@@ -801,20 +801,20 @@ namespace System.Xaml
             // 3. First element has leading whitespace
             private static bool ShouldUnwrapDueToWhitespace(string value, XamlType xamlType, bool isFirstElementOfCollection, bool isLastElementOfCollection)
             {
-                if(XamlXmlWriter.HasSignificantWhitespace(value))
+                if (XamlXmlWriter.HasSignificantWhitespace(value))
                 {
-                    if(xamlType.IsWhitespaceSignificantCollection)
+                    if (xamlType.IsWhitespaceSignificantCollection)
                     {
-                        if(XamlXmlWriter.ContainsConsecutiveInnerSpaces(value) ||
+                        if (XamlXmlWriter.ContainsConsecutiveInnerSpaces(value) ||
                            XamlXmlWriter.ContainsWhitespaceThatIsNotSpace(value))
                         {
                             return true;
                         }
-                        else if(XamlXmlWriter.ContainsTrailingSpace(value) && isLastElementOfCollection)
+                        else if (XamlXmlWriter.ContainsTrailingSpace(value) && isLastElementOfCollection)
                         {
                             return true;
                         }
-                        else if(XamlXmlWriter.ContainsLeadingSpace(value) && isFirstElementOfCollection)
+                        else if (XamlXmlWriter.ContainsLeadingSpace(value) && isFirstElementOfCollection)
                         {
                             return true;
                         }
@@ -1874,7 +1874,7 @@ namespace System.Xaml
                     foreach (var ap in props)
                     {
                         XamlType owningType = context.GetXamlType(ap.Key.DeclaringType);
-                        if(!owningType.IsVisibleTo(context.LocalAssembly))
+                        if (!owningType.IsVisibleTo(context.LocalAssembly))
                         {
                             continue;
                         }
@@ -2650,7 +2650,7 @@ namespace System.Xaml
             public XamlType LocalAssemblyAwareGetXamlType(Type clrType)
             {
                 XamlType result = GetXamlType(clrType);
-                if(!result.IsVisibleTo(LocalAssembly) && !typeof(Type).IsAssignableFrom(clrType))
+                if (!result.IsVisibleTo(LocalAssembly) && !typeof(Type).IsAssignableFrom(clrType))
                 {
                     throw new XamlObjectReaderException(SR.Format(SR.ObjectReader_TypeNotVisible, clrType.FullName));
                 }
@@ -2787,7 +2787,7 @@ namespace System.Xaml
             public bool IsPropertyReadVisible(XamlMember property)
             {
                 Type allowProtectedMemberOnType = null;
-                if(Settings.AllowProtectedMembersOnRoot && IsRoot)
+                if (Settings.AllowProtectedMembersOnRoot && IsRoot)
                 {
                     allowProtectedMemberOnType = RootType;
                 }
@@ -2798,7 +2798,7 @@ namespace System.Xaml
             public bool IsPropertyWriteVisible(XamlMember property)
             {
                 Type allowProtectedMemberOnType = null;
-                if(Settings.AllowProtectedMembersOnRoot && IsRoot)
+                if (Settings.AllowProtectedMembersOnRoot && IsRoot)
                 {
                     allowProtectedMemberOnType = RootType;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlReader.cs
@@ -24,7 +24,7 @@ namespace System.Xaml
 
         public virtual void Skip()
         {
-            switch(NodeType)
+            switch (NodeType)
             {
             case XamlNodeType.NamespaceDeclaration:
             case XamlNodeType.Value:
@@ -79,7 +79,7 @@ namespace System.Xaml
         private void SkipFromTo(XamlNodeType startNodeType, XamlNodeType endNodeType)
         {
 #if DEBUG
-            if(NodeType != startNodeType)
+            if (NodeType != startNodeType)
             {
                 throw new XamlInternalException("SkipFromTo() called incorrectly");
             }


### PR DESCRIPTION
Fixes #10524 

## Description

Fixes spacing around keywords as per `SA1000`, the only violations were in `System.Xaml`.

## Customer Impact

Cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10602)