### PR TITLE
[MilCodeGen] Declare Equals/GetHashCode and property getters for fields as readonly

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Matrix3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Matrix3D.cs
@@ -143,15 +143,9 @@ namespace System.Windows.Media.Media3D
         /// bool - true if the object is an instance of Matrix3D and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Matrix3D))
-            {
-                return false;
-            }
-
-            Matrix3D value = (Matrix3D)o;
-            return Matrix3D.Equals(this,value);
+            return o is Matrix3D other && Matrix3D.Equals(this, other);
         }
 
         /// <summary>
@@ -165,7 +159,7 @@ namespace System.Windows.Media.Media3D
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Matrix3D to compare to "this"</param>
-        public bool Equals(Matrix3D value)
+        public readonly bool Equals(Matrix3D value)
         {
             return Matrix3D.Equals(this, value);
         }
@@ -175,7 +169,7 @@ namespace System.Windows.Media.Media3D
         /// <returns>
         /// int - the HashCode for this Matrix3D
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             if (IsDistinguishedIdentity)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3D.cs
@@ -103,15 +103,9 @@ namespace System.Windows.Media.Media3D
         /// bool - true if the object is an instance of Point3D and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Point3D))
-            {
-                return false;
-            }
-
-            Point3D value = (Point3D)o;
-            return Point3D.Equals(this,value);
+            return o is Point3D other && Point3D.Equals(this, other);
         }
 
         /// <summary>
@@ -125,7 +119,7 @@ namespace System.Windows.Media.Media3D
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Point3D to compare to "this"</param>
-        public bool Equals(Point3D value)
+        public readonly bool Equals(Point3D value)
         {
             return Point3D.Equals(this, value);
         }
@@ -135,7 +129,7 @@ namespace System.Windows.Media.Media3D
         /// <returns>
         /// int - the HashCode for this Point3D
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             // Perform field-by-field XOR of HashCodes
             return X.GetHashCode() ^
@@ -187,7 +181,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double X
         {
-            get
+            readonly get
             {
                 return _x;
             }
@@ -204,7 +198,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double Y
         {
-            get
+            readonly get
             {
                 return _y;
             }
@@ -221,7 +215,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double Z
         {
-            get
+            readonly get
             {
                 return _z;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point4D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point4D.cs
@@ -105,15 +105,9 @@ namespace System.Windows.Media.Media3D
         /// bool - true if the object is an instance of Point4D and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Point4D))
-            {
-                return false;
-            }
-
-            Point4D value = (Point4D)o;
-            return Point4D.Equals(this,value);
+            return o is Point4D other && Point4D.Equals(this, other);
         }
 
         /// <summary>
@@ -127,7 +121,7 @@ namespace System.Windows.Media.Media3D
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Point4D to compare to "this"</param>
-        public bool Equals(Point4D value)
+        public readonly bool Equals(Point4D value)
         {
             return Point4D.Equals(this, value);
         }
@@ -137,7 +131,7 @@ namespace System.Windows.Media.Media3D
         /// <returns>
         /// int - the HashCode for this Point4D
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             // Perform field-by-field XOR of HashCodes
             return X.GetHashCode() ^
@@ -191,7 +185,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double X
         {
-            get
+            readonly get
             {
                 return _x;
             }
@@ -208,7 +202,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double Y
         {
-            get
+            readonly get
             {
                 return _y;
             }
@@ -225,7 +219,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double Z
         {
-            get
+            readonly get
             {
                 return _z;
             }
@@ -242,7 +236,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double W
         {
-            get
+            readonly get
             {
                 return _w;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Quaternion.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Quaternion.cs
@@ -119,15 +119,9 @@ namespace System.Windows.Media.Media3D
         /// bool - true if the object is an instance of Quaternion and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Quaternion))
-            {
-                return false;
-            }
-
-            Quaternion value = (Quaternion)o;
-            return Quaternion.Equals(this,value);
+            return o is Quaternion other && Quaternion.Equals(this, other);
         }
 
         /// <summary>
@@ -141,7 +135,7 @@ namespace System.Windows.Media.Media3D
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Quaternion to compare to "this"</param>
-        public bool Equals(Quaternion value)
+        public readonly bool Equals(Quaternion value)
         {
             return Quaternion.Equals(this, value);
         }
@@ -151,7 +145,7 @@ namespace System.Windows.Media.Media3D
         /// <returns>
         /// int - the HashCode for this Quaternion
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             if (IsDistinguishedIdentity)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Rect3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Rect3D.cs
@@ -116,15 +116,9 @@ namespace System.Windows.Media.Media3D
         /// bool - true if the object is an instance of Rect3D and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Rect3D))
-            {
-                return false;
-            }
-
-            Rect3D value = (Rect3D)o;
-            return Rect3D.Equals(this,value);
+            return o is Rect3D other && Rect3D.Equals(this, other);
         }
 
         /// <summary>
@@ -138,7 +132,7 @@ namespace System.Windows.Media.Media3D
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Rect3D to compare to "this"</param>
-        public bool Equals(Rect3D value)
+        public readonly bool Equals(Rect3D value)
         {
             return Rect3D.Equals(this, value);
         }
@@ -148,7 +142,7 @@ namespace System.Windows.Media.Media3D
         /// <returns>
         /// int - the HashCode for this Rect3D
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             if (IsEmpty)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Size3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Size3D.cs
@@ -110,15 +110,9 @@ namespace System.Windows.Media.Media3D
         /// bool - true if the object is an instance of Size3D and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Size3D))
-            {
-                return false;
-            }
-
-            Size3D value = (Size3D)o;
-            return Size3D.Equals(this,value);
+            return o is Size3D other && Size3D.Equals(this, other);
         }
 
         /// <summary>
@@ -132,7 +126,7 @@ namespace System.Windows.Media.Media3D
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Size3D to compare to "this"</param>
-        public bool Equals(Size3D value)
+        public readonly bool Equals(Size3D value)
         {
             return Size3D.Equals(this, value);
         }
@@ -142,7 +136,7 @@ namespace System.Windows.Media.Media3D
         /// <returns>
         /// int - the HashCode for this Size3D
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             if (IsEmpty)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3D.cs
@@ -103,15 +103,9 @@ namespace System.Windows.Media.Media3D
         /// bool - true if the object is an instance of Vector3D and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Vector3D))
-            {
-                return false;
-            }
-
-            Vector3D value = (Vector3D)o;
-            return Vector3D.Equals(this,value);
+            return o is Vector3D other && Vector3D.Equals(this, other);
         }
 
         /// <summary>
@@ -125,7 +119,7 @@ namespace System.Windows.Media.Media3D
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Vector3D to compare to "this"</param>
-        public bool Equals(Vector3D value)
+        public readonly bool Equals(Vector3D value)
         {
             return Vector3D.Equals(this, value);
         }
@@ -135,7 +129,7 @@ namespace System.Windows.Media.Media3D
         /// <returns>
         /// int - the HashCode for this Vector3D
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             // Perform field-by-field XOR of HashCodes
             return X.GetHashCode() ^
@@ -187,7 +181,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double X
         {
-            get
+            readonly get
             {
                 return _x;
             }
@@ -204,7 +198,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double Y
         {
-            get
+            readonly get
             {
                 return _y;
             }
@@ -221,7 +215,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double Z
         {
-            get
+            readonly get
             {
                 return _z;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Matrix3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Matrix3D.cs
@@ -668,7 +668,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M11
         {
-            get
+            readonly get
             {
                 if (IsDistinguishedIdentity)
                 {
@@ -695,7 +695,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M12
         {
-            get
+            readonly get
             {
                 return _m12;
             }
@@ -715,7 +715,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M13
         {
-            get
+            readonly get
             {
                 return _m13;
             }
@@ -735,7 +735,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M14
         {
-            get
+            readonly get
             {
                 return _m14;
             }
@@ -756,7 +756,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M21
         {
-            get
+            readonly get
             {
                 return _m21;
             }
@@ -776,7 +776,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M22
         {
-            get
+            readonly get
             {
                 if (IsDistinguishedIdentity)
                 {
@@ -803,7 +803,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M23
         {
-            get
+            readonly get
             {
                 return _m23;
             }
@@ -823,7 +823,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M24
         {
-            get
+            readonly get
             {
                 return _m24;
             }
@@ -845,7 +845,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M31
         {
-            get
+            readonly get
             {
                 return _m31;
             }
@@ -865,7 +865,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M32
         {
-            get
+            readonly get
             {
                 return _m32;
             }
@@ -885,7 +885,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M33
         {
-            get
+            readonly get
             {
                 if (IsDistinguishedIdentity)
                 {
@@ -912,7 +912,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M34
         {
-            get
+            readonly get
             {
                 return _m34;
             }
@@ -933,7 +933,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double OffsetX
         {
-            get
+            readonly get
             {
                 return _offsetX;
             }
@@ -952,7 +952,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double OffsetY
         {
-            get
+            readonly get
             {
                 return _offsetY;
             }
@@ -971,7 +971,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double OffsetZ
         {
-            get
+            readonly get
             {
                 return _offsetZ;
             }
@@ -992,7 +992,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double M44
         {
-            get
+            readonly get
             {
                 if (IsDistinguishedIdentity)
                 {
@@ -1391,7 +1391,7 @@ namespace System.Windows.Media.Media3D
         //
         private bool IsDistinguishedIdentity
         {
-            get
+            readonly get
             {
                 Debug.Assert(
                     _isNotKnownToBeIdentity

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Quaternion.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Quaternion.cs
@@ -598,7 +598,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double X
         {
-            get
+            readonly get
             {
                 return _x;
             }
@@ -619,7 +619,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double Y
         {
-            get
+            readonly get
             {
                 return _y;
             }
@@ -640,7 +640,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double Z
         {
-            get
+            readonly get
             {
                 return _z;
             }
@@ -661,7 +661,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double W
         {
-            get
+            readonly get
             {
                 if (IsDistinguishedIdentity)
                 {
@@ -710,7 +710,7 @@ namespace System.Windows.Media.Media3D
 
         private bool IsDistinguishedIdentity
         {
-            get 
+            readonly get
             {
                 return !_isNotDistinguishedIdentity;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Rect3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Rect3D.cs
@@ -120,7 +120,7 @@ namespace System.Windows.Media.Media3D
         /// Note: If size is 0 this Rectangle still contains a 0 or 1 dimensional set
         /// of points, so this method should not be used to check for 0 area.
         /// </summary>
-        public bool IsEmpty
+        public readonly bool IsEmpty
         {
             get
             {
@@ -187,7 +187,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double SizeX
         {
-            get
+            readonly get
             {
                 return _sizeX;
             }
@@ -212,7 +212,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double SizeY
         {
-            get
+            readonly get
             {
                 return _sizeY;
             }
@@ -237,7 +237,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double SizeZ
         {
-            get
+            readonly get
             {
                 return _sizeZ;
             }
@@ -262,7 +262,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double X
         {
-            get
+            readonly get
             {
                 return _x;
             }
@@ -282,7 +282,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double Y
         {
-            get
+            readonly get
             {
                 return _y;
             }
@@ -302,7 +302,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double Z
         {
-            get
+            readonly get
             {
                 return _z;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Size3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Size3D.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Media.Media3D
         /// Note: If size is 0 this Size3D still contains a 0, 1, or 2 dimensional set
         /// of points, so this method should not be used to check for 0 volume.
         /// </summary>
-        public bool IsEmpty
+        public readonly bool IsEmpty
         {
             get
             {
@@ -70,7 +70,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double X
         {
-            get
+            readonly get
             {
                 return _x;
             }
@@ -95,7 +95,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double Y
         {
-            get
+            readonly get
             {
                 return _y;
             }
@@ -121,7 +121,7 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public double Z
         {
-            get
+            readonly get
             {
                 return _z;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
@@ -12263,27 +12263,27 @@ namespace System.Windows.Media.Media3D
         public static System.Windows.Media.Media3D.Matrix3D Identity { get { throw null; } }
         public bool IsAffine { get { throw null; } }
         public bool IsIdentity { get { throw null; } }
-        public double M11 { get { throw null; } set { } }
-        public double M12 { get { throw null; } set { } }
-        public double M13 { get { throw null; } set { } }
-        public double M14 { get { throw null; } set { } }
-        public double M21 { get { throw null; } set { } }
-        public double M22 { get { throw null; } set { } }
-        public double M23 { get { throw null; } set { } }
-        public double M24 { get { throw null; } set { } }
-        public double M31 { get { throw null; } set { } }
-        public double M32 { get { throw null; } set { } }
-        public double M33 { get { throw null; } set { } }
-        public double M34 { get { throw null; } set { } }
-        public double M44 { get { throw null; } set { } }
-        public double OffsetX { get { throw null; } set { } }
-        public double OffsetY { get { throw null; } set { } }
-        public double OffsetZ { get { throw null; } set { } }
+        public double M11 { readonly get { throw null; } set { } }
+        public double M12 { readonly get { throw null; } set { } }
+        public double M13 { readonly get { throw null; } set { } }
+        public double M14 { readonly get { throw null; } set { } }
+        public double M21 { readonly get { throw null; } set { } }
+        public double M22 { readonly get { throw null; } set { } }
+        public double M23 { readonly get { throw null; } set { } }
+        public double M24 { readonly get { throw null; } set { } }
+        public double M31 { readonly get { throw null; } set { } }
+        public double M32 { readonly get { throw null; } set { } }
+        public double M33 { readonly get { throw null; } set { } }
+        public double M34 { readonly get { throw null; } set { } }
+        public double M44 { readonly get { throw null; } set { } }
+        public double OffsetX { readonly get { throw null; } set { } }
+        public double OffsetY { readonly get { throw null; } set { } }
+        public double OffsetZ { readonly get { throw null; } set { } }
         public void Append(System.Windows.Media.Media3D.Matrix3D matrix) { }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Media.Media3D.Matrix3D value) { throw null; }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Media.Media3D.Matrix3D value) { throw null; }
         public static bool Equals(System.Windows.Media.Media3D.Matrix3D matrix1, System.Windows.Media.Media3D.Matrix3D matrix2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public void Invert() { }
         public static System.Windows.Media.Media3D.Matrix3D Multiply(System.Windows.Media.Media3D.Matrix3D matrix1, System.Windows.Media.Media3D.Matrix3D matrix2) { throw null; }
         public static bool operator ==(System.Windows.Media.Media3D.Matrix3D matrix1, System.Windows.Media.Media3D.Matrix3D matrix2) { throw null; }
@@ -12479,14 +12479,14 @@ namespace System.Windows.Media.Media3D
     public partial struct Point3D : System.IFormattable
     {
         public Point3D(double x, double y, double z) { throw null; }
-        public double X { get { throw null; } set { } }
-        public double Y { get { throw null; } set { } }
-        public double Z { get { throw null; } set { } }
+        public double X { readonly get { throw null; } set { } }
+        public double Y { readonly get { throw null; } set { } }
+        public double Z { readonly get { throw null; } set { } }
         public static System.Windows.Media.Media3D.Point3D Add(System.Windows.Media.Media3D.Point3D point, System.Windows.Media.Media3D.Vector3D vector) { throw null; }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Media.Media3D.Point3D value) { throw null; }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Media.Media3D.Point3D value) { throw null; }
         public static bool Equals(System.Windows.Media.Media3D.Point3D point1, System.Windows.Media.Media3D.Point3D point2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public static System.Windows.Media.Media3D.Point3D Multiply(System.Windows.Media.Media3D.Point3D point, System.Windows.Media.Media3D.Matrix3D matrix) { throw null; }
         public void Offset(double offsetX, double offsetY, double offsetZ) { }
         public static System.Windows.Media.Media3D.Point3D operator +(System.Windows.Media.Media3D.Point3D point, System.Windows.Media.Media3D.Vector3D vector) { throw null; }
@@ -12577,15 +12577,15 @@ namespace System.Windows.Media.Media3D
     public partial struct Point4D : System.IFormattable
     {
         public Point4D(double x, double y, double z, double w) { throw null; }
-        public double W { get { throw null; } set { } }
-        public double X { get { throw null; } set { } }
-        public double Y { get { throw null; } set { } }
-        public double Z { get { throw null; } set { } }
+        public double W { readonly get { throw null; } set { } }
+        public double X { readonly get { throw null; } set { } }
+        public double Y { readonly get { throw null; } set { } }
+        public double Z { readonly get { throw null; } set { } }
         public static System.Windows.Media.Media3D.Point4D Add(System.Windows.Media.Media3D.Point4D point1, System.Windows.Media.Media3D.Point4D point2) { throw null; }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Media.Media3D.Point4D value) { throw null; }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Media.Media3D.Point4D value) { throw null; }
         public static bool Equals(System.Windows.Media.Media3D.Point4D point1, System.Windows.Media.Media3D.Point4D point2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public static System.Windows.Media.Media3D.Point4D Multiply(System.Windows.Media.Media3D.Point4D point, System.Windows.Media.Media3D.Matrix3D matrix) { throw null; }
         public void Offset(double deltaX, double deltaY, double deltaZ, double deltaW) { }
         public static System.Windows.Media.Media3D.Point4D operator +(System.Windows.Media.Media3D.Point4D point1, System.Windows.Media.Media3D.Point4D point2) { throw null; }
@@ -12658,16 +12658,16 @@ namespace System.Windows.Media.Media3D
         public static System.Windows.Media.Media3D.Quaternion Identity { get { throw null; } }
         public bool IsIdentity { get { throw null; } }
         public bool IsNormalized { get { throw null; } }
-        public double W { get { throw null; } set { } }
-        public double X { get { throw null; } set { } }
-        public double Y { get { throw null; } set { } }
-        public double Z { get { throw null; } set { } }
+        public double W { readonly get { throw null; } set { } }
+        public double X { readonly get { throw null; } set { } }
+        public double Y { readonly get { throw null; } set { } }
+        public double Z { readonly get { throw null; } set { } }
         public static System.Windows.Media.Media3D.Quaternion Add(System.Windows.Media.Media3D.Quaternion left, System.Windows.Media.Media3D.Quaternion right) { throw null; }
         public void Conjugate() { }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Media.Media3D.Quaternion value) { throw null; }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Media.Media3D.Quaternion value) { throw null; }
         public static bool Equals(System.Windows.Media.Media3D.Quaternion quaternion1, System.Windows.Media.Media3D.Quaternion quaternion2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public void Invert() { }
         public static System.Windows.Media.Media3D.Quaternion Multiply(System.Windows.Media.Media3D.Quaternion left, System.Windows.Media.Media3D.Quaternion right) { throw null; }
         public void Normalize() { }
@@ -12736,22 +12736,22 @@ namespace System.Windows.Media.Media3D
         public Rect3D(double x, double y, double z, double sizeX, double sizeY, double sizeZ) { throw null; }
         public Rect3D(System.Windows.Media.Media3D.Point3D location, System.Windows.Media.Media3D.Size3D size) { throw null; }
         public static System.Windows.Media.Media3D.Rect3D Empty { get { throw null; } }
-        public bool IsEmpty { get { throw null; } }
+        public readonly bool IsEmpty { get { throw null; } }
         public System.Windows.Media.Media3D.Point3D Location { get { throw null; } set { } }
         public System.Windows.Media.Media3D.Size3D Size { get { throw null; } set { } }
-        public double SizeX { get { throw null; } set { } }
-        public double SizeY { get { throw null; } set { } }
-        public double SizeZ { get { throw null; } set { } }
-        public double X { get { throw null; } set { } }
-        public double Y { get { throw null; } set { } }
-        public double Z { get { throw null; } set { } }
+        public double SizeX { readonly get { throw null; } set { } }
+        public double SizeY { readonly get { throw null; } set { } }
+        public double SizeZ { readonly get { throw null; } set { } }
+        public double X { readonly get { throw null; } set { } }
+        public double Y { readonly get { throw null; } set { } }
+        public double Z { readonly get { throw null; } set { } }
         public bool Contains(double x, double y, double z) { throw null; }
         public bool Contains(System.Windows.Media.Media3D.Point3D point) { throw null; }
         public bool Contains(System.Windows.Media.Media3D.Rect3D rect) { throw null; }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Media.Media3D.Rect3D value) { throw null; }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Media.Media3D.Rect3D value) { throw null; }
         public static bool Equals(System.Windows.Media.Media3D.Rect3D rect1, System.Windows.Media.Media3D.Rect3D rect2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public void Intersect(System.Windows.Media.Media3D.Rect3D rect) { }
         public static System.Windows.Media.Media3D.Rect3D Intersect(System.Windows.Media.Media3D.Rect3D rect1, System.Windows.Media.Media3D.Rect3D rect2) { throw null; }
         public bool IntersectsWith(System.Windows.Media.Media3D.Rect3D rect) { throw null; }
@@ -12837,14 +12837,14 @@ namespace System.Windows.Media.Media3D
     {
         public Size3D(double x, double y, double z) { throw null; }
         public static System.Windows.Media.Media3D.Size3D Empty { get { throw null; } }
-        public bool IsEmpty { get { throw null; } }
-        public double X { get { throw null; } set { } }
-        public double Y { get { throw null; } set { } }
-        public double Z { get { throw null; } set { } }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Media.Media3D.Size3D value) { throw null; }
+        public readonly bool IsEmpty { get { throw null; } }
+        public double X { readonly get { throw null; } set { } }
+        public double Y { readonly get { throw null; } set { } }
+        public double Z { readonly get { throw null; } set { } }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Media.Media3D.Size3D value) { throw null; }
         public static bool Equals(System.Windows.Media.Media3D.Size3D size1, System.Windows.Media.Media3D.Size3D size2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public static bool operator ==(System.Windows.Media.Media3D.Size3D size1, System.Windows.Media.Media3D.Size3D size2) { throw null; }
         public static explicit operator System.Windows.Media.Media3D.Point3D(System.Windows.Media.Media3D.Size3D size) { throw null; }
         public static explicit operator System.Windows.Media.Media3D.Vector3D(System.Windows.Media.Media3D.Size3D size) { throw null; }
@@ -12991,19 +12991,19 @@ namespace System.Windows.Media.Media3D
         public Vector3D(double x, double y, double z) { throw null; }
         public double Length { get { throw null; } }
         public double LengthSquared { get { throw null; } }
-        public double X { get { throw null; } set { } }
-        public double Y { get { throw null; } set { } }
-        public double Z { get { throw null; } set { } }
+        public double X { readonly get { throw null; } set { } }
+        public double Y { readonly get { throw null; } set { } }
+        public double Z { readonly get { throw null; } set { } }
         public static System.Windows.Media.Media3D.Point3D Add(System.Windows.Media.Media3D.Vector3D vector, System.Windows.Media.Media3D.Point3D point) { throw null; }
         public static System.Windows.Media.Media3D.Vector3D Add(System.Windows.Media.Media3D.Vector3D vector1, System.Windows.Media.Media3D.Vector3D vector2) { throw null; }
         public static double AngleBetween(System.Windows.Media.Media3D.Vector3D vector1, System.Windows.Media.Media3D.Vector3D vector2) { throw null; }
         public static System.Windows.Media.Media3D.Vector3D CrossProduct(System.Windows.Media.Media3D.Vector3D vector1, System.Windows.Media.Media3D.Vector3D vector2) { throw null; }
         public static System.Windows.Media.Media3D.Vector3D Divide(System.Windows.Media.Media3D.Vector3D vector, double scalar) { throw null; }
         public static double DotProduct(System.Windows.Media.Media3D.Vector3D vector1, System.Windows.Media.Media3D.Vector3D vector2) { throw null; }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Media.Media3D.Vector3D value) { throw null; }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Media.Media3D.Vector3D value) { throw null; }
         public static bool Equals(System.Windows.Media.Media3D.Vector3D vector1, System.Windows.Media.Media3D.Vector3D vector2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public static System.Windows.Media.Media3D.Vector3D Multiply(double scalar, System.Windows.Media.Media3D.Vector3D vector) { throw null; }
         public static System.Windows.Media.Media3D.Vector3D Multiply(System.Windows.Media.Media3D.Vector3D vector, double scalar) { throw null; }
         public static System.Windows.Media.Media3D.Vector3D Multiply(System.Windows.Media.Media3D.Vector3D vector, System.Windows.Media.Media3D.Matrix3D matrix) { throw null; }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Int32Rect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Int32Rect.cs
@@ -106,15 +106,9 @@ namespace System.Windows
         /// bool - true if the object is an instance of Int32Rect and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Int32Rect))
-            {
-                return false;
-            }
-
-            Int32Rect value = (Int32Rect)o;
-            return Int32Rect.Equals(this,value);
+            return o is Int32Rect other && Int32Rect.Equals(this, other);
         }
 
         /// <summary>
@@ -128,7 +122,7 @@ namespace System.Windows
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Int32Rect to compare to "this"</param>
-        public bool Equals(Int32Rect value)
+        public readonly bool Equals(Int32Rect value)
         {
             return Int32Rect.Equals(this, value);
         }
@@ -138,7 +132,7 @@ namespace System.Windows
         /// <returns>
         /// int - the HashCode for this Int32Rect
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             if (IsEmpty)
             {
@@ -208,7 +202,7 @@ namespace System.Windows
         /// </summary>
         public int X
         {
-            get
+            readonly get
             {
                 return _x;
             }
@@ -225,7 +219,7 @@ namespace System.Windows
         /// </summary>
         public int Y
         {
-            get
+            readonly get
             {
                 return _y;
             }
@@ -242,7 +236,7 @@ namespace System.Windows
         /// </summary>
         public int Width
         {
-            get
+            readonly get
             {
                 return _width;
             }
@@ -259,7 +253,7 @@ namespace System.Windows
         /// </summary>
         public int Height
         {
-            get
+            readonly get
             {
                 return _height;
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Point.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Point.cs
@@ -95,15 +95,9 @@ namespace System.Windows
         /// bool - true if the object is an instance of Point and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Point))
-            {
-                return false;
-            }
-
-            Point value = (Point)o;
-            return Point.Equals(this,value);
+            return o is Point other && Point.Equals(this, other);
         }
 
         /// <summary>
@@ -117,7 +111,7 @@ namespace System.Windows
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Point to compare to "this"</param>
-        public bool Equals(Point value)
+        public readonly bool Equals(Point value)
         {
             return Point.Equals(this, value);
         }
@@ -127,7 +121,7 @@ namespace System.Windows
         /// <returns>
         /// int - the HashCode for this Point
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             // Perform field-by-field XOR of HashCodes
             return X.GetHashCode() ^
@@ -177,7 +171,7 @@ namespace System.Windows
         /// </summary>
         public double X
         {
-            get
+            readonly get
             {
                 return _x;
             }
@@ -194,7 +188,7 @@ namespace System.Windows
         /// </summary>
         public double Y
         {
-            get
+            readonly get
             {
                 return _y;
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Rect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Rect.cs
@@ -106,15 +106,9 @@ namespace System.Windows
         /// bool - true if the object is an instance of Rect and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Rect))
-            {
-                return false;
-            }
-
-            Rect value = (Rect)o;
-            return Rect.Equals(this,value);
+            return o is Rect other && Rect.Equals(this, other);
         }
 
         /// <summary>
@@ -128,7 +122,7 @@ namespace System.Windows
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Rect to compare to "this"</param>
-        public bool Equals(Rect value)
+        public readonly bool Equals(Rect value)
         {
             return Rect.Equals(this, value);
         }
@@ -138,7 +132,7 @@ namespace System.Windows
         /// <returns>
         /// int - the HashCode for this Rect
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             if (IsEmpty)
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Size.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Size.cs
@@ -102,15 +102,9 @@ namespace System.Windows
         /// bool - true if the object is an instance of Size and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Size))
-            {
-                return false;
-            }
-
-            Size value = (Size)o;
-            return Size.Equals(this,value);
+            return o is Size other && Size.Equals(this, other);
         }
 
         /// <summary>
@@ -124,7 +118,7 @@ namespace System.Windows
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Size to compare to "this"</param>
-        public bool Equals(Size value)
+        public readonly bool Equals(Size value)
         {
             return Size.Equals(this, value);
         }
@@ -134,7 +128,7 @@ namespace System.Windows
         /// <returns>
         /// int - the HashCode for this Size
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             if (IsEmpty)
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Vector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Vector.cs
@@ -95,15 +95,9 @@ namespace System.Windows
         /// bool - true if the object is an instance of Vector and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Vector))
-            {
-                return false;
-            }
-
-            Vector value = (Vector)o;
-            return Vector.Equals(this,value);
+            return o is Vector other && Vector.Equals(this, other);
         }
 
         /// <summary>
@@ -117,7 +111,7 @@ namespace System.Windows
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Vector to compare to "this"</param>
-        public bool Equals(Vector value)
+        public readonly bool Equals(Vector value)
         {
             return Vector.Equals(this, value);
         }
@@ -127,7 +121,7 @@ namespace System.Windows
         /// <returns>
         /// int - the HashCode for this Vector
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             // Perform field-by-field XOR of HashCodes
             return X.GetHashCode() ^
@@ -177,7 +171,7 @@ namespace System.Windows
         /// </summary>
         public double X
         {
-            get
+            readonly get
             {
                 return _x;
             }
@@ -194,7 +188,7 @@ namespace System.Windows
         /// </summary>
         public double Y
         {
-            get
+            readonly get
             {
                 return _y;
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Int32Rect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Int32Rect.cs
@@ -37,7 +37,7 @@ namespace System.Windows
         /// <summary>
         /// Returns true if this Int32Rect is the Empty integer rectangle.
         /// </summary>
-        public bool IsEmpty
+        public readonly bool IsEmpty
         {
             get
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Generated/Matrix.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Generated/Matrix.cs
@@ -117,15 +117,9 @@ namespace System.Windows.Media
         /// bool - true if the object is an instance of Matrix and if it's equal to "this".
         /// </returns>
         /// <param name='o'>The object to compare to "this"</param>
-        public override bool Equals(object o)
+        public override readonly bool Equals(object o)
         {
-            if ((null == o) || !(o is Matrix))
-            {
-                return false;
-            }
-
-            Matrix value = (Matrix)o;
-            return Matrix.Equals(this,value);
+            return o is Matrix other && Matrix.Equals(this, other);
         }
 
         /// <summary>
@@ -139,7 +133,7 @@ namespace System.Windows.Media
         /// bool - true if "value" is equal to "this".
         /// </returns>
         /// <param name='value'>The Matrix to compare to "this"</param>
-        public bool Equals(Matrix value)
+        public readonly bool Equals(Matrix value)
         {
             return Matrix.Equals(this, value);
         }
@@ -149,7 +143,7 @@ namespace System.Windows.Media
         /// <returns>
         /// int - the HashCode for this Matrix
         /// </returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             if (IsDistinguishedIdentity)
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Matrix.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Matrix.cs
@@ -481,7 +481,7 @@ namespace System.Windows.Media
         /// </summary>
         public double M11
         {
-            get
+            readonly get
             {
                 if (_type == MatrixTypes.TRANSFORM_IS_IDENTITY)
                 {
@@ -517,7 +517,7 @@ namespace System.Windows.Media
         /// </summary>
         public double M12
         {
-            get
+            readonly get
             {
                 if (_type == MatrixTypes.TRANSFORM_IS_IDENTITY)
                 {
@@ -550,7 +550,7 @@ namespace System.Windows.Media
         /// </summary>
         public double M21
         {
-            get
+            readonly get
             {
                 if (_type == MatrixTypes.TRANSFORM_IS_IDENTITY)
                 {
@@ -583,7 +583,7 @@ namespace System.Windows.Media
         /// </summary>
         public double M22
         {
-            get
+            readonly get
             {
                 if (_type == MatrixTypes.TRANSFORM_IS_IDENTITY)
                 {
@@ -619,7 +619,7 @@ namespace System.Windows.Media
         /// </summary>
         public double OffsetX
         {
-            get
+            readonly get
             {
                 if (_type == MatrixTypes.TRANSFORM_IS_IDENTITY)
                 {
@@ -655,7 +655,7 @@ namespace System.Windows.Media
         /// </summary>
         public double OffsetY
         {
-            get
+            readonly get
             {
                 if (_type == MatrixTypes.TRANSFORM_IS_IDENTITY)
                 {
@@ -962,7 +962,7 @@ namespace System.Windows.Media
         /// true if the the matrix is identity.  If it returns false
         /// the matrix may still be identity.
         /// </summary>
-        private bool IsDistinguishedIdentity
+        private readonly bool IsDistinguishedIdentity
         {
             get
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Rect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Rect.cs
@@ -122,7 +122,7 @@ namespace System.Windows
         /// Note: If width or height are 0 this Rectangle still contains a 0 or 1 dimensional set
         /// of points, so this method should not be used to check for 0 area.
         /// </summary>
-        public bool IsEmpty
+        public readonly bool IsEmpty
         {
             get
             {
@@ -191,7 +191,7 @@ namespace System.Windows
         /// </summary>
         public double X
         {
-            get
+            readonly get
             {
                 return _x;
             }
@@ -213,7 +213,7 @@ namespace System.Windows
         /// </summary>
         public double Y
         {
-            get
+            readonly get
             {
                 return _y;
             }
@@ -235,7 +235,7 @@ namespace System.Windows
         /// </summary>
         public double Width
         {
-            get
+            readonly get
             {
                 return _width;
             }
@@ -262,7 +262,7 @@ namespace System.Windows
         /// </summary>
         public double Height
         {
-            get
+            readonly get
             {
                 return _height;
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Size.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Size.cs
@@ -53,7 +53,7 @@ namespace System.Windows
         /// Note: If size is 0 this Size still contains a 0 or 1 dimensional set
         /// of points, so this method should not be used to check for 0 area.
         /// </summary>
-        public bool IsEmpty
+        public readonly bool IsEmpty
         {
             get
             {
@@ -66,7 +66,7 @@ namespace System.Windows
         /// </summary>
         public double Width
         {
-            get
+            readonly get
             {
                 return _width;
             }
@@ -91,7 +91,7 @@ namespace System.Windows
         /// </summary>
         public double Height
         {
-            get
+            readonly get
             {
                 return _height;
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/ref/WindowsBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/ref/WindowsBase.cs
@@ -810,15 +810,15 @@ namespace System.Windows
         public Int32Rect(int x, int y, int width, int height) { throw null; }
         public static System.Windows.Int32Rect Empty { get { throw null; } }
         public bool HasArea { get { throw null; } }
-        public int Height { get { throw null; } set { } }
-        public bool IsEmpty { get { throw null; } }
-        public int Width { get { throw null; } set { } }
-        public int X { get { throw null; } set { } }
-        public int Y { get { throw null; } set { } }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Int32Rect value) { throw null; }
+        public int Height { readonly get { throw null; } set { } }
+        public readonly bool IsEmpty { get { throw null; } }
+        public int Width { readonly get { throw null; } set { } }
+        public int X { readonly get { throw null; } set { } }
+        public int Y { readonly get { throw null; } set { } }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Int32Rect value) { throw null; }
         public static bool Equals(System.Windows.Int32Rect int32Rect1, System.Windows.Int32Rect int32Rect2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public static bool operator ==(System.Windows.Int32Rect int32Rect1, System.Windows.Int32Rect int32Rect2) { throw null; }
         public static bool operator !=(System.Windows.Int32Rect int32Rect1, System.Windows.Int32Rect int32Rect2) { throw null; }
         public static System.Windows.Int32Rect Parse(string source) { throw null; }
@@ -891,13 +891,13 @@ namespace System.Windows
     public partial struct Point : System.IFormattable
     {
         public Point(double x, double y) { throw null; }
-        public double X { get { throw null; } set { } }
-        public double Y { get { throw null; } set { } }
+        public double X { readonly get { throw null; } set { } }
+        public double Y { readonly get { throw null; } set { } }
         public static System.Windows.Point Add(System.Windows.Point point, System.Windows.Vector vector) { throw null; }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Point value) { throw null; }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Point value) { throw null; }
         public static bool Equals(System.Windows.Point point1, System.Windows.Point point2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public static System.Windows.Point Multiply(System.Windows.Point point, System.Windows.Media.Matrix matrix) { throw null; }
         public void Offset(double offsetX, double offsetY) { }
         public static System.Windows.Point operator +(System.Windows.Point point, System.Windows.Vector vector) { throw null; }
@@ -951,8 +951,8 @@ namespace System.Windows
         public System.Windows.Point BottomLeft { get { throw null; } }
         public System.Windows.Point BottomRight { get { throw null; } }
         public static System.Windows.Rect Empty { get { throw null; } }
-        public double Height { get { throw null; } set { } }
-        public bool IsEmpty { get { throw null; } }
+        public double Height { readonly get { throw null; } set { } }
+        public readonly bool IsEmpty { get { throw null; } }
         public double Left { get { throw null; } }
         public System.Windows.Point Location { get { throw null; } set { } }
         public double Right { get { throw null; } }
@@ -960,16 +960,16 @@ namespace System.Windows
         public double Top { get { throw null; } }
         public System.Windows.Point TopLeft { get { throw null; } }
         public System.Windows.Point TopRight { get { throw null; } }
-        public double Width { get { throw null; } set { } }
-        public double X { get { throw null; } set { } }
-        public double Y { get { throw null; } set { } }
+        public double Width { readonly get { throw null; } set { } }
+        public double X { readonly get { throw null; } set { } }
+        public double Y { readonly get { throw null; } set { } }
         public bool Contains(double x, double y) { throw null; }
         public bool Contains(System.Windows.Point point) { throw null; }
         public bool Contains(System.Windows.Rect rect) { throw null; }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Rect value) { throw null; }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Rect value) { throw null; }
         public static bool Equals(System.Windows.Rect rect1, System.Windows.Rect rect2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public void Inflate(double width, double height) { }
         public static System.Windows.Rect Inflate(System.Windows.Rect rect, double width, double height) { throw null; }
         public static System.Windows.Rect Inflate(System.Windows.Rect rect, System.Windows.Size size) { throw null; }
@@ -1009,13 +1009,13 @@ namespace System.Windows
     {
         public Size(double width, double height) { throw null; }
         public static System.Windows.Size Empty { get { throw null; } }
-        public double Height { get { throw null; } set { } }
-        public bool IsEmpty { get { throw null; } }
-        public double Width { get { throw null; } set { } }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Size value) { throw null; }
+        public double Height { readonly get { throw null; } set { } }
+        public readonly bool IsEmpty { get { throw null; } }
+        public double Width { readonly get { throw null; } set { } }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Size value) { throw null; }
         public static bool Equals(System.Windows.Size size1, System.Windows.Size size2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public static bool operator ==(System.Windows.Size size1, System.Windows.Size size2) { throw null; }
         public static explicit operator System.Windows.Point (System.Windows.Size size) { throw null; }
         public static explicit operator System.Windows.Vector (System.Windows.Size size) { throw null; }
@@ -1049,18 +1049,18 @@ namespace System.Windows
         public Vector(double x, double y) { throw null; }
         public double Length { get { throw null; } }
         public double LengthSquared { get { throw null; } }
-        public double X { get { throw null; } set { } }
-        public double Y { get { throw null; } set { } }
+        public double X { readonly get { throw null; } set { } }
+        public double Y { readonly get { throw null; } set { } }
         public static System.Windows.Point Add(System.Windows.Vector vector, System.Windows.Point point) { throw null; }
         public static System.Windows.Vector Add(System.Windows.Vector vector1, System.Windows.Vector vector2) { throw null; }
         public static double AngleBetween(System.Windows.Vector vector1, System.Windows.Vector vector2) { throw null; }
         public static double CrossProduct(System.Windows.Vector vector1, System.Windows.Vector vector2) { throw null; }
         public static double Determinant(System.Windows.Vector vector1, System.Windows.Vector vector2) { throw null; }
         public static System.Windows.Vector Divide(System.Windows.Vector vector, double scalar) { throw null; }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Vector value) { throw null; }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Vector value) { throw null; }
         public static bool Equals(System.Windows.Vector vector1, System.Windows.Vector vector2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public static System.Windows.Vector Multiply(double scalar, System.Windows.Vector vector) { throw null; }
         public static System.Windows.Vector Multiply(System.Windows.Vector vector, double scalar) { throw null; }
         public static System.Windows.Vector Multiply(System.Windows.Vector vector, System.Windows.Media.Matrix matrix) { throw null; }
@@ -1627,17 +1627,17 @@ namespace System.Windows.Media
         public bool HasInverse { get { throw null; } }
         public static System.Windows.Media.Matrix Identity { get { throw null; } }
         public bool IsIdentity { get { throw null; } }
-        public double M11 { get { throw null; } set { } }
-        public double M12 { get { throw null; } set { } }
-        public double M21 { get { throw null; } set { } }
-        public double M22 { get { throw null; } set { } }
-        public double OffsetX { get { throw null; } set { } }
-        public double OffsetY { get { throw null; } set { } }
+        public double M11 { readonly get { throw null; } set { } }
+        public double M12 { readonly get { throw null; } set { } }
+        public double M21 { readonly get { throw null; } set { } }
+        public double M22 { readonly get { throw null; } set { } }
+        public double OffsetX { readonly get { throw null; } set { } }
+        public double OffsetY { readonly get { throw null; } set { } }
         public void Append(System.Windows.Media.Matrix matrix) { }
-        public override bool Equals(object o) { throw null; }
-        public bool Equals(System.Windows.Media.Matrix value) { throw null; }
+        public override readonly bool Equals(object o) { throw null; }
+        public readonly bool Equals(System.Windows.Media.Matrix value) { throw null; }
         public static bool Equals(System.Windows.Media.Matrix matrix1, System.Windows.Media.Matrix matrix2) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public void Invert() { }
         public static System.Windows.Media.Matrix Multiply(System.Windows.Media.Matrix trans1, System.Windows.Media.Matrix trans2) { throw null; }
         public static bool operator ==(System.Windows.Media.Matrix matrix1, System.Windows.Media.Matrix matrix2) { throw null; }

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/ManagedResource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/ManagedResource.cs
@@ -1449,7 +1449,7 @@ namespace MS.Internal.MilCodeGen.Generators
                     /// </summary>
                     [[visibility]] [[field.Type.ManagedName]] [[field.PropertyName]]
                     {
-                        get
+                        readonly get
                         {
                             return [[fieldName]];
                         }

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/ManagedStruct.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/ManagedStruct.cs
@@ -101,7 +101,7 @@ namespace MS.Internal.MilCodeGen.Generators
                     /// <returns>
                     /// int - the HashCode for this [[resource.Name]]
                     /// </returns>
-                    public override int GetHashCode()
+                    public override readonly int GetHashCode()
                     {
                         [[getHashCodeBody]]
                     }
@@ -204,15 +204,9 @@ namespace MS.Internal.MilCodeGen.Generators
                     /// bool - true if the object is an instance of [[resource.Name]] and if it's equal to "this".
                     /// </returns>
                     /// <param name='o'>The object to compare to "this"</param>
-                    public override bool Equals(object o)
+                    public override readonly bool Equals(object o)
                     {
-                        if ((null == o) || !(o is [[resource.Name]]))
-                        {
-                            return false;
-                        }
-
-                        [[resource.Name]] value = ([[resource.Name]])o;
-                        return [[resource.Name]].Equals(this,value);
+                        return o is [[resource.Name]] other && [[resource.Name]].Equals(this, other);
                     }
 
                     /// <summary>
@@ -226,7 +220,7 @@ namespace MS.Internal.MilCodeGen.Generators
                     /// bool - true if "value" is equal to "this".
                     /// </returns>
                     /// <param name='value'>The [[resource.Name]] to compare to "this"</param>
-                    public bool Equals([[resource.Name]] value)
+                    public readonly bool Equals([[resource.Name]] value)
                     {
                         return [[resource.Name]].Equals(this, value);
                     }


### PR DESCRIPTION
## Description

Modifiers MilCodeGen to generate `readonly` getters for fields where `SkipProperties="false"`, in case the properties are skipped (`SkipProperties="true"`) they live in the non-generated area and thus were modified manually.
- The `Equals` override uses new syntax and is `readonly`.
- The non-override `Equals ` is now `readonly`.
- `GetHashCode` is `readonly` and all the supporting props (`IsEmpty`, `IsDistinguishedIdentity`) are `readonly` to prevent copies in the particular call chain.

Rest of the members that were not in the impact zone are left untouched and shall be done separately in subsequent PRs.

## Customer Impact

Increased performance/better codegen.

## Regression

No.

## Testing

Local build, most of the generated structs have unit tests already including `Equals`/`GetHashCode` checks.

## Risk

Low. The point to consider is whether we could make any of the members that are to become `readonly` mutate the struct in the future, for me that answer is no. `Equals`/`GetHashCode` should never modify the state, even on mutable structs.
