### PR TITLE
[StyleCleanUp] Use compound assignment (IDE0054)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/SerializationHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/SerializationHelper.cs
@@ -189,7 +189,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                 if ((ull & 0x0001) > 0)
                     fneg = true;
 
-                ull = ull >> 1;
+                ull >>= 1;
 
                 long l = (long)ull;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNode.cs
@@ -1059,7 +1059,7 @@ namespace MS.Internal.Ink
             // eg turn 2.75 into .75
             //
             double floor = Math.Floor(findex);
-            findex = findex - floor;
+            findex -= floor;
 
             double xDiff = (_thisNode.Position.X - _lastNode.Position.X) * findex;
             double yDiff = (_thisNode.Position.Y - _lastNode.Position.Y) * findex;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media/XamlSerializationHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media/XamlSerializationHelper.cs
@@ -350,7 +350,7 @@ namespace MS.Internal.Media
         internal static double ReadScaledInteger(BinaryReader reader )
         {
             double value = (double) reader.ReadInt32(); 
-            value = value * inverseScaleFactor ; 
+            value *= inverseScaleFactor ; 
 
             return value ; 
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media3D/GeneralTransform2DTo3DTo2D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media3D/GeneralTransform2DTo3DTo2D.cs
@@ -294,7 +294,7 @@ namespace MS.Internal.Media3D
                 
                 // in this case we have a non-indexed mesh
                 int count = positions.Count;
-                count = count - (count % 3);
+                count -= (count % 3);
 
                 for (int i = 0; i < count; i+=3)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media3D/LineUtil.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media3D/LineUtil.cs
@@ -459,9 +459,9 @@ namespace MS.Internal.Media3D
             double t = Vector3D.DotProduct(ref e2, ref q);
             double f = 1 / a;
             
-            t = t * f;
-            u = u * f;
-            v = v * f;
+            t *= f;
+            u *= f;
+            v *= f;
   
             hitCoord = new Point(u, v);
             dist = t;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/Bidi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/Bidi.cs
@@ -2082,7 +2082,7 @@ namespace MS.Internal.TextFormatting
                     lastStrongClass = tempClass;
                 }
 
-                counter = counter + wordCount;
+                counter += wordCount;
             }
 
             if (counter < cchText)  // couldn't optimize.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/FormatSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/FormatSettings.cs
@@ -167,7 +167,7 @@ namespace MS.Internal.TextFormatting
             // indent is part of our text line but not of LS line
             // paragraph width == 0 means format width is unlimited
             int formatWidth = (paragraphWidth <= 0 ? Constants.IdealInfiniteWidth : paragraphWidth);
-            formatWidth = formatWidth - _pap.ParagraphIndent;
+            formatWidth -= _pap.ParagraphIndent;
             
             // sanitize the format width value before passing to LS
             formatWidth = Math.Max(formatWidth, 0);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/LineServicesCallbacks.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/LineServicesCallbacks.cs
@@ -1316,7 +1316,7 @@ namespace MS.Internal.TextFormatting
                             );
 
                         // adjust the pen's thickness as it will be scaled back by the scale transform
-                        drawingPenThickness = drawingPenThickness / Math.Abs(unitValue);
+                        drawingPenThickness /= Math.Abs(unitValue);
                                                     
                         // applied transforms
                         drawingContext.PushTransform(scaleTransform);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
@@ -2025,7 +2025,7 @@ namespace System.Windows.Automation.Peers
             ContextLayoutManager lm = ContextLayoutManager.From(this.Dispatcher);
             if(lm != null)
             {
-                lm.AutomationSyncUpdateCounter = lm.AutomationSyncUpdateCounter + 1;
+                lm.AutomationSyncUpdateCounter += 1;
 
                 try
                 {
@@ -2108,7 +2108,7 @@ namespace System.Windows.Automation.Peers
                 }
                 finally
                 {
-                    lm.AutomationSyncUpdateCounter = lm.AutomationSyncUpdateCounter - 1;
+                    lm.AutomationSyncUpdateCounter -= 1;
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/Stroke.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/Stroke.cs
@@ -891,11 +891,11 @@ namespace System.Windows.Ink
             //
             if (!DoubleUtil.AreClose(beginFIndex, StrokeFIndices.BeforeFirst))
             {
-                beginFIndex = beginFIndex - beginIndex;
+                beginFIndex -= beginIndex;
             }
             if (!DoubleUtil.AreClose(endFIndex, StrokeFIndices.AfterLast))
             {
-                endFIndex = endFIndex - beginIndex;
+                endFIndex -= beginIndex;
             }
 
             if (stylusPoints.Count > 1)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerStylusPlugInManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerStylusPlugInManager.cs
@@ -160,7 +160,7 @@ namespace System.Windows.Input.StylusPointer
                 System.Diagnostics.Debug.Assert(data.Length % pointLength == 0);
                 Point ptTablet = new Point(data[data.Length - pointLength], data[data.Length - pointLength + 1]);
                 // Note: the StylusLogic data inside DeviceUnitsFromMeasurUnits is protected by __rtiLock.
-                ptTablet = ptTablet * stylusDevice.TabletDevice.TabletDeviceImpl.TabletToScreen;
+                ptTablet *= stylusDevice.TabletDevice.TabletDeviceImpl.TabletToScreen;
                 ptTablet.X = (int)Math.Round(ptTablet.X); // Make sure we snap to whole window pixels.
                 ptTablet.Y = (int)Math.Round(ptTablet.Y);
                 ptTablet *= inputReport.InputSource.CompositionTarget.TransformFromDevice; // change to measured units now.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenContexts.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenContexts.cs
@@ -486,7 +486,7 @@ namespace System.Windows.Input
                 System.Diagnostics.Debug.Assert(data.Length % pointLength == 0);
                 Point ptTablet = new Point(data[data.Length - pointLength], data[data.Length - pointLength + 1]);
                 // Note: the StylusLogic data inside DeviceUnitsFromMeasurUnits is protected by __rtiLock.
-                ptTablet = ptTablet * stylusDevice.TabletDevice.TabletDeviceImpl.TabletToScreen;
+                ptTablet *= stylusDevice.TabletDevice.TabletDeviceImpl.TabletToScreen;
                 ptTablet.X = (int)Math.Round(ptTablet.X); // Make sure we snap to whole window pixels.
                 ptTablet.Y = (int)Math.Round(ptTablet.Y);
                 ptTablet = _stylusLogic.MeasureUnitsFromDeviceUnits(stylusDevice.CriticalActiveSource, ptTablet); // change to measured units now.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Clock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Clock.cs
@@ -2130,7 +2130,7 @@ namespace System.Windows.Media.Animation
                             IsBackwardsProgressingGlobal = !IsBackwardsProgressingGlobal;
                             parentSpeed = -parentSpeed;  // Negate parent speed here for tick logic, since we negated localProgress
                         }
-                        newIteration = newIteration / 2;  // Definition of iteration with AutoReverse is a front and back segment, divide by 2
+                        newIteration /= 2;  // Definition of iteration with AutoReverse is a front and back segment, divide by 2
                     }
 
                     _currentIteration = 1 + newIteration;  // Officially, iterations are numbered from 1

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/ClockController.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/ClockController.cs
@@ -169,7 +169,7 @@ namespace System.Windows.Media.Animation
                 }
                 else
                 {
-                    offset = offset + duration.TimeSpan;
+                    offset += duration.TimeSpan;
                 }
             }
 
@@ -211,7 +211,7 @@ namespace System.Windows.Media.Animation
                 }
                 else
                 {
-                    offset = offset + duration.TimeSpan;
+                    offset += duration.TimeSpan;
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/MatrixAnimationUsingPath.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/MatrixAnimationUsingPath.cs
@@ -274,13 +274,13 @@ namespace System.Windows.Media.Animation
             {
                 if (IsOffsetCumulative)
                 {
-                    pathPoint = pathPoint + (_accumulatingOffset * currentRepeat);
+                    pathPoint += (_accumulatingOffset * currentRepeat);
                 }
 
                 if (   DoesRotateWithTangent
                     && IsAngleCumulative)
                 {
-                    angle = angle + (_accumulatingAngle * currentRepeat);
+                    angle += (_accumulatingAngle * currentRepeat);
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/PointAnimationUsingPath.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/PointAnimationUsingPath.cs
@@ -156,7 +156,7 @@ namespace System.Windows.Media.Animation
             if (   IsCumulative
                 && currentRepeat > 0)
             {
-                pathPoint = pathPoint + (_accumulatingVector * currentRepeat);
+                pathPoint += (_accumulatingVector * currentRepeat);
             }
 
             if (IsAdditive) 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimeIntervalCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimeIntervalCollection.cs
@@ -1054,7 +1054,7 @@ namespace System.Windows.Media.Animation
                     if (isAutoReversed)
                     {
                         long doublePeriod = periodInTicks << 1;  // Fast multiply by 2
-                        outputInTicks = outputInTicks % doublePeriod;
+                        outputInTicks %= doublePeriod;
 
                         if (outputInTicks > periodInTicks)
                         {
@@ -1063,7 +1063,7 @@ namespace System.Windows.Media.Animation
                     }
                     else
                     {
-                        outputInTicks = outputInTicks % periodInTicks;
+                        outputInTicks %= periodInTicks;
                         if (outputInTicks == 0)
                         {
                             outputInTicks = periodInTicks;  // If we are at the end, stick to the max value

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyMap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyMap.cs
@@ -242,7 +242,7 @@ namespace System.Windows.Media
                     {
                         do
                         {
-                            firstNum = firstNum * 16;
+                            firstNum *= 16;
                             lastNum = lastNum * 16 + 0x0F;
                             index++;
                         } while (

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/PropVariant.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/PropVariant.cs
@@ -431,7 +431,7 @@ namespace System.Windows.Media.Imaging
             {
                 if (ca.pElems != IntPtr.Zero)
                 {
-                    vt = vt & ~VarEnum.VT_VECTOR;
+                    vt &= ~VarEnum.VT_VECTOR;
 
                     if (vt == VarEnum.VT_UNKNOWN)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -57,22 +57,22 @@ namespace MS.Internal
             else if (trimmedColor.Length > 4)
             {
                 a = ParseHexChar(trimmedColor[1]);
-                a = a + a*16;
+                a += a*16;
                 r = ParseHexChar(trimmedColor[2]);
-                r = r + r*16;
+                r += r*16;
                 g = ParseHexChar(trimmedColor[3]);
-                g = g + g*16;
+                g += g*16;
                 b = ParseHexChar(trimmedColor[4]);
-                b = b + b*16;
+                b += b*16;
             }
             else
             {
                 r = ParseHexChar(trimmedColor[1]);
-                r = r + r*16;
+                r += r*16;
                 g = ParseHexChar(trimmedColor[2]);
-                g = g + g*16;
+                g += g*16;
                 b = ParseHexChar(trimmedColor[3]);
-                b = b + b*16;
+                b += b*16;
             }
 
             return ( Color.FromArgb ((byte)a, (byte)r, (byte)g, (byte)b) );

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Visual.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Visual.cs
@@ -905,8 +905,7 @@ namespace System.Windows.Media
             else
             {
                 // Decrease the number os times this ICyclicBrush uses this Visual across all channels
-                cyclicBrushToChannelsMap[cyclicBrush] =
-                    cyclicBrushToChannelsMap[cyclicBrush] - 1;
+                cyclicBrushToChannelsMap[cyclicBrush] -= 1;
             }
 
             // Decrease the number of ICyclicBrush using the visual as root on this channel
@@ -916,8 +915,7 @@ namespace System.Windows.Media
             Debug.Assert(channelsToCyclicBrushMap.ContainsKey(channel));
             Debug.Assert(channelsToCyclicBrushMap[channel] > 0);
 
-            channelsToCyclicBrushMap[channel] =
-                    channelsToCyclicBrushMap[channel] - 1;
+            channelsToCyclicBrushMap[channel] -= 1;
 
             //
             // If on this channel, there are no more ICyclicBrushes using this visual as
@@ -2102,7 +2100,7 @@ namespace System.Windows.Media
                             Point newHitPoint = hitPoint;
 
                             // Apply the offset.
-                            newHitPoint = newHitPoint - child._offset;
+                            newHitPoint -= child._offset;
 
                             // If we have a transform, apply the transform.
                             Transform childTransform = TransformField.GetValue(child);
@@ -2120,7 +2118,7 @@ namespace System.Windows.Media
 
                                 inv.Invert();
 
-                                newHitPoint = newHitPoint * inv;
+                                newHitPoint *= inv;
                             }
 
                             // Set the new hittesting point into the hittest params.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/MatrixTransform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/MatrixTransform3D.cs
@@ -84,7 +84,7 @@ namespace System.Windows.Media.Media3D
 
         internal override void Append(ref Matrix3D matrix)
         {
-            matrix = matrix * Matrix;
+            matrix *= Matrix;
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/RotateTransform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/RotateTransform3D.cs
@@ -112,7 +112,7 @@ namespace System.Windows.Media.Media3D
 
         internal override void Append(ref Matrix3D matrix)
         {
-            matrix = matrix * Value;
+            matrix *= Value;
         }
 }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Viewport2DVisual3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Viewport2DVisual3D.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Media.Media3D
                 
                     // in this case we have a non-indexed mesh
                     int count = positions.Count;
-                    count = count - (count % 3);
+                    count -= (count % 3);
 
                     for (int i = 0; i < count; i+=3)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/SizeChangedInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/SizeChangedInfo.cs
@@ -91,8 +91,8 @@ namespace System.Windows
         //there could be several size changes before it will actually fire.
         internal void Update(bool widthChanged, bool heightChanged)
         {
-            _widthChanged = _widthChanged | widthChanged;
-            _heightChanged = _heightChanged | heightChanged;
+            _widthChanged |= widthChanged;
+            _heightChanged |= heightChanged;
         }
 
         internal UIElement Element

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -2316,7 +2316,7 @@ namespace System.Windows
             public int Skip(int celt)
             {
                 // Make sure we don't overflow on the skip.
-                _current = _current + (int)Math.Min(celt, Int32.MaxValue - _current);
+                _current += (int)Math.Min(celt, Int32.MaxValue - _current);
 
                 return (_current < _formats.Length) ? NativeMethods.S_OK : NativeMethods.S_FALSE;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DifferencingCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DifferencingCollection.cs
@@ -75,7 +75,7 @@ namespace MS.Internal.Data
                             change = Change.Remove;
                             index1 = index;
                             target = list[index];
-                            index = index + 2;
+                            index += 2;
                         }
                         else
                         {
@@ -112,7 +112,7 @@ namespace MS.Internal.Data
                                 change = Change.Reset;
                             }
 
-                            index = index + 2;
+                            index += 2;
                         }
                         else
                         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
@@ -1012,7 +1012,7 @@ namespace MS.Internal.PtsHost
             }
 
             flowDirection = textBounds[0].FlowDirection;           
-            rect.X = rect.X + delta;
+            rect.X += delta;
             return rect;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/ListMarkerSourceInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/ListMarkerSourceInfo.cs
@@ -246,7 +246,7 @@ namespace MS.Internal.PtsHost
             {
                 // Do quick search by looking only at size increments
                 int thousands = highestIndex / 1000;
-                highestIndex = highestIndex % 1000;            
+                highestIndex %= 1000;            
                 for (int i = 0; i < RomanNumericSizeIncrements.Length; i++)
                 {
                     Invariant.Assert(highestIndex >= RomanNumericSizeIncrements[i]);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParaClient.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParaClient.cs
@@ -2078,9 +2078,9 @@ namespace MS.Internal.PtsHost
                 lineRect.Width = Math.Max(lineVisual.WidthIncludingTrailingWhitespace, 0);
             }
 
-            lineRect.Y = lineRect.Y - lineTopSpace;
-            lineRect.Height = lineRect.Height + lineTopSpace;
-            lineRect.Width = lineRect.Width + lineRightSpace;
+            lineRect.Y -= lineTopSpace;
+            lineRect.Height += lineTopSpace;
+            lineRect.Width += lineRightSpace;
 
             // Ignore horizontal offset because TextBox page width != extent width.
             // It's ok to include content that doesn't strictly intersect -- this
@@ -2119,8 +2119,8 @@ namespace MS.Internal.PtsHost
                         for (int i = 0, count = rectangles.Count; i < count; ++i)
                         {
                             Rect r = rectangles[i];
-                            r.Y = r.Y - lineTopSpace;
-                            r.Height = r.Height + lineTopSpace;
+                            r.Y -= lineTopSpace;
+                            r.Height += lineTopSpace;
                             rectangles[i] = r;
                         }
                     }
@@ -2189,9 +2189,9 @@ namespace MS.Internal.PtsHost
                 elementRect.Width = Math.Max(lineVisual.WidthIncludingTrailingWhitespace, 0);
             }
 
-            elementRect.Y = elementRect.Y - lineTopSpace;
-            elementRect.Height = elementRect.Height + lineTopSpace;
-            elementRect.Width = elementRect.Width + lineRightSpace;
+            elementRect.Y -= lineTopSpace;
+            elementRect.Height += lineTopSpace;
+            elementRect.Width += lineRightSpace;
 
             // Ignore horizontal offset because TextBox page width != extent width.
             // It's ok to include content that doesn't strictly intersect -- this
@@ -2229,8 +2229,8 @@ namespace MS.Internal.PtsHost
                         for (int i = 0, count = rectangles.Count; i < count; ++i)
                         {
                             Rect r = rectangles[i];
-                            r.Y = r.Y - lineTopSpace;
-                            r.Height = r.Height + lineTopSpace;
+                            r.Y -= lineTopSpace;
+                            r.Height += lineTopSpace;
                             rectangles[i] = r;
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/UncommonValueTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/UncommonValueTable.cs
@@ -114,7 +114,7 @@ namespace MS.Internal
                 // 1. Discard the bits at or above the given id
                 uint x = (_bitmask << (31 - id)) << 1;      // (x<<32) is undefined
                 // 2. Replace each 2-bit chunk with the count of 1's in that chunk
-                x = x - ((x>>1) & 0x55555555u);
+                x -= ((x>>1) & 0x55555555u);
                 // 3. Accumulate the counts within each 4-bit chunk
                 x = (x & 0x33333333u) + ((x>>2) & 0x33333333u);
                 // 4. Accumulate the counts within each 8-bit chunk (i.e. byte)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/MultiPageTextView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/MultiPageTextView.cs
@@ -760,7 +760,7 @@ namespace MS.Internal.Documents
             Invariant.Assert(Math.Abs(request.NewCount) >= Math.Abs(linesMoved));
             request.NewPosition = newPosition;
             request.NewSuggestedX = newSuggestedX;
-            request.NewCount = request.NewCount - linesMoved;
+            request.NewCount -= linesMoved;
             request.NewPageNumber = pageNumber;
 
             if (request.NewCount == 0)
@@ -832,7 +832,7 @@ namespace MS.Internal.Documents
             Invariant.Assert(Math.Abs(request.NewCount) >= Math.Abs(pagesMoved));
             request.NewPosition = newPosition;
             request.NewSuggestedOffset = newSuggestedOffset;
-            request.NewCount = request.NewCount - pagesMoved;
+            request.NewCount -= pagesMoved;
 
             if (request.NewCount == 0 || newPageNumber == -1)
             {
@@ -1385,7 +1385,7 @@ namespace MS.Internal.Documents
                             newPosition = pageTextView.GetTextPositionFromPoint(new Point(-1, -1), true);
                             if (newPosition != null)
                             {
-                                lineRequest.NewCount = lineRequest.NewCount - 1;
+                                lineRequest.NewCount -= 1;
                             }
                         }
                         else
@@ -1393,7 +1393,7 @@ namespace MS.Internal.Documents
                             newPosition = pageTextView.GetTextPositionFromPoint((Point)pageTextView.RenderScope.RenderSize, true);
                             if (newPosition != null)
                             {
-                                lineRequest.NewCount = lineRequest.NewCount + 1;
+                                lineRequest.NewCount += 1;
                             }
                         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextDocumentView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextDocumentView.cs
@@ -2472,7 +2472,7 @@ namespace MS.Internal.Documents
                         }
                         else
                         {
-                            lineIndex = lineIndex + count;
+                            lineIndex += count;
                             count = 0;
                         }
 
@@ -2951,7 +2951,7 @@ namespace MS.Internal.Documents
                 }
                 else
                 {
-                    lineIndex = lineIndex + count;
+                    lineIndex += count;
                     count = 0;
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumnFloatingHeader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumnFloatingHeader.cs
@@ -129,7 +129,7 @@ namespace System.Windows.Controls
                 }
                 else
                 {
-                    width = width - GetVisualCanvasMarginX();
+                    width -= GetVisualCanvasMarginX();
                 }
 
                 double height = Height;
@@ -139,7 +139,7 @@ namespace System.Windows.Controls
                 }
                 else
                 {
-                    height = height - GetVisualCanvasMarginY();
+                    height -= GetVisualCanvasMarginY();
                 }
 
                 Vector offset = VisualTreeHelper.GetOffset(_referenceHeader);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
@@ -2235,7 +2235,7 @@ namespace System.Windows.Controls
                     // Compute deltas
                     for (int i = 0; i < definitions.Length; ++i)
                     {
-                        roundingErrors[i] = roundingErrors[i] - definitions[i].SizeCache;
+                        roundingErrors[i] -= definitions[i].SizeCache;
                         definitionIndices[i] = i;
                     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
@@ -2819,9 +2819,9 @@ namespace System.Windows.Controls.Primitives
                                 // byteWidth = bytes per row AND bytes per vertical pixel
                                 int byteWidth = bm.bmWidth / 8;
                                 int right /*px*/ = (bottom /*bytes*/ % byteWidth) * 8 /*px/byte*/;
-                                bottom /*px*/ = bottom /*bytes*/ / byteWidth /*bytes/px*/;
+                                bottom /*px*/ /= /*bytes*/ byteWidth /*bytes/px*/;
                                 int left /*px*/ = top /*bytes*/ % byteWidth * 8 /*px/byte*/;
-                                top /*px*/ = top /*bytes*/ / byteWidth /*bytes/px*/;
+                                top /*px*/ /= /*bytes*/ byteWidth /*bytes/px*/;
 
                                 // (Final value) Convert LRTB to Width and Height
                                 width = right - left + 1;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/StickyNote.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/StickyNote.cs
@@ -917,13 +917,13 @@ namespace System.Windows.Controls
                 if (newRectangle.X < 0)
                 {
                     //newRect.X is negative, simply add it to width to subtract it
-                    newRectangle.Width = newRectangle.Width + newRectangle.X;
+                    newRectangle.Width += newRectangle.X;
                     newRectangle.X = 0d;
                 }
                 if (newRectangle.Y < 0)
                 {
                     //newRect.Y is negative, simply add it to height to subtract it
-                    newRectangle.Height = newRectangle.Height + newRectangle.Y;
+                    newRectangle.Height += newRectangle.Y;
                     newRectangle.Y = 0d;
                 }
                 e.NewRectangle = newRectangle;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextAdaptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextAdaptor.cs
@@ -284,8 +284,8 @@ namespace MS.Internal.Automation
                 return null;
 
             // map null into the appropriate endpoint
-            rangeStart = rangeStart ?? _textContainer.Start;
-            rangeEnd = rangeEnd ?? _textContainer.End;
+            rangeStart ??= _textContainer.Start;
+            rangeEnd ??= _textContainer.End;
 
             // if either pointer belongs to the wrong tree, return null (meaning "entire range")
             if (rangeStart.TextContainer != _textContainer || rangeEnd.TextContainer != _textContainer)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -176,7 +176,7 @@ namespace System.Windows.Controls
 
             if (_complexContent == null)
             {
-                Text = Text + text;
+                Text += text;
             }
             else
             {
@@ -2328,7 +2328,7 @@ Debug.Assert(lineCount == LineCount);
                                        && TextPointerBase.IsNextToAnyBreak(endOfLineTextPointer, LogicalDirection.Backward))
                                     {
                                         double endOfParaGlyphWidth = FontSize * CaretElement.c_endOfParaMagicMultiplier;
-                                        rect.Width = rect.Width + endOfParaGlyphWidth;
+                                        rect.Width += endOfParaGlyphWidth;
                                     }
 
                                     RectangleGeometry rectGeometry = new RectangleGeometry(rect);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingListCollectionView.cs
@@ -919,7 +919,7 @@ namespace System.Windows.Data
                     else
                     {
                         int delta = (NewItemPlaceholderPosition == NewItemPlaceholderPosition.AtBeginning) ? 1 : 0;
-                        index = index - delta;
+                        index -= delta;
                     }
 
                     // remove the item from the list
@@ -2370,7 +2370,7 @@ namespace System.Windows.Data
             LiveShapingFlags result = 0;
 
             if (IsLiveGrouping == true)
-                result = result | LiveShapingFlags.Grouping;
+                result |= LiveShapingFlags.Grouping;
 
             return result;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
@@ -1868,11 +1868,11 @@ namespace System.Windows.Data
         {
             if (value)
             {
-                _flags = _flags | flags;
+                _flags |= flags;
             }
             else
             {
-                _flags = _flags & ~flags;
+                _flags &= ~flags;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
@@ -3071,11 +3071,11 @@ namespace System.Windows.Data
             LiveShapingFlags result = 0;
 
             if (IsLiveSorting == true)
-                result = result | LiveShapingFlags.Sorting;
+                result |= LiveShapingFlags.Sorting;
             if (IsLiveFiltering == true)
-                result = result | LiveShapingFlags.Filtering;
+                result |= LiveShapingFlags.Filtering;
             if (IsLiveGrouping == true)
-                result = result | LiveShapingFlags.Grouping;
+                result |= LiveShapingFlags.Grouping;
 
             return result;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CaretElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CaretElement.cs
@@ -706,7 +706,7 @@ namespace System.Windows.Documents
                     if (flowDirection == FlowDirection.RightToLeft)
                     {
                         // BiDi caret indicator should always direct by the right to left
-                        bidiCaretIndicatorWidth = bidiCaretIndicatorWidth * (-1);
+                        bidiCaretIndicatorWidth *= (-1);
                     }
 
                     // Draw BIDI caret to indicate the coming input is BIDI characters.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedPage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedPage.cs
@@ -107,7 +107,7 @@ namespace System.Windows.Documents
                     _drawDebugVisual++;
                 }
 
-                _drawDebugVisual = _drawDebugVisual % (int)DrawDebugVisual.LastOne;
+                _drawDebugVisual %= (int)DrawDebugVisual.LastOne;
 
                 if (_drawDebugVisual < 0)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedPageStructure.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedPageStructure.cs
@@ -291,7 +291,7 @@ namespace System.Windows.Documents
                     currentFixedNode[1] == FixedFlowMap.FixedOrderEndVisual)
                 {
                     prevTextPoint.X = 2;
-                    prevTextPoint.Y = prevTextPoint.Y + 10;
+                    prevTextPoint.Y += 10;
                     String outputString = currentFixedNode[1] == FixedFlowMap.FixedOrderStartVisual ?
                                 "FixedOrderStartVisual" : "FixedOrderEndVisual";
                     ft = new FormattedText(outputString,
@@ -329,7 +329,7 @@ namespace System.Windows.Documents
                     else
                     {
                         prevTextPoint.X = 2;
-                        prevTextPoint.Y = prevTextPoint.Y + 10;
+                        prevTextPoint.Y += 10;
                     }
                     ft = new FormattedText(currentFixedNode.ToString(),
                                             EnglishCulture,
@@ -363,7 +363,7 @@ namespace System.Windows.Documents
                     else
                     {
                         prevTextPoint.X = 2;
-                        prevTextPoint.Y = prevTextPoint.Y + 10;
+                        prevTextPoint.Y += 10;
                     }
                     ft = new FormattedText(currentFixedNode.ToString(),
                                             EnglishCulture,
@@ -407,7 +407,7 @@ namespace System.Windows.Documents
                     else
                     {
                         prevTextPoint.X = 2;
-                        prevTextPoint.Y = prevTextPoint.Y + 10;
+                        prevTextPoint.Y += 10;
 
                     }
 
@@ -426,7 +426,7 @@ namespace System.Windows.Documents
                 // For anything else, there is this code to draw ...
                 //
                 prevTextPoint.X = 2;
-                prevTextPoint.Y = prevTextPoint.Y + 10;
+                prevTextPoint.Y += 10;
                 ft = new FormattedText(currentFixedNode.ToString(),
                                         EnglishCulture,
                                         FlowDirection.LeftToRight,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/InlineCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/InlineCollection.cs
@@ -193,7 +193,7 @@ namespace System.Windows.Documents
             {
                 if (!textBlock.HasComplexContent)
                 {
-                    textBlock.Text = textBlock.Text + text;
+                    textBlock.Text += text;
                     return 0; // There's always one implicit Run with simple content, at index 0.
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
@@ -520,7 +520,7 @@ namespace System.Windows.Documents
                 case 0:
                     break;
             }
-            nCount = nCount % 100;
+            nCount %= 100;
 
             // 10's
             switch (nCount / 10)
@@ -546,7 +546,7 @@ namespace System.Windows.Documents
                 case 0:
                     break;
             }
-            nCount = nCount % 10;
+            nCount %= 10;
 
             // 1's
             switch (nCount)
@@ -7146,7 +7146,7 @@ namespace System.Windows.Documents
                     if (!dnPa.IsPending)
                     {
                         Debug.Assert(dnPa.LastChildIndex >= nAt + nExcise - 1);
-                        dnPa.ChildCount = dnPa.ChildCount - nExcise;
+                        dnPa.ChildCount -= nExcise;
                     }
                 }
 
@@ -7231,7 +7231,7 @@ namespace System.Windows.Documents
 
                 if (ddn.Type == DocumentNodeType.dnParagraph)
                 {
-                    ddn.NearMargin = ddn.NearMargin - nMargin;
+                    ddn.NearMargin -= nMargin;
                 }
             }
         }
@@ -7321,7 +7321,7 @@ namespace System.Windows.Documents
                 dnNewTable.Parent = dn.ClosedParent;
                 for (DocumentNode dnPa = dnNewTable.ClosedParent; dnPa != null; dnPa = dnPa.ClosedParent)
                 {
-                    dnPa.ChildCount = dnPa.ChildCount + 2;
+                    dnPa.ChildCount += 2;
                 }
 
                 // Adjust the loop end to account for the newly inserted elements
@@ -7470,7 +7470,7 @@ namespace System.Windows.Documents
                             DocumentNode dnSpanningCell = dnaSpanCells.EntryAt(kCSA);
                             if (dnSpanningCell != null)
                             {
-                                dnSpanningCell.RowSpan = dnSpanningCell.RowSpan + 1;
+                                dnSpanningCell.RowSpan += 1;
                             }
                             kCSA += dnCell.ColSpan;
                             dnCell.ColSpan = 0;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElementCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElementCollection.cs
@@ -838,7 +838,7 @@ namespace System.Windows.Documents
                 else if (_indexCache.Index < index)
                 {
                     element = _indexCache.Element;
-                    index = index - _indexCache.Index;
+                    index -= _indexCache.Index;
                 }
                 else // _indexCache.Index > index
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
@@ -438,7 +438,7 @@ namespace System.Windows.Documents
                         // Increment current listitem number
                         if (openLists.Count > 0)
                         {
-                            openCounts[openLists.Count - 1] = openCounts[openLists.Count - 1] + 1;
+                            openCounts[openLists.Count - 1] += 1;
                         }
                         break;
                     case DocumentNodeType.dnParagraph:

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/ActiveXHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/ActiveXHost.cs
@@ -427,7 +427,7 @@ namespace System.Windows.Interop
                                 break;
                             default:
                                 Debug.Fail("bad state");
-                                this.ActiveXState = this.ActiveXState + 1;  // To exit the loop
+                                this.ActiveXState += 1;  // To exit the loop
                                 break;
                         }
 
@@ -483,7 +483,7 @@ namespace System.Windows.Interop
                                 break;
                             default:
                                 Debug.Fail("bad state");
-                                this.ActiveXState = this.ActiveXState - 1;  // To exit the loop
+                                this.ActiveXState -= 1;  // To exit the loop
                                 break;
                         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlReader.cs
@@ -1043,7 +1043,7 @@ namespace System.Windows.Markup
             {
                 Type declaringType = null;
                 _propertyDP = _bamlRecordReader.GetCustomDependencyPropertyValue(bamlRecord, out declaringType);
-                declaringType = declaringType ?? _propertyDP.OwnerType;
+                declaringType ??= _propertyDP.OwnerType;
                 info.Value = $"{declaringType.Name}.{_propertyDP.Name}";
 
                 string xmlns = _parserContext.XamlTypeMapper.GetXmlNamespace(declaringType.Namespace,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
@@ -503,7 +503,7 @@ namespace System.Windows.Markup
             if (baseException is System.Windows.Markup.XamlParseException)
             {
                 var xe = ((System.Windows.Markup.XamlParseException)baseException);
-                xe.BaseUri = xe.BaseUri ?? baseUri;
+                xe.BaseUri ??= baseUri;
                 if (lineInfo != null && xe.LinePosition == 0 && xe.LineNumber == 0)
                 {
                     xe.LinePosition = lineInfo.LinePosition;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/FilePresentation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/FilePresentation.cs
@@ -87,7 +87,7 @@ namespace MS.Internal.Documents.Application
                 Path.GetExtension(filePath), 
                 StringComparison.OrdinalIgnoreCase))
             {
-                filePath = filePath + extension;
+                filePath += extension;
             }
 
             Uri file = new Uri(filePath);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/SigningDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/SigningDialog.cs
@@ -212,7 +212,7 @@ namespace MS.Internal.Documents
             // then we should disable the checkbox option that says additional signatures 
             // will break this signature.   This covers ad hoc signing when signatures requests
             // also exist.
-            _addDigSigCheckBox.Enabled = _addDigSigCheckBox.Enabled & !_docSigManager.HasRequests;
+            _addDigSigCheckBox.Enabled &= !_docSigManager.HasRequests;
         }
 
         #endregion Private Methods

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/BrushProxy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/BrushProxy.cs
@@ -383,7 +383,7 @@ namespace Microsoft.Internal.AlphaFlattener
 
             if (_brush != null)
             {
-                str = str + _brush.GetType();
+                str += _brush.GetType();
             }
             else if (_brushList != null)
             {
@@ -3814,7 +3814,7 @@ namespace Microsoft.Internal.AlphaFlattener
                         i = -i;
                     }
 
-                    i = i % (steps * 2);
+                    i %= (steps * 2);
 
                     if (i >= steps)
                     {
@@ -3829,7 +3829,7 @@ namespace Microsoft.Internal.AlphaFlattener
                         i += steps;
                     }
 
-                    i = i % steps;
+                    i %= steps;
                     break;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/Flattener.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/Flattener.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Internal.AlphaFlattener
                 }
 
                 // Push transform/clip/opacity to leaf node
-                tree.Transform = tree.Transform * transform;
+                tree.Transform *= transform;
 
                 if (tree.Clip == null)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/PrimitiveList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/PrimitiveList.cs
@@ -42,10 +42,10 @@ namespace Microsoft.Internal.AlphaFlattener
                 {
                     if (s.Length > 1)
                     {
-                        s = s + ' ';
+                        s += ' ';
                     }
                     
-                    s = s + i;
+                    s += i;
                 }
 
                 return s + ">";

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsManager.cs
@@ -1273,7 +1273,7 @@ namespace System.Windows.Xps.Packaging
         {
             lock (_globalLock)
             {
-                _packageCache[uri] = _packageCache[uri]+1;
+                _packageCache[uri] += 1;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/VisualSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/VisualSerializer.cs
@@ -661,7 +661,7 @@ namespace System.Windows.Xps.Serialization
                             bitmapUri = bitmapUri + " " + destinationProfile;
                         }
 
-                        bitmapUri = bitmapUri + "}";
+                        bitmapUri += "}";
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/VisualTreeFlattener.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/VisualTreeFlattener.cs
@@ -115,13 +115,13 @@ namespace MS.Internal.ReachFramework
                 {
                     encoder = new WmpBitmapEncoder();
 
-                    bitmapName = bitmapName + ".wmp";
+                    bitmapName += ".wmp";
                 }
                 else
                 {
                     encoder = new PngBitmapEncoder();
 
-                    bitmapName = bitmapName + ".png";
+                    bitmapName += ".png";
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/MetroSerializationManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/MetroSerializationManager.cs
@@ -884,8 +884,8 @@ namespace System.Windows.Xps.Serialization
                                                       out designerSerializationFlagsAttr) == true)
                               {
                                   TypeCacheItem typeCacheItem = GetTypeCacheItem(propertyType);
-                                  serializerTypeForProperty = serializerTypeForProperty ?? typeCacheItem.SerializerType;
-                                  typeConverterForProperty  = typeConverterForProperty ?? typeCacheItem.TypeConverter;
+                                  serializerTypeForProperty ??= typeCacheItem.SerializerType;
+                                  typeConverterForProperty ??= typeCacheItem.TypeConverter;
 
                                   TypeDependencyPropertyCache
                                   dependencyPropertyCache = new TypeDependencyPropertyCache(memberInfo,

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonContextualTabGroupsPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonContextualTabGroupsPanel.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
                         // If label is truncated - show the tooltip
                         tabGroupHeader.ShowLabelToolTip = DoubleUtil.GreaterThan(tabGroupHeader.IdealDesiredWidth, width);
 
-                        remainingSpace = remainingSpace - width;
+                        remainingSpace -= width;
                     }
 
                     desiredSize.Width += width;

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonDropDownHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonDropDownHelper.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                     && DoubleUtil.LessThanOrClose(minDropDownSize.Height, newHeight))
                 {
                     itemsPresenter.Height = newHeight;
-                    result = result & true;
+                    result &= true;
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTwoLineText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTwoLineText.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                     extraLength += Math.Abs(lastCharacter.X - firstCharacter.X);
 
                     // Redistribute the extraLength among first two lines
-                    _textBlock1.Width = _textBlock1.Width + extraLength / 2;
+                    _textBlock1.Width += extraLength / 2;
                     _textBlock1.Measure(infinity);
                     _textBlock1.Arrange(new Rect(_textBlock1.DesiredSize));
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/InertiaProcessor2D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/InertiaProcessor2D.cs
@@ -1259,7 +1259,7 @@ namespace System.Windows.Input.Manipulations
                 double result = InitialVelocity - Deceleration * elapsedTimeSinceInitialTimestamp;
 
                 // convert to milliseconds
-                result = result * timestampTicksPerMillisecond;
+                result *= timestampTicksPerMillisecond;
                 Debug.Assert(Validations.IsFinite((float)result));
                 return (float)result;
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/ManipulationSequence.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/ManipulationSequence.cs
@@ -1054,7 +1054,7 @@ namespace System.Windows.Input.Manipulations
             float result = CalculateWeightedMovingAverage(queue, accessor);
 
             // convert to milliseconds
-            result = result * ManipulationProcessor2D.TimestampTicksPerMillisecond;
+            result *= ManipulationProcessor2D.TimestampTicksPerMillisecond;
             return result;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterFrame.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -205,11 +205,11 @@ namespace MS.Internal.Xaml.Context
         {
             if (value)
             {
-                _flags = _flags | flag;
+                _flags |= flag;
             }
             else
             {
-                _flags = _flags & ~flag;
+                _flags &= ~flag;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
@@ -296,7 +296,7 @@ namespace MS.Internal.Xaml.Parser
 
             // In curly form, we search for TypeName + 'Extension' before TypeName
             string bareTypeName = typeName.Name;
-            typeName.Name = typeName.Name + KnownStrings.Extension;
+            typeName.Name += KnownStrings.Extension;
             XamlType xamlType = _context.GetXamlType(typeName, false);
             // This would be cleaner if we moved the Extension fallback logic out of XSC
             if (xamlType is null ||

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
@@ -33,7 +33,7 @@ namespace System.Xaml
         {
             this.xamlXmlWriter = xamlXmlWriter;
             settings = xamlXmlWriter.Settings; // This will clone, only want to do this once
-            meSettings = meSettings ?? new XamlMarkupExtensionWriterSettings();
+            meSettings ??= new XamlMarkupExtensionWriterSettings();
             currentState = Start.State;
             sb = new StringBuilder();
             nodes = new Stack<Node>();

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
@@ -2073,7 +2073,7 @@ namespace System.Xaml
                 };
 
                 // we want to treat all null values returned by TCs as String.Empty
-                value = value ?? string.Empty;
+                value ??= string.Empty;
 
                 objectInfo.Properties.Add(new MemberMarkupInfo()
                 {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -1039,7 +1039,7 @@ namespace System.Xaml
             ConcurrentDictionary<string, IList<string>> assemblyMappings = nsInfo.ClrToXmlNs;
             IList<string> result;
 
-            clrNs = clrNs ?? string.Empty;
+            clrNs ??= string.Empty;
 
             if (!assemblyMappings.TryGetValue(clrNs, out result))
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ShutDownListener.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ShutDownListener.cs
@@ -89,7 +89,7 @@ namespace MS.Internal
             if ((_flags & PrivateFlags.Listening) == 0)
                 return;
 
-            _flags = _flags & ~PrivateFlags.Listening;
+            _flags &= ~PrivateFlags.Listening;
 
             if ((_flags & PrivateFlags.DomainUnload) != 0)
             {


### PR DESCRIPTION
Fixes #10619

## Description

Fixes all `IDE0054` warnings by switching to compound assignment. All changes were automated, with the exception of restoring comments in `Popup.cs`.

## Customer Impact

Cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

None.
