### PR TITLE
Update Coverlet version and revert ContentType changes from #10514

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -104,9 +104,9 @@
   </PropertyGroup>
   <!-- Code Coverage -->
   <PropertyGroup>
-    <CoverletMSBuildPackageVersion>3.1.2</CoverletMSBuildPackageVersion>
+    <CoverletMSBuildPackageVersion>6.0.4</CoverletMSBuildPackageVersion>
     <CodecovVersion>1.12.3</CodecovVersion>
-    <CoverletVersion>3.1.2</CoverletVersion>
+    <CoverletVersion>6.0.4</CoverletVersion>
     <ReportGeneratorVersion>4.0.9</ReportGeneratorVersion>
   </PropertyGroup>
   <!-- External Analyzers -->

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -654,15 +654,13 @@ namespace MS.Internal
         private const char       _equalSeparator     = '=';
 
         //This array is sorted by the ascii value of these characters.
-        private static readonly char[] s_allowedCharacters = [
+        private static ReadOnlySpan<char> AllowedCharacters => [
         '!' /*33*/, '#' /*35*/ , '$'  /*36*/,
         '%' /*37*/, '&' /*38*/ , '\'' /*39*/,
         '*' /*42*/, '+' /*43*/ , '-'  /*45*/,
         '.' /*46*/, '^' /*94*/ , '_'  /*95*/,
         '`' /*96*/, '|' /*124*/, '~'  /*126*/,
         ];
-
-        private static ReadOnlySpan<char> AllowedCharacters => s_allowedCharacters;
         
         //Linear White Space characters
         private static readonly char[] _linearWhiteSpaceChars = [


### PR DESCRIPTION
Fixes #10624

## Description

Updates Coverlet to newest version and reverts a workaround change in `ContentType`.

## Customer Impact

Less memory usage at runtime.

## Regression

Yes

## Testing

Local build, CI flow.

## Risk

Low.
