### PR TITLE
Optimize ComputerInkBoundingBox(LtoR), remove unnecessary additional branch

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -765,6 +765,7 @@
     <Compile Include="System\Windows\Media\DrawingVisual.cs" />
     <Compile Include="System\Windows\Media\DrawingVisualDrawingContext.cs" />
     <Compile Include="System\Windows\Media\EllipseGeometry.cs" />
+    <Compile Include="System\Windows\Media\EmGlyphMetrics.cs" />
     <Compile Include="System\Windows\Media\EventProxy.cs" />
     <Compile Include="System\Windows\Media\FactoryMaker.cs" />
     <Compile Include="System\Windows\Media\FamilyMap.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EmGlyphMetrics.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EmGlyphMetrics.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using MS.Internal.Text.TextInterface;
+using MS.Internal.TextFormatting;
+
+namespace System.Windows.Media;
+
+/// <summary>
+/// Helper that scales a raw DWrite GlyphMetrics into em space. Used when computing ink bounding box.
+/// </summary>
+internal readonly struct EmGlyphMetrics
+{
+    internal readonly double LeftSideBearing { get; }
+    internal readonly double AdvanceWidth { get; }
+    internal readonly double RightSideBearing { get; }
+    internal readonly double TopSideBearing { get; }
+    internal readonly double AdvanceHeight { get; }
+    internal readonly double BottomSideBearing { get; }
+    internal readonly double Baseline { get; }
+
+    internal EmGlyphMetrics(GlyphMetrics glyphMetrics, double designToEm, double pixelsPerDip, TextFormattingMode textFormattingMode)
+    {
+        if (textFormattingMode is TextFormattingMode.Display)
+        {
+            AdvanceWidth = TextFormatterImp.RoundDipForDisplayMode(designToEm * glyphMetrics.AdvanceWidth, pixelsPerDip);
+            AdvanceHeight = TextFormatterImp.RoundDipForDisplayMode(designToEm * glyphMetrics.AdvanceHeight, pixelsPerDip);
+            LeftSideBearing = TextFormatterImp.RoundDipForDisplayMode(designToEm * glyphMetrics.LeftSideBearing, pixelsPerDip);
+            RightSideBearing = TextFormatterImp.RoundDipForDisplayMode(designToEm * glyphMetrics.RightSideBearing, pixelsPerDip);
+            TopSideBearing = TextFormatterImp.RoundDipForDisplayMode(designToEm * glyphMetrics.TopSideBearing, pixelsPerDip);
+            BottomSideBearing = TextFormatterImp.RoundDipForDisplayMode(designToEm * glyphMetrics.BottomSideBearing, pixelsPerDip);
+            Baseline = TextFormatterImp.RoundDipForDisplayMode(designToEm * GlyphTypeface.BaselineHelper(glyphMetrics), pixelsPerDip);
+
+            // Workaround for short or narrow glyphs - see comment in AdjustAdvanceForDisplayLayout
+            AdvanceWidth = AdjustAdvanceForDisplayLayout(AdvanceWidth, LeftSideBearing, RightSideBearing);
+            AdvanceHeight = AdjustAdvanceForDisplayLayout(AdvanceHeight, TopSideBearing, BottomSideBearing);
+        }
+        else
+        {
+            AdvanceWidth = designToEm * glyphMetrics.AdvanceWidth;
+            AdvanceHeight = designToEm * glyphMetrics.AdvanceHeight;
+            LeftSideBearing = designToEm * glyphMetrics.LeftSideBearing;
+            RightSideBearing = designToEm * glyphMetrics.RightSideBearing;
+            TopSideBearing = designToEm * glyphMetrics.TopSideBearing;
+            BottomSideBearing = designToEm * glyphMetrics.BottomSideBearing;
+            Baseline = designToEm * GlyphTypeface.BaselineHelper(glyphMetrics);
+        }
+    }
+
+    private static double AdjustAdvanceForDisplayLayout(double advance, double oneSideBearing, double otherSideBearing)
+    {
+        // AdvanceHeight is used to compute the bounding box. In some case, eg. the dash
+        // character '-', the bounding box is computed to be empty in Display
+        // TextFormattingMode (because the metrics are rounded to be pixel aligned) and so the
+        // dash is not rendered!
+        //
+        // Thus we coerce ah to be at least 1 pixel greater than tsb + bsb to gurantee that all
+        // glyphs will be rendered (with non-zero bounding box).
+        //
+        // Note: A side effect to this is that spaces will now be processed when rendering.
+        // That is, if the bounding box was empty the rendering engine will not process the
+        // text for rendering. But now even spaces will be processed but will be rendered as
+        // empty space.
+
+        // This problem also applies to the width of some characters, such as '.', ':', and 'l'
+        // The fix is the same: coerce AdvanceWidth to be at least
+        // LeftSideBearing + RightSideBearing + 1 pixels.
+
+        return Math.Max(advance, oneSideBearing + otherSideBearing + 1);
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EmGlyphMetrics.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EmGlyphMetrics.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Media;
 /// <summary>
 /// Helper that scales a raw DWrite GlyphMetrics into em space. Used when computing ink bounding box.
 /// </summary>
-internal readonly struct EmGlyphMetrics
+internal readonly ref struct EmGlyphMetrics
 {
     internal readonly double LeftSideBearing { get; }
     internal readonly double AdvanceWidth { get; }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
@@ -1279,7 +1279,7 @@ namespace System.Windows.Media
 
                 for (int i = 0; i < GlyphCount; ++i)
                 {
-                    EmGlyphMetrics emGlyphMetrics = new(glyphMetrics[i], designToEm, _pixelsPerDip, _textFormattingMode);
+                    EmGlyphMetrics emGlyphMetrics = new(in glyphMetrics[i], designToEm, _pixelsPerDip, _textFormattingMode);
 
                     Point glyphOffset = GetGlyphOffset(i);
                     double originX;
@@ -1411,7 +1411,7 @@ namespace System.Windows.Media
 
             for (int i = 0; i < glyphCount; ++i)
             {
-                EmGlyphMetrics emGlyphMetrics = new(glyphMetrics[i], designToEm, _pixelsPerDip, _textFormattingMode);
+                EmGlyphMetrics emGlyphMetrics = new(in glyphMetrics[i], designToEm, _pixelsPerDip, _textFormattingMode);
 
                 if (GlyphOffsets != null)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphTypeface.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphTypeface.cs
@@ -21,7 +21,7 @@ using MS.Internal;
 using MS.Internal.TextFormatting;
 using MS.Internal.FontCache;
 using MS.Internal.FontFace;
-using MS.Internal.PresentationCore;
+using MS.Internal.Text.TextInterface;
 using UnsafeNativeMethods = MS.Win32.PresentationCore.UnsafeNativeMethods;
 
 
@@ -1142,13 +1142,14 @@ namespace System.Windows.Media
                                    TextFormattingMode textFormattingMode,
                                    bool isSideways)
         {
-            MS.Internal.Text.TextInterface.GlyphMetrics glyphMetrics = GlyphMetrics(glyph, DesignEmHeight, pixelsPerDip, textFormattingMode, isSideways);
-            return BaselineHelper(glyphMetrics) / DesignEmHeight;
+            GlyphMetrics glyphMetrics = GlyphMetrics(glyph, DesignEmHeight, pixelsPerDip, textFormattingMode, isSideways);
+
+            return BaselineHelper(in glyphMetrics) / DesignEmHeight;
         }
 
-        internal static double BaselineHelper(MS.Internal.Text.TextInterface.GlyphMetrics metrics)
+        internal static double BaselineHelper(ref readonly GlyphMetrics metrics)
         {
-            return  -1 * ((double)metrics.BottomSideBearing + metrics.VerticalOriginY - metrics.AdvanceHeight);
+            return -1 * ((double)metrics.BottomSideBearing + metrics.VerticalOriginY - metrics.AdvanceHeight);
         }
 
         /// <summary>
@@ -1180,7 +1181,7 @@ namespace System.Windows.Media
 
             unsafe
             {
-                MS.Internal.Text.TextInterface.GlyphMetrics glyphMetrics = GlyphMetrics(glyph, renderingEmSize, pixelsPerDip, textFormattingMode, isSideways);
+                GlyphMetrics glyphMetrics = GlyphMetrics(glyph, renderingEmSize, pixelsPerDip, textFormattingMode, isSideways);
 
                 double designToEm = renderingEmSize / DesignEmHeight;
 
@@ -1192,7 +1193,7 @@ namespace System.Windows.Media
                     rsb = TextFormatterImp.RoundDipForDisplayMode(designToEm * glyphMetrics.RightSideBearing, pixelsPerDip) * scalingFactor;
                     tsb = TextFormatterImp.RoundDipForDisplayMode(designToEm * glyphMetrics.TopSideBearing, pixelsPerDip) * scalingFactor;
                     bsb = TextFormatterImp.RoundDipForDisplayMode(designToEm * glyphMetrics.BottomSideBearing, pixelsPerDip) * scalingFactor;
-                    baseline = TextFormatterImp.RoundDipForDisplayMode(designToEm * BaselineHelper(glyphMetrics), pixelsPerDip) * scalingFactor;
+                    baseline = TextFormatterImp.RoundDipForDisplayMode(designToEm * BaselineHelper(in glyphMetrics), pixelsPerDip) * scalingFactor;
                 }
                 else
                 {
@@ -1202,7 +1203,7 @@ namespace System.Windows.Media
                     rsb = designToEm * glyphMetrics.RightSideBearing * scalingFactor;
                     tsb = designToEm * glyphMetrics.TopSideBearing * scalingFactor;
                     bsb = designToEm * glyphMetrics.BottomSideBearing * scalingFactor;
-                    baseline = designToEm * BaselineHelper(glyphMetrics) * scalingFactor;
+                    baseline = designToEm * BaselineHelper(in glyphMetrics) * scalingFactor;
                 }
             }
         }


### PR DESCRIPTION
## Description

Optimizes `ComputerInkBoundingBox` / `ComputerInkBoundingBoxLtoR` methods, collapsing additional branch for `TextFormattingMode.Display` into `EmGlyphMetrics`, which now takes a readonly `ref` of `GlyphMetrics` to avoid copies.

This is one of the hottest methods traditionally when working with glyphs, so it deserves a bit of special care. `EmGlyphMetrics` is just a data container with a bit of logic, and it is kind of imperative that the logic in the `ctor` is actually inlined inside the original method and the `struct` ceases to exist at runtime, otherwise due to the nature of the code, this could get pretty messy at the given JIT state.

This gets inlined usually even without forcing it via `AggressiveInlining` but it doesn't hurt to force it in this case, it would hurt in case it didn't get inlined, so we want to prevent that from happening.

For 8 glyphs, the difference is already significant:

| Method    | otherVal    | Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Allocated [B] |
|---------- |---------------- |----------:|-----------:|------------:|--------------:|--------------:|
| Original |  GlyphMetrics[8] |  42.41 ns |   0.251 ns |    0.222 ns |       2,882 B |             - |
| PR__EDIT  | GlyphMetrics[8] |  34.01 ns |   0.188 ns |    0.166 ns |       2,736 B |             - |

## Customer Impact

Improved performance.

## Regression

No.

## Testing

Local build, perf benchmarks.

## Risk

Imho it is low, we don't change any existing logic.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10630)