### PR TITLE
[StyleCleanUp] Test for NaN correctly (CA2242)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -146,9 +146,6 @@ dotnet_diagnostic.CA2208.severity = suggestion
 # CA2219: Do not raise exceptions in finally clauses
 dotnet_diagnostic.CA2219.severity = suggestion
 
-# CA2242: Test for NaN correctly
-dotnet_diagnostic.CA2242.severity = suggestion
-
 # CA2300: Do not use insecure deserializer BinaryFormatter
 dotnet_diagnostic.CA2300.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPoint.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPoint.cs
@@ -78,9 +78,8 @@ namespace System.Windows.Input
             }
 
 
-            //we don't validate pressure when called by StylusPointDescription.Reformat
-            if (validatePressureFactor &&
-                (pressureFactor == Single.NaN || pressureFactor < 0.0f || pressureFactor > 1.0f))
+            // we don't validate pressure when called by StylusPointDescription.Reformat
+            if (validatePressureFactor && (float.IsNaN(pressureFactor) || pressureFactor < 0.0f || pressureFactor > 1.0f))
             {
                 throw new ArgumentOutOfRangeException(nameof(pressureFactor), SR.InvalidPressureValue);
             }

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Controls/AnimationFactorToValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Controls/AnimationFactorToValueConverter.cs
@@ -13,7 +13,7 @@ namespace Fluent.Controls
                 return 0.0;
             }
 
-            if (values[1] is not double factor || factor == double.NaN)
+            if (values[1] is not double factor || double.IsNaN(factor))
             {
                 return 0.0;
             }


### PR DESCRIPTION
Fixes #10616

## Description

Fixes two comparisons for NaN that were done incorrectly and will always evaluate to `false`.

## Customer Impact

Depends, the code will now finally do what has been the original intent.

## Regression

No.

## Testing

Local build, I did not test these two changes.

## Risk

For the converter, I guess we can properly test that it doesn't break the `Expander`
(@dipeshmsft, you're signed under that change to test for NaN that can never evaluate to `true`).

For the stylus, seems appropriate to check.