### PR TITLE
Use HashSet<T> in CommitManager instead of wrapped Dictionary<K, V>

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CommitManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CommitManager.cs
@@ -1,17 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
-//
-// Description: CommitManager provides global services for committing dirty bindings.
-//
-
-using System.Windows;
-using System.Windows.Data;
 using System.Windows.Media;
+using System.Windows.Data;
+using System.Windows;
 
 namespace MS.Internal.Data;
 
+/// <summary>
+/// <see cref="CommitManager"/> provides global services for committing dirty bindings.
+/// </summary>
 internal sealed class CommitManager
 {
     private readonly HashSet<BindingGroup> _bindingGroups = new();


### PR DESCRIPTION
## Description

Swaps use of `Dictionary<K, V>` where only `K` is used under the `Set<T>` wrapper for `HashSet<T>`.

- This decreases memory usage by a substantial amount.
- Also improves performance by further avoiding the double look-up on the original `Add` method.
- `IsInScope` was made static as it has no instance dependencies.
- Members were made `readonly` so they can be treated as JIT constants.
- Seals the class.

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10603)