### PR TITLE
Remove dead code in BamlRecordReader associated with TreeBuilderBamlTranslator

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -3876,69 +3876,6 @@ namespace System.Windows.Markup
             return DependencyProperty.UnsetValue;
         }
 
-        /// <summary>
-        /// Helper function for loading a Resources from RootElement/AppResources/SystemResources.
-        /// The passed in object must be a trimmed string or a type.
-        /// </summary>
-        /// <returns>
-        ///  The resource value, if found.  Otherwise DependencyProperty.UnsetValue.
-        /// </returns>
-        private object FindResourceInRootOrAppOrTheme(
-            object  resourceNameObject,
-            bool    allowDeferredResourceReference,
-            bool    mustReturnDeferredResourceReference)
-        {
-            // This method should not exist since resource references should be references
-            // and not looked up at this point.
-            // That not being the case, we need to look at SystemResources and App Resources
-            // even when we don't have a reference to an element or tree.
-            // System resources lucked out, though...
-            object result;
-            if (!SystemResources.IsSystemResourcesParsing)
-            {
-                object source;
-                result = FrameworkElement.FindResourceFromAppOrSystem(resourceNameObject, out source, false /*throwOnError*/, allowDeferredResourceReference, mustReturnDeferredResourceReference);
-            }
-            else
-            {
-                result = SystemResources.FindResourceInternal(resourceNameObject, allowDeferredResourceReference, mustReturnDeferredResourceReference);
-            }
-
-            if (result != null)
-            {
-                return result;
-            }
-
-            return DependencyProperty.UnsetValue;
-        }
-
-        // Given a key, find object in the parser stack that may hold a
-        // ResourceDictionary and search for an object keyed by that key.
-        internal object FindResourceInParentChain(
-            object  resourceNameObject,
-            bool    allowDeferredResourceReference,
-            bool    mustReturnDeferredResourceReference)
-        {
-            // Try the parser stack first.
-            object resource = FindResourceInParserStack(resourceNameObject, allowDeferredResourceReference, mustReturnDeferredResourceReference);
-
-            if (resource == DependencyProperty.UnsetValue)
-            {
-                // If we get to here, we've either walked off the top of the reader stack, or haven't
-                // found a value on an element that is in the tree.  In that case, give the RootElement
-                // and the parent held in the parser context one last try.  This would occur if the
-                // parser is used for literal content that did not contain a DependencyObject tree.
-                resource = FindResourceInRootOrAppOrTheme(resourceNameObject, allowDeferredResourceReference, mustReturnDeferredResourceReference);
-            }
-
-            if (resource == DependencyProperty.UnsetValue && mustReturnDeferredResourceReference)
-            {
-                resource = new DeferredResourceReferenceHolder(resourceNameObject, DependencyProperty.UnsetValue);
-            }
-
-            return resource;
-        }
-
         private object GetObjectDataFromContext(ReaderContextStackData context)
         {
             if (null == context.ObjectData &&

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -798,11 +798,6 @@ namespace System.Windows.Markup
                 {
                     RootList.Add(element);
                 }
-
-                // Set a flag to prevent the TreeBuilder from clobbering the
-                // XamlTypeMapper's xmlns hashtable on the root element as this
-                // would have already been set by the inner Baml loading Context.
-                IsRootAlreadyLoaded = true;
             }
             else
             {
@@ -5165,12 +5160,6 @@ namespace System.Windows.Markup
             get { return _bamlStream.Length; }
         }
 
-        internal bool IsRootAlreadyLoaded
-        {
-            get { return _isRootAlreadyLoaded; }
-            set { _isRootAlreadyLoaded = value; }
-        }
-
 #endregion Properties
 
 #region Data
@@ -5178,7 +5167,6 @@ namespace System.Windows.Markup
         // state vars
         private IComponentConnector          _componentConnector;
         private object                       _rootElement;
-        private bool                         _isRootAlreadyLoaded;
         private ArrayList                    _rootList;
         private ParserContext                _parserContext;   // XamlTypeMapper, namespace state, lang/space values
         private TypeConvertContext           _typeConvertContext;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -5119,14 +5119,6 @@ namespace System.Windows.Markup
             }
         }
 
-        // Determines sync and async parsing modes.  Not used directly by the record
-        // reader, but is needed when spinning off other deserializers
-        internal XamlParseMode XamlParseMode
-        {
-            get { return _parseMode; }
-            set { _parseMode = value; }
-        }
-
         // Table for mapping types, attributes and assemblies.
         // This should always be a part of the ParserContext
         internal BamlMapTable MapTable
@@ -5270,7 +5262,6 @@ namespace System.Windows.Markup
         private TypeConvertContext           _typeConvertContext;
         private int                          _persistId;
         private ParserStack                  _contextStack = new ParserStack();
-        private XamlParseMode                _parseMode = XamlParseMode.Synchronous;
         // end of state vars
 
         private Stream                       _bamlStream;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -114,17 +114,6 @@ namespace System.Windows.Markup
             set { _rootList = value; }
         }
 
-
-        /// <summary>
-        /// True if tree is to be built strictly (well, more or less strictly)
-        /// top down.
-        /// </summary>
-        internal bool BuildTopDown
-        {
-            get { return _buildTopDown; }
-            set { _buildTopDown = value; }
-        }
-
         /// <summary>
         /// Read a BamlRecord from the underlying binary stream and return it.
         /// If we're at the end of the stream, return null.
@@ -846,11 +835,7 @@ namespace System.Windows.Markup
                 // of the logical tree.  Other objects, such as Freezables, are added bottom-up
                 // to aid in having all properties set prior to adding them to the tree.
                 // See PS workitem #19080
-                if (BuildTopDown &&
-                    element != null &&
-                    ((element is UIElement) ||
-                    (element is ContentElement) ||
-                    (element is UIElement3D)))
+                if (element is not null and (UIElement or ContentElement or UIElement3D))
                 {
                     SetPropertyValueToParent(true);
                 }
@@ -5206,7 +5191,6 @@ namespace System.Windows.Markup
         private BamlBinaryReader             _binaryReader;
         private BamlRecordManager            _bamlRecordManager;
         private bool                         _endOfDocument = false;
-        private bool                         _buildTopDown = true;
 
         private static List<ReaderContextStackData> _stackDataFactoryCache = new List<ReaderContextStackData>();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -3896,29 +3896,8 @@ namespace System.Windows.Markup
                     }
                 }
 
-
-                // If we reach the end of this reader's context stack, see if we should
-                // look at another one.
-
-                bool newContextStackFound = false;
-                while (reader._previousBamlRecordReader != null)
-                {
-                    // Yes, move to the next reader
-                    reader = reader._previousBamlRecordReader;
-
-                    if (reader.ReaderContextStack != contextStack)
-                    {
-                        contextStack = reader.ReaderContextStack;
-                        newContextStackFound = true;
-                        break;
-                    }
-                }
-
-                if( !newContextStackFound )
-                {
-                    // Terminate the loop
-                    contextStack = null;
-                }
+                // Terminate the loop
+                contextStack = null;
             }
 
             return DependencyProperty.UnsetValue;
@@ -5100,20 +5079,6 @@ namespace System.Windows.Markup
             PreParsedCurrentRecord = PreParsedRecordsStart;
         }
 
-
-        //+--------------------------------------------------------------------------------------------------------------
-        //
-        //  SetPreviousBamlRecordReader
-        //
-        //  Link this nested BamlRecordReader to one that is higher in the stack.
-        //
-        //+--------------------------------------------------------------------------------------------------------------
-
-        protected internal void SetPreviousBamlRecordReader( BamlRecordReader previousBamlRecordReader )
-        {
-            _previousBamlRecordReader = previousBamlRecordReader;
-        }
-
         #endregion Methods
 
         #region Properties
@@ -5354,14 +5319,6 @@ namespace System.Windows.Markup
             set { _isRootAlreadyLoaded = value; }
         }
 
-        // The PreviousBamlRecordReader is set when this BRR is nested inside
-        // another.
-
-        internal BamlRecordReader PreviousBamlRecordReader
-        {
-            get { return _previousBamlRecordReader; }
-        }
-
 #endregion Properties
 
 #region Data
@@ -5387,9 +5344,6 @@ namespace System.Windows.Markup
         private BamlRecord                   _preParsedIndexRecord = null;
         private bool                         _endOfDocument = false;
         private bool                         _buildTopDown = true;
-
-        // The outer BRR, when this one is nested.
-        private BamlRecordReader             _previousBamlRecordReader;
 
         private static List<ReaderContextStackData> _stackDataFactoryCache = new List<ReaderContextStackData>();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -5052,14 +5052,6 @@ namespace System.Windows.Markup
 
         #region Properties
 
-        // Index into the list of preparsed records for the next
-        // record to be read.
-        internal BamlRecord PreParsedCurrentRecord
-        {
-            get { return _preParsedIndexRecord; }
-            set { _preParsedIndexRecord= value; }
-        }
-
         // Stream that contains baml records in binary form.  This is used when
         // reading from a file.
         internal Stream BamlStream
@@ -5300,7 +5292,6 @@ namespace System.Windows.Markup
         private ReaderStream                 _xamlReaderStream;
         private BamlBinaryReader             _binaryReader;
         private BamlRecordManager            _bamlRecordManager;
-        private BamlRecord                   _preParsedIndexRecord = null;
         private bool                         _endOfDocument = false;
         private bool                         _buildTopDown = true;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -5230,13 +5230,6 @@ namespace System.Windows.Markup
             get { return _xamlReaderStream; }
         }
 
-        // The stack of context information accumulated during reading.
-        internal ParserStack ContextStack
-        {
-            get { return _contextStack; }
-            set { _contextStack = value; }
-        }
-
         internal int LineNumber
         {
             get { return ParserContext.LineNumber; }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -5127,13 +5127,6 @@ namespace System.Windows.Markup
             set { _parseMode = value; }
         }
 
-        // The maximum number of records to read while in async mode
-        internal int MaxAsyncRecords
-        {
-            get { return _maxAsyncRecords; }
-            set { _maxAsyncRecords = value; }
-        }
-
         // Table for mapping types, attributes and assemblies.
         // This should always be a part of the ParserContext
         internal BamlMapTable MapTable
@@ -5278,7 +5271,6 @@ namespace System.Windows.Markup
         private int                          _persistId;
         private ParserStack                  _contextStack = new ParserStack();
         private XamlParseMode                _parseMode = XamlParseMode.Synchronous;
-        private int                          _maxAsyncRecords;
         // end of state vars
 
         private Stream                       _bamlStream;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1308,55 +1308,6 @@ namespace System.Windows
             }
         }
 
-#if false
-        // need to call this (and do similar for Template) to cache RDs.
-
-        private void SetStaticResources(object[] staticResourceValues, ParserContext context)
-        {
-            if (staticResourceValues != null && staticResourceValues.Length > 0)
-            {
-                bool inDeferredSection = context.InDeferredSection;
-
-                for (int i=0; i<staticResourceValues.Length; i++)
-                {
-                    // If this dictionary is a top level deferred section then we lookup the parser stack
-                    // and then look in the app and theme dictionaries to resolve the current static resource.
-
-                    if (!inDeferredSection)
-                    {
-                        staticResourceValues[i] = context.BamlReader.FindResourceInParentChain(
-                            ((StaticResourceExtension)staticResourceValues[i]).ResourceKey,
-                            true /*allowDeferredResourceReference*/,
-                            true /*mustReturnDeferredResourceReference*/);
-                    }
-                    else
-                    {
-                        // If this dictionary is nested within another deferred section then we try to
-                        // resolve the current staticresource against the parser stack and if not
-                        // able to resolve then we fallback to the pre-fetched value from the outer
-                        // deferred section.
-
-                        StaticResourceHolder srHolder = (StaticResourceHolder)staticResourceValues[i];
-
-                        object value = context.BamlReader.FindResourceInParserStack(
-                            srHolder.ResourceKey,
-                            true /*allowDeferredResourceReference*/,
-                            true /*mustReturnDeferredResourceReference*/);
-
-                        if (value == DependencyProperty.UnsetValue)
-                        {
-                            // If value wan't found the fallback
-                            // to the prefetched value
-
-                            value = srHolder.PrefetchedValue;
-                        }
-
-                        staticResourceValues[i] = value;
-                    }
-                }
-            }
-        }
-#endif
         private Type GetTypeOfFirstObject(KeyRecord keyRecord)
         {
             Type rootType = _reader.GetTypeOfFirstStartObject(keyRecord);


### PR DESCRIPTION
## Description

Removes unused/dead code that's just a remnant from `TreeBuilderBamlTranslator` which was only in use for `NetFX 3.5`, it is unused since `NetFX 4.0` and therefore can be safely removed. There's a bit more but this one I'm confident with.

## Customer Impact

Cleaner codebase for developers, less memory usage.

## Regression

No.

## Testing

Local build.

## Risk

Reviewers should check the correctness of removing/adjusting the if statements after removal of the properties/fields based on their default values.
