### PR TITLE
[StyleCleanUp] Use `is null` check (IDE0041)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -173,9 +173,6 @@ dotnet_diagnostic.IDE0034.severity = suggestion
 # IDE0036: Order modifiers
 dotnet_diagnostic.IDE0036.severity = suggestion
 
-# IDE0041: Use 'is null' check
-dotnet_diagnostic.IDE0041.severity = suggestion
-
 # IDE0044: Add readonly modifier
 dotnet_diagnostic.IDE0044.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/DpiScale2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/DpiScale2.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -92,13 +92,7 @@ namespace MS.Internal
         /// <returns>True if the objects are not equal, otherwise False</returns>
         public static bool operator !=(DpiScale2 dpiScaleA, DpiScale2 dpiScaleB)
         {
-            if ((object.ReferenceEquals(dpiScaleA, null) && !object.ReferenceEquals(dpiScaleB, null)) ||
-                (!object.ReferenceEquals(dpiScaleA, null) && object.ReferenceEquals(dpiScaleB, null)))
-            {
-                return true;
-            }
-
-            return !dpiScaleA.Equals(dpiScaleB);
+            return !(dpiScaleA == dpiScaleB);
         }
 
         /// <summary>
@@ -109,13 +103,7 @@ namespace MS.Internal
         /// <returns>True if the two objects are equal, otherwise False</returns>
         public static bool operator ==(DpiScale2 dpiScaleA, DpiScale2 dpiScaleB)
         {
-            if (object.ReferenceEquals(dpiScaleA, null) && 
-                object.ReferenceEquals(dpiScaleB, null))
-            {
-                return true;
-            }
-
-            return dpiScaleA.Equals(dpiScaleB);
+            return dpiScaleA is null ? dpiScaleB is null : dpiScaleA.Equals(dpiScaleB);
         }
 
         /// <summary>
@@ -150,12 +138,7 @@ namespace MS.Internal
         /// </remarks>
         public bool Equals(DpiScale2 dpiScale2)
         {
-            if (object.ReferenceEquals(dpiScale2, null))
-            {
-                return false;
-            }
-
-            return this.Equals(dpiScale2.dpiScale);
+            return dpiScale2 is not null && this.Equals(dpiScale2.dpiScale);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/ExtendedProperty.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/ExtendedProperty.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -86,18 +86,7 @@ namespace System.Windows.Ink
         /// two ExtendedProperty objects</summary>
         public static bool operator ==(ExtendedProperty first, ExtendedProperty second)
         {
-            if ((object)first == null && (object)second == null)
-            {
-                return true;
-            }
-            else if ((object)first == null || (object)second == null)
-            {
-                return false;
-            }
-            else
-            {
-                return first.Equals(second);
-            }
+            return first is null ? second is null : first.Equals(second);
         }
 
         /// <summary>Compare two custom attributes for Id and value inequality</summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/ExtendedPropertyCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/ExtendedPropertyCollection.cs
@@ -63,27 +63,12 @@ namespace System.Windows.Ink
         /// if two ExtendedPropertyCollections are equal</summary>
         public static bool operator ==(ExtendedPropertyCollection first, ExtendedPropertyCollection second)
         {
-            // compare the GC ptrs for the obvious reference equality
-            if (((object)first == null && (object)second == null) ||
-                ((object)first == (object)second))
-            {
-                return true;
-            }
-            // otherwise, if one of the ptrs are null, but not the other then return false
-            else if ((object)first == null || (object)second == null)
-            {
-                return false;
-            }
-            // finally use the full `blown value-style comparison against the collection contents
-            else
-            {
-                return first.Equals(second);
-            }
+            return first is null ? second is null : ReferenceEquals(first, second) || first.Equals(second);
         }
 
         /// <summary>Overload of the not equals operator to determine if two
         /// ExtendedPropertyCollections have different key/value pairs</summary>
-        public static bool operator!=(ExtendedPropertyCollection first, ExtendedPropertyCollection second)
+        public static bool operator !=(ExtendedPropertyCollection first, ExtendedPropertyCollection second)
         {
             return !(first == second);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/DrawingAttributes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/DrawingAttributes.cs
@@ -517,19 +517,7 @@ namespace System.Windows.Ink
         /// if two DrawingAttributes are equal</summary>
         public static bool operator ==(DrawingAttributes first, DrawingAttributes second)
         {
-            // compare the GC ptrs for the obvious reference equality
-            if (((object)first == null && (object)second == null) ||
-                ((object)first == (object)second))
-            {
-                return true;
-            }
-                // otherwise, if one of the ptrs are null, but not the other then return false
-            else if ((object)first == null || (object)second == null)
-            {
-                return false;
-            }
-            // finally use the full `blown value-style comparison against the collection contents
-            return first.Equals(second);
+            return first is null ? second is null : ReferenceEquals(first, second) || first.Equals(second);
         }
 
         /// <summary>Overload of the not equals operator to determine if two

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimelineClockCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimelineClockCollection.cs
@@ -219,8 +219,7 @@ namespace System.Windows.Media.Animation
                 // Exact same object.
                 return true;
             }
-            else if (   Object.ReferenceEquals(objA, null)
-                     || Object.ReferenceEquals(objB, null))
+            else if (objA is null || objB is null)
             {
                 // One is null, the other isn't.
                 return false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualTreeHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualTreeHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -102,10 +102,6 @@ namespace System.Windows.Media
         /// </summary>
         public static void SetRootDpi(Visual visual, DpiScale dpiInfo)
         {
-            if ((object)dpiInfo == null)
-            {
-                throw new NullReferenceException("dpiInfo cannot be null");
-            }
             if (visual.InternalVisualParent != null)
             {
                 throw new InvalidOperationException("UpdateDPI should only be called on the root of a Visual tree");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Component/AdornerPresentationContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Component/AdornerPresentationContext.cs
@@ -280,10 +280,7 @@ namespace MS.Internal.Annotations.Component
         /// <returns></returns>
         public static bool operator ==(AdornerPresentationContext left, AdornerPresentationContext right)
         {
-            if ((object)left == null)
-                return (object)right == null;
-
-            return left.Equals(right);
+            return left is null ? right is null : left.Equals(right);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ViewManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ViewManager.cs
@@ -195,9 +195,6 @@ namespace MS.Internal.Data
         // overload operator for ==, to be same as Equal implementation.
         public static bool operator ==(WeakRefKey left, WeakRefKey right)
         {
-            if ((object)left == null)
-                return (object)right == null;
-
             return left.Equals(right);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlNamespaceMapping.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlNamespaceMapping.cs
@@ -82,21 +82,15 @@ namespace System.Windows.Data
         /// <summary>
         /// Equality comparison by value
         /// </summary>
-        public static bool operator == (XmlNamespaceMapping mappingA, XmlNamespaceMapping mappingB)
+        public static bool operator ==(XmlNamespaceMapping mappingA, XmlNamespaceMapping mappingB)
         {
-            // cannot just compare with (mappingX == null), it'll cause recursion and stack overflow!
-            if (object.ReferenceEquals(mappingA, null))
-                return object.ReferenceEquals(mappingB, null);
-            if (object.ReferenceEquals(mappingB, null))
-                return false;
-
-            return ((mappingA.Prefix == mappingB.Prefix) && (mappingA.Uri == mappingB.Uri)) ;
+            return mappingA is null ? mappingB is null : mappingB is not null && (mappingA.Prefix == mappingB.Prefix) && (mappingA.Uri == mappingB.Uri);
         }
 
         /// <summary>
         /// Inequality comparison by value
         /// </summary>
-        public static bool operator != (XmlNamespaceMapping mappingA, XmlNamespaceMapping mappingB)
+        public static bool operator !=(XmlNamespaceMapping mappingA, XmlNamespaceMapping mappingB)
         {
             return !(mappingA == mappingB);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FlowNode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FlowNode.cs
@@ -67,7 +67,7 @@ namespace System.Windows.Documents
         // force object comparision
         public static bool IsNull(FlowNode flow)
         {
-            return (object)flow == null;
+            return flow is null;
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
@@ -292,12 +292,7 @@ namespace System.Xaml
 
         public static bool operator ==(WeakRefKey left, WeakRefKey right)
         {
-            if (object.ReferenceEquals(left, null))
-            {
-                return object.ReferenceEquals(right, null);
-            }
-
-            return left.Equals(right);
+            return left is null ? right is null : left.Equals(right);
         }
 
         public static bool operator !=(WeakRefKey left, WeakRefKey right)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AutomationElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AutomationElement.cs
@@ -304,11 +304,7 @@ namespace System.Windows.Automation
         /// </remarks>
         public override bool Equals(object obj)
         {
-            AutomationElement el = obj as AutomationElement;
-            if (obj == null || el == null)
-                return false;
-
-            return Misc.Compare(this, el);
+            return obj is AutomationElement element && Misc.Compare(this, element);
         }
 
         /// <summary>
@@ -347,13 +343,7 @@ namespace System.Windows.Automation
         /// </remarks>
         public static bool operator ==(AutomationElement left, AutomationElement right)
         {
-            if ((object)left == null)
-                return (object)right == null;
-
-            if ((object)right == null)
-                return (object)left == null;
-
-            return left.Equals(right);
+            return left is null ? right is null : left.Equals(right);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/VersionPair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/VersionPair.cs
@@ -119,23 +119,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// <param name="v2">version to be compared</param>
         public static bool operator ==(VersionPair v1, VersionPair v2)
         {
-            bool result = false;
-
-            // If both v1 & v2 are null they are same
-            if ((Object) v1 == null && (Object) v2 == null)
-            {
-                result = true;
-            }
-            // Do comparison only if both v1 and v2 are not null
-            else if ((Object) v1 != null && (Object) v2 != null)
-            {
-                if (v1.Major == v2.Major && v1.Minor == v2.Minor)
-                {
-                    result = true;
-                }
-            }
-
-            return result;
+            return v1 is null ? v2 is null : v2 is not null && (v1.Major == v2.Major && v1.Minor == v2.Minor);
         }
 
         /// <summary>
@@ -159,11 +143,11 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         {
             bool result = false;
 
-            if ((Object) v1 == null && (Object) v2 != null)
+            if (v1 is null && v2 is not null)
             {
                 result = true;
             }
-            else if ((Object) v1 != null && (object) v2 != null)
+            else if (v1 is not null && v2 is not null)
             {
                 // == is previously define so it can be used
                 if (v1.Major < v2.Major || ((v1.Major == v2.Major) && (v1.Minor < v2.Minor)))
@@ -184,12 +168,12 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         {
             bool result = false;
 
-            if ((Object) v1 != null && (Object) v2 == null)
+            if (v1 is not null && v2 is null)
             {
                 result = true;
             }
             // Comare only if neither v1 nor v2 are not null
-            else if ((Object) v1 != null && (object) v2 != null)
+            else if (v1 is not null && v2 is not null)
             {
                 // < and == are previously define so it can be used
                 if (!(v1 < v2) && v1 != v2)


### PR DESCRIPTION
Fixes #10612

## Description

Avoids using `ReferenceEquals` to check each object and uses `is null` check instead. 
- In case of `WeakRefKey` and `DpiScale`, the boxing casts are removed as they're both non-nullable structs.

## Customer Impact

Cleaner codebase for developers, should reduce some boxes and branches.

## Regression

No.

## Testing

Local testing.

## Risk

Should be low, mostly analyzer fixes but I did adjust some to remove double-checks on the same field.
