### PR TITLE
Add BitmapImage initialization tests validating fix in #10428

### DIFF
--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/PresentationCore.Tests.csproj
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/PresentationCore.Tests.csproj
@@ -33,8 +33,9 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
     <PackageReference Include="System.Formats.Nrbf" Version="$(SystemFormatsNrbfVersion)" />
+    <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" />
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
+    <PackageReference Include="$(SystemDrawingCommonPackage)" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="System.Private.Windows.Core.TestUtilities" Version="$(SystemPrivateWindowsCoreTestUtilitiesVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/Imaging/BitmapImage.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/Imaging/BitmapImage.Tests.cs
@@ -1,0 +1,119 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Media.Imaging;
+
+public sealed class BitmapImageTests
+{
+    private static readonly byte[] s_png120DPI1x1 = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+                                                     0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+                                                     0xDE, 0x00, 0x00, 0x00, 0x01, 0x73, 0x52, 0x47, 0x42, 0x00, 0xAE, 0xCE, 0x1C, 0xE9, 0x00, 0x00,
+                                                     0x00, 0x04, 0x67, 0x41, 0x4D, 0x41, 0x00, 0x00, 0xB1, 0x8F, 0x0B, 0xFC, 0x61, 0x05, 0x00, 0x00,
+                                                     0x00, 0x09, 0x70, 0x48, 0x59, 0x73, 0x00, 0x00, 0x12, 0x74, 0x00, 0x00, 0x12, 0x74, 0x01, 0xDE,
+                                                     0x66, 0x1F, 0x78, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x18, 0x57, 0x63, 0x60, 0x60,
+                                                     0x60, 0x00, 0x00, 0x00, 0x04, 0x00, 0x01, 0x5C, 0xCD, 0xFF, 0x69, 0x00, 0x00, 0x00, 0x00, 0x49,
+                                                     0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82];
+
+    [WpfFact]
+    public void Initialization_StreamSource_Invalid_ThrowsNotSupportedException()
+    {
+        using MemoryStream stream = new("invalid image"u8.ToArray());
+        BitmapImage image = new BitmapImage();
+
+        // InitializeInit
+
+        image.BeginInit();
+
+        image.StreamSource = stream;
+        image.CacheOption = BitmapCacheOption.OnLoad;
+
+        Assert.Throws<NotSupportedException>(image.EndInit);
+    }
+
+    [WpfFact]
+    public void Initialization_StreamSource_PNG_Succeeds()
+    {
+        using MemoryStream stream = new(s_png120DPI1x1);
+
+        BitmapImage image = new BitmapImage();
+
+        // InitializeInit
+
+        image.BeginInit();
+
+        image.CacheOption = BitmapCacheOption.OnLoad;
+        image.StreamSource = stream;
+
+        image.EndInit();
+        image.Freeze();
+
+        // Check sources
+        Assert.Null(image.UriSource);
+        Assert.NotNull(image.StreamSource);
+
+        // It is 1x1 at 120 DPI
+        Assert.Equal(1, image.PixelWidth);
+        Assert.Equal(1, image.PixelHeight);
+    }
+
+    [WpfFact]
+    public void Initialization_UriSource_Invalid_ThrowsNotSupportedException()
+    {
+        string tempFile = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllBytes(tempFile, "invalid image"u8.ToArray());
+
+            BitmapImage image = new BitmapImage();
+
+            // InitializeInit (with OnLoad, so the file handle is closed)
+
+            image.BeginInit();
+
+            image.CacheOption = BitmapCacheOption.OnLoad;
+            image.UriSource = new Uri(tempFile);
+
+            Assert.Throws<NotSupportedException>(image.EndInit);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [WpfFact]
+    public void Initialization_UriSource_PNG_Succeeds()
+    {
+        string tempFile = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllBytes(tempFile, s_png120DPI1x1);
+
+            BitmapImage image = new BitmapImage();
+
+            // InitializeInit (with OnLoad, so the file handle is closed)
+
+            image.BeginInit();
+
+            image.CacheOption = BitmapCacheOption.OnLoad;
+            image.UriSource = new Uri(tempFile);
+
+            image.EndInit();
+            image.Freeze();
+
+            // Check sources
+            Assert.NotNull(image.UriSource);
+            Assert.Null(image.StreamSource);
+
+            // It is 1x1 at 120 DPI
+            Assert.Equal(1, image.PixelWidth);
+            Assert.Equal(1, image.PixelHeight);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds very basic initialization tests for `BitmapImage`, mostly driven just to provide a test validating fix in #10428.

Also adds reference to `System.IO.Packaging` for `PresentationCore.Tests` since otherwise the package ain't present, causing any `PresentationCore` tests to fail that load types which rely on it as the library cannot be loaded.

## Customer Impact

None, just a few more tests validating codebase health.

## Regression

No.

## Testing

Local build.

## Risk

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10623)