### PR TITLE
Stop boxing booleans in DataBindEngine, use BooleanBoxes instead

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DataBindEngine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DataBindEngine.cs
@@ -14,6 +14,7 @@ using System.Threading;
 
 using System.Windows;
 using System.Windows.Data;
+using MS.Internal.KnownBoxes;
 
 namespace MS.Internal.Data
 {
@@ -580,12 +581,12 @@ namespace MS.Internal.Data
         private void RequestRun()
         {
             // Run tasks before layout, to front load as much layout work as possible
-            Dispatcher.BeginInvoke(DispatcherPriority.DataBind, new DispatcherOperationCallback(Run), false);
+            Dispatcher.BeginInvoke(DispatcherPriority.DataBind, new DispatcherOperationCallback(Run), BooleanBoxes.FalseBox);
 
             // Run tasks (especially re-tried AttachToContext tasks) again after
             // layout as the last chance.  Any failures in AttachToContext will
             // be treated as an error.
-            Dispatcher.BeginInvoke(DispatcherPriority.Loaded, new DispatcherOperationCallback(Run), true);
+            Dispatcher.BeginInvoke(DispatcherPriority.Loaded, new DispatcherOperationCallback(Run), BooleanBoxes.TrueBox);
         }
 
         // run a cleanup pass


### PR DESCRIPTION
## Description

A tiny PR that avoids boxing the booleans when posted into `Dispatcher` queue, using the established `BooleanBoxes` instead.

## Customer Impact

Decreased allocations.

## Regression

Nope, has been like that since the start.

## Testing

Local build.

## Risk

Next to none.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10628)