### PR TITLE
Fix: Plausible Exception while closing an Application

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -121,7 +121,12 @@ namespace MS.Win32
                 try
                 {
                     result = UnsafeNativeMethods.SetWindowLong(new HandleRef(null,hwnd), NativeMethods.GWL_WNDPROC, defWindowProc);
-}
+
+                    if (result != IntPtr.Zero)
+                    {
+                        UnsafeNativeMethods.PostMessage(new HandleRef(null, hwnd), WindowMessage.WM_CLOSE, IntPtr.Zero, IntPtr.Zero);
+                    }
+                }
                 catch(System.ComponentModel.Win32Exception e)
                 {
                     // We failed to change the window proc.  Now what?
@@ -133,10 +138,6 @@ namespace MS.Win32
                         // the wrong thread.
                         throw;
                     }
-                }
-                if (result != IntPtr.Zero )
-                {
-                    UnsafeNativeMethods.PostMessage(new HandleRef(null,hwnd), WindowMessage.WM_CLOSE, IntPtr.Zero, IntPtr.Zero);
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
@@ -964,7 +964,8 @@ namespace MS.Win32
         {
             if (!IntPostMessage(hwnd, msg, wparam, lparam))
             {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
+                int errorCode = Marshal.GetLastWin32Error();
+                throw new Win32Exception(errorCode);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
@@ -964,8 +964,7 @@ namespace MS.Win32
         {
             if (!IntPostMessage(hwnd, msg, wparam, lparam))
             {
-                int errorCode = Marshal.GetLastWin32Error();
-                throw new Win32Exception(errorCode);
+                throw new Win32Exception();
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -964,7 +964,7 @@ namespace MS.Win32
         {
             if (!IntPostMessage(hwnd, msg, wparam, lparam))
             {
-                throw new Win32Exception();
+                throw new Win32Exception(Marshal.GetLastWin32Error());
             }
         }
 


### PR DESCRIPTION
## Description
The `PostMessage` call while closing the application might throw an invalid window handle exception. Ideally, the `Win32`'s `PostMessage` call is not designed to throw an exception; instead, it is meant to return a boolean indicating success or failure. However, the current call is wrapped to throw a `Win32Exception`. Interestingly, the `SetWindowLong` call just above this call is in a try-catch block that ignores the invalid window handle exception. It makes sense to move the `PostMessage` call inside the try-catch block to avoid the same exception being thrown.

The current `PostMessage` wrapper being used is also modified to get the error code as soon as the failure in `IntPostMessage` is encountered.

## Customer Impact
This might be a potential fix to the issue #7536 

## Regression
No

## Testing
Local Build Pass
Tested with a possible failing scenario

## Risk
Low
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10631)