### PR TITLE
[StyleCleanUp] Remove unnecessary equality operator (IDE0100) 

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -209,9 +209,6 @@ dotnet_diagnostic.IDE0077.severity = suggestion
 # IDE0078: Use pattern matching
 dotnet_diagnostic.IDE0078.severity = suggestion
 
-# IDE0100: Remove redundant equality
-dotnet_diagnostic.IDE0100.severity = suggestion
-
 # IDE0180: Use tuple to swap values
 dotnet_diagnostic.IDE0180.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -3355,7 +3355,7 @@ namespace MS.Internal
                 relPath = TaskHelper.GetRootRelativePath(Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar, fullFilePath);
             }
 
-            if (string.IsNullOrEmpty(relPath) == false)
+            if (!string.IsNullOrEmpty(relPath))
             {
                 resourceId = relPath;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/CompilerLocalReference.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/CompilerLocalReference.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //----------------------------------------------------------------------------------------
@@ -173,7 +173,7 @@ namespace MS.Internal.Tasks
         //
         internal bool SaveCacheInformation(MarkupCompilePass1 mcPass1)
         {
-            Debug.Assert(String.IsNullOrEmpty(_localCacheFile) != true, "_localCacheFile must not be empty.");
+            Debug.Assert(!String.IsNullOrEmpty(_localCacheFile), "_localCacheFile must not be empty.");
             Debug.Assert(mcPass1 != null, "A valid instance of MarkupCompilePass1 must be passed to method SaveCacheInformation.");
 
             bool bSuccess = false;
@@ -235,7 +235,7 @@ namespace MS.Internal.Tasks
         //
         internal bool LoadCacheFile()
         {
-            Debug.Assert(String.IsNullOrEmpty(_localCacheFile) != true, "_localCacheFile must not be empty.");
+            Debug.Assert(!String.IsNullOrEmpty(_localCacheFile), "_localCacheFile must not be empty.");
 
             bool loadSuccess = false;
 
@@ -261,7 +261,7 @@ namespace MS.Internal.Tasks
 
                 ArrayList alMarkupPages = new ArrayList();
 
-                while (srCache.EndOfStream != true)
+                while (!srCache.EndOfStream)
                 {
                     lineText = srCache.ReadLine();
                     LocalReferenceFile lrf = LocalReferenceFile.Deserialize(lineText);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/CompilerState.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/CompilerState.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //----------------------------------------------------------------------------------------
@@ -87,7 +87,7 @@ namespace MS.Internal.Tasks
 
         internal bool SaveStateInformation(MarkupCompilePass1 mcPass1)
         {
-            Debug.Assert(String.IsNullOrEmpty(_stateFilePath) != true, "StateFilePath must not be empty.");
+            Debug.Assert(!String.IsNullOrEmpty(_stateFilePath), "StateFilePath must not be empty.");
             Debug.Assert(mcPass1 != null, "A valid instance of MarkupCompilePass1 must be passed to method SaveCacheInformation.");
             Debug.Assert(_cacheInfoList.Length == (int)CompilerStateType.MaxCount, "The Cache string array should be already allocated.");
 
@@ -148,7 +148,7 @@ namespace MS.Internal.Tasks
         //
         internal bool LoadStateInformation( )
         {
-            Debug.Assert(String.IsNullOrEmpty(_stateFilePath) != true, "_stateFilePath must be not be empty.");
+            Debug.Assert(!String.IsNullOrEmpty(_stateFilePath), "_stateFilePath must be not be empty.");
             Debug.Assert(_cacheInfoList.Length == (int)CompilerStateType.MaxCount, "The Cache string array should be already allocated.");
 
             bool loadSuccess = false;
@@ -176,7 +176,7 @@ namespace MS.Internal.Tasks
 
                 int i = 0;
 
-                while (srCache.EndOfStream != true)
+                while (!srCache.EndOfStream)
                 {
                     if (i >= (int)CompilerStateType.MaxCount)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //-----------------------------------------------------------------------------
@@ -207,7 +207,7 @@ namespace MS.Internal.Tasks
                 e = eInner;
             }
 
-            if (message != null && message.EndsWith(".", StringComparison.Ordinal) == false)
+            if (message != null && !message.EndsWith(".", StringComparison.Ordinal))
             {
                 message += ".";
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/FileClassifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/FileClassifier.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Build.Tasks.Windows
 
                 ret = VerifyTaskInputs();
 
-                if (ret != false)
+                if (ret)
                 {
                     // Do the real work to classify input files.
                     Classify(SourceFiles, mainEmbeddedList, satelliteEmbeddedList);
@@ -276,7 +276,7 @@ namespace Microsoft.Build.Tasks.Windows
             // MSBUILD Engine should have checked the setting for this property
             // so don't need to recheck here.
 
-            if (TaskHelper.IsValidCultureName(Culture) == false)
+            if (!TaskHelper.IsValidCultureName(Culture))
             {
                 Log.LogErrorWithCodeFromResources(nameof(SR.InvalidCulture), Culture);
                 bValidInput = false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -618,7 +618,7 @@ namespace Microsoft.Build.Tasks.Windows
 
             XmlNode root = xmlProjectDoc.DocumentElement;
 
-            if (root.HasChildNodes == false)
+            if (!root.HasChildNodes)
             {
                 // If there is no child element in this project file, just return immediatelly.
                 return;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
@@ -973,7 +973,7 @@ namespace Microsoft.Build.Tasks.Windows
                     break;
             }
 
-            if (isSupported == false)
+            if (!isSupported)
             {
                 Log.LogErrorWithCodeFromResources(nameof(SR.TargetIsNotSupported), outputType);
 
@@ -1019,7 +1019,7 @@ namespace Microsoft.Build.Tasks.Windows
 
                 bValidItem = IsValidInputFile(inputItem.ItemSpec);
 
-                if (bValidItem == false)
+                if (!bValidItem)
                 {
                     bValid = false;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass2.cs
@@ -817,7 +817,7 @@ namespace Microsoft.Build.Tasks.Windows
                     break;
             }
 
-            if (isSupported == false)
+            if (!isSupported)
             {
                 Log.LogErrorWithCodeFromResources(nameof(SR.TargetIsNotSupported), outputType);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Build.Tasks.Windows
             // Validate the property settings
             //
 
-            if (ValidResourceFiles(ResourceFiles) == false)
+            if (!ValidResourceFiles(ResourceFiles))
             {
                // ValidResourceFiles has already showed up error message.
                // Just stop here.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UpdateManifestForBrowserApplication.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UpdateManifestForBrowserApplication.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Build.Tasks.Windows
             bool successful = true;
             TaskHelper.DisplayLogo(Log, nameof(UpdateManifestForBrowserApplication));
 
-            if (HostInBrowser != true)
+            if (!HostInBrowser)
             {
                 // HostInBrowser is not true, don't modify the manifest.
                 // Stop here.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/CuspData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/CuspData.cs
@@ -498,7 +498,7 @@ namespace MS.Internal.Ink
             rR -= rL;
             rB -= rT;
             _dist = Math.Abs(rR) + Math.Abs(rB);
-            if (false == DoubleUtil.IsZero(rSpan))
+            if (!DoubleUtil.IsZero(rSpan))
                 _span = rSpan;
             else if (0 < _dist)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/EllipticalNodeOperations.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/EllipticalNodeOperations.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -43,7 +43,7 @@ namespace MS.Internal.Ink
             else
             {
                 // Reverse the rotation
-                if (false == DoubleUtil.IsZero(nodeShape.Rotation))
+                if (!DoubleUtil.IsZero(nodeShape.Rotation))
                 {
                     _nodeShapeToCircle.Rotate(-nodeShape.Rotation);
                     Debug.Assert(_nodeShapeToCircle.HasInverse, "Just rotated an invertible transform and produced a non-invertible one");
@@ -90,7 +90,7 @@ namespace MS.Internal.Ink
 
             // Get the vector between the node positions
             Vector spine = endNode.Position - beginNode.Position;
-            if (_nodeShapeToCircle.IsIdentity == false)
+            if (!_nodeShapeToCircle.IsIdentity)
             {
                 spine = _nodeShapeToCircle.Transform(spine);
             }
@@ -147,7 +147,7 @@ namespace MS.Internal.Ink
 
             // Get the common tangent points
 
-            if (_circleToNodeShape.IsIdentity == false)
+            if (!_circleToNodeShape.IsIdentity)
             {
                 vectorToLeftTangent = _circleToNodeShape.Transform(vectorToLeftTangent);
                 vectorToRightTangent = _circleToNodeShape.Transform(vectorToRightTangent);
@@ -167,7 +167,7 @@ namespace MS.Internal.Ink
         /// <returns></returns>
         internal override IEnumerable<ContourSegment> GetContourSegments(StrokeNodeData node, Quad quad)
         {
-            System.Diagnostics.Debug.Assert(node.IsEmpty == false);
+            System.Diagnostics.Debug.Assert(!node.IsEmpty);
 
             if (quad.IsEmpty)
             {
@@ -229,7 +229,7 @@ namespace MS.Internal.Ink
             Vector hitEnd = hitEndPoint - bigNode.Position;
 
             // If the node shape is an ellipse, transform the scene to turn the shape to a circle
-            if (_nodeShapeToCircle.IsIdentity == false)
+            if (!_nodeShapeToCircle.IsIdentity)
             {
                 hitBegin = _nodeShapeToCircle.Transform(hitBegin);
                 hitEnd = _nodeShapeToCircle.Transform(hitEnd);
@@ -244,11 +244,11 @@ namespace MS.Internal.Ink
             {
                 isHit = true;
             }
-            else if (quad.IsEmpty == false)
+            else if (!quad.IsEmpty)
             {
                 // Hit-test the other node
                 Vector spineVector = smallNode.Position - bigNode.Position;
-                if (_nodeShapeToCircle.IsIdentity == false)
+                if (!_nodeShapeToCircle.IsIdentity)
                 {
                     spineVector = _nodeShapeToCircle.Transform(spineVector);
                 }
@@ -297,7 +297,7 @@ namespace MS.Internal.Ink
                 // Find position of smallNode relative to the bigNode.
                 spineVector = smallNode.Position - bigNode.Position;
                 // If the node shape is an ellipse, transform the scene to turn the shape to a circle
-                if (_nodeShapeToCircle.IsIdentity == false)
+                if (!_nodeShapeToCircle.IsIdentity)
                 {
                     spineVector = _nodeShapeToCircle.Transform(spineVector);
                 }
@@ -330,7 +330,7 @@ namespace MS.Internal.Ink
                     // Find position of the hitting segment relative to bigNode transformed to circle.
                     Vector hitBegin = hitSegment.Begin - bigNode.Position;
                     Vector hitEnd = hitBegin + hitSegment.Vector;
-                    if (_nodeShapeToCircle.IsIdentity == false)
+                    if (!_nodeShapeToCircle.IsIdentity)
                     {
                         hitBegin = _nodeShapeToCircle.Transform(hitBegin);
                         hitEnd = _nodeShapeToCircle.Transform(hitEnd);
@@ -345,7 +345,7 @@ namespace MS.Internal.Ink
                     }
 
                     // Hit-test the other node
-                    if (quad.IsEmpty == false)
+                    if (!quad.IsEmpty)
                     {
                         nearest = GetNearest(hitBegin - spineVector, hitEnd - spineVector);
                         if ((nearest.LengthSquared <= smallRadiusSquared) ||
@@ -387,7 +387,7 @@ namespace MS.Internal.Ink
             Vector hitEnd = hitEndPoint - endNode.Position;
 
             // If the node shape is an ellipse, transform the scene to turn the shape to a circle
-            if (_nodeShapeToCircle.IsIdentity == false)
+            if (!_nodeShapeToCircle.IsIdentity)
             {
                 spineVector = _nodeShapeToCircle.Transform(spineVector);
                 hitBegin = _nodeShapeToCircle.Transform(hitBegin);
@@ -404,7 +404,7 @@ namespace MS.Internal.Ink
                 result.EndFIndex = StrokeFIndices.AfterLast;
                 result.BeginFIndex = beginNode.IsEmpty ? StrokeFIndices.BeforeFirst : 1;
             }
-            if (beginNode.IsEmpty == false)
+            if (!beginNode.IsEmpty)
             {
                 // Hit-test the first node
                 beginRadius = _radius * beginNode.PressureFactor;
@@ -421,7 +421,7 @@ namespace MS.Internal.Ink
 
             // If both nodes are hit or nothing is hit at all, return.
             if (result.IsFull || quad.IsEmpty
-                || (result.IsEmpty && (HitTestQuadSegment(quad, hitBeginPoint, hitEndPoint) == false)))
+                || (result.IsEmpty && (!HitTestQuadSegment(quad, hitBeginPoint, hitEndPoint))))
             {
                 return result;
             }
@@ -462,7 +462,7 @@ namespace MS.Internal.Ink
             // Compute the positions of the beginNode relative to the endNode.
             Vector spineVector = beginNode.IsEmpty ? new Vector(0, 0) : (beginNode.Position - endNode.Position);
             // If the node shape is an ellipse, transform the scene to turn the shape to a circle
-            if (_nodeShapeToCircle.IsIdentity == false)
+            if (!_nodeShapeToCircle.IsIdentity)
             {
                 spineVector = _nodeShapeToCircle.Transform(spineVector);
             }
@@ -472,7 +472,7 @@ namespace MS.Internal.Ink
 
             endRadius = _radius * endNode.PressureFactor;
             endRadiusSquared = endRadius * endRadius;
-            if (beginNode.IsEmpty == false)
+            if (!beginNode.IsEmpty)
             {
                 beginRadius = _radius * beginNode.PressureFactor;
                 beginRadiusSquared = beginRadius * beginRadius;
@@ -495,7 +495,7 @@ namespace MS.Internal.Ink
 
                     // If the node shape is an ellipse, transform the scene to turn
                     // the shape into circle.
-                    if (_nodeShapeToCircle.IsIdentity == false)
+                    if (!_nodeShapeToCircle.IsIdentity)
                     {
                         hitBegin = _nodeShapeToCircle.Transform(hitBegin);
                         hitEnd = _nodeShapeToCircle.Transform(hitEnd);
@@ -523,7 +523,7 @@ namespace MS.Internal.Ink
                         }
                     }
 
-                    if ((beginNode.IsEmpty == false) && (!isHit || !DoubleUtil.AreClose(result.BeginFIndex, StrokeFIndices.BeforeFirst)))
+                    if ((!beginNode.IsEmpty) && (!isHit || !DoubleUtil.AreClose(result.BeginFIndex, StrokeFIndices.BeforeFirst)))
                     {
                         // Hit-test the first node
                         nearest = GetNearest(hitBegin - spineVector, hitEnd - spineVector);
@@ -543,7 +543,7 @@ namespace MS.Internal.Ink
 
                     // If both nodes are hit or nothing is hit at all, return.
                     if (beginNode.IsEmpty || (!isHit && (quad.IsEmpty ||
-                        (HitTestQuadSegment(quad, hitSegment.Begin, hitSegment.End) == false))))
+                        (!HitTestQuadSegment(quad, hitSegment.Begin, hitSegment.End)))))
                     {
                         if (isInside && (WhereIsVectorAboutVector(
                             endNode.Position - hitSegment.Begin, hitSegment.Vector) != HitResult.Right))
@@ -568,7 +568,7 @@ namespace MS.Internal.Ink
             //
             if (!result.IsFull)
             {
-                if (isInside == true)
+                if (isInside)
                 {
                     System.Diagnostics.Debug.Assert(result.IsEmpty);
                     result = StrokeFIndices.Full;
@@ -608,7 +608,7 @@ namespace MS.Internal.Ink
             // when the stylus stays at the the location but pressure changes.
             if (DoubleUtil.IsZero(spineVector.X) && DoubleUtil.IsZero(spineVector.Y))
             {
-                System.Diagnostics.Debug.Assert(DoubleUtil.AreClose(beginRadius, endRadius) == false);
+                System.Diagnostics.Debug.Assert(!DoubleUtil.AreClose(beginRadius, endRadius));
 
                 Vector nearest = GetNearest(hitBegin, hitEnd);
                 double radius;
@@ -649,7 +649,7 @@ namespace MS.Internal.Ink
                 Vector P1Xp = hitBegin + (hitVector * x);
                 if (P1Xp.LengthSquared < (beginRadius * beginRadius))
                 {
-                    System.Diagnostics.Debug.Assert(DoubleUtil.IsBetweenZeroAndOne(x) == false);
+                    System.Diagnostics.Debug.Assert(!DoubleUtil.IsBetweenZeroAndOne(x));
                     findex = ClipTest(spineVector, beginRadius, endRadius, (0 > x) ? hitBegin : hitEnd);
                     System.Diagnostics.Debug.Assert(!double.IsNaN(findex));
                 }
@@ -676,7 +676,7 @@ namespace MS.Internal.Ink
 
                     // If the nearest point misses the segment, then find the findex
                     // of the node nearest to the segment.
-                    if (false == DoubleUtil.IsBetweenZeroAndOne(r))
+                    if (!DoubleUtil.IsBetweenZeroAndOne(r))
                     {
                         findex = ClipTest(spineVector, beginRadius, endRadius, (0 > r) ? hitBegin : hitEnd);
                         System.Diagnostics.Debug.Assert(!double.IsNaN(findex));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/ErasingStroke.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/ErasingStroke.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //#define POINTS_FILTER_TRACE
@@ -157,7 +157,7 @@ namespace MS.Internal.Ink
                     int index = eraseAt.Count;
                     foreach (StrokeNode erasingStrokeNode in _erasingStrokeNodes)
                     {
-                        if (false == inkSegmentBounds.IntersectsWith(erasingStrokeNode.GetBoundsConnected()))
+                        if (!inkSegmentBounds.IntersectsWith(erasingStrokeNode.GetBoundsConnected()))
                         {
                             continue;
                         }
@@ -206,7 +206,7 @@ namespace MS.Internal.Ink
                         }
 
                         // If not merged nor inserted, add it to the end of the list
-                        if (false == inserted)
+                        if (!inserted)
                         {
                             eraseAt.Add(fragment);
                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/DrawingAttributeSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/DrawingAttributeSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //#define OLD_ISF
@@ -447,7 +447,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
         {
 #if DEBUG
             System.Diagnostics.Debug.Assert(compressionAlgorithm == 0);
-            System.Diagnostics.Debug.Assert(fTag == true);
+            System.Diagnostics.Debug.Assert(fTag);
 #endif
             Debug.Assert(stream != null);
             uint cbData = 0;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/InkSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/InkSerializer.cs
@@ -117,7 +117,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                         DecodeRawISF(ms);
                     }
                 }
-                else if (true == isGif)
+                else if (isGif)
                 {
                     DecodeRawISF(SystemDrawingHelper.GetCommentFromGifStream(inkData));
                 }
@@ -1467,7 +1467,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                 }
             }
 
-            if (false == fSetDefault)
+            if (!fSetDefault)
             {
                 // We will come here if the property is not found in the Optional List
                 // All other cases, we will have only default values
@@ -2549,7 +2549,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                         break;
                     }
                 }
-                if (false == fMatch)
+                if (!fMatch)
                 {
                     _strokeDescriptorTable.Add(strokeDescriptor);
                     _strokeLookupTable[stroke].StrokeDescriptorTableIndex = (uint)_strokeDescriptorTable.Count - 1;
@@ -2578,7 +2578,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                     }
                 }
 
-                if (false == fMatch)
+                if (!fMatch)
                 {
                     _metricTable.Add(metricBlock);
                     _strokeLookupTable[stroke].MetricDescriptorTableIndex = (uint)(_metricTable.Count - 1);
@@ -2595,7 +2595,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                 // First check to see if this matches with any existing Transform Blocks
                 for (int i = 0; i < _transformTable.Count; i++)
                 {
-                    if (true == xform.Compare(_transformTable[i]))
+                    if (xform.Compare(_transformTable[i]))
                     {
                         fMatch = true;
                         _strokeLookupTable[stroke].TransformTableIndex = (uint)i;
@@ -2603,7 +2603,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                     }
                 }
 
-                if (false == fMatch)
+                if (!fMatch)
                 {
                     _transformTable.Add(xform);
                     _strokeLookupTable[stroke].TransformTableIndex = (uint)(_transformTable.Count - 1);
@@ -2617,7 +2617,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                 // First check to see if this matches with any existing transform blocks
                 for (int i = 0; i < _drawingAttributesTable.Count; i++)
                 {
-                    if (true == drattrs.Equals(_drawingAttributesTable[i]))
+                    if (drattrs.Equals(_drawingAttributesTable[i]))
                     {
                         fMatch = true;
                         _strokeLookupTable[stroke].DrawingAttributesTableIndex = (uint)i;
@@ -2625,7 +2625,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                     }
                 }
 
-                if (false == fMatch)
+                if (!fMatch)
                 {
                     _drawingAttributesTable.Add(drattrs);
                     _strokeLookupTable[stroke].DrawingAttributesTableIndex = (uint)_drawingAttributesTable.Count - 1;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Lasso.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Lasso.cs
@@ -118,7 +118,7 @@ namespace MS.Internal.Ink
         {
             System.Diagnostics.Debug.Assert(_points != null);
 
-            if (false == _bounds.Contains(point))
+            if (!_bounds.Contains(point))
             {
                 return false;
             }
@@ -224,7 +224,7 @@ namespace MS.Internal.Ink
                 currentStrokeSegmentBounds.Union(nodeBounds);
 
                 // Skip the node if it's outside of the lasso's bounds
-                if (currentStrokeSegmentBounds.IntersectsWith(_bounds) == true)
+                if (currentStrokeSegmentBounds.IntersectsWith(_bounds))
                 {
                     // currentStrokeSegmentBounds, made up of the bounding box of
                     // this StrokeNode unioned with the last StrokeNode,
@@ -689,7 +689,7 @@ namespace MS.Internal.Ink
 
             // Don't add this point if the lasso already has a loop; or
             // if it's filtered by base class's filter.
-            if (true == _hasLoop || true == base.Filter(point))
+            if (_hasLoop || base.Filter(point))
             {
                 // Don't add this point to the lasso.
                 return true;
@@ -700,7 +700,7 @@ namespace MS.Internal.Ink
             // Now check whether the line lastPoint->point intersect with the
             // existing lasso.
 
-            if (true == GetIntersectionWithExistingLasso(point, ref intersection))
+            if (GetIntersectionWithExistingLasso(point, ref intersection))
             {
                 System.Diagnostics.Debug.Assert(intersection >= 0 && intersection <= points.Count - 2);
 
@@ -732,7 +732,7 @@ namespace MS.Internal.Ink
                     IsIncrementalLassoDirty = true;
                 }
 
-                if (true == IsIncrementalLassoDirty)
+                if (IsIncrementalLassoDirty)
                 {
                     // Update the bounds
                     Rect bounds = Rect.Empty;
@@ -771,7 +771,7 @@ namespace MS.Internal.Ink
 
             Rect newRect = new Rect(points[count - 1], point);
 
-            if (false == _prevBounds.IntersectsWith(newRect))
+            if (!_prevBounds.IntersectsWith(newRect))
             {
                 // The point is not contained in the bound of the existing lasso, no intersection.
                 return false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Renderer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Renderer.cs
@@ -68,7 +68,7 @@ namespace System.Windows.Ink
                 {
                     bool highContrast = _renderer.IsHighContrast();
 
-                    if (highContrast == true && _stroke.DrawingAttributes.IsHighlighter)
+                    if (highContrast && _stroke.DrawingAttributes.IsHighlighter)
                     {
                         // we don't render highlighters in high contrast
                         return;
@@ -80,7 +80,7 @@ namespace System.Windows.Ink
                         da = _stroke.DrawingAttributes.Clone();
                         da.Color = _renderer.GetHighContrastColor();
                     }
-                    else if (_stroke.DrawingAttributes.IsHighlighter == true)
+                    else if (_stroke.DrawingAttributes.IsHighlighter)
                     {
                         // Get the drawing attributes to use for a highlighter stroke. This can be a copied DA with color.A
                         // overridden if color.A != 255.
@@ -320,7 +320,7 @@ namespace System.Windows.Ink
             ArgumentNullException.ThrowIfNull(visual);
 
             // Remove the visual in the list of attached via AttachIncrementalRendering
-            if ((_attachedVisuals == null) || (_attachedVisuals.Remove(visual) == false))
+            if ((_attachedVisuals == null) || (!_attachedVisuals.Remove(visual)))
             {
                 throw new System.InvalidOperationException(SR.VisualCannotBeDetached);
             }
@@ -476,7 +476,7 @@ namespace System.Windows.Ink
             // Find the visual associated with the changed stroke.
             StrokeVisual visual;
             Stroke stroke = (Stroke)sender;
-            if (_visuals.TryGetValue(stroke, out visual) == false)
+            if (!_visuals.TryGetValue(stroke, out visual))
             {
                 throw new System.ArgumentException(SR.UnknownStroke1);
             }
@@ -572,8 +572,8 @@ namespace System.Windows.Ink
                 while (--i >= 0)
                 {
                     Stroke stroke = _strokes[i];
-                    if ((stroke.DrawingAttributes.IsHighlighter == false)
-                        && (_visuals.TryGetValue(stroke, out precedingVisual) == true)
+                    if ((!stroke.DrawingAttributes.IsHighlighter)
+                        && (_visuals.TryGetValue(stroke, out precedingVisual))
                         && (VisualTreeHelper.GetParent(precedingVisual) != null))
                     {
                         VisualCollection children = ((ContainerVisual)(VisualTreeHelper.GetParent(precedingVisual))).Children;
@@ -650,7 +650,7 @@ namespace System.Windows.Ink
             {
                 // For a highlighter stroke, the color.A is neglected.
                 Color color = StrokeRenderer.GetHighlighterColor(drawingAttributes.Color);
-                if ((_highlighters == null) || (_highlighters.TryGetValue(color, out hcVisual) == false))
+                if ((_highlighters == null) || (!_highlighters.TryGetValue(color, out hcVisual)))
                 {
                     if (_highlighters == null)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNode.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //#define DEBUG_RENDERING_FEEDBACK
@@ -33,7 +33,7 @@ namespace MS.Internal.Ink
             bool isLastNode)
         {
             System.Diagnostics.Debug.Assert(operations != null);
-            System.Diagnostics.Debug.Assert((nodeData.IsEmpty == false) && (index >= 0));
+            System.Diagnostics.Debug.Assert((!nodeData.IsEmpty) && (index >= 0));
           
 
             _operations = operations;
@@ -862,7 +862,7 @@ namespace MS.Internal.Ink
         /// <returns></returns>
         internal StrokeFIndices CutTest(StrokeNode hitNode)
         {
-            if ((IsValid == false) || (hitNode.IsValid == false))
+            if ((!IsValid) || (!hitNode.IsValid))
             {
                 return StrokeFIndices.Empty;
             }
@@ -885,7 +885,7 @@ namespace MS.Internal.Ink
         /// <returns></returns>
         internal StrokeFIndices CutTest(Point begin, Point end)
         {
-            if (IsValid == false)
+            if (!IsValid)
             {
                 return StrokeFIndices.Empty;
             }
@@ -914,7 +914,7 @@ namespace MS.Internal.Ink
         {
             System.Diagnostics.Debug.Assert(IsValid && (_index >= 0));
 
-            if (fragment.IsEmpty == false)
+            if (!fragment.IsEmpty)
             {
                 // Adjust only findices which are on this segment of thew spine (i.e. between 0 and 1)
                 if (!DoubleUtil.AreClose(fragment.BeginFIndex, StrokeFIndices.BeforeFirst))
@@ -999,7 +999,7 @@ namespace MS.Internal.Ink
             {
                 System.Diagnostics.Debug.Assert(IsValid);
 
-                if (_isQuadCached == false)
+                if (!_isQuadCached)
                 {
                     _connectingQuad = _operations.GetConnectingQuad(_lastNode, _thisNode);
                     _isQuadCached = true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeOperations.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeOperations.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -115,7 +115,7 @@ namespace MS.Internal.Ink
         /// <returns>contour segments enumerator</returns>
         internal virtual IEnumerable<ContourSegment> GetContourSegments(StrokeNodeData node, Quad quad)
         {
-            System.Diagnostics.Debug.Assert(node.IsEmpty == false);
+            System.Diagnostics.Debug.Assert(!node.IsEmpty);
 
             if (quad.IsEmpty)
             {
@@ -223,7 +223,7 @@ namespace MS.Internal.Ink
 
                 if (goingTo == HitResult.Left)
                 {
-                    if (false == foundAB)
+                    if (!foundAB)
                     {
                         // Find out where the node edge [i-1][i] is about the connecting vector 
                         HitResult comingFrom = WhereIsVectorAboutVector(_vertices[i] - _vertices[j], connection);
@@ -232,7 +232,7 @@ namespace MS.Internal.Ink
                             foundAB = true;
                             quad.A = beginNode.Position + _vertices[i] * beginNode.PressureFactor;
                             quad.B = endNode.Position + _vertices[i] * endNode.PressureFactor;
-                            if (true == foundCD)
+                            if (foundCD)
                             {
                                 // Found all 4 points. Break out from the 'for' loop.
                                 break;
@@ -242,7 +242,7 @@ namespace MS.Internal.Ink
                 }
                 else
                 {
-                    if (false == foundCD)
+                    if (!foundCD)
                     {
                         // Find out where the node edge [i-1][i] is about the connecting vector 
                         HitResult comingFrom = WhereIsVectorAboutVector(_vertices[i] - _vertices[j], connection);
@@ -251,7 +251,7 @@ namespace MS.Internal.Ink
                             foundCD = true;
                             quad.C = endNode.Position + _vertices[i] * endNode.PressureFactor;
                             quad.D = beginNode.Position + _vertices[i] * beginNode.PressureFactor;
-                            if (true == foundAB)
+                            if (foundAB)
                             {
                                 // Found all 4 points. Break out from the 'for' loop.
                                 break;
@@ -313,7 +313,7 @@ namespace MS.Internal.Ink
                     // Instead of applying pressure to the node, do reverse scaling on
                     // the hitting segment. This allows us use the original array of vertices 
                     // in hit-testing.
-                    System.Diagnostics.Debug.Assert(DoubleUtil.IsZero(pressureFactor) == false);
+                    System.Diagnostics.Debug.Assert(!DoubleUtil.IsZero(pressureFactor));
                     hitBegin /= pressureFactor;
                     hitEnd /= pressureFactor;
                 }
@@ -382,7 +382,7 @@ namespace MS.Internal.Ink
                         {
                             return true;
                         }
-                        if (true == IsOutside(hitResult, lastResult))
+                        if (IsOutside(hitResult, lastResult))
                         {
                             return false;
                         }
@@ -416,7 +416,7 @@ namespace MS.Internal.Ink
                         i--;
                     }
                 }
-                return (false == IsOutside(firstResult, hitResult));
+                return (!IsOutside(firstResult, hitResult));
             }
         }
 
@@ -473,12 +473,12 @@ namespace MS.Internal.Ink
                 Vector hitEnd = hitEndPoint - position;
                 if (pressureFactor != 1)
                 {
-                    System.Diagnostics.Debug.Assert(DoubleUtil.IsZero(pressureFactor) == false);
+                    System.Diagnostics.Debug.Assert(!DoubleUtil.IsZero(pressureFactor));
                     hitBegin /= pressureFactor;
                     hitEnd /= pressureFactor;
                 }
                 // Hit-test the node against the segment
-                if (true == HitTestPolygonSegment(_vertices, hitBegin, hitEnd))
+                if (HitTestPolygonSegment(_vertices, hitBegin, hitEnd))
                 {
                     if (node == 0)
                     {
@@ -554,7 +554,7 @@ namespace MS.Internal.Ink
         {
             if (beginNode.IsEmpty)
             {
-                if (HitTest(beginNode, endNode, quad, hitContour) == true)
+                if (HitTest(beginNode, endNode, quad, hitContour))
                 {
                     return StrokeFIndices.Full;
                 }
@@ -581,7 +581,7 @@ namespace MS.Internal.Ink
                 }
 
                 // If neither of the nodes is hit, hit-test the connecting quad
-                if (isHit == false)
+                if (!isHit)
                 {
                     // If neither of the nodes is hit and the contour of one node is entirely 
                     // inside the contour of the other node, then done with this hitting segment
@@ -592,9 +592,9 @@ namespace MS.Internal.Ink
                              : HitTestQuadSegment(quad, hitSegment.Begin, hitSegment.End);
                     }
                     
-                    if (isHit == false)
+                    if (!isHit)
                     {
-                        if (isInside == true)
+                        if (isInside)
                         {
                             isInside = hitSegment.IsArc
                                 ? (WhereIsVectorAboutArc(endNode.Position - hitSegment.Begin - hitSegment.Radius,
@@ -765,13 +765,13 @@ namespace MS.Internal.Ink
                     {
                         // This segment is collinear with the edge connecting the nodes, 
                         // no need to hit-test the other edges.
-                        System.Diagnostics.Debug.Assert(true == DoubleUtil.IsBetweenZeroAndOne(findex));
+                        System.Diagnostics.Debug.Assert(DoubleUtil.IsBetweenZeroAndOne(findex));
                         break;
                     }
                     // The hitting segment intersects the line of the edge connecting 
                     // the nodes. Find the findex of the intersection point.
                     double det = -Vector.Determinant(nextNode, hitVector);
-                    if (DoubleUtil.IsZero(det) == false)
+                    if (!DoubleUtil.IsZero(det))
                     {
                         double s = Vector.Determinant(hitVector, hitBegin - lastVertex) / det;
                         if ((findex > s) && DoubleUtil.IsBetweenZeroAndOne(s))
@@ -953,12 +953,12 @@ namespace MS.Internal.Ink
                     Vector hitRadius = hitSegment.Radius;
                     if (!DoubleUtil.AreClose(pressureFactor, 1d))
                     {
-                        System.Diagnostics.Debug.Assert(DoubleUtil.IsZero(pressureFactor) == false);
+                        System.Diagnostics.Debug.Assert(!DoubleUtil.IsZero(pressureFactor));
                         hitCenter /= pressureFactor;
                         hitRadius /= pressureFactor;
                     }
                     // If the segment is an arc, hit-test against the entire circle the arc is part of.
-                    if (true == HitTestPolygonCircle(_vertices, hitCenter, hitRadius))
+                    if (HitTestPolygonCircle(_vertices, hitCenter, hitRadius))
                     {
                         isHit = true;
                         break;
@@ -978,12 +978,12 @@ namespace MS.Internal.Ink
                     Vector hitEnd = hitBegin + hitSegment.Vector;
                     if (!DoubleUtil.AreClose(pressureFactor, 1d))
                     {
-                        System.Diagnostics.Debug.Assert(DoubleUtil.IsZero(pressureFactor) == false);
+                        System.Diagnostics.Debug.Assert(!DoubleUtil.IsZero(pressureFactor));
                         hitBegin /= pressureFactor;
                         hitEnd /= pressureFactor;
                     }
                     // Hit-test the node against the segment
-                    if (true == HitTestPolygonSegment(_vertices, hitBegin, hitEnd))
+                    if (HitTestPolygonSegment(_vertices, hitBegin, hitEnd))
                     {
                         isHit = true;
                         break;
@@ -1108,7 +1108,7 @@ namespace MS.Internal.Ink
                         {
                             return true;  //Got a hit
                         }
-                        if (true == IsOutside(hitResult, lastResult))
+                        if (IsOutside(hitResult, lastResult))
                         {
                             // This hitSegment is definitely outside the ink contour, drop it.
                             // Change k to something > 2 to leave the for loop and skip 
@@ -1130,7 +1130,7 @@ namespace MS.Internal.Ink
                         Vector spineVector = endNode.Position - beginNode.Position;
                         vertex -= spineVector; // now vertex = quad.A - spineVector
                         hitBegin -= spineVector; // adjust hitBegin to the space of endNode
-                        if (hitSegment.IsArc == false)
+                        if (!hitSegment.IsArc)
                         {
                             hitEnd -= spineVector;
                         }
@@ -1146,7 +1146,7 @@ namespace MS.Internal.Ink
                         i--;
                     }
                 }
-                if ((k == 2) && (false == IsOutside(firstResult, hitResult)))
+                if ((k == 2) && (!IsOutside(firstResult, hitResult)))
                 {
                     isHit = true;
                     break;
@@ -1215,7 +1215,7 @@ namespace MS.Internal.Ink
 
                 if (pressureFactor != 1)
                 {
-                    System.Diagnostics.Debug.Assert(DoubleUtil.IsZero(pressureFactor) == false);
+                    System.Diagnostics.Debug.Assert(!DoubleUtil.IsZero(pressureFactor));
                     hitBegin /= pressureFactor;
                     hitEnd /= pressureFactor;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeOperations2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeOperations2.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -60,7 +60,7 @@ namespace MS.Internal.Ink
                 prevResult = hitResult;
                 vertex = nextVertex;
             }
-            return (false == IsOutside(firstResult, hitResult));
+            return (!IsOutside(firstResult, hitResult));
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace MS.Internal.Ink
         /// <returns>true if hit, false otherwise</returns>
         internal static bool HitTestQuadSegment(Quad quad, Point hitBegin, Point hitEnd)
         {
-            System.Diagnostics.Debug.Assert(quad.IsEmpty == false);
+            System.Diagnostics.Debug.Assert(!quad.IsEmpty);
 
             HitResult hitResult = HitResult.Right, firstResult = HitResult.Right, prevResult = HitResult.Right;
             int count = 4;
@@ -90,7 +90,7 @@ namespace MS.Internal.Ink
                 {
                     return true;
                 }
-                if (true == IsOutside(hitResult, prevResult))
+                if (IsOutside(hitResult, prevResult))
                 {
                     return false;
                 }
@@ -101,7 +101,7 @@ namespace MS.Internal.Ink
                 prevResult = hitResult;
                 vertex = nextVertex;
             }
-            return (false == IsOutside(firstResult, hitResult));
+            return (!IsOutside(firstResult, hitResult));
         }
 
         /// <summary>
@@ -500,7 +500,7 @@ namespace MS.Internal.Ink
             Vector nearestOnSecond = GetProjection(hitPoint, hitPoint + linesVector);
 
             Vector shortest = nearestOnFirst - nearestOnSecond;
-            System.Diagnostics.Debug.Assert((false == DoubleUtil.IsZero(shortest.X)) || (false == DoubleUtil.IsZero(shortest.Y)));
+            System.Diagnostics.Debug.Assert((!DoubleUtil.IsZero(shortest.X)) || (!DoubleUtil.IsZero(shortest.Y)));
 
             //return DoubleUtil.IsZero(shortest.X) ? (nearestOnFirst.Y / shortest.Y) : (nearestOnFirst.X / shortest.X);
             return Math.Sqrt(nearestOnFirst.LengthSquared / shortest.LengthSquared);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeRenderer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeRenderer.cs
@@ -67,7 +67,7 @@ namespace MS.Internal.Ink
                 for (int index = 0; index < iterator.Count; index++)
                 {
                     StrokeNode strokeNode = iterator[index];
-                    System.Diagnostics.Debug.Assert(true == strokeNode.IsValid);
+                    System.Diagnostics.Debug.Assert(strokeNode.IsValid);
 
                     //the only code that calls this with !calculateBounds
                     //is dynamic rendering, which already draws enough strokeNodes

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StylusShape.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StylusShape.cs
@@ -210,7 +210,7 @@ namespace System.Windows.Ink
                                         topLeft + new Vector(m_width, 0),
                                         topLeft + new Vector(m_width, m_height),
                                         topLeft + new Vector(0, m_height)};
-            if (false == DoubleUtil.IsZero(m_rotation))
+            if (!DoubleUtil.IsZero(m_rotation))
             {
                 Matrix rotationTransform = Matrix.Identity;
                 rotationTransform.Rotate(m_rotation);
@@ -298,12 +298,12 @@ namespace System.Windows.Ink
                 transform.Rotate(m_rotation);
             }
 
-            if (_transform.IsIdentity == false)
+            if (!_transform.IsIdentity)
             {
                 transform *= _transform;
             }
 
-            if (transform.IsIdentity == false)
+            if (!transform.IsIdentity)
             {
                 for (int i = 0; i < controlPoints.Length; i++)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/UIElementHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/UIElementHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows;
@@ -188,7 +188,7 @@ namespace MS.Internal
             e = o as UIElement;
             if (e != null)
             {
-                if (e.HasAutomationPeer == true)
+                if (e.HasAutomationPeer)
                     ap = e.GetAutomationPeer();
             }
             else
@@ -196,7 +196,7 @@ namespace MS.Internal
                 ce = o as ContentElement;
                 if (ce != null)
                 {
-                    if (ce.HasAutomationPeer == true)
+                    if (ce.HasAutomationPeer)
                         ap = ce.GetAutomationPeer();
                 }
                 else
@@ -204,7 +204,7 @@ namespace MS.Internal
                     e3d = o as UIElement3D;
                     if (e3d != null)
                     {
-                        if (e3d.HasAutomationPeer == true)
+                        if (e3d.HasAutomationPeer)
                             ap = e3d.GetAutomationPeer();
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/ClassHandlersStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/ClassHandlersStore.cs
@@ -40,7 +40,7 @@ namespace System.Windows
 
             // Check if we need to create a new node in the linked list
             RoutedEventHandlerInfoList handlers =  _eventHandlersList.List[index].Handlers;
-            if (handlers == null || _eventHandlersList.List[index].HasSelfHandlers == false)
+            if (handlers == null || !_eventHandlersList.List[index].HasSelfHandlers)
             {
                 // Create a new node in the linked list of class 
                 // handlers for this type and routed event.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/GlobalEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/GlobalEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -82,7 +82,7 @@ namespace System.Windows
                 
                 for (int i=0; i<keys.Count; i++)
                 {
-                    if (keys.List[i].IsSubclassOf(dType) == true)
+                    if (keys.List[i].IsSubclassOf(dType))
                     {
                         classListenersLists = (ClassHandlersStore)_dTypedClassListeners[keys.List[i]];                            
                         classListenersLists.UpdateSubClassHandlers(routedEvent, updatedClassListeners);
@@ -126,7 +126,7 @@ namespace System.Windows
                 // Requires GlobalLock to access _ownerTypedRoutedEventList
                 IDictionaryEnumerator htEnumerator = _ownerTypedRoutedEventList.GetEnumerator();
                 
-                while(htEnumerator.MoveNext() == true)
+                while(htEnumerator.MoveNext())
                 {
                     FrugalObjectList<RoutedEvent> ownerRoutedEventList = (FrugalObjectList<RoutedEvent>)htEnumerator.Value;
                 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/DrawingAttributes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/DrawingAttributes.cs
@@ -265,12 +265,12 @@ namespace System.Windows.Ink
                 //prevent boxing / unboxing if possible
                 if (!_extendedProperties.Contains(KnownIds.IsHighlighter))
                 {
-                    Debug.Assert(false == (bool)GetDefaultDrawingAttributeValue(KnownIds.IsHighlighter));
+                    Debug.Assert(!(bool)GetDefaultDrawingAttributeValue(KnownIds.IsHighlighter));
                     return false;
                 }
                 else
                 {
-                    Debug.Assert(true == (bool)GetExtendedPropertyBackedProperty(KnownIds.IsHighlighter));
+                    Debug.Assert((bool)GetExtendedPropertyBackedProperty(KnownIds.IsHighlighter));
                     return true;
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/IncrementalHitTester.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/IncrementalHitTester.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Ink
                 throw new System.ArgumentException(SR.EmptyArrayNotAllowedAsArgument, nameof(points));
             }
 
-            if (false == _fValid)
+            if (!_fValid)
             {
                 throw new System.InvalidOperationException(SR.EndHitTestingCalled);
             }
@@ -64,7 +64,7 @@ namespace System.Windows.Ink
                 throw new System.ArgumentException(SR.EmptyArrayNotAllowedAsArgument, nameof(stylusPoints));
             }
 
-            if (false == _fValid)
+            if (!_fValid)
             {
                 throw new System.InvalidOperationException(SR.EndHitTestingCalled);
             }
@@ -326,7 +326,7 @@ namespace System.Windows.Ink
             // Do nothing if there's not enough points, or there's nobody listening
             // The points may be filtered out, so if all the points are filtered out, (lastPointIndex == (_lasso.PointCount - 1).
             // For this case, check if the incremental lasso is disabled (i.e., points modified).
-            if ((_lasso.IsEmpty) || (lastPointIndex == (_lasso.PointCount - 1) && false == _lasso.IsIncrementalLassoDirty)
+            if ((_lasso.IsEmpty) || (lastPointIndex == (_lasso.PointCount - 1) && !_lasso.IsIncrementalLassoDirty)
                 || (SelectionChanged == null))
             {
                 return;
@@ -339,7 +339,7 @@ namespace System.Windows.Ink
             // Create a lasso that represents the current increment
             Lasso lassoUpdate = new Lasso();
 
-            if (false == _lasso.IsIncrementalLassoDirty)
+            if (!_lasso.IsIncrementalLassoDirty)
             {
                 if (0 < lastPointIndex)
                 {
@@ -358,7 +358,7 @@ namespace System.Windows.Ink
             foreach (StrokeInfo strokeInfo in this.StrokeInfos)
             {
                 Lasso lasso;
-                if (true == strokeInfo.IsDirty || true == _lasso.IsIncrementalLassoDirty)
+                if (strokeInfo.IsDirty || _lasso.IsIncrementalLassoDirty)
                 {
                     // If this is the first time this stroke gets hit-tested with this lasso,
                     // or if the stroke (or its DAs) has changed since the last hit-testing,
@@ -389,7 +389,7 @@ namespace System.Windows.Ink
                     for (int i = 0; i < stylusPoints.Count; i++)
                     {
                         // Consider only the points that become captured/released with this particular update
-                        if (true == lasso.Contains((Point)stylusPoints[i]))
+                        if (lasso.Contains((Point)stylusPoints[i]))
                         {
                             double weight = strokeInfo.GetPointWeight(i);
 
@@ -531,8 +531,8 @@ namespace System.Windows.Ink
                     StrokeInfo strokeInfo = this.StrokeInfos[x];
 
                     // Skip the stroke if its bounding box doesn't intersect with the one of the hitting shape.
-                    if ((erasingBounds.IntersectsWith(strokeInfo.StrokeBounds) == false) ||
-                        (_erasingStroke.EraseTest(StrokeNodeIterator.GetIterator(strokeInfo.Stroke, strokeInfo.Stroke.DrawingAttributes), eraseAt) == false))
+                    if ((!erasingBounds.IntersectsWith(strokeInfo.StrokeBounds)) ||
+                        (!_erasingStroke.EraseTest(StrokeNodeIterator.GetIterator(strokeInfo.Stroke, strokeInfo.Stroke.DrawingAttributes), eraseAt)))
                     {
                         continue;
                     }
@@ -892,7 +892,7 @@ namespace MS.Internal.Ink
         {
             // If the drawing attributes change involves Width, Height, StylusTipTransform, IgnorePressure, or FitToCurve,
             // we need to invalidate
-            if (false == DrawingAttributes.GeometricallyEqual(args.NewDrawingAttributes, args.PreviousDrawingAttributes))
+            if (!DrawingAttributes.GeometricallyEqual(args.NewDrawingAttributes, args.PreviousDrawingAttributes))
             {
                 Invalidate();
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/Stroke.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/Stroke.cs
@@ -474,7 +474,7 @@ namespace System.Windows.Ink
                 // If the drawing attributes change involves Width, Height, StylusTipTransform, IgnorePressure, or FitToCurve,
                 // we need to force a recaculation of the cached path geometry right after the
                 // DrawingAttributes changed, beforet the events are raised.
-                if (false == DrawingAttributes.GeometricallyEqual(previousDa, _drawingAttributes))
+                if (!DrawingAttributes.GeometricallyEqual(previousDa, _drawingAttributes))
                 {
                     _cachedGeometry = null;
                     // Set the cached bounds to empty, which will force a re-calculation of the _cachedBounds upon next GetBounds call.
@@ -743,8 +743,8 @@ namespace System.Windows.Ink
             //
             // Assert the findices are NOT out of range with the packets
             //
-            System.Diagnostics.Debug.Assert(false == ((!DoubleUtil.AreClose(cutAt[cutAt.Length - 1].EndFIndex, StrokeFIndices.AfterLast)) &&
-                                        Math.Ceiling(cutAt[cutAt.Length - 1].EndFIndex) > sourceStylusPoints.Count - 1));
+            System.Diagnostics.Debug.Assert(DoubleUtil.AreClose(cutAt[cutAt.Length - 1].EndFIndex, StrokeFIndices.AfterLast) ||
+                                        Math.Ceiling(cutAt[cutAt.Length - 1].EndFIndex) <= sourceStylusPoints.Count - 1);
 
             for (int i = 0; i < cutAt.Length; i++)
             {
@@ -799,8 +799,8 @@ namespace System.Windows.Ink
             //
             // Assert the findices are NOT out of range with the packets
             //
-            System.Diagnostics.Debug.Assert(false == ((!DoubleUtil.AreClose(cutAt[cutAt.Length - 1].EndFIndex, StrokeFIndices.AfterLast)) &&
-                                        Math.Ceiling(cutAt[cutAt.Length - 1].EndFIndex) > sourceStylusPoints.Count - 1));
+            System.Diagnostics.Debug.Assert(DoubleUtil.AreClose(cutAt[cutAt.Length - 1].EndFIndex, StrokeFIndices.AfterLast) ||
+                                        Math.Ceiling(cutAt[cutAt.Length - 1].EndFIndex) <= sourceStylusPoints.Count - 1);
 
 
             int i = 0;
@@ -1036,7 +1036,7 @@ namespace System.Windows.Ink
         private void DrawingAttributes_Changed(object sender, PropertyDataChangedEventArgs e)
         {
             // set Geometry flag to be dirty if the DA change will cause change in geometry
-            if (DrawingAttributes.IsGeometricalDaGuid(e.PropertyGuid) == true)
+            if (DrawingAttributes.IsGeometricalDaGuid(e.PropertyGuid))
             {
                 _cachedGeometry = null;
                 // Set the cached bounds to empty, which will force a re-calculation of the _cachedBounds upon next GetBounds call.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/Stroke2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/Stroke2.cs
@@ -225,7 +225,7 @@ namespace System.Windows.Ink
 
                 for (int i = 0; i < stylusPoints.Count; i++)
                 {
-                    if (true == bounds.Contains((Point)stylusPoints[i]))
+                    if (bounds.Contains((Point)stylusPoints[i]))
                     {
                         target -= strokeInfo.GetPointWeight(i);
                         if (DoubleUtil.LessThanOrClose(target, 0d))
@@ -278,7 +278,7 @@ namespace System.Windows.Ink
 
                 for (int i = 0; i < stylusPoints.Count; i++)
                 {
-                    if (true == lasso.Contains((Point)stylusPoints[i]))
+                    if (lasso.Contains((Point)stylusPoints[i]))
                     {
                         target -= strokeInfo.GetPointWeight(i);
                         if (DoubleUtil.LessThan(target, 0f))
@@ -366,7 +366,7 @@ namespace System.Windows.Ink
 
             ArgumentNullException.ThrowIfNull(drawingAttributes);
 
-            if (_drawAsHollow == true)
+            if (_drawAsHollow)
             {
                 // Draw as hollow. Our profiler result shows that the two-pass-rendering approach is about 5 times
                 // faster that using GetOutlinePathGeometry.
@@ -450,7 +450,7 @@ namespace System.Windows.Ink
 
             // need to recalculate the PathGeometry if the DA passed in is "geometrically" different from
             // this DA, or if the cached PathGeometry is dirty.
-            if (false == geometricallyEqual || (true == geometricallyEqual && null == _cachedGeometry))
+            if (!geometricallyEqual || (geometricallyEqual && null == _cachedGeometry))
             {
                 //Recalculate _pathGeometry;
                 StrokeNodeIterator iterator = StrokeNodeIterator.GetIterator(this, drawingAttributes);
@@ -467,7 +467,7 @@ namespace System.Windows.Ink
 
                 // return the calculated value directly. We cannot cache the result since the DA passed in
                 // is "geometrically" different from this.DrawingAttributes.
-                if (false == geometricallyEqual)
+                if (!geometricallyEqual)
                 {
                     return geometry;
                 }
@@ -495,7 +495,7 @@ namespace System.Windows.Ink
         /// </summary>
         internal void DrawInternal(DrawingContext dc, DrawingAttributes DrawingAttributes, bool drawAsHollow)
         {
-            if (drawAsHollow == true)
+            if (drawAsHollow)
             {
                 // The Stroke.DrawCore may be overriden in the 3rd party code.
                 // The out-side code could throw exception. We use try/finally block to protect our status.
@@ -512,7 +512,7 @@ namespace System.Windows.Ink
             else
             {
                 // IsSelected can be true or false, but _drawAsHollow must be false
-                System.Diagnostics.Debug.Assert(false == _drawAsHollow);
+                System.Diagnostics.Debug.Assert(!_drawAsHollow);
                 this.DrawCore(dc, DrawingAttributes);
             }
         }
@@ -550,7 +550,7 @@ namespace System.Windows.Ink
         /// </summary>
         internal void SetBounds(Rect newBounds)
         {
-            System.Diagnostics.Debug.Assert(newBounds.IsEmpty == false);
+            System.Diagnostics.Debug.Assert(!newBounds.IsEmpty);
             _cachedBounds = newBounds;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollection.cs
@@ -221,7 +221,7 @@ namespace System.Windows.Ink
         public void Transform(Matrix transformMatrix, bool applyToStylusTip)
         {
             // Ensure that the transformMatrix is invertible.
-            if ( false == transformMatrix.HasInverse )
+            if (!transformMatrix.HasInverse)
                 throw new ArgumentException(SR.MatrixNotInvertible, nameof(transformMatrix));
 
             // if transformMatrix is identity or the StrokeCollection is empty

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollection2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/StrokeCollection2.cs
@@ -112,7 +112,7 @@ namespace System.Windows.Ink
 
                         for (int i = 0; i < stylusPoints.Count; i++)
                         {
-                            if (true == lasso.Contains((Point)stylusPoints[i]))
+                            if (lasso.Contains((Point)stylusPoints[i]))
                             {
                                 target -= strokeInfo.GetPointWeight(i);
                                 if (DoubleUtil.LessThanOrClose(target, 0f))
@@ -162,7 +162,7 @@ namespace System.Windows.Ink
                 // Presharp gives a warning when get methods might deref a null.  It's complaining
                 // here that 'stroke'' could be null, but StrokeCollection never allows nulls to be added
                 // so this is not possible
-                if (true == stroke.HitTest(bounds, percentageWithinBounds))
+                if (stroke.HitTest(bounds, percentageWithinBounds))
                 {
                     hits.Add(stroke);
                 }
@@ -255,7 +255,7 @@ namespace System.Windows.Ink
         /// <param name="bounds">rectangle to clip with</param>
         public void Clip(Rect bounds)
         {
-            if (bounds.IsEmpty == false)
+            if (!bounds.IsEmpty)
             {
                 Clip(new Point[4] { bounds.TopLeft, bounds.TopRight, bounds.BottomRight, bounds.BottomLeft });
             }
@@ -298,7 +298,7 @@ namespace System.Windows.Ink
         /// <param name="bounds">rectangle to erase within</param>
         public void Erase(Rect bounds)
         {
-            if (bounds.IsEmpty == false)
+            if (!bounds.IsEmpty)
             {
                 Erase(new Point[4] { bounds.TopLeft, bounds.TopRight, bounds.BottomRight, bounds.BottomLeft });
             }
@@ -361,7 +361,7 @@ namespace System.Windows.Ink
                     // It's very important to override the Alpha value so that Colors of the same RGB vale
                     // but different Alpha would be in the same list.
                     Color color = StrokeRenderer.GetHighlighterColor(stroke.DrawingAttributes.Color);
-                    if (highLighters.TryGetValue(color, out strokes) == false)
+                    if (!highLighters.TryGetValue(color, out strokes))
                     {
                         strokes = new List<Stroke>();
                         highLighters.Add(color, strokes);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputElement.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Media;
@@ -243,7 +243,7 @@ namespace System.Windows.Input
                 {
                     ptTranslated = mUp.Transform(ptTranslated);
                 }
-                else if (gUp.TryTransform(ptTranslated, out ptTranslated) == false)
+                else if (!gUp.TryTransform(ptTranslated, out ptTranslated))
                 {
                     // Error.  Out parameter has been set false.
                     return new Point();
@@ -315,7 +315,7 @@ namespace System.Windows.Input
                         }
                         else if (gDown != null)
                         {
-                            if (gDown.TryTransform(ptTranslated, out ptTranslated) == false)
+                            if (!gDown.TryTransform(ptTranslated, out ptTranslated))
                             {
                                 // Error.  Out parameter has been set false.
                                 return new Point();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputMethod.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputMethod.cs
@@ -1660,7 +1660,7 @@ namespace System.Windows.Input
                 while(enumIpp.Next(1, tf_profiles,  out fetched) == NativeMethods.S_OK)
                 {
                     // Check if this profile is active.
-                    if (tf_profiles[0].fActive == true)
+                    if (tf_profiles[0].fActive)
                     {
                         // Check if this profile is keyboard category..
                         if (tf_profiles[0].catid.Equals(UnsafeNativeMethods.GUID_TFCAT_TIP_KEYBOARD))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Keyboard.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Keyboard.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows.Input
@@ -381,13 +381,13 @@ namespace System.Windows.Input
             UIElement uie = element as UIElement;
             if(uie != null)
             {
-                if(uie.IsVisible == false)
+                if(!uie.IsVisible)
                 {
                     return false;
                 }
             }
 
-            if((bool)element.GetValue(UIElement.IsEnabledProperty) == false)
+            if(!(bool)element.GetValue(UIElement.IsEnabledProperty))
             {
                 return false;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
@@ -717,7 +717,7 @@ namespace System.Windows.Input
             // Second, if we still haven't thought of a reason to kill capture, validate
             // it on a Visual basis for things like still being in the right tree.
             //
-            if (killCapture == false)
+            if (!killCapture)
             {
                 DependencyObject containingVisual = InputElement.GetContainingVisual(dependencyObject);
                 killCapture = !ValidateVisualForCapture(containingVisual);
@@ -747,13 +747,13 @@ namespace System.Windows.Input
 
         private bool ValidateUIElementForCapture(UIElement element)
         {
-            if (element.IsEnabled == false)
+            if (!element.IsEnabled)
                 return false;
 
-            if (element.IsVisible == false)
+            if (!element.IsVisible)
                 return false;
 
-            if (element.IsHitTestVisible == false)
+            if (!element.IsHitTestVisible)
                 return false;
 
             return true;
@@ -761,13 +761,13 @@ namespace System.Windows.Input
 
         private bool ValidateUIElement3DForCapture(UIElement3D element)
         {
-            if (element.IsEnabled == false)
+            if (!element.IsEnabled)
                 return false;
 
-            if (element.IsVisible == false)
+            if (!element.IsVisible)
                 return false;
 
-            if (element.IsHitTestVisible == false)
+            if (!element.IsHitTestVisible)
                 return false;
 
             return true;
@@ -776,7 +776,7 @@ namespace System.Windows.Input
 
         private bool ValidateContentElementForCapture(ContentElement element)
         {
-            if (element.IsEnabled == false)
+            if (!element.IsEnabled)
                 return false;
 
             // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
@@ -1480,7 +1480,7 @@ namespace System.Windows.Input
                             IInputElement mouseOver = _mouseOver; // assume mouse is still over whatever it was before
                             IInputElement rawMouseOver = (_rawMouseOver != null) ? (IInputElement)_rawMouseOver.Target : null;
                             bool isPhysicallyOver = _isPhysicallyOver;
-                            bool isGlobalChange = ArePointsClose(ptClient, _lastPosition) == false;  // determine if the mouse actually physically moved
+                            bool isGlobalChange = !ArePointsClose(ptClient, _lastPosition);  // determine if the mouse actually physically moved
 
                             // Invoke Hit Test logic to determine what element the mouse will be over AFTER the move is processed.
                             // - Only do this if:
@@ -1668,7 +1668,7 @@ namespace System.Windows.Input
                             // element we are over or a change in which element
                             // we are over.
                             //
-                            bool isLocalChange = isMouseOverChange || ArePointsClose(ptRelativeToOver, _positionRelativeToOver) == false;
+                            bool isLocalChange = isMouseOverChange || !ArePointsClose(ptRelativeToOver, _positionRelativeToOver);
 
                             // Console.WriteLine("RawMouseActions.AbsoluteMove: isGlobalChange=" + isGlobalChange + " isLocalChange=" + isLocalChange);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPlugin.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPlugin.cs
@@ -235,7 +235,7 @@ namespace System.Windows.Input.StylusPlugIns
                                 // depending on whether we are going active or inactive so you don't
                                 // get input events after going inactive or before going active.
                                 __enabled = value;
-                                if (value == false)
+                                if (!value)
                                 {
                                     // Make sure we fire OnIsActivateForInputChanged if we need to.
                                     InvalidateIsActiveForInput();
@@ -252,7 +252,7 @@ namespace System.Windows.Input.StylusPlugIns
                     else
                     {
                         __enabled = value;
-                        if (value == false)
+                        if (!value)
                         {
                             // Make sure we fire OnIsActivateForInputChanged if we need to.
                             InvalidateIsActiveForInput();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerLogic.cs
@@ -795,7 +795,7 @@ namespace System.Windows.Input.StylusPointer
             // Second, if we still haven't thought of a reason to kill capture, validate
             // it on a Visual basis for things like still being in the right tree.
             //
-            if (killCapture == false)
+            if (!killCapture)
             {
                 DependencyObject containingVisual = InputElement.GetContainingVisual(dependencyObject);
                 killCapture = !ValidateVisualForCapture(containingVisual, CurrentStylusDevice);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerStylusDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerStylusDevice.cs
@@ -618,7 +618,7 @@ namespace System.Windows.Input.StylusPointer
                 if (_stylusOver == stylusOver)
                 {
                     Point ptOffset = GetPosition(stylusOver);
-                    fOffsetChanged = MS.Internal.DoubleUtil.AreClose(ptOffset.X, _rawElementRelativePosition.X) == false || MS.Internal.DoubleUtil.AreClose(ptOffset.Y, _rawElementRelativePosition.Y) == false;
+                    fOffsetChanged = !MS.Internal.DoubleUtil.AreClose(ptOffset.X, _rawElementRelativePosition.X) || !MS.Internal.DoubleUtil.AreClose(ptOffset.Y, _rawElementRelativePosition.Y);
                 }
 
                 if (fOffsetChanged || _stylusOver != stylusOver)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
@@ -2448,7 +2448,7 @@ namespace System.Windows.Input.StylusWisp
             // Second, if we still haven't thought of a reason to kill capture, validate
             // it on a Visual basis for things like still being in the right tree.
             //
-            if (killCapture == false)
+            if (!killCapture)
             {
                 DependencyObject containingVisual = InputElement.GetContainingVisual(dependencyObject);
                 killCapture = !ValidateVisualForCapture(containingVisual, CurrentStylusDevice);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispStylusDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispStylusDevice.cs
@@ -326,7 +326,7 @@ namespace System.Windows.Input.StylusWisp
                 if (_stylusOver == stylusOver)
                 {
                     Point ptOffset = GetPosition(stylusOver);
-                    fOffsetChanged = MS.Internal.DoubleUtil.AreClose(ptOffset.X, _rawElementRelativePosition.X) == false || MS.Internal.DoubleUtil.AreClose(ptOffset.Y, _rawElementRelativePosition.Y) == false;
+                    fOffsetChanged = !MS.Internal.DoubleUtil.AreClose(ptOffset.X, _rawElementRelativePosition.X) || !MS.Internal.DoubleUtil.AreClose(ptOffset.Y, _rawElementRelativePosition.Y);
                 }
 
                 if (fOffsetChanged || _stylusOver != stylusOver)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesContext.cs
@@ -94,7 +94,7 @@ namespace System.Windows.Input
             }
 
             // Free up any remaining textstores.
-            if (_istimactivated == true)
+            if (_istimactivated)
             {
                 // Shut down the thread manager when the last TextStore goes away.
                 // On XP, if we're called on a worker thread (during AppDomain shutdown)
@@ -199,7 +199,7 @@ namespace System.Windows.Input
                 int editCookie = UnsafeNativeMethods.TF_INVALID_COOKIE;
 
                 // Activate TSF on this thread if this is the first TextStore.
-                if (_istimactivated == false)
+                if (!_istimactivated)
                 {
                     //temp variable created to retrieve the value
                     // which is then stored in the critical data.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TouchDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TouchDevice.cs
@@ -539,7 +539,7 @@ namespace System.Windows.Input
             // Second, if we still haven't thought of a reason to kill capture, validate
             // it on a Visual basis for things like still being in the right tree.
             //
-            if (killCapture == false)
+            if (!killCapture)
             {
                 DependencyObject containingVisual = InputElement.GetContainingVisual(_captured as DependencyObject);
                 killCapture = !ValidateVisualForCapture(containingVisual);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
@@ -443,7 +443,7 @@ namespace System.Windows.Interop
 
                 // New world transform has been set-up by HwndTarget
                 // set the layouts size again to account for this
-                if (IsLayoutActive() == true)
+                if (IsLayoutActive())
                 {
                     // Call the helper method SetLayoutSize to set Layout's size
                     // We may already be inside a call to SetLayoutSize - schedule another call
@@ -497,7 +497,7 @@ namespace System.Windows.Interop
                 // whichever code handles the DPI changes set up updated
                 // window sizes etc. in screen/client coordinates, and now
                 // we must adapt and update the corresponding layout sizes as well.
-                if (IsLayoutActive() == true)
+                if (IsLayoutActive())
                 {
                     // Call the helper method SetLayoutSize to set Layout's size
                     // We may already be inside a call to SetLayoutSize - schedule another call
@@ -576,7 +576,7 @@ namespace System.Windows.Interop
                             ((UIElement)(_rootVisual)).LayoutUpdated += new EventHandler(OnLayoutUpdated);
                         }
 
-                        if (_hwndTarget != null && _hwndTarget.IsDisposed == false)
+                        if (_hwndTarget != null && !_hwndTarget.IsDisposed)
                         {
                             _hwndTarget.RootVisual = _rootVisual;
                         }
@@ -604,7 +604,7 @@ namespace System.Windows.Interop
 
                     RootChanged(oldRoot, _rootVisual);
 
-                    if (IsLayoutActive() == true)
+                    if (IsLayoutActive())
                     {
                         // Call the helper method SetLayoutSize to set Layout's size
                         SetLayoutSize();
@@ -701,7 +701,7 @@ namespace System.Windows.Interop
 
                 // Even though we created the HwndTarget, it can get disposed out from
                 // underneath us.
-                if (_hwndTarget!= null && _hwndTarget.IsDisposed == true)
+                if (_hwndTarget!= null && _hwndTarget.IsDisposed)
                 {
                     return null;
                 }
@@ -886,7 +886,7 @@ namespace System.Windows.Interop
             // For windows with UsesPerPixelOpacity, we force the client to
             // fill the window, so we don't need to add in any frame space.
             //
-            if (_adjustSizingForNonClientArea == false && !UsesPerPixelOpacity)
+            if (!_adjustSizingForNonClientArea && !UsesPerPixelOpacity)
             {
                 int style = NativeMethods.IntPtrToInt32((IntPtr)SafeNativeMethods.GetWindowStyle(new HandleRef(this, _hwndWrapper.Handle), false));
                 int styleEx = NativeMethods.IntPtrToInt32((IntPtr)SafeNativeMethods.GetWindowStyle(new HandleRef(this, _hwndWrapper.Handle), true));
@@ -975,7 +975,7 @@ namespace System.Windows.Interop
             {
                 CheckDisposed(true);
 
-                if (IsValidSizeToContent(value) != true)
+                if (!IsValidSizeToContent(value))
                 {
                     throw new InvalidEnumArgumentException("value", (int)value, typeof(SizeToContent));
                 }
@@ -991,7 +991,7 @@ namespace System.Windows.Interop
                 // if a developer goes directly to HwndSource and sets SizeToContent, we will
                 // not notify the wrapping Window
 
-                if (IsLayoutActive() == true)
+                if (IsLayoutActive())
                 {
                     // Call the helper method SetLayoutSize to set Layout's size
                     SetLayoutSize();
@@ -1001,7 +1001,7 @@ namespace System.Windows.Interop
 
         private bool IsLayoutActive()
         {
-            if ((_rootVisual is UIElement) && _hwndTarget!= null && _hwndTarget.IsDisposed == false)
+            if ((_rootVisual is UIElement) && _hwndTarget!= null && !_hwndTarget.IsDisposed)
             {
                 return true;
             }
@@ -1016,7 +1016,7 @@ namespace System.Windows.Interop
         private void SetLayoutSize()
         {
             Debug.Assert(_hwndTarget!= null, "HwndTarget is null");
-            Debug.Assert(_hwndTarget.IsDisposed == false, "HwndTarget is disposed");
+            Debug.Assert(!_hwndTarget.IsDisposed, "HwndTarget is disposed");
 
             UIElement rootUIElement = null;
             rootUIElement = _rootVisual as UIElement;
@@ -1139,7 +1139,7 @@ namespace System.Windows.Interop
             // Compute View's size and set
             NativeMethods.RECT rc = new NativeMethods.RECT(0, 0, 0, 0);
 
-            if (_adjustSizingForNonClientArea == true)
+            if (_adjustSizingForNonClientArea)
             {
                 GetNonClientRect(ref rc);
             }
@@ -1329,7 +1329,7 @@ namespace System.Windows.Interop
             // Only if SizeToContent overrides Win32 sizing change calls.
             // If it's coming from OnResize (_myOwnUpdate != true), it means we are adjusting
             // to the right size; don't need to do anything here.
-            if ((_myOwnUpdate != true) && (SizeToContent != SizeToContent.Manual))
+            if ((!_myOwnUpdate) && (SizeToContent != SizeToContent.Manual))
             {
                 // Get the current style and calculate the size to be with the new style.
                 // If WM_WINDOWPOSCHANGING is sent because of style changes, WM_STYLECHANGED is sent
@@ -1424,7 +1424,7 @@ namespace System.Windows.Interop
 
                 // WM_SIZE has the client size of the window.
                 // for appmodel window case, get the outside size of the hwnd.
-                if (_adjustSizingForNonClientArea == true)
+                if (_adjustSizingForNonClientArea)
                 {
                     NativeMethods.RECT rect = new NativeMethods.RECT(0, 0, (int)pt.X, (int)pt.Y);
                     GetNonClientRect(ref rect);
@@ -1451,7 +1451,7 @@ namespace System.Windows.Interop
                 // call to Measure is optimized out and no layout happens.  Invalidating
                 // layout here ensures that we do layout.
                 // This can happen only in the Window case
-                if (_adjustSizingForNonClientArea == true)
+                if (_adjustSizingForNonClientArea)
                 {
                     rootUIElement.InvalidateMeasure();
                 }
@@ -1520,7 +1520,7 @@ namespace System.Windows.Interop
         // HwndSourceParameters.TreatAncestorsAsNonClientArea setting.
         private void GetNonClientRect(ref NativeMethods.RECT rc)
         {
-            Debug.Assert(_adjustSizingForNonClientArea == true);
+            Debug.Assert(_adjustSizingForNonClientArea);
 
             IntPtr hwndRoot = IntPtr.Zero;
 
@@ -2639,9 +2639,9 @@ namespace System.Windows.Interop
         {
             get
             {
-                return _isDisposed == false &&
+                return !_isDisposed &&
                        _hwndTarget != null &&
-                       _hwndTarget.IsDisposed == false;
+!_hwndTarget.IsDisposed;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
@@ -2639,9 +2639,7 @@ namespace System.Windows.Interop
         {
             get
             {
-                return !_isDisposed &&
-                       _hwndTarget != null &&
-!_hwndTarget.IsDisposed;
+                return !_isDisposed && _hwndTarget is not null && !_hwndTarget.IsDisposed;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Clock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Clock.cs
@@ -606,7 +606,7 @@ namespace System.Windows.Media.Animation
                 if (!_resolvedDuration.HasTimeSpan || _resolvedDuration.TimeSpan > TimeSpan.Zero)
                 {
                     // Verify that we only use SlipBehavior in supported scenarios
-                    if ((_timeline.AutoReverse == true) ||
+                    if ((_timeline.AutoReverse) ||
                         (_timeline.AccelerationRatio > 0) ||
                         (_timeline.DecelerationRatio > 0))
                     {
@@ -3169,7 +3169,7 @@ namespace System.Windows.Media.Animation
             Debug.Assert(!_syncData.IsInSyncPeriod);
 
             // Verify our limitations on slip functionality, but don't throw here for perf
-            Debug.Assert(_timeline.AutoReverse == false);
+            Debug.Assert(!_timeline.AutoReverse);
             Debug.Assert(_timeline.AccelerationRatio == 0);
             Debug.Assert(_timeline.DecelerationRatio == 0);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/ClockGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/ClockGroup.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows.Media.Animation
@@ -120,7 +120,7 @@ namespace System.Windows.Media.Animation
                     // Verify that we only use SlipBehavior in supported scenarios
                     if (!IsRoot ||
                        (_timeline.RepeatBehavior.HasDuration) ||
-                       (_timeline.AutoReverse == true) ||
+                       (_timeline.AutoReverse) ||
                        (_timeline.AccelerationRatio > 0) ||
                        (_timeline.DecelerationRatio > 0))
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimeIntervalCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimeIntervalCollection.cs
@@ -136,7 +136,7 @@ namespace System.Windows.Media.Animation
             _nodeTime[0] = point;
             _nodeIsPoint[0] = true;
             _nodeIsInterval[0] = false;
-            Debug.Assert(_nodeIsInterval[0] == false);
+            Debug.Assert(!_nodeIsInterval[0]);
 
             _count = 1;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Timeline.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Timeline.cs
@@ -1085,7 +1085,7 @@ namespace System.Windows.Media.Animation
                 builder.Append(", AccelerationRatio = ");
                 builder.Append(AccelerationRatio);
             }
-            if (AutoReverse != false)
+            if (AutoReverse)
             {
                 builder.Append(", AutoReverse = ");
                 builder.Append(AutoReverse);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FactoryMaker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FactoryMaker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -54,7 +54,7 @@ namespace System.Windows.Media
         {
                 if (!_disposed)
                 {
-                    if (_fValidObject == true)
+                    if (_fValidObject)
                     {
                         lock (s_factoryMakerLock)
                         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GeneralTransformGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GeneralTransformGroup.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -42,7 +42,7 @@ namespace System.Windows.Media
             // transform the point through each of the transforms
             for (int i = 0; i < Children.Count; i++)
             {
-                if (Children.Internal_GetItem(i).TryTransform(inPoint, out result) == false)
+                if (!Children.Internal_GetItem(i).TryTransform(inPoint, out result))
                 {
                     fPointTransformed = false;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HitTestWithPointDrawingContextWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HitTestWithPointDrawingContextWalker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -397,7 +397,7 @@ namespace System.Windows.Media
         {
             set
             {
-                if (value == true)
+                if (value)
                 {
                     // Guard that we aren't already in a no-op layer
                     //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
@@ -1101,7 +1101,7 @@ namespace System.Windows.Media.Imaging
                 System.IO.FileStream filestream = stream as System.IO.FileStream;
                 try
                 {
-                    if (filestream.IsAsync is false)
+                    if (!filestream.IsAsync)
                     {
                         safeFilehandle = filestream.SafeFileHandle;
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapFrameDecode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapFrameDecode.cs
@@ -679,7 +679,7 @@ namespace System.Windows.Media.Imaging
                 if (_decoder.InternalDecoder == null)
                 {
                     Debug.Assert(_decoder is LateBoundBitmapDecoder);
-                    Debug.Assert(IsDownloading == false);
+                    Debug.Assert(!IsDownloading);
 
                     _decoder = ((LateBoundBitmapDecoder)_decoder).Decoder;
                     _syncObject = _decoder.SyncObject;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
@@ -197,21 +197,21 @@ namespace System.Windows.Media.Imaging
         {
             if (_pixelWidth == 0 && _pixelHeight != 0)
             {
-                Debug.Assert(_preservesAspectRatio == true);
+                Debug.Assert(_preservesAspectRatio);
 
                 newWidth = (uint)((_pixelHeight * width)/height);
                 newHeight = (uint)_pixelHeight;
             }
             else if (_pixelWidth != 0 && _pixelHeight == 0)
             {
-                Debug.Assert(_preservesAspectRatio == true);
+                Debug.Assert(_preservesAspectRatio);
 
                 newWidth = (uint)_pixelWidth;
                 newHeight = (uint)((_pixelWidth * height)/width);
             }
             else if (_pixelWidth != 0 && _pixelHeight != 0)
             {
-                Debug.Assert(_preservesAspectRatio == false);
+                Debug.Assert(!_preservesAspectRatio);
 
                 newWidth = (uint)_pixelWidth;
                 newHeight = (uint)_pixelHeight;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
@@ -533,7 +533,7 @@ namespace System.Windows.Media.Imaging
 
         private void EnsureShouldUseVirtuals()
         {
-            if (_useVirtuals == false)
+            if (!_useVirtuals)
             {
                 throw new NotImplementedException();
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/CachedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/CachedBitmap.cs
@@ -340,7 +340,7 @@ namespace System.Windows.Media.Imaging
                     int stride
                     )
         {
-            if (pixelFormat.Palettized == true && palette == null)
+            if (pixelFormat.Palettized && palette == null)
                 throw new InvalidOperationException(SR.Image_IndexedPixelFormatRequiresPalette);
 
             if (pixelFormat.Format == PixelFormatEnum.Default && pixelFormat.Guid == WICPixelFormatGUIDs.WICPixelFormatDontCare)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/LateBoundBitmapDecoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/LateBoundBitmapDecoder.cs
@@ -287,7 +287,7 @@ namespace System.Windows.Media.Imaging
             Stream newStream = (Stream)arg;
 
             // Assert that we are able to seek the new stream
-            Debug.Assert(newStream.CanSeek == true);
+            Debug.Assert(newStream.CanSeek);
 
             _stream = newStream;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
@@ -246,7 +246,7 @@ namespace System.Windows.Media
             else
                 isNumericColor = false;
 
-            if ((trimmedString.StartsWith("sc#", StringComparison.Ordinal) == true))
+            if ((trimmedString.StartsWith("sc#", StringComparison.Ordinal)))
             {
                 isNumericColor = false;
                 isScRgbColor = true;
@@ -258,7 +258,7 @@ namespace System.Windows.Media
                 isScRgbColor = false;
             }
 
-            if ((trimmedString.StartsWith(Parsers.s_ContextColor, StringComparison.OrdinalIgnoreCase) == true))
+            if ((trimmedString.StartsWith(Parsers.s_ContextColor, StringComparison.OrdinalIgnoreCase)))
             {
                 isContextColor = true;
                 isScRgbColor = false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -196,10 +196,10 @@ namespace MS.Internal
             bool isContextColor;
             string trimmedColor = KnownColors.MatchColor(color, out isPossibleKnowColor, out isNumericColor, out isContextColor, out isScRgbColor);
 
-            if ((isPossibleKnowColor == false) &&
-                (isNumericColor == false) &&
-                (isScRgbColor == false) &&
-                (isContextColor== false))
+            if ((!isPossibleKnowColor) &&
+                (!isNumericColor) &&
+                (!isScRgbColor) &&
+                (!isContextColor))
             {
                 throw new FormatException(SR.Parsers_IllegalToken);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/GeneralTransform3DGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/GeneralTransform3DGroup.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -45,7 +45,7 @@ namespace System.Windows.Media.Media3D
             // transform the point through each of the transforms
             for (int i = 0, count = children.Count; i < count; i++)
             {
-                if (children._collection[i].TryTransform(inPoint, out result) == false)
+                if (!children._collection[i].TryTransform(inPoint, out result))
                 {
                     pointTransformed = false;
                     break;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Navigation
             }
             else
             {
-                if (baseUri.IsAbsoluteUri == false)
+                if (!baseUri.IsAbsoluteUri)
                 {
                     // Most likely the BaseUriDP in element or IUriContext.BaseUri
                     // is set to a relative Uri programmatically in user's code.
@@ -226,7 +226,7 @@ namespace System.Windows.Navigation
         //
         internal static void GetAssemblyNameAndPart(Uri uri, out string partName, out string assemblyName, out string assemblyVersion, out string assemblyKey)
         {
-            Invariant.Assert(uri != null && uri.IsAbsoluteUri == false, "This method accepts relative uri only.");
+            Invariant.Assert(uri != null && !uri.IsAbsoluteUri, "This method accepts relative uri only.");
 
             string original = uri.ToString(); // only relative Uri here (enforced by Package)
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
@@ -258,7 +258,7 @@ namespace System.Windows
             ArgumentNullException.ThrowIfNull(ce);
 
 
-            if (true == (bool)ce.GetValue(GetsSourceChangedEventProperty))
+            if ((bool)ce.GetValue(GetsSourceChangedEventProperty))
             {
                 UpdateSourceOfElement(ce, null, null);
             }
@@ -519,7 +519,7 @@ namespace System.Windows
         {
             Debug.Assert(uie is UIElement3D or UIElement);
             
-            if (true == (bool)uie.GetValue(GetsSourceChangedEventProperty))
+            if ((bool)uie.GetValue(GetsSourceChangedEventProperty))
             {
                 UpdateSourceOfElement(uie, e.Ancestor, e.OldParent);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/RoutedEventHandlerInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/RoutedEventHandlerInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows
@@ -63,7 +63,7 @@ namespace System.Windows
         // invocation preferences
         internal void InvokeHandler(object target, RoutedEventArgs routedEventArgs)
         {
-            if ((routedEventArgs.Handled == false) || (_handledEventsToo == true))
+            if ((!routedEventArgs.Handled) || (_handledEventsToo))
             {
                 if (_handler is RoutedEventHandler)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
@@ -701,7 +701,7 @@ namespace System.Windows
             }
             finally
             {
-                if (etwTracingEnabled == true)
+                if (etwTracingEnabled)
                 {
                     EventTrace.EventProvider.TraceEvent(EventTrace.Event.WClientMeasureElementEnd, EventTrace.Keyword.KeywordLayout, EventTrace.Level.Verbose, perfElementID, _desiredSize.Width, _desiredSize.Height);
                 }
@@ -918,7 +918,7 @@ namespace System.Windows
                             try
                             {
                                 bool etwGeneralEnabled = EventTrace.IsEnabled(EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.Verbose);
-                                if (etwGeneralEnabled == true)
+                                if (etwGeneralEnabled)
                                 {
                                     EventTrace.EventProvider.TraceEvent(EventTrace.Event.WClientOnRenderBegin, EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.Verbose, perfElementID);
                                 }
@@ -929,7 +929,7 @@ namespace System.Windows
                                 }
                                 finally
                                 {
-                                    if (etwGeneralEnabled == true)
+                                    if (etwGeneralEnabled)
                                     {
                                         EventTrace.EventProvider.TraceEvent(EventTrace.Event.WClientOnRenderEnd, EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.Verbose, perfElementID);
                                     }
@@ -953,7 +953,7 @@ namespace System.Windows
             }
             finally
             {
-                if (etwTracingEnabled == true)
+                if (etwTracingEnabled)
                 {
                     EventTrace.EventProvider.TraceEvent(EventTrace.Event.WClientArrangeElementEnd, EventTrace.Keyword.KeywordLayout, EventTrace.Level.Verbose, perfElementID, finalRect.Top, finalRect.Left, finalRect.Width, finalRect.Height);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/JournalNavigationScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/JournalNavigationScope.cs
@@ -178,7 +178,7 @@ namespace MS.Internal.AppModel
         public void GoForward()
         {
             // CanGoForward checks the calling thread and InAppShutdown as well
-            if (CanGoForward == false)
+            if (!CanGoForward)
                 throw new InvalidOperationException(SR.NoForwardEntry);
 
             if (!_host.GoForwardOverride())
@@ -200,7 +200,7 @@ namespace MS.Internal.AppModel
         public void GoBack()
         {
             // CanGoBack checks the calling thread and InAppShutdown as well
-            if (CanGoBack == false)
+            if (!CanGoBack)
                 throw new InvalidOperationException(SR.NoBackEntry);
 
             if (!_host.GoBackOverride())

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/StickyNote/StickyNoteAnnotations.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/StickyNote/StickyNoteAnnotations.cs
@@ -1026,7 +1026,7 @@ namespace System.Windows.Controls
                 transformations.Children.Add(new TranslateTransform(anchor.X, anchor.Y));
 
                 TranslateTransform offsetTransform = new TranslateTransform(0, 0);
-                if (IsExpanded == true)
+                if (IsExpanded)
                 {
                     offsetTransform = PositionTransform.Clone();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/InkCanvasSelection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/InkCanvasSelection.cs
@@ -126,7 +126,7 @@ namespace MS.Internal.Ink
         /// <param name="activeSelectionHitResult"></param>
         internal void StartFeedbackAdorner(Rect feedbackRect, InkCanvasSelectionHitResult activeSelectionHitResult)
         {
-            Debug.Assert( _inkCanvas.EditingCoordinator.UserIsEditing == true );
+            Debug.Assert( _inkCanvas.EditingCoordinator.UserIsEditing);
             Debug.Assert(activeSelectionHitResult != InkCanvasSelectionHitResult.None, "activeSelectionHitResult cannot be InkCanvasSelectionHitResult.None.");
 
             _activeSelectionHitResult = activeSelectionHitResult;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/InkCollectionBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/InkCollectionBehavior.cs
@@ -204,7 +204,7 @@ namespace MS.Internal.Ink
         /// <returns></returns>
         protected override Cursor GetCurrentCursor()
         {
-            if ( EditingCoordinator.UserIsEditing == true )
+            if ( EditingCoordinator.UserIsEditing)
             {
                 return Cursors.None;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoHelper.cs
@@ -178,7 +178,7 @@ namespace MS.Internal.Ink
 
             foreach (Point point in points)
             {
-                if (true == Contains(point))
+                if (Contains(point))
                 {
                     countPointsInLasso++;
                     if (countPointsInLasso == marginCount)
@@ -192,7 +192,7 @@ namespace MS.Internal.Ink
         /// <summary>Checks whether supplied point is inside.</summary>
         private bool Contains(Point point)
         {
-            if (false == _boundingBox.Contains(point))
+            if (!_boundingBox.Contains(point))
             {
                 return false;
             }
@@ -202,7 +202,7 @@ namespace MS.Internal.Ink
 
             while (--last >= 0)
             {
-                if (false == DoubleUtil.AreClose(_lasso[last].Y, point.Y))
+                if (!DoubleUtil.AreClose(_lasso[last].Y, point.Y))
                 {
                     isHigher = point.Y < _lasso[last].Y;
                     break;
@@ -286,7 +286,7 @@ namespace MS.Internal.Ink
         /// </summary>
         private void EnsureReady()
         {
-            if (false == _isActivated)
+            if (!_isActivated)
             {
                 _isActivated = true;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoSelectionBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoSelectionBehavior.cs
@@ -357,7 +357,7 @@ namespace MS.Internal.Ink
         private void HitTestElement(InkCanvasInnerCanvas parent, UIElement uiElement, List<UIElement> elementsToSelect)
         {
             ElementCornerPoints elementPoints = GetTransformedElementCornerPoints(parent, uiElement);
-            if (elementPoints.Set != false)
+            if (elementPoints.Set)
             {
                 ReadOnlySpan<Point> points = GeneratePointGrid(elementPoints);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/SelectionEditingBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/SelectionEditingBehavior.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -372,7 +372,7 @@ namespace MS.Internal.Ink
         /// </summary>
         private void InitializeCapture()
         {
-            Debug.Assert(EditingCoordinator.UserIsEditing == false, "Unexpect UserIsEditng state." );
+            Debug.Assert(!EditingCoordinator.UserIsEditing, "Unexpect UserIsEditng state." );
             EditingCoordinator.UserIsEditing = true;
             InkCanvas.SelectionAdorner.CaptureMouse();
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Navigation/BindStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Navigation/BindStream.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -59,7 +59,7 @@ namespace MS.Internal.Navigation
 
         private void UpdateNavProgressHelper(long numBytes)
         {
-            if ((_callbackDispatcher != null) && (_callbackDispatcher.CheckAccess() != true))
+            if ((_callbackDispatcher != null) && (!_callbackDispatcher.CheckAccess()))
             {
                 _callbackDispatcher.BeginInvoke(
                                 DispatcherPriority.Send,
@@ -194,7 +194,7 @@ namespace MS.Internal.Navigation
 
             // if current dispatcher is not the same as the dispatcher we should call back on,
             // post to the call back dispatcher.
-            if ((_callbackDispatcher != null) && (_callbackDispatcher.CheckAccess() != true))
+            if ((_callbackDispatcher != null) && (!_callbackDispatcher.CheckAccess()))
             {
                 _callbackDispatcher.BeginInvoke(
                                 DispatcherPriority.Send,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FlowDocumentPage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FlowDocumentPage.cs
@@ -797,7 +797,7 @@ namespace MS.Internal.PtsHost
         private void Dispose(bool disposing)
         {
             // Do actual dispose only once.
-            if (Interlocked.CompareExchange(ref _disposed, true, false) == false)
+            if (!Interlocked.CompareExchange(ref _disposed, true, false))
             {
                 if (disposing)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PageBreakRecord.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PageBreakRecord.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -130,7 +130,7 @@ namespace MS.Internal.PtsHost
             PtsContext ptsContext = null;
 
             // Do actual dispose only once.
-            if (Interlocked.CompareExchange(ref _disposed, true, false) == false)
+            if (!Interlocked.CompareExchange(ref _disposed, true, false))
             {
                 // Dispose PTS break record.
                 // According to following article the entire reachable graph from 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsCache.cs
@@ -162,7 +162,7 @@ namespace MS.Internal.PtsHost
         ~PtsCache()
         {
             // After shutdown is initiated, do not allow Finalizer thread to the cleanup.
-            if (Interlocked.CompareExchange(ref _disposed, true, false) == false)
+            if (!Interlocked.CompareExchange(ref _disposed, true, false))
             {
                 // Destroy all PTS contexts
                 DestroyPTSContexts();
@@ -224,7 +224,7 @@ namespace MS.Internal.PtsHost
             {
                 // After shutdown is initiated, do not allow Finalizer thread to add any
                 // items to _releaseQueue.
-                if (_disposed == false)
+                if (!_disposed)
                 {
                     // Add PtsContext to collection of released PtsContexts.
                     // If the queue is empty, schedule Dispatcher time to dispose
@@ -291,7 +291,7 @@ namespace MS.Internal.PtsHost
 
             // After shutdown is initiated, do not allow Finalizer thread to add any
             // items to _releaseQueue.
-            if (Interlocked.CompareExchange(ref _disposed, true, false) == false)
+            if (!Interlocked.CompareExchange(ref _disposed, true, false))
             {
                 // Dispose any pending PtsContexts stored in _releaseQueue
                 OnPtsContextReleased(false);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -71,7 +71,7 @@ namespace MS.Internal.PtsHost
             int index;
 
             // Do actual dispose only once.
-            if (Interlocked.CompareExchange(ref _disposed, true, false) == false)
+            if (!Interlocked.CompareExchange(ref _disposed, true, false))
             {
                 // Destroy all page break records. The collection is allocated during creation
                 // of the context, and can be only destroyed during dispose process.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsPage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsPage.cs
@@ -704,7 +704,7 @@ namespace MS.Internal.PtsHost
         /// </remarks>
         private void Dispose(bool disposing)
         {
-            if (Interlocked.CompareExchange(ref _disposed, true, false) == false)
+            if (!Interlocked.CompareExchange(ref _disposed, true, false))
             {
                 // Destroy PTS page.
                 // According to following article the entire reachable graph from 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TableParaClient.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TableParaClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -2100,7 +2100,7 @@ namespace MS.Internal.PtsHost
             {
                 // have no choice - table's parent requires the width to be exact
                 durTableUserWidth = durAvailableWidth;
-                if (durTableUserWidth < _durMinWidth && DoubleUtil.AreClose(durTableUserWidth, _durMinWidth) == false)
+                if (durTableUserWidth < _durMinWidth && !DoubleUtil.AreClose(durTableUserWidth, _durMinWidth))
                 {
                     durTableUserWidth = _durMinWidth;
                 }
@@ -2114,7 +2114,7 @@ namespace MS.Internal.PtsHost
                     double tr = iP * mul;
 
                     // floating point (tl > tr)
-                    if (tl > tr && DoubleUtil.AreClose(tl, tr) == false)
+                    if (tl > tr && !DoubleUtil.AreClose(tl, tr))
                     {
                         mul = durAbsoluteMax + durAutoMax;
                         div = iP;
@@ -2130,7 +2130,7 @@ namespace MS.Internal.PtsHost
                     durTableUserWidth = mul * 100 / div + durTotalPadding;
 
                     // floating point (durTableUserWidth > durAvailableWidth)
-                    if (durTableUserWidth > durAvailableWidth && DoubleUtil.AreClose(durTableUserWidth, durAvailableWidth) == false)
+                    if (durTableUserWidth > durAvailableWidth && !DoubleUtil.AreClose(durTableUserWidth, durAvailableWidth))
                     {
                         durTableUserWidth = durAvailableWidth;
                     }
@@ -2142,7 +2142,7 @@ namespace MS.Internal.PtsHost
                 }
 
                 // floating point (durTableUserWidth < _durMinWidth)
-                if (durTableUserWidth < _durMinWidth && DoubleUtil.AreClose(durTableUserWidth, _durMinWidth) == false)
+                if (durTableUserWidth < _durMinWidth && !DoubleUtil.AreClose(durTableUserWidth, _durMinWidth))
                 {
                     durTableUserWidth = _durMinWidth;
                 }
@@ -2150,13 +2150,13 @@ namespace MS.Internal.PtsHost
             else
             {
                 // floating point (_durMaxWidth < durAvailableWidth)
-                if (_durMaxWidth < durAvailableWidth && DoubleUtil.AreClose(_durMaxWidth, durAvailableWidth) == false)
+                if (_durMaxWidth < durAvailableWidth && !DoubleUtil.AreClose(_durMaxWidth, durAvailableWidth))
                 {
                     // use max value if that smaller the parent size
                     durTableUserWidth = _durMaxWidth;
                 }
                 // floating point (_durMinWidth > durAvailableWidth)
-                else if (_durMinWidth > durAvailableWidth && DoubleUtil.AreClose(_durMinWidth, durAvailableWidth) == false)
+                else if (_durMinWidth > durAvailableWidth && !DoubleUtil.AreClose(_durMinWidth, durAvailableWidth))
                 {
                     // have to use min if that is bigger the parent
                     durTableUserWidth = _durMinWidth;
@@ -2179,19 +2179,19 @@ namespace MS.Internal.PtsHost
 
             // floating point (0 < (durAutoMax + durAbsoluteMax))
             // Step 4 - Calculate the space for 'auto' sized columns.
-            if (0 < (durAutoMax + durAbsoluteMax) && DoubleUtil.IsZero(durAutoMax + durAbsoluteMax) == false)
+            if (0 < (durAutoMax + durAbsoluteMax) && !DoubleUtil.IsZero(durAutoMax + durAbsoluteMax))
             {
                 // cache width remaining for normal and user columns over percent columns (durAbsoluteAndAutoWidths)
                 durAbsoluteAndAutoWidths = iP * durTableUserWidth / 100;
 
                 // floating point (durAbsoluteAndAutoWidths < (durAbsoluteMin + durAutoMin))
-                if (durAbsoluteAndAutoWidths < (durAbsoluteMin + durAutoMin) && DoubleUtil.AreClose(durAbsoluteAndAutoWidths, (durAbsoluteMin + durAutoMin)) == false)
+                if (durAbsoluteAndAutoWidths < (durAbsoluteMin + durAutoMin) && !DoubleUtil.AreClose(durAbsoluteAndAutoWidths, (durAbsoluteMin + durAutoMin)))
                 {
                     durAbsoluteAndAutoWidths = durAbsoluteMin + durAutoMin;
                 }
 
                 // floating point (durAbsoluteAndAutoWidths > (durTableUserWidth - durScalableMin))
-                if (durAbsoluteAndAutoWidths > (durTableUserWidth - durScalableMin) && DoubleUtil.AreClose(durAbsoluteAndAutoWidths, (durTableUserWidth - durScalableMin)) == false)
+                if (durAbsoluteAndAutoWidths > (durTableUserWidth - durScalableMin) && !DoubleUtil.AreClose(durAbsoluteAndAutoWidths, (durTableUserWidth - durScalableMin)))
                 {
                     durAbsoluteAndAutoWidths = durTableUserWidth - durScalableMin;
                 }
@@ -2207,16 +2207,16 @@ namespace MS.Internal.PtsHost
             // first try to use max width for user columns and normal columns
             //
             // floating point (0 < durAbsoluteMax)
-            if (0 < durAbsoluteMax && DoubleUtil.IsZero(durAbsoluteMax) == false)
+            if (0 < durAbsoluteMax && !DoubleUtil.IsZero(durAbsoluteMax))
             {
                 durAbsoluteWidths = durAbsoluteMax;
-                if (durAbsoluteWidths > durAbsoluteAndAutoWidths && DoubleUtil.AreClose(durAbsoluteWidths, durAbsoluteAndAutoWidths) == false)
+                if (durAbsoluteWidths > durAbsoluteAndAutoWidths && !DoubleUtil.AreClose(durAbsoluteWidths, durAbsoluteAndAutoWidths))
                 {
                     durAbsoluteWidths = durAbsoluteAndAutoWidths;
                 }
 
                 // floating point (0 < durAutoMax)
-                if (0 < durAutoMax && DoubleUtil.IsZero(durAutoMax) == false)
+                if (0 < durAutoMax && !DoubleUtil.IsZero(durAutoMax))
                 {
                     durAutoWidths = durAutoMin;
 
@@ -2241,7 +2241,7 @@ namespace MS.Internal.PtsHost
                     durAutoWidths = 0;
 
                     // floating point (durAbsoluteWidths < durAbsoluteAndAutoWidths)
-                    if (durAbsoluteWidths < durAbsoluteAndAutoWidths && DoubleUtil.AreClose(durAbsoluteWidths, durAbsoluteAndAutoWidths) == false)
+                    if (durAbsoluteWidths < durAbsoluteAndAutoWidths && !DoubleUtil.AreClose(durAbsoluteWidths, durAbsoluteAndAutoWidths))
                     {
                         durAbsoluteWidths = durAbsoluteAndAutoWidths;
                     }
@@ -2252,12 +2252,12 @@ namespace MS.Internal.PtsHost
                 durAbsoluteWidths = 0;
 
                 // floating point (0 < durAutoMax)
-                if (0 < durAutoMax && DoubleUtil.IsZero(durAutoMax) == false)
+                if (0 < durAutoMax && !DoubleUtil.IsZero(durAutoMax))
                 {
                     durAutoWidths = durAutoMin;
 
                     // floating point (durAutoWidths < durAbsoluteAndAutoWidths)
-                    if (durAutoWidths < durAbsoluteAndAutoWidths && DoubleUtil.AreClose(durAutoWidths, durAbsoluteAndAutoWidths) == false)
+                    if (durAutoWidths < durAbsoluteAndAutoWidths && !DoubleUtil.AreClose(durAutoWidths, durAbsoluteAndAutoWidths))
                     {
                         durAutoWidths = durAbsoluteAndAutoWidths;
                     }
@@ -2269,7 +2269,7 @@ namespace MS.Internal.PtsHost
             }
 
             // floating point (durAutoWidths > durAutoMax)
-            if (durAutoWidths > durAutoMax && DoubleUtil.AreClose(durAutoWidths, durAutoMax) == false)
+            if (durAutoWidths > durAutoMax && !DoubleUtil.AreClose(durAutoWidths, durAutoMax))
             {
                 fUseMaxMax = true;
             }
@@ -2284,13 +2284,13 @@ namespace MS.Internal.PtsHost
                 fUseMin = true;
             }
             // floating point (durAutoWidths < durAutoMax)
-            else if (durAutoWidths < durAutoMax && DoubleUtil.AreClose(durAutoWidths, durAutoMax) == false)
+            else if (durAutoWidths < durAutoMax && !DoubleUtil.AreClose(durAutoWidths, durAutoMax))
             {
                 fSubtract = true;
             }
 
             // floating point (durAbsoluteWidths > durAbsoluteMax)
-            if (durAbsoluteWidths > durAbsoluteMax && DoubleUtil.AreClose(durAbsoluteWidths, durAbsoluteMax) == false)
+            if (durAbsoluteWidths > durAbsoluteMax && !DoubleUtil.AreClose(durAbsoluteWidths, durAbsoluteMax))
             {
                 fUseUserMaxMax = true;
             }
@@ -2305,7 +2305,7 @@ namespace MS.Internal.PtsHost
                 fUseUserMin = true;
             }
             // floating point (durAbsoluteWidths < durAbsoluteMax)
-            else if (durAbsoluteWidths < durAbsoluteMax && DoubleUtil.AreClose(durAbsoluteWidths, durAbsoluteMax) == false)
+            else if (durAbsoluteWidths < durAbsoluteMax && !DoubleUtil.AreClose(durAbsoluteWidths, durAbsoluteMax))
             {
                 fUserSubtract = true;
             }
@@ -2336,7 +2336,7 @@ namespace MS.Internal.PtsHost
                         : fUseMin
                         ? _calculatedColumns[i].DurMinWidth
                           // floating point (0 < durAutoMax)
-                        : (0 < durAutoMax && DoubleUtil.IsZero(durAutoMax) == false)
+                        : (0 < durAutoMax && !DoubleUtil.IsZero(durAutoMax))
                         ? _calculatedColumns[i].DurMinWidth + (_calculatedColumns[i].DurMaxWidth * (durAutoWidths - durAutoMin) / durAutoMax)
                         : 0;
                 }
@@ -2356,7 +2356,7 @@ namespace MS.Internal.PtsHost
                     durAbsoluteAndAutoWidths -= _calculatedColumns[i].DurMinWidth;
 
                     // floating point (durAbsoluteAndAutoWidths < 0)
-                    if (durAbsoluteAndAutoWidths < 0 && DoubleUtil.IsZero(durAbsoluteAndAutoWidths) == false)
+                    if (durAbsoluteAndAutoWidths < 0 && !DoubleUtil.IsZero(durAbsoluteAndAutoWidths))
                     {
                         durAbsoluteAndAutoWidths = 0;
                     }
@@ -2384,7 +2384,7 @@ namespace MS.Internal.PtsHost
                         : fUseUserMin
                         ? _calculatedColumns[i].DurMinWidth
                         // floating point (0 < durAbsoluteMax)
-                        : (0 < durAbsoluteMax && DoubleUtil.IsZero(durAbsoluteMax) == false)
+                        : (0 < durAbsoluteMax && !DoubleUtil.IsZero(durAbsoluteMax))
                         ? _calculatedColumns[i].DurMinWidth + (_calculatedColumns[i].DurMaxWidth * (durAbsoluteWidths - durAbsoluteMin) / durAbsoluteMax)
                         : 0;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Utility/BindUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Utility/BindUriHelper.cs
@@ -69,7 +69,7 @@ namespace MS.Internal.Utility
         {
             Uri uriToNavigate = inputUri;
 
-            if ((inputUri == null) || (inputUri.IsAbsoluteUri == true))
+            if ((inputUri == null) || (inputUri.IsAbsoluteUri))
             {
                 return uriToNavigate;
             }
@@ -84,7 +84,7 @@ namespace MS.Internal.Utility
 
             if (baseUri != null)
             {
-                if (baseUri.IsAbsoluteUri == false)
+                if (!baseUri.IsAbsoluteUri)
                 {
                     uriToNavigate = GetResolvedUri(BindUriHelper.GetResolvedUri(null, baseUri), inputUri);
                 }
@@ -147,7 +147,7 @@ namespace MS.Internal.Utility
             string fragment = String.Empty;
             string frag;
 
-            if (uri.IsAbsoluteUri == false)
+            if (!uri.IsAbsoluteUri)
             {
                 // this is a relative uri, and Fragement() doesn't work with relative uris.  The base uri is completley irrelevant 
                 // here and will never affect the returned fragment, but the method requires something to be there.  Therefore, 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Appearance/WindowBackdropManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Appearance/WindowBackdropManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Interop;
@@ -30,7 +30,7 @@ internal static class WindowBackdropManager
         if (window is null ||
                 !IsSupported(backdropType) ||
                 window.AllowsTransparency ||
-                IsBackdropEnabled == false)
+!IsBackdropEnabled)
         {
             return false;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -102,7 +102,7 @@ namespace System.Windows
             {
                 // set the default statics
                 // DO NOT move this from the begining of this constructor
-                if (_appCreatedInThisAppDomain == false)
+                if (!_appCreatedInThisAppDomain)
                 {
                     Debug.Assert(_appInstance == null, "_appInstance must be null here.");
                     _appInstance = this;
@@ -240,7 +240,7 @@ namespace System.Windows
         {
             VerifyAccess();
             //Already called once??
-            if (IsShuttingDown == true)
+            if (IsShuttingDown)
             {
                 return;
             }
@@ -351,7 +351,7 @@ namespace System.Windows
             if (resourceLocator.OriginalString == null)
                 throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull,"resourceLocator", "OriginalString"));
 
-            if (resourceLocator.IsAbsoluteUri == true)
+            if (resourceLocator.IsAbsoluteUri)
                 throw new ArgumentException(SR.AbsoluteUriNotAllowed);
 
             // Passed a relative Uri here.
@@ -378,7 +378,7 @@ namespace System.Windows
             // Check if this component was originally being created from the same Uri by the BamlConverter
             // or LoadComponent(uri).
             //
-            if (IsComponentBeingLoadedFromOuterLoadBaml(currentUri) == true)
+            if (IsComponentBeingLoadedFromOuterLoadBaml(currentUri))
             {
                 NestedBamlLoadInfo nestedBamlLoadInfo = s_NestedBamlLoadInfo.Peek();
 
@@ -441,7 +441,7 @@ namespace System.Windows
             if (resourceLocator.OriginalString == null)
                 throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull,"resourceLocator", "OriginalString"));
 
-            if (resourceLocator.IsAbsoluteUri == true)
+            if (resourceLocator.IsAbsoluteUri)
                 throw new ArgumentException(SR.AbsoluteUriNotAllowed);
 
             return LoadComponent(resourceLocator, false);
@@ -578,7 +578,7 @@ namespace System.Windows
             if (uriResource.OriginalString == null)
                 throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull, "uriResource", "OriginalString"));
 
-            if (uriResource.IsAbsoluteUri == true && !BaseUriHelper.IsPackApplicationUri(uriResource))
+            if (uriResource.IsAbsoluteUri && !BaseUriHelper.IsPackApplicationUri(uriResource))
             {
                 throw new ArgumentException(SR.NonPackAppAbsoluteUriNotAllowed);
             }
@@ -610,7 +610,7 @@ namespace System.Windows
             if (uriContent.OriginalString == null)
                 throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull, "uriContent", "OriginalString"));
 
-            if (uriContent.IsAbsoluteUri == true && !BaseUriHelper.IsPackApplicationUri(uriContent))
+            if (uriContent.IsAbsoluteUri && !BaseUriHelper.IsPackApplicationUri(uriContent))
             {
                 throw new ArgumentException(SR.NonPackAppAbsoluteUriNotAllowed);
             }
@@ -639,9 +639,9 @@ namespace System.Windows
             if (uriRemote.OriginalString == null)
                 throw new ArgumentException(SR.Format(SR.ArgumentPropertyMustNotBeNull, "uriRemote", "OriginalString"));
 
-            if (uriRemote.IsAbsoluteUri == true)
+            if (uriRemote.IsAbsoluteUri)
             {
-                if (BaseUriHelper.SiteOfOriginBaseUri.IsBaseOf(uriRemote) != true)
+                if (!BaseUriHelper.SiteOfOriginBaseUri.IsBaseOf(uriRemote))
                 {
                     throw new ArgumentException(SR.NonPackSooAbsoluteUriNotAllowed);
                 }
@@ -698,7 +698,7 @@ namespace System.Windows
             }
 
             // When stream is not null, sooPart cannot be null either
-            Debug.Assert( ((stream != null) && (sooPart == null)) != true,  "When stream is not null, sooPart cannot be null either");
+            Debug.Assert(stream == null || sooPart != null,  "When stream is not null, sooPart cannot be null either");
 
             return (stream == null) ? null : new StreamResourceInfo(stream, sooPart.ContentType);
         }
@@ -835,7 +835,7 @@ namespace System.Windows
                 {
                     throw new InvalidEnumArgumentException("value", (int)value, typeof(ShutdownMode));
                 }
-                if (IsShuttingDown == true || _appIsShutdown == true)
+                if (IsShuttingDown || _appIsShutdown)
                 {
                     throw new InvalidOperationException(SR.ShutdownModeWhenAppShutdown);
                 }
@@ -1528,7 +1528,7 @@ namespace System.Windows
 
             if (StartupUri != null)
             {
-                if (StartupUri.IsAbsoluteUri == false)
+                if (!StartupUri.IsAbsoluteUri)
                 {
                     // Resolve it against the ApplicationMarkupBaseUri.
                     StartupUri = new Uri(ApplicationMarkupBaseUri, StartupUri);
@@ -1585,7 +1585,7 @@ namespace System.Windows
         /// </summary>
         internal virtual void DoShutdown()
         {
-            Debug.Assert(CheckAccess() == true, "DoShutdown can only be called on the Dispatcer thread");
+            Debug.Assert(CheckAccess(), "DoShutdown can only be called on the Dispatcer thread");
             // We need to know if we have been shut down already.
             // We cannot check the IsShuttingDown variable because it is set true
             // in the function that calls us.
@@ -1675,19 +1675,19 @@ namespace System.Windows
             // In this case, we should throw an exception when Run is called for the second time.
             // When app is shutdown, _appIsShutdown is set to true.  If it is true here, then we
             // throw an exception
-            if (_appIsShutdown == true)
+            if (_appIsShutdown)
             {
                 throw new InvalidOperationException(SR.Format(SR.CannotCallRunMultipleTimes, this.GetType().FullName));
             }
 
             if (window != null)
             {
-                if (window.CheckAccess() == false)
+                if (!window.CheckAccess())
                 {
                     throw new ArgumentException(SR.Format(SR.WindowPassedShouldBeOnApplicationThread, window.GetType().FullName, this.GetType().FullName));
                 }
 
-                if (WindowsInternal.HasItem(window) == false)
+                if (!WindowsInternal.HasItem(window))
                 {
                     WindowsInternal.Add(window);
                 }
@@ -2099,7 +2099,7 @@ namespace System.Windows
             // Event handler exception continuality: if exception occurs in Activate/Deactivate event handlers, our state would not
             // be corrupted because no internal state are affected by Activate/Deactivate. Please check Event handler exception continuality
             // if a state depending on those events is added.
-            if (isActivated == true)
+            if (isActivated)
             {
                 OnActivated(EventArgs.Empty);
             }
@@ -2122,7 +2122,7 @@ namespace System.Windows
             OnSessionEnding( secEventArgs );
 
             // shut down the app if not cancelled
-            if ( secEventArgs.Cancel == false )
+            if (!secEventArgs.Cancel)
             {
                 Shutdown();
                 // return true to the wnd proc to signal that we can terminate properly
@@ -2148,7 +2148,7 @@ namespace System.Windows
             {
                 // calling thread is the same as the wc[i] thread so synchronously invalidate
                 // resouces, else, post a dispatcher workitem to invalidate resources.
-                if (wc[i].CheckAccess() == true)
+                if (wc[i].CheckAccess())
                 {
                     // Set the ShouldLookupImplicitStyles flag on the App's windows
                     // to true if App.Resources has implicit styles.
@@ -2210,7 +2210,7 @@ namespace System.Windows
             finally
             {
                 // Quit the dispatcher if we ran our own.
-                if (_ownDispatcherStarted == true)
+                if (_ownDispatcherStarted)
                 {
                     Dispatcher.CriticalInvokeShutdown();
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/BroadcastEventHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/BroadcastEventHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Media;
@@ -128,7 +128,7 @@ namespace System.Windows
             // Added to a tree
             if (oldParent == null && newParent != null)
             {
-                if(IsLoadedHelper(newParent) == true)
+                if(IsLoadedHelper(newParent))
                 {
                     // Broadcast Loaded event if your new parent is loaded
                     // Note that this broadcast will take place when you are
@@ -139,7 +139,7 @@ namespace System.Windows
             // Removed from a tree
             else if (oldParent != null && newParent == null)
             {
-                if (IsLoadedHelper(oldParent) == true)
+                if (IsLoadedHelper(oldParent))
                 {
                     // Broadcast Unloaded event if your old parent was loaded
                     // Note that this broadcast will take place when you are

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/AVElementHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/AVElementHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -454,7 +454,7 @@ namespace System.Windows.Controls
                 // We shouldn't have a clock to open because this would have a state
                 // request of MediaState.Manual.
                 //
-                Invariant.Assert(openClock == false);
+                Invariant.Assert(!openClock);
 
                 //
                 // If we had a clock, get rid of it now. This is to handle the case

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Button.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Button.cs
@@ -218,7 +218,7 @@ namespace System.Windows.Controls
                 thisScope = e.Scope;
 
                 // Step 3: Compare scopes
-                if (thisScope == focusScope && (focusDO == null || (bool)focusDO.GetValue(KeyboardNavigation.AcceptsReturnProperty) == false))
+                if (thisScope == focusScope && (focusDO == null || !(bool)focusDO.GetValue(KeyboardNavigation.AcceptsReturnProperty)))
                 {
                     isDefaulted = BooleanBoxes.TrueBox;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ComboBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ComboBox.cs
@@ -1846,7 +1846,7 @@ namespace System.Windows.Controls
 
             SetCurrentValueInternal(IsDropDownOpenProperty, BooleanBoxes.Box(openDropDown));
 
-            if (openDropDown == false && commitSelection && (infoToSelect != null))
+            if (!openDropDown && commitSelection && (infoToSelect != null))
             {
                 SelectionChange.SelectJustThisItem(infoToSelect, true /* assumeInItemsCollection */);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ContextMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ContextMenu.cs
@@ -628,7 +628,7 @@ namespace System.Windows.Controls
             // in this case.
             //
             // See MenuBase.OnIsKeyboardFocusWithinChanged
-            if((bool)e.NewValue == false)
+            if(!(bool)e.NewValue)
             {
                 _weakRefToPreviousFocus = null;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -3933,7 +3933,7 @@ namespace System.Windows.Controls
         internal void OnLoadingRowDetailsWrapper(DataGridRow row)
         {
             if (row != null &&
-                row.DetailsLoaded == false &&
+!row.DetailsLoaded &&
                 row.DetailsVisibility == Visibility.Visible &&
                 row.DetailsPresenter != null)
             {
@@ -3946,7 +3946,7 @@ namespace System.Windows.Controls
         internal void OnUnloadingRowDetailsWrapper(DataGridRow row)
         {
             if (row != null &&
-                row.DetailsLoaded == true &&
+                row.DetailsLoaded &&
                 row.DetailsPresenter != null)
             {
                 DataGridRowDetailsEventArgs e = new DataGridRowDetailsEventArgs(row, row.DetailsPresenter.DetailsElement);
@@ -7046,7 +7046,7 @@ namespace System.Windows.Controls
             DataGrid dataGrid = (DataGrid)d;
             if (DataGridHelper.IsPropertyTransferEnabled(dataGrid, CanUserSortColumnsProperty) &&
                 DataGridHelper.IsDefaultValue(dataGrid, CanUserSortColumnsProperty) &&
-                dataGrid.Items.CanSort == false)
+!dataGrid.Items.CanSort)
             {
                 return false;
             }
@@ -7611,7 +7611,7 @@ namespace System.Windows.Controls
                 _selectedCells.RestoreOnlyFullRows(ranges);
             }
 
-            if (AutoGenerateColumns == true)
+            if (AutoGenerateColumns)
             {
                 RegenerateAutoColumns();
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -3933,7 +3933,7 @@ namespace System.Windows.Controls
         internal void OnLoadingRowDetailsWrapper(DataGridRow row)
         {
             if (row != null &&
-!row.DetailsLoaded &&
+                !row.DetailsLoaded &&
                 row.DetailsVisibility == Visibility.Visible &&
                 row.DetailsPresenter != null)
             {
@@ -7046,7 +7046,7 @@ namespace System.Windows.Controls
             DataGrid dataGrid = (DataGrid)d;
             if (DataGridHelper.IsPropertyTransferEnabled(dataGrid, CanUserSortColumnsProperty) &&
                 DataGridHelper.IsDefaultValue(dataGrid, CanUserSortColumnsProperty) &&
-!dataGrid.Items.CanSort)
+                !dataGrid.Items.CanSort)
             {
                 return false;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumnCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumnCollection.cs
@@ -409,7 +409,7 @@ namespace System.Windows.Controls
             Debug.Assert(
                 newColumns.Count == 1,
                 "This derives from ObservableCollection; it is impossible to add multiple columns at once");
-            Debug.Assert(IsUpdatingDisplayIndex == false, "We don't add new columns as part of a display index update operation");
+            Debug.Assert(!IsUpdatingDisplayIndex, "We don't add new columns as part of a display index update operation");
 
             try
             {
@@ -553,7 +553,7 @@ namespace System.Windows.Controls
             Debug.Assert(
                 oldColumns.Count == 1,
                 "This derives from ObservableCollection; it is impossible to remove multiple columns at once");
-            Debug.Assert(IsUpdatingDisplayIndex == false, "We don't remove columns as part of a display index update operation");
+            Debug.Assert(!IsUpdatingDisplayIndex, "We don't remove columns as part of a display index update operation");
 
             try
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Frame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Frame.cs
@@ -561,7 +561,7 @@ namespace System.Windows.Controls
             // post it from the LoadedHandler.  This guarantees that
             // we don't fire ContentRendered on a subtree that is not
             // connected to a PresentationSource
-            if (IsLoaded == true)
+            if (IsLoaded)
             {
                 PostContentRendered();
             }
@@ -571,7 +571,7 @@ namespace System.Windows.Controls
                 // that we deferred to the Loaded event to PostConetentRendered
                 // for the previous content change and Loaded has not fired yet.
                 // Thus we don't want to hook up another event handler
-                if (_postContentRenderedFromLoadedHandler == false)
+                if (!_postContentRenderedFromLoadedHandler)
                 {
                     this.Loaded += new RoutedEventHandler(LoadedHandler);
                     _postContentRenderedFromLoadedHandler = true;
@@ -581,7 +581,7 @@ namespace System.Windows.Controls
 
         private void LoadedHandler(object sender, RoutedEventArgs args)
         {
-            if (_postContentRenderedFromLoadedHandler == true)
+            if (_postContentRenderedFromLoadedHandler)
             {
                 PostContentRendered();
                 _postContentRenderedFromLoadedHandler = false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
@@ -3983,7 +3983,7 @@ namespace System.Windows.Controls
                 {
                     Grid grid = VisualTreeHelper.GetParent(this) as Grid;
                     if (    grid == null
-                        ||  grid.ShowGridLines == false )
+                        || !grid.ShowGridLines)
                     {
                         return;
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumnCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumnCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -137,7 +137,7 @@ namespace System.Windows.Controls
         /// </summary>
         internal void BlockWrite()
         {
-            Debug.Assert(IsImmutable != true, "IsImmutable is true before BlockWrite");
+            Debug.Assert(!IsImmutable, "IsImmutable is true before BlockWrite");
             IsImmutable = true;
         }
 
@@ -146,7 +146,7 @@ namespace System.Windows.Controls
         /// </summary>
         internal void UnblockWrite()
         {
-            Debug.Assert(IsImmutable != false, "IsImmutable is flase before UnblockWrite");
+            Debug.Assert(IsImmutable, "IsImmutable is flase before UnblockWrite");
             IsImmutable = false;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/InkCanvas.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/InkCanvas.cs
@@ -1089,7 +1089,7 @@ namespace System.Windows.Controls
                             // now that we've raised the Gesture event and the developer
                             // has had a chance to change args.Cancel, see what their intent is.
                             //
-                            if (args.Cancel == false)
+                            if (!args.Cancel)
                             {
                                 //bail out and don't add
                                 //the stroke to InkCanvas.Strokes

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemCollection.cs
@@ -1545,7 +1545,7 @@ namespace System.Windows.Controls
 
         internal void BeginInit()
         {
-            Debug.Assert(_isInitializing == false);
+            Debug.Assert(!_isInitializing);
             _isInitializing = true;
             if (_collectionView != null)            // disconnect from collectionView to cut extraneous events
                 UnhookCollectionView(_collectionView);
@@ -1553,7 +1553,7 @@ namespace System.Windows.Controls
 
         internal void EndInit()
         {
-            Debug.Assert(_isInitializing == true);
+            Debug.Assert(_isInitializing);
             EnsureCollectionView();
             _isInitializing = false;                // now we allow collectionView to be hooked up again
             if (_collectionView != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
@@ -391,7 +391,7 @@ namespace System.Windows.Controls
                 case Key.Space:
                 case Key.Enter:
                     {
-                        if (e.Key == Key.Enter && (bool)GetValue(KeyboardNavigation.AcceptsReturnProperty) == false)
+                        if (e.Key == Key.Enter && !(bool)GetValue(KeyboardNavigation.AcceptsReturnProperty))
                         {
                             handled = false;
                             break;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -1500,7 +1500,7 @@ namespace System.Windows.Controls
 
                     if (role == MenuItemRole.TopLevelItem || role == MenuItemRole.SubmenuItem)
                     {
-                        if (_userInitiatedPress == true)
+                        if (_userInitiatedPress)
                         {
                             ClickItem(e.UserInitiated);
                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Page.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Page.cs
@@ -168,7 +168,7 @@ namespace System.Windows.Controls
                     PageHelperObject._windowTitle = value;
                     PropertyIsSet(SetPropertyFlags.WindowTitle);
                 }
-                else if (_isTopLevel == true) // only top level page can set this property
+                else if (_isTopLevel) // only top level page can set this property
                 {
                     WindowService.Title = value;
                     PropertyIsSet(SetPropertyFlags.WindowTitle);
@@ -223,7 +223,7 @@ namespace System.Windows.Controls
                     PageHelperObject._windowHeight = value;
                     PropertyIsSet(SetPropertyFlags.WindowHeight);
                 }
-                else if (_isTopLevel == true)// only top level page can set this property
+                else if (_isTopLevel)// only top level page can set this property
                 {
                     if (!WindowService.UserResized)
                     {
@@ -275,7 +275,7 @@ namespace System.Windows.Controls
                     PageHelperObject._windowWidth = value;
                     PropertyIsSet(SetPropertyFlags.WindowWidth);
                 }
-                else if (_isTopLevel == true) // only top level page can set this property
+                else if (_isTopLevel) // only top level page can set this property
                 {
                     if (!WindowService.UserResized)
                     {
@@ -381,7 +381,7 @@ namespace System.Windows.Controls
                     PageHelperObject._showsNavigationUI = value;
                     PropertyIsSet(SetPropertyFlags.ShowsNavigationUI);
                 }
-                else if (_isTopLevel == true) // only top level page can set this property
+                else if (_isTopLevel) // only top level page can set this property
                 {
                     SetShowsNavigationUI(value);
                     PropertyIsSet(SetPropertyFlags.ShowsNavigationUI);
@@ -692,7 +692,7 @@ namespace System.Windows.Controls
                 }
             }
 
-            if (isParentValid == false)
+            if (!isParentValid)
             {
                 throw new InvalidOperationException(SR.ParentOfPageMustBeWindowOrFrame);
             }
@@ -744,7 +744,7 @@ namespace System.Windows.Controls
 
             if (_currentIws != null)
             {
-                if (_isTopLevel == true)
+                if (_isTopLevel)
                 {
                     PropagateProperties();
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Selector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Selector.cs
@@ -1198,7 +1198,7 @@ namespace System.Windows.Controls.Primitives
 
                     // This is to support the MasterDetail scenario.
                     // When the Items is refreshed, Items.Current could be the old selection for this view.
-                    if (Items.CurrentItem != null && IsSynchronizedWithCurrentItemPrivate == true)
+                    if (Items.CurrentItem != null && IsSynchronizedWithCurrentItemPrivate)
                     {
                         // This won't work if the items are the containers and they have IsSelected=true.
 
@@ -1425,7 +1425,7 @@ namespace System.Windows.Controls.Primitives
 
             selectable = ItemGetIsSelectable(item);
 
-            if (selectable == false && selected)
+            if (!selectable && selected)
             {
                 throw new InvalidOperationException(SR.CannotSelectNotSelectableItem);
             }
@@ -2846,7 +2846,7 @@ namespace System.Windows.Controls.Primitives
                 get { return _set != null; }
                 set
                 {
-                    if (value == true && _set == null)
+                    if (value && _set == null)
                     {
                         _set = new Dictionary<ItemInfo, ItemInfo>(_list.Count);
                         for (int i=0; i<_list.Count; ++i)
@@ -2854,7 +2854,7 @@ namespace System.Windows.Controls.Primitives
                             _set.Add(_list[i], _list[i]);
                         }
                     }
-                    else if (value == false)
+                    else if (!value)
                     {
                         _set = null;
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PrintDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PrintDialog.cs
@@ -240,8 +240,8 @@ namespace System.Windows.Controls
         {
             get
             {
-                if( ((_isPrintableAreaWidthUpdated == false) && (_isPrintableAreaHeightUpdated == false)) ||
-                    ((_isPrintableAreaWidthUpdated == true)  && (_isPrintableAreaHeightUpdated == false)))
+                if( ((!_isPrintableAreaWidthUpdated) && (!_isPrintableAreaHeightUpdated)) ||
+                    ((_isPrintableAreaWidthUpdated)  && (!_isPrintableAreaHeightUpdated)))
                 {
                     _isPrintableAreaWidthUpdated  = true;
                     _isPrintableAreaHeightUpdated = false;
@@ -262,8 +262,8 @@ namespace System.Windows.Controls
         {
             get
             {
-                if( ((_isPrintableAreaWidthUpdated == false) && (_isPrintableAreaHeightUpdated == false)) ||
-                    ((_isPrintableAreaWidthUpdated == false)  && (_isPrintableAreaHeightUpdated == true)))
+                if( ((!_isPrintableAreaWidthUpdated) && (!_isPrintableAreaHeightUpdated)) ||
+                    ((!_isPrintableAreaWidthUpdated)  && (_isPrintableAreaHeightUpdated)))
                 {
                     _isPrintableAreaWidthUpdated  = false;
                     _isPrintableAreaHeightUpdated = true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/StickyNote.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/StickyNote.cs
@@ -557,7 +557,7 @@ namespace System.Windows.Controls
             ApplyTemplate();
 
             // We are interested in the expanded note.
-            if ( IsExpanded == true )
+            if (IsExpanded)
             {
                 Invariant.Assert(Content != null);
 
@@ -569,7 +569,7 @@ namespace System.Windows.Controls
                     Invariant.Assert(innerControl != null, "InnerControl is null or not a UIElement.");
 
                     // Don't mess with focus if its already on our inner control
-                    if ( innerControl.IsKeyboardFocused == false )
+                    if (!innerControl.IsKeyboardFocused)
                     {
                         // We should set the focus to the inner control after it is added the visual tree.
                         innerControl.Focus();
@@ -1052,7 +1052,7 @@ namespace System.Windows.Controls
         /// </summary>
         private void OnDragDelta(object sender, DragDeltaEventArgs args)
         {
-            Invariant.Assert(IsExpanded == true, "Dragging occurred when the StickyNoteControl was not expanded.");
+            Invariant.Assert(IsExpanded, "Dragging occurred when the StickyNoteControl was not expanded.");
 
             Thumb source = args.Source as Thumb;
             double horizontalChange = args.HorizontalChange;
@@ -1085,7 +1085,7 @@ namespace System.Windows.Controls
         /// </summary>
         private void OnTitleDragDelta(double horizontalChange, double verticalChange)
         {
-            Invariant.Assert(IsExpanded != false);
+            Invariant.Assert(IsExpanded);
 
             Rect rectNote = StickyNoteBounds;
             Rect rectPage = PageBounds;
@@ -1126,7 +1126,7 @@ namespace System.Windows.Controls
         /// </summary>
         private void OnResizeDragDelta(double horizontalChange, double verticalChange)
         {
-            Invariant.Assert(IsExpanded != false);
+            Invariant.Assert(IsExpanded);
 
             Rect rectNote = StickyNoteBounds;
 
@@ -1214,7 +1214,7 @@ namespace System.Windows.Controls
                     Focus();
                 }
 
-                if (eatEvent == true)
+                if (eatEvent)
                 {
                     args.Handled = true;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextSearch.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextSearch.cs
@@ -290,8 +290,8 @@ namespace System.Windows.Controls
         private static void GetMatchingPrefixAndRemainingTextLength(string matchedText, string newText, CultureInfo cultureInfo,
                                                                 bool ignoreCase, out int matchedPrefixLength, out int textExcludingPrefixLength)
         {
-            Debug.Assert(String.IsNullOrEmpty(matchedText) == false, "matchedText cannot be null or empty");
-            Debug.Assert(String.IsNullOrEmpty(newText) == false, "newText cannot be null or empty");
+            Debug.Assert(!String.IsNullOrEmpty(matchedText), "matchedText cannot be null or empty");
+            Debug.Assert(!String.IsNullOrEmpty(newText), "newText cannot be null or empty");
             Debug.Assert(matchedText.StartsWith(newText, ignoreCase, cultureInfo), "matchedText should start with newText");
             
             matchedPrefixLength = 0;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
@@ -9192,7 +9192,7 @@ namespace System.Windows.Controls
             System.Windows.Controls.ItemContainerGenerator generator = Generator as System.Windows.Controls.ItemContainerGenerator;
             ItemsControl itemsControl = ItemsControl.GetItemsOwner(this);
 
-            if (generator != null && itemsControl != null && itemsControl.IsGrouping == false)
+            if (generator != null && itemsControl != null && !itemsControl.IsGrouping)
             {
                 foreach (UIElement child in InternalChildren)
                 {
@@ -11390,7 +11390,7 @@ namespace System.Windows.Controls
                 // We must be the ItemsHost to turn on Virtualization.
                 bool isVirtualizing = IsItemsHost && value;
 
-                if (isVirtualizing == false)
+                if (!isVirtualizing)
                 {
                     _realizedChildren = null;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlDataProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlDataProvider.cs
@@ -349,7 +349,7 @@ namespace System.Windows.Data
         {
             // convert the Source into an absolute URI
             Uri sourceUri = this.Source;
-            if (sourceUri.IsAbsoluteUri == false)
+            if (!sourceUri.IsAbsoluteUri)
             {
                 Uri baseUri = _baseUri ?? BindUriHelper.BaseUri;
                 sourceUri = BindUriHelper.GetResolvedUri(baseUri, sourceUri);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequence.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequence.cs
@@ -137,7 +137,7 @@ namespace System.Windows.Documents
 
         void IFixedNavigate.NavigateAsync(string elementID)
         {
-            if (IsPageCountValid == true)
+            if (IsPageCountValid)
             {
                 FixedHyperLink.NavigateToElement(this, elementID);
             }
@@ -671,7 +671,7 @@ namespace System.Windows.Documents
                 }
             }
 
-            if (documentSequencePageCountFinal == true)
+            if (documentSequencePageCountFinal)
             {
                 _paginator.NotifyPaginationCompleted(EventArgs.Empty);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedDSBuilder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedDSBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Controls;
@@ -87,7 +87,7 @@ namespace System.Windows.Documents
 
             for (int i = 0; i< _visitedArray.Count; i++ )
             {
-                if (_visitedArray[i] == false)
+                if (!_visitedArray[i])
                 {
                     AddFixedNodeInFlow(i, null);
                 }
@@ -214,7 +214,7 @@ namespace System.Windows.Documents
             if (listItem != null && listItem.Marker != null)
             {
                 NameHashFixedNode fen;
-                if (_nameHashTable.TryGetValue(listItem.Marker, out fen) == true)
+                if (_nameHashTable.TryGetValue(listItem.Marker, out fen))
                 {
                     _visitedArray[fen.index] = true;
                 }
@@ -224,7 +224,7 @@ namespace System.Windows.Documents
         private void ConstructSomElement(NamedElement ne)
         {
             NameHashFixedNode fen;
-            if (_nameHashTable.TryGetValue(ne.NameReference, out fen) == true)
+            if (_nameHashTable.TryGetValue(ne.NameReference, out fen))
             {
                 if (fen.uiElement is Glyphs || fen.uiElement is Path ||
                     fen.uiElement is Image)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedDocument.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedDocument.cs
@@ -182,7 +182,7 @@ namespace System.Windows.Documents
         #region IFixedNavigate
         void IFixedNavigate.NavigateAsync(string elementID)
         {
-            if (IsPageCountValid == true)
+            if (IsPageCountValid)
             {
                 FixedHyperLink.NavigateToElement(this, elementID);
             }
@@ -867,8 +867,8 @@ namespace System.Windows.Documents
             if (baseUri.Scheme.Equals(PackUriHelper.UriSchemePack, StringComparison.OrdinalIgnoreCase))
             {
                 // avoid the case of pack://application,,,
-                if (baseUri.Host.Equals(BaseUriHelper.PackAppBaseUri.Host) != true &&
-                    baseUri.Host.Equals(BaseUriHelper.SiteOfOriginBaseUri.Host) != true)
+                if (!baseUri.Host.Equals(BaseUriHelper.PackAppBaseUri.Host) &&
+!baseUri.Host.Equals(BaseUriHelper.SiteOfOriginBaseUri.Host))
                 {
                     Uri structureUri = GetStructureUriFromRelationship(baseUri, _structureRelationshipName);
                     if (structureUri != null)
@@ -895,8 +895,8 @@ namespace System.Windows.Documents
             if (baseUri.Scheme.Equals(PackUriHelper.UriSchemePack, StringComparison.OrdinalIgnoreCase))
             {
                 // avoid the case of pack://application,,,
-                if (baseUri.Host.Equals(BaseUriHelper.PackAppBaseUri.Host) != true &&
-                    baseUri.Host.Equals(BaseUriHelper.SiteOfOriginBaseUri.Host) != true)
+                if (!baseUri.Host.Equals(BaseUriHelper.PackAppBaseUri.Host) &&
+!baseUri.Host.Equals(BaseUriHelper.SiteOfOriginBaseUri.Host))
                 {
                     Uri structureUri = GetStructureUriFromRelationship(baseUri, _storyFragmentsRelationshipName);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedDocument.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedDocument.cs
@@ -868,7 +868,7 @@ namespace System.Windows.Documents
             {
                 // avoid the case of pack://application,,,
                 if (!baseUri.Host.Equals(BaseUriHelper.PackAppBaseUri.Host) &&
-!baseUri.Host.Equals(BaseUriHelper.SiteOfOriginBaseUri.Host))
+                    !baseUri.Host.Equals(BaseUriHelper.SiteOfOriginBaseUri.Host))
                 {
                     Uri structureUri = GetStructureUriFromRelationship(baseUri, _structureRelationshipName);
                     if (structureUri != null)
@@ -896,7 +896,7 @@ namespace System.Windows.Documents
             {
                 // avoid the case of pack://application,,,
                 if (!baseUri.Host.Equals(BaseUriHelper.PackAppBaseUri.Host) &&
-!baseUri.Host.Equals(BaseUriHelper.SiteOfOriginBaseUri.Host))
+                    !baseUri.Host.Equals(BaseUriHelper.SiteOfOriginBaseUri.Host))
                 {
                     Uri structureUri = GetStructureUriFromRelationship(baseUri, _storyFragmentsRelationshipName);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedPage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedPage.cs
@@ -621,7 +621,7 @@ namespace System.Windows.Documents
                 // not tell betweeen myFile.xaml and myFile.xaml#
                 //
                 Uri workuri = inputUri;
-                if (inputUri.IsAbsoluteUri == false)
+                if (!inputUri.IsAbsoluteUri)
                 {
                     // this is a relative uri, and Fragement() doesn't work with relative uris.  The base uri is completley irrelevant
                     // here and will never affect the returned fragment, but the method requires something to be there.  Therefore,
@@ -641,7 +641,7 @@ namespace System.Windows.Documents
                     inputUri = new Uri(inputUriStringWithoutFragment, UriKind.RelativeOrAbsolute);
 
                     //Only Check for the startpart uri if the hyperlink is relative, else it's not part of the package
-                    if (inputUri.IsAbsoluteUri == false)
+                    if (!inputUri.IsAbsoluteUri)
                     {
                         String startPartUriString = GetStartPartUriString(dpo);
                         if (startPartUriString != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
@@ -8719,7 +8719,7 @@ namespace System.Windows.Documents
                 imageStringBuilder.Append('"');
 
                 // Add the xaml image baseline offset property
-                if (formatState.IncludeImageBaselineOffset == true)
+                if (formatState.IncludeImageBaselineOffset)
                 {
                     double baselineOffset = height - formatState.ImageBaselineOffset;
                     imageStringBuilder.Append(" TextBlock.BaselineOffset=\"");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TableRow.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TableRow.cs
@@ -231,7 +231,7 @@ namespace System.Windows.Documents
             Debug.Assert(_spannedCells != null);
 
             if ((_formatCellCount > 0) ||
-               isLastRowOfAnySpan == true)
+               isLastRowOfAnySpan)
             {
                 SetFlags(true, Flags.HasRealCells);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditor.cs
@@ -1646,7 +1646,7 @@ namespace System.Windows.Documents
             This.SetSpellCheckEnabled(This.IsSpellCheckEnabled);
 
             // Finalize any active IME composition when transitioning to true.
-            if ((bool)e.NewValue == true && This._textstore != null)
+            if ((bool)e.NewValue && This._textstore != null)
             {
                 This._textstore.CompleteCompositionAsync();
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorTyping.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorTyping.cs
@@ -1737,7 +1737,7 @@ namespace System.Windows.Documents
                     case Key.RightShift:
                         // Only support RTL flow direction in case of having the installed
                         // bidi input language.
-                        if (TextSelection.IsBidiInputLanguageInstalled() == true)
+                        if (TextSelection.IsBidiInputLanguageInstalled())
                         {
                             TextEditorTyping.OnFlowDirectionCommand(TextEditor, _key);
                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSchema.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSchema.cs
@@ -283,7 +283,7 @@ namespace System.Windows.Documents
         internal static bool IsNonMergeableInline(Type elementType)
         {
             TextElementEditingBehaviorAttribute att = (TextElementEditingBehaviorAttribute)Attribute.GetCustomAttribute(elementType, typeof(TextElementEditingBehaviorAttribute));
-            if (att != null && att.IsMergeable == false)
+            if (att != null && !att.IsMergeable)
             {
                 return true;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSelection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSelection.cs
@@ -886,7 +886,7 @@ namespace System.Windows.Documents
             else
             {
                 // Define whether word adjustment is allowed. Pressing Shift+Control prevents from auto-word expansion.
-                bool disableWordExpansion = _textEditor.AutoWordSelection == false || ((Keyboard.Modifiers & ModifierKeys.Shift) != 0 && (Keyboard.Modifiers & ModifierKeys.Control) != 0);
+                bool disableWordExpansion = !_textEditor.AutoWordSelection || ((Keyboard.Modifiers & ModifierKeys.Shift) != 0 && (Keyboard.Modifiers & ModifierKeys.Control) != 0);
 
                 if (disableWordExpansion)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesHost.cs
@@ -263,7 +263,7 @@ namespace System.Windows.Documents
         private void OnDispatcherShutdownFinished(object sender, EventArgs args)
         {
             Debug.Assert(CheckAccess(), "OnDispatcherShutdownFinished called on bad thread!");
-            Debug.Assert(_isDispatcherShutdownFinished == false, "Was this dispather finished???");
+            Debug.Assert(!_isDispatcherShutdownFinished, "Was this dispather finished???");
 
             // Remove the callback.
             Dispatcher.ShutdownFinished -= new EventHandler(OnDispatcherShutdownFinished);
@@ -296,7 +296,7 @@ namespace System.Windows.Documents
             // Get ITfThreadMgr
             if (_threadManager == null)
             {
-                Debug.Assert(_isDispatcherShutdownFinished == false, "Was this dispather finished?");
+                Debug.Assert(!_isDispatcherShutdownFinished, "Was this dispather finished?");
                 Debug.Assert(_registeredtextstorecount == 0, "TextStore was registered without ThreadMgr?");
 
                 // TextServicesLoader.Load() might return null if no text services are installed or enabled.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
@@ -1089,7 +1089,7 @@ namespace System.Windows.Documents
                         end = navigator;
                     }
 
-                    if (lineRect.IsEmpty == false)
+                    if (!lineRect.IsEmpty)
                     {
                         rectBound.Union(lineRect);
                     }
@@ -3052,7 +3052,7 @@ namespace System.Windows.Documents
 
             int i;
             bool eaten = false;
-            for (i = 0; (i < _mouseSinks.Count) && (eaten == false); i++)
+            for (i = 0; (i < _mouseSinks.Count) && (!eaten); i++)
             {
                 MouseSink mSink = (MouseSink)_mouseSinks[i];
 
@@ -3170,7 +3170,7 @@ namespace System.Windows.Documents
 
             // Scan the line range and compute the top and the height of the bounding rectangle.
             ITextPointer navigator = start.CreatePointer(LogicalDirection.Forward);
-            while (navigator.MoveToNextContextPosition(LogicalDirection.Forward) == true && navigator.CompareTo(end) < 0)
+            while (navigator.MoveToNextContextPosition(LogicalDirection.Forward) && navigator.CompareTo(end) < 0)
             {
                 TextPointerContext context = navigator.GetPointerContext(LogicalDirection.Backward);
                 switch (context)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkContentElement.cs
@@ -540,7 +540,7 @@ namespace System.Windows
                     // Inheritance
                     //
 
-                    if (!TreeWalkHelper.SkipNext(InheritanceBehavior) || fmetadata.OverridesInheritanceBehavior == true)
+                    if (!TreeWalkHelper.SkipNext(InheritanceBehavior) || fmetadata.OverridesInheritanceBehavior)
                     {
                         // Used to terminate tree walk if a tree boundary is hit
                         InheritanceBehavior inheritanceBehavior;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
@@ -1947,7 +1947,7 @@ namespace System.Windows
             // Inheritance
             //
 
-            if (!TreeWalkHelper.SkipNext(InheritanceBehavior) || fmetadata.OverridesInheritanceBehavior == true)
+            if (!TreeWalkHelper.SkipNext(InheritanceBehavior) || fmetadata.OverridesInheritanceBehavior)
             {
                 // Used to terminate tree walk if a tree boundary is hit
                 InheritanceBehavior inheritanceBehavior = InheritanceBehavior.Default;
@@ -2459,7 +2459,7 @@ namespace System.Windows
             // Fire Loaded and Unloaded Events
             BroadcastEventHelper.BroadcastLoadedOrUnloadedEvent(this, oldParent, newParent);
 
-            if (newParent != null && (newParent is FrameworkElement) == false)
+            if (newParent != null && newParent is not FrameworkElement)
             {
                 // If you are being connected to a non-FE parent then start listening for VisualAncestor
                 // changes because otherwise you won't know about changes happening above you
@@ -2473,7 +2473,7 @@ namespace System.Windows
                     ((Visual3D)newParent).VisualAncestorChanged += new Visual.AncestorChangedEventHandler(OnVisualAncestorChanged);
                 }
             }
-            else if (oldParent != null && (oldParent is FrameworkElement) == false)
+            else if (oldParent != null && oldParent is not FrameworkElement)
             {
                 // If you are being disconnected from a non-FE parent then stop listening for
                 // VisualAncestor changes

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
@@ -462,7 +462,7 @@ namespace System.Windows.Interop
         /// </remarks>
         protected virtual void Dispose(bool disposing)
         {
-            if (_isDisposed == true)
+            if (_isDisposed)
             {
                 return;
             }
@@ -479,7 +479,7 @@ namespace System.Windows.Interop
                 if (_hwndSubclass != null)
                 {
                     // Check if it is trusted (WebOC and AddInHost), call CriticalDetach to avoid the Demand.
-                    if (_fTrusted == true)
+                    if (_fTrusted)
                     {
                         _hwndSubclass.CriticalDetach(false);
                     }
@@ -756,7 +756,7 @@ namespace System.Windows.Interop
 
                                     // First try to use the PrintWindow API.
                                     bool result = UnsafeNativeMethods.CriticalPrintWindow(_hwnd, hdcBitmap, 0);
-                                    if(result == false)
+                                    if(!result)
                                     {
                                         // Fall back to sending a WM_PRINT message to the window.
                                         //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/LogicalTreeHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/LogicalTreeHelper.cs
@@ -89,7 +89,7 @@ namespace System.Windows
             {
                 childEnumerator.Reset();
                 while( namedElement == null &&
-                       childEnumerator.MoveNext() == true)
+                       childEnumerator.MoveNext())
                 {
                     childNode = childEnumerator.Current as DependencyObject;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006Reader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006Reader.cs
@@ -1037,7 +1037,7 @@ namespace System.Windows.Baml2006
 
         private void Process_Text_Helper(string stringValue)
         {
-            if (_context.InsideKeyRecord != true && _context.InsideStaticResource != true)
+            if (!_context.InsideKeyRecord && !_context.InsideStaticResource)
             {
                 InjectPropertyAndFrameIfNeeded(_context.SchemaContext.GetXamlType(typeof(String)), 0);
             }
@@ -1203,7 +1203,7 @@ namespace System.Windows.Baml2006
             }
 
             // Need to output the keys if we're in deferred content
-            if (_context.PreviousFrame.IsDeferredContent && _context.InsideStaticResource == false)
+            if (_context.PreviousFrame.IsDeferredContent && !_context.InsideStaticResource)
             {         
                 // If we're providing binary, that means we've delay loaded the ResourceDictionary
                 // and the object we're currently creating doens't actually need the key.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/SharedStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/SharedStream.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
@@ -42,7 +42,7 @@ namespace System.Windows.Baml2006
 
         private void Initialize(Stream baseStream, long offset, long length)
         {
-            if (baseStream.CanSeek == false)
+            if (!baseStream.CanSeek)
             {
                 throw new ArgumentException("can\u2019t seek on baseStream");
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -223,7 +223,7 @@ namespace System.Windows.Markup
 #if DEBUG
                         // this case can happen if doing BAML Async and entire record hasn't
                         // been downloaded.
-                        Debug.Assert(false == XamlReaderStream.IsWriteComplete,
+                        Debug.Assert(!XamlReaderStream.IsWriteComplete,
                                 "not enough bytes for RecordSize but write is complete");
 #endif
                         stream.Seek(currentPosition,SeekOrigin.Begin);
@@ -366,7 +366,7 @@ namespace System.Windows.Markup
             bool moreData = true;
 
             // loop through the records until the end building the Tree.
-            while ( (true == moreData)
+            while ( (moreData)
                 && null != (bamlRecord = GetNextRecord()))
             {
                 moreData = ReadRecord(bamlRecord);
@@ -4351,7 +4351,7 @@ namespace System.Windows.Markup
             {
                 baseuri = BindUriHelper.BaseUri;
             }
-            else if (baseuri.IsAbsoluteUri == false)
+            else if (!baseuri.IsAbsoluteUri)
             {
                 baseuri = new Uri(BindUriHelper.BaseUri, baseuri);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordWriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /***************************************************************************\
@@ -679,7 +679,7 @@ namespace System.Windows.Markup
             // specific XmlNamespace. Add the relevant assemblies into MapTable.
             //
 
-            if (xamlXmlnsPropertyNode.XmlNamespace.StartsWith(XamlReaderHelper.MappingProtocol, StringComparison.Ordinal) == false)
+            if (!xamlXmlnsPropertyNode.XmlNamespace.StartsWith(XamlReaderHelper.MappingProtocol, StringComparison.Ordinal))
             {
                 NamespaceMapEntry[] nsMapEntry = _xamlTypeMapper.GetNamespaceMapEntries(xamlXmlnsPropertyNode.XmlNamespace);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/WpfXamlLoader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/WpfXamlLoader.cs
@@ -272,7 +272,7 @@ namespace System.Windows.Markup
                                     if (prop != null)
                                     {
                                         FrameworkPropertyMetadata metadata = prop.GetMetadata(stack.CurrentFrame.Type.UnderlyingType) as FrameworkPropertyMetadata;
-                                        if (metadata != null && metadata.Journal == true)
+                                        if (metadata != null && metadata.Journal)
                                         {
                                             // Ignore the BAML for this member, unless it declares a value that wasn't journaled - namely a binding or a dynamic resource
                                             int count = 1;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
@@ -416,14 +416,14 @@ namespace System.Windows.Markup
                     }
                     else if (xamlReader.NodeType == System.Xaml.XamlNodeType.Value)
                     {
-                        if (lastPropWasSyncMode == true)
+                        if (lastPropWasSyncMode)
                         {
                             if (xamlReader.Value as String == "Async")
                             {
                                 async = true;
                             }
                         }
-                        else if (lastPropWasSyncRecords == true)
+                        else if (lastPropWasSyncRecords)
                         {
                             if (xamlReader.Value is int)
                             {
@@ -656,7 +656,7 @@ namespace System.Windows.Markup
                 else
                 {
                     // if not at the EndOfDocument then post another work item
-                    if (false == _textReader.IsEof)
+                    if (!_textReader.IsEof)
                     {
                         Post();
                     }
@@ -1136,7 +1136,7 @@ namespace System.Windows.Markup
             {
                 return MS.Internal.Utility.BindUriHelper.BaseUri;
             }
-            else if (uri.IsAbsoluteUri == false)
+            else if (!uri.IsAbsoluteUri)
             {
                 return new Uri(MS.Internal.Utility.BindUriHelper.BaseUri, uri);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -1995,7 +1995,7 @@ namespace System.Windows.Markup
                 if (!endTagHasBeenRead)
                 {
                     CompileBamlTag(XmlNodeType.EndElement, ref endTagHasBeenRead);
-                    Debug.Assert(false == endTagHasBeenRead, "Read past end tag on end tag");
+                    Debug.Assert(!endTagHasBeenRead, "Read past end tag on end tag");
                 }
 
                 // Empty Complex Properties of type Dictionary should be popped now as
@@ -2066,7 +2066,7 @@ namespace System.Windows.Markup
             {
 
                 CompileBamlTag(XmlReader.NodeType, ref endTagHasBeenRead);
-                Debug.Assert(false == endTagHasBeenRead);
+                Debug.Assert(!endTagHasBeenRead);
 
                 // If we're in the context of an IDictionary or complex property, we
                 // have to keep reading until we get to an element in case there is an

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlStream.cs
@@ -375,7 +375,7 @@ namespace System.Windows.Markup
             if (bufferArray.Count <= bufferIndex)
             {
                 Debug.Assert(bufferArray.Count == bufferIndex,"Need to allocate more than one buffer");
-                Debug.Assert(false == reader,"Allocating a buffer on Read");
+                Debug.Assert(!reader, "Allocating a buffer on Read");
 
                 buffer = new byte[BufferSize];
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlAttributeProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlAttributeProperties.cs
@@ -232,7 +232,7 @@ namespace System.Windows.Markup
                 throw new ArgumentNullException( nameof(dependencyObject));
             }
 
-            if (dependencyObject.IsSealed == false)
+            if (!dependencyObject.IsSealed)
             {
                 dependencyObject.SetValue(XmlnsDictionaryProperty, value);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/Journal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/Journal.cs
@@ -253,7 +253,7 @@ namespace System.Windows.Navigation
                 {
                     return null;
                 }
-            } while (IsNavigable(_journalEntryList[index]) == false);
+            } while (!IsNavigable(_journalEntryList[index]));
             JournalEntry removedEntry = RemoveEntryInternal(index);
             Debug.Assert(ValidateIndexes());
             UpdateView();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
@@ -77,7 +77,7 @@ namespace System.Windows.Navigation
 
         #if DEBUG
             // We should only be replacing queue items that aren't already posted
-            Debug.Assert(_navigateQueueItem == null || _navigateQueueItem.IsPosted == false);
+            Debug.Assert(_navigateQueueItem == null || !_navigateQueueItem.IsPosted);
         #endif
             _navigateQueueItem = null;
             _request = null;
@@ -95,7 +95,7 @@ namespace System.Windows.Navigation
 
             // If the Uri is absolute uri, we just take the uri. Otherwise we require sender to implement
             // IUriContext so we can resolve with its base uri.
-            if ((bpu != null) && (bpu.IsAbsoluteUri == false))
+            if ((bpu != null) && (!bpu.IsAbsoluteUri))
             {
                 DependencyObject dobj = e.OriginalSource as DependencyObject;
 
@@ -160,7 +160,7 @@ namespace System.Windows.Navigation
 
                         if (navigator != null)
                         {
-                            inSameThread = (((DispatcherObject)navigator).CheckAccess() == true);
+                            inSameThread = (((DispatcherObject)navigator).CheckAccess());
                         }
                     }
                 }
@@ -498,7 +498,7 @@ namespace System.Windows.Navigation
                     // if we're on the same thread as that of nw then we can simple try to
                     // find target in nw, else we need to find target on the nw's thread.
                     // We do that below by using nw.Dispatcher.Invoke
-                    if (nw.CheckAccess() == true)
+                    if (nw.CheckAccess())
                     {
                         navigator = FindTargetInNavigationWindow(nw, targetName);
                     }
@@ -711,7 +711,7 @@ namespace System.Windows.Navigation
                 // Get the content from the attached DP
                 keepAlive = JournalEntry.GetKeepAlive(o);
 
-                if (keepAlive == false)
+                if (!keepAlive)
                 {
                     PageFunctionBase pf = o as PageFunctionBase;
 
@@ -1087,7 +1087,7 @@ namespace System.Windows.Navigation
             }
 
             // If an invalid root element is passed to Navigation Service, throw exception here.
-            if (IsValidRootElement(bp) == false)
+            if (!IsValidRootElement(bp))
             {
                 throw new InvalidOperationException(SR.Format(SR.WrongNavigateRootElement, bp.ToString()));
             }
@@ -1553,7 +1553,7 @@ namespace System.Windows.Navigation
             }
 
             // HandleNavigating will call DoStopLoading which aborts current webrequest if there is any.
-            if (HandleNavigating(resolvedSource, null, navigationState, newRequest, navigateOnSourceChanged) == false)
+            if (!HandleNavigating(resolvedSource, null, navigationState, newRequest, navigateOnSourceChanged))
             {
                 return false;
             }
@@ -1626,7 +1626,7 @@ namespace System.Windows.Navigation
 
             // HandleNavigating will set the pending Uri from navigationState if available
             // See comments in NavigateInfo class
-            if (HandleNavigating(source, root, navigationState, null, false) == false)
+            if (!HandleNavigating(source, root, navigationState, null, false))
             {
                 return false;
             }
@@ -2004,7 +2004,7 @@ namespace System.Windows.Navigation
             {
                 // This should happen only for the Application case when processing the Startup Uri
                 Debug.Assert(this.Application != null &&
-                             this.Application.CheckAccess() == true &&
+                             this.Application.CheckAccess() &&
                              IsSameUri(null, Application.StartupUri,
                                                      navigateInfo.Source, false /* withFragment */),
                              "Encountered unexpected condition in FireNavigating, see comments in the file");
@@ -2102,14 +2102,14 @@ namespace System.Windows.Navigation
                 throw;
             }
 
-            if (allowNavigation == true)
+            if (allowNavigation)
             {
                 DoStopLoading(false /*clearRecursiveLoads*/, true /*fireEvents*/);
                 Debug.Assert(PendingNavigationList.Count == 0,
                              "Pending child navigations were not stopped before starting a new navigation");
 
                 // NavigationStopped event handler could have caused a new navigation.
-                if (_recursiveNavigateList.Contains(localNavigateQueueItem) == false)
+                if (!_recursiveNavigateList.Contains(localNavigateQueueItem))
                     return false;
 
                 _recursiveNavigateList.Clear();
@@ -3162,7 +3162,7 @@ namespace System.Windows.Navigation
 
                     if (baseUri != null)
                     {
-                        Invariant.Assert(baseUri.IsAbsoluteUri == true, "BaseUri for root element should be absolute.");
+                        Invariant.Assert(baseUri.IsAbsoluteUri, "BaseUri for root element should be absolute.");
 
                         Uri markupUri;
 
@@ -3179,7 +3179,7 @@ namespace System.Windows.Navigation
                         //
                         //   For all other cases, take whatever value of BaseUri in root element.
                         //
-                        if (_currentCleanSource != null && BindUriHelper.StartWithFragment(_currentCleanSource) == false )
+                        if (_currentCleanSource != null && !BindUriHelper.StartWithFragment(_currentCleanSource))
                         {
                             markupUri = _currentSource;
                         }
@@ -3431,7 +3431,7 @@ namespace System.Windows.Navigation
                 // into App to determine top level container does not make sense.
                 return (INavigatorHost is NavigationWindow ||
                         (this.Application != null &&
-                        this.Application.CheckAccess() == true &&
+                        this.Application.CheckAccess() &&
                         this.Application.NavService == this)
                         );
             }
@@ -3533,8 +3533,8 @@ namespace System.Windows.Navigation
                 // into App to determine if app is shuttind down does not make sense.
                 bool isAppShuttingDown = false;
                 if ((this.Application != null) &&
-                    (this.Application.CheckAccess() == true) &&
-                    (Application.IsShuttingDown == true))
+                    (this.Application.CheckAccess()) &&
+                    (Application.IsShuttingDown))
                 {
                     isAppShuttingDown = true;
                 }
@@ -3634,7 +3634,7 @@ namespace System.Windows.Navigation
             }
 
             // Need to Check for refresh on history navigations as well and call LoadHistory instead?
-            if (ps._Resume == false)
+            if (!ps._Resume)
             {
                 ps.CallStart();
             }
@@ -3914,7 +3914,7 @@ namespace System.Windows.Navigation
             //    ExceptionStringTable.txt.
             //
             // For now, only block Window as root element.
-            if (AllowWindowNavigation == false &&
+            if (!AllowWindowNavigation &&
                 bp != null &&
                 bp is Window)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -342,7 +342,7 @@ namespace System.Windows
             {
                 WritePrivateFlag(PrivateFlags.IsReadOnly, value);
 
-                if (value == true)
+                if (value)
                 {
                     // Seal all the styles and templates in this dictionary
                     SealValues();
@@ -949,7 +949,7 @@ namespace System.Windows
             {
                 throw new InvalidOperationException(SR.EndInitWithoutBeginInitNotSupported);
             }
-            Debug.Assert(IsInitialized == false, "Dictionary should not be initialized when EndInit is called");
+            Debug.Assert(!IsInitialized, "Dictionary should not be initialized when EndInit is called");
 
             IsInitializePending = false;
             IsInitialized = true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceExpression.cs
@@ -52,7 +52,7 @@ namespace System.Windows
             ArgumentNullException.ThrowIfNull(dp);
 
             // If the cached value is valid then return it
-            if (ReadInternalState(InternalState.HasCachedResourceValue) == true)
+            if (ReadInternalState(InternalState.HasCachedResourceValue))
                 return _cachedResourceValue;
 
             object source;
@@ -87,7 +87,7 @@ namespace System.Windows
             //   </Button.Background>
             // </Button
             // Button is the mentor for the ResourceReference on SolidColorBrush
-            if (ReadInternalState(InternalState.IsMentorCacheValid) == false)
+            if (!ReadInternalState(InternalState.IsMentorCacheValid))
             {
                 // Find the mentor by walking up the InheritanceContext
                 // links and update the cache
@@ -305,7 +305,7 @@ namespace System.Windows
         /// </summary>
         private void InvalidateMentorCache()
         {
-            if (ReadInternalState(InternalState.IsMentorCacheValid) == true)
+            if (ReadInternalState(InternalState.IsMentorCacheValid))
             {
                 if (_mentorCache != null)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -2069,7 +2069,7 @@ namespace System.Windows
                 if( walkNode != container && nextParent != null ) // Only interested in nodes that are "Not me" and not auto-generated (== no TemplatedParent)
                 {
                     // Do the cheaper comparison first - the Style reference should be cached
-                    if ((frameworkTemplate != null && walkNodeIsFE == true && feWalkNode.TemplateInternal == frameworkTemplate) )
+                    if ((frameworkTemplate != null && walkNodeIsFE && feWalkNode.TemplateInternal == frameworkTemplate) )
                     {
                         // Then the expensive one - pulling in reflection to check if they're also the same types.
                         if( walkNode.GetType() == container.GetType() )

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -2117,7 +2117,7 @@ namespace System.Windows
 
                 foreach (KeyValuePair<object, WeakReference<DeferredResourceReference>> entry in _entries)
                 {
-                    if (entry.Value.TryGetTarget(out var item) is false)
+                    if (!entry.Value.TryGetTarget(out var item))
                     {
                         deadKeys.Add(entry.Key);
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateContent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateContent.cs
@@ -569,10 +569,8 @@ namespace System.Windows
                                 stack.CurrentFrame.ContentSourceSet = true;
                         }
 
-                        if (!stack.CurrentFrame.IsInNameScope &&
-!xamlReader.Member.IsDirective)
+                        if (!stack.CurrentFrame.IsInNameScope && !xamlReader.Member.IsDirective)
                         {
-
                             // Try to see if the property is shareable
                             PropertyValue? sharedValue;
                             var iReader = xamlReader as IXamlIndexingReader;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateContent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateContent.cs
@@ -422,7 +422,7 @@ namespace System.Windows
 
                         // Check to see if the parent object needs to have the name set
                         if (stack.Depth > 0 &&
-                            stack.CurrentFrame.NameSet == false &&
+!stack.CurrentFrame.NameSet &&
                             stack.CurrentFrame.Type != null &&
                             !stack.CurrentFrame.IsInNameScope &&
                             !stack.CurrentFrame.IsInStyleOrTemplate)
@@ -450,7 +450,7 @@ namespace System.Windows
                     {
                         // Check to see if the parent object needs to have the name set
                         if (stack.Depth > 0 &&
-                            stack.CurrentFrame.NameSet == false &&
+!stack.CurrentFrame.NameSet &&
                             stack.CurrentFrame.Type != null &&
                             !stack.CurrentFrame.IsInNameScope &&
                             !stack.CurrentFrame.IsInStyleOrTemplate)
@@ -478,7 +478,7 @@ namespace System.Windows
                 case System.Xaml.XamlNodeType.EndObject:
                     if (!stack.CurrentFrame.IsInStyleOrTemplate)
                     {
-                        if (stack.CurrentFrame.NameSet == false && !stack.CurrentFrame.IsInNameScope)
+                        if (!stack.CurrentFrame.NameSet && !stack.CurrentFrame.IsInNameScope)
                         {
                             // FEs and FCEs need to be added to the name to index map
                             if (typeof(FrameworkElement).IsAssignableFrom(stack.CurrentFrame.Type.UnderlyingType) ||
@@ -570,7 +570,7 @@ namespace System.Windows
                         }
 
                         if (!stack.CurrentFrame.IsInNameScope &&
-                            xamlReader.Member.IsDirective == false)
+!xamlReader.Member.IsDirective)
                         {
 
                             // Try to see if the property is shareable
@@ -722,7 +722,7 @@ namespace System.Windows
                     if (!stack.CurrentFrame.IsInStyleOrTemplate)
                     {
                         // Check to see if the parent object needs to have the name set
-                        if (stack.Depth > 0 && stack.CurrentFrame.NameSet == false && stack.CurrentFrame.Type != null && !stack.CurrentFrame.IsInNameScope)
+                        if (stack.Depth > 0 && !stack.CurrentFrame.NameSet && stack.CurrentFrame.Type != null && !stack.CurrentFrame.IsInNameScope)
                         {
                             // FEs and FCEs need to be added to the name to index map
                             if (typeof(FrameworkElement).IsAssignableFrom(stack.CurrentFrame.Type.UnderlyingType) ||
@@ -1220,7 +1220,7 @@ namespace System.Windows
             bool isContentStringFormatPropertyDefined
             )
         {
-            if (String.IsNullOrEmpty(contentSource) && isContentSourceSet == false)
+            if (String.IsNullOrEmpty(contentSource) && !isContentSourceSet)
                 contentSource = "Content";
 
             if (!String.IsNullOrEmpty(contentSource) && !isContentPropertyDefined)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateContent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateContent.cs
@@ -450,7 +450,7 @@ namespace System.Windows
                     {
                         // Check to see if the parent object needs to have the name set
                         if (stack.Depth > 0 &&
-!stack.CurrentFrame.NameSet &&
+                            !stack.CurrentFrame.NameSet &&
                             stack.CurrentFrame.Type != null &&
                             !stack.CurrentFrame.IsInNameScope &&
                             !stack.CurrentFrame.IsInStyleOrTemplate)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
@@ -316,7 +316,7 @@ namespace System.Windows
             Debug.Assert(d != null, "Must have non-null current node");
 
             // This must be an inherited dependency property
-            Debug.Assert(fMetadata.IsInherited == true, "This must be an inherited dependency property");
+            Debug.Assert(fMetadata.IsInherited, "This must be an inherited dependency property");
 
             // IsSelfInheritanceParent can only change from false to true
             Debug.Assert(!wasSelfInheritanceParent || isSelfInheritanceParent, "IsSelfInheritanceParent changed from true to false");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/VisualStateManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/VisualStateManager.cs
@@ -251,7 +251,7 @@ namespace System.Windows
                     transition.DynamicStoryboardCompleted = true;
                 };
 
-                if (transition.Storyboard != null && transition.ExplicitStoryboardCompleted == true)
+                if (transition.Storyboard != null && transition.ExplicitStoryboardCompleted)
                 {
                     EventHandler transitionCompleted = null;
                     transitionCompleted = new EventHandler(delegate(object sender, EventArgs e)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -180,7 +180,7 @@ namespace System.Windows
         {
             VerifyContextAndObjectState();
 
-            if (_disposed == true)
+            if (_disposed)
             {
                 return;
             }
@@ -275,11 +275,11 @@ namespace System.Windows
             VerifyNotClosing();
             VerifyConsistencyWithAllowsTransparency();
 
-            if ( _isVisible == true )
+            if (_isVisible)
             {
                 throw new InvalidOperationException(SR.ShowDialogOnVisible);
             }
-            else if ( _showingAsDialog == true )
+            else if (_showingAsDialog)
             {
                 throw new InvalidOperationException(SR.ShowDialogOnModal);
             }
@@ -287,7 +287,7 @@ namespace System.Windows
             _dialogOwnerHandle = _ownerHandle;
 
             // verify owner handle is window
-            if (UnsafeNativeMethods.IsWindow( new HandleRef( null, _dialogOwnerHandle ) ) != true)
+            if (!UnsafeNativeMethods.IsWindow( new HandleRef( null, _dialogOwnerHandle ) ))
             {
                 _dialogOwnerHandle = IntPtr.Zero;
             }
@@ -424,7 +424,7 @@ namespace System.Windows
                 // Activate the previously active window.
                 // This code/logic came from User.
                 if ( (_dialogPreviousActiveHandle != IntPtr.Zero) &&
-                    (UnsafeNativeMethods.IsWindow(new HandleRef(null, _dialogPreviousActiveHandle)) == true))
+                    (UnsafeNativeMethods.IsWindow(new HandleRef(null, _dialogPreviousActiveHandle))))
                 {
                     // SetFocus fails if the input hwnd is not a Window or if the Window is not on the
                     // calling thread.
@@ -1234,12 +1234,12 @@ namespace System.Windows
                     throw new ArgumentException(SR.CannotSetOwnerToItself);
                 }
 
-                if ( _showingAsDialog == true )
+                if (_showingAsDialog)
                 {
                     throw new InvalidOperationException(SR.CantSetOwnerAfterDialogIsShown);
                 }
 
-                if (value != null && value.IsSourceWindowNull == true)
+                if (value != null && value.IsSourceWindowNull)
                 {
                     // Try to be specific in the error message.
                     if (value._disposed)
@@ -1357,12 +1357,12 @@ namespace System.Windows
                 // DialogResult is not allowed
                 VerifyApiSupported();
 
-                if (_showingAsDialog == true)
+                if (_showingAsDialog)
                 {
                     // This value should be set only after the window is created and shown as dialog.
 
                     // When _showingAsDialog is set, _sourceWindow must be set too.
-                    Debug.Assert( IsSourceWindowNull == false , "IsSourceWindowNull cannot be true when _showingAsDialog is true");
+                    Debug.Assert(!IsSourceWindowNull, "IsSourceWindowNull cannot be true when _showingAsDialog is true");
 
 
                     // According to the new design, setting DialogResult to its current value will not have any effect.
@@ -1377,7 +1377,7 @@ namespace System.Windows
                         // Note: Windows OS bug # 934500 Setting DialogResult
                         // on the Closing EventHandler of a Dialog causes StackOverFlowException
 
-                        if(_isClosing == false)
+                        if(!_isClosing)
                         {
                             Close();
                         }
@@ -1921,7 +1921,7 @@ namespace System.Windows
             // post it from the LoadedHandler.  This guarantees that
             // we don't fire ContentRendered on a subtree that is not
             // connected to a PresentationSource
-            if (IsLoaded == true)
+            if (IsLoaded)
             {
                 PostContentRendered();
             }
@@ -1931,7 +1931,7 @@ namespace System.Windows
                 // that we deferred to the Loaded event to PostConetentRendered
                 // for the previous content change and Loaded has not fired yet.
                 // Thus we don't want to hook up another event handler
-                if (_postContentRenderedFromLoadedHandler == false)
+                if (!_postContentRenderedFromLoadedHandler)
                 {
                     this.Loaded += new RoutedEventHandler(LoadedHandler);
                     _postContentRenderedFromLoadedHandler = true;
@@ -2117,14 +2117,14 @@ namespace System.Windows
         #region Internal Methods
         internal Point DeviceToLogicalUnits(Point ptDeviceUnits)
         {
-            Invariant.Assert(IsCompositionTargetInvalid == false, "IsCompositionTargetInvalid is supposed to be false here");
+            Invariant.Assert(!IsCompositionTargetInvalid, "IsCompositionTargetInvalid is supposed to be false here");
             Point ptLogicalUnits = _swh.CompositionTarget.TransformFromDevice.Transform(ptDeviceUnits);
             return ptLogicalUnits;
         }
 
         internal Point LogicalToDeviceUnits(Point ptLogicalUnits)
         {
-            Invariant.Assert(IsCompositionTargetInvalid == false, "IsCompositionTargetInvalid is supposed to be false here");
+            Invariant.Assert(!IsCompositionTargetInvalid, "IsCompositionTargetInvalid is supposed to be false here");
             Point ptDeviceUnits = _swh.CompositionTarget.TransformToDevice.Transform(ptLogicalUnits);
             return ptDeviceUnits;
         }
@@ -2198,7 +2198,7 @@ namespace System.Windows
         {
             VerifyNotClosing();
 
-            if (_disposed == true)
+            if (_disposed)
             {
                 return;
             }
@@ -2478,7 +2478,7 @@ namespace System.Windows
             VerifyConsistencyWithAllowsTransparency();
 
             // We do not support create hwnd before shown for RBW.
-            if (duringShow == false)
+            if (!duringShow)
             {
                 VerifyApiSupported();
             }
@@ -2831,7 +2831,7 @@ namespace System.Windows
             // has happened.
             //
 
-            if (updateHwndPlacement == true)
+            if (updateHwndPlacement)
             {
                 if (WindowState == WindowState.Normal)
                 {
@@ -2884,7 +2884,7 @@ namespace System.Windows
             SetIWindowService();
 
             // set root visual  synchronously, shell request
-            if ( IsSourceWindowNull == false )
+            if (!IsSourceWindowNull)
             {
                 _swh.RootVisual = this;
             }
@@ -2906,7 +2906,7 @@ namespace System.Windows
                 // And if the hwnd is created but is not shown yet, we need to re-calculate the location again because
                 // the value of the WindowStartupLocation can change after EnsureHandle is called.
                 // We only update location if there is any change needed.
-                if ((SizeToContent != SizeToContent.Manual) || (HwndCreatedButNotShown == true))
+                if ((SizeToContent != SizeToContent.Manual) || (HwndCreatedButNotShown))
                 {
                     NativeMethods.RECT rc = WindowBounds;
                     double xDeviceUnits = rc.left;
@@ -3004,7 +3004,7 @@ namespace System.Windows
         internal virtual void UpdateTitle(string title)
         {
             // Adding check for IsCompositionTargetInvalid
-            if ( IsSourceWindowNull == false && IsCompositionTargetInvalid == false)
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid)
             {
                 UnsafeNativeMethods.SetWindowText(new HandleRef(this, Handle), title);
             }
@@ -3016,7 +3016,7 @@ namespace System.Windows
             if (!_inTrustedSubWindow)
             {
             }
-            Debug.Assert( IsSourceWindowNull == false , "IsSourceWindowNull cannot be true when calling this function");
+            Debug.Assert(!IsSourceWindowNull, "IsSourceWindowNull cannot be true when calling this function");
 
             Point ptDeviceUnits = LogicalToDeviceUnits(new Point(widthLogicalUnits, heightLogicalUnits));
             UnsafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
@@ -3047,12 +3047,12 @@ namespace System.Windows
             // Event handler exception continuality: if exception occurs in Activated/Deactivated event handlers, our state will not be
             // corrupted because the state related to Activated/Deactivated, IsActive is set before the event is fired.
             // Please check Event handler exception continuality if the logic changes.
-            if ((windowActivated == true) && (IsActive == false))
+            if ((windowActivated) && (!IsActive))
             {
                 SetValue(IsActivePropertyKey, BooleanBoxes.TrueBox);
                 OnActivated(EventArgs.Empty);
             }
-            else if ((windowActivated == false) && (IsActive == true))
+            else if ((!windowActivated) && (IsActive))
             {
                 SetValue(IsActivePropertyKey, BooleanBoxes.FalseBox);
                 OnDeactivated(EventArgs.Empty);
@@ -3218,7 +3218,7 @@ namespace System.Windows
 
                 VerifyContextAndObjectState();
 
-                if ( _showingAsDialog == true )
+                if (_showingAsDialog)
                 {
                     throw new InvalidOperationException(SR.CantSetOwnerAfterDialogIsShown);
                 }
@@ -3280,7 +3280,7 @@ namespace System.Windows
                 {
                     return _styleExDoNotUse;
 }
-                else if (IsSourceWindowNull == true  )
+                else if (IsSourceWindowNull)
                 {
                     return _styleExDoNotUse;
 }
@@ -3449,7 +3449,7 @@ namespace System.Windows
         {
             WindowMinMax mm = new WindowMinMax( );
 
-            Invariant.Assert(IsCompositionTargetInvalid == false, "IsCompositionTargetInvalid is supposed to be false here");
+            Invariant.Assert(!IsCompositionTargetInvalid, "IsCompositionTargetInvalid is supposed to be false here");
 
             // convert the max/min size (taken in to account the hwnd size restrictions by win32) into logical units
             double maxWidthDeviceUnits = _trackMaxWidthDeviceUnits;
@@ -3514,7 +3514,7 @@ namespace System.Windows
 
         private void LoadedHandler(object sender, RoutedEventArgs e)
         {
-            if (_postContentRenderedFromLoadedHandler == true)
+            if (_postContentRenderedFromLoadedHandler)
             {
                 PostContentRendered();
                 _postContentRenderedFromLoadedHandler = false;
@@ -3639,7 +3639,7 @@ namespace System.Windows
             // EnableThreadWindows is called with true only when dialog is going away.  Now
             // we've enabled the windows that we had earlier disabled; thus, disposing
             // _threadWindowHandles.
-            if (state == true)
+            if (state)
             {
                 _threadWindowHandles = null;
             }
@@ -3661,7 +3661,7 @@ namespace System.Windows
             BypassLayoutPolicies = true;
 
             // check if within an app && on the same thread
-            if (IsInsideApp == true)
+            if (IsInsideApp)
             {
                 if (Application.Current.Dispatcher.Thread == Dispatcher.CurrentDispatcher.Thread)
                 {
@@ -3697,7 +3697,7 @@ namespace System.Windows
 
         private void VerifyCanShow()
         {
-            if (_disposed == true)
+            if (_disposed)
             {
                 throw new InvalidOperationException(SR.ReshowNotAllowed);
             }
@@ -3705,12 +3705,12 @@ namespace System.Windows
 
         private void VerifyNotClosing()
         {
-            if (_isClosing == true)
+            if (_isClosing)
             {
                 throw new InvalidOperationException(SR.InvalidOperationDuringClosing);
             }
 
-            if (IsSourceWindowNull == false && IsCompositionTargetInvalid == true)
+            if (!IsSourceWindowNull && IsCompositionTargetInvalid)
             {
                 throw new InvalidOperationException(SR.InvalidCompositionTarget);
             }
@@ -3759,7 +3759,7 @@ namespace System.Windows
         // <param name="currentSize"></param>
         private bool CalculateWindowLocation(ref double leftDeviceUnits, ref double topDeviceUnits, Size currentSizeDeviceUnits)
         {
-            Debug.Assert(IsSourceWindowNull == false, "_swh should not be null here");
+            Debug.Assert(!IsSourceWindowNull, "_swh should not be null here");
             double inLeft = leftDeviceUnits;
             double inTop = topDeviceUnits;
 
@@ -3805,7 +3805,7 @@ namespace System.Windows
 
                     // If the owner is WPF window.
                     // The owner can be non-WPF window. It can be set via WindowInteropHelper.Owner.
-                    if (CanCenterOverWPFOwner == true)
+                    if (CanCenterOverWPFOwner)
                     {
                         // If the owner is in a non-normal state use the screen bounds for centering the window.
                         // Top/Left/Width/Height reflect the restore bounds, so they can't be used in this scenario.
@@ -3920,7 +3920,7 @@ namespace System.Windows
         {
             get
             {
-                Debug.Assert(IsSourceWindowNull == false, "_swh should not be null here");
+                Debug.Assert(!IsSourceWindowNull, "_swh should not be null here");
 
                 // if Owner is null, we cannot CenterOwner
                 if (Owner == null)
@@ -4177,7 +4177,7 @@ namespace System.Windows
                 ? EnsureHiddenWindow().Handle
                 : ownerHandle;
 
-            if (IsSourceWindowNull == false)
+            if (!IsSourceWindowNull)
             {
                 UnsafeNativeMethods.SetWindowLong(new HandleRef(null, Handle),
                     NativeMethods.GWL_HWNDPARENT,
@@ -4211,7 +4211,7 @@ namespace System.Windows
         /// <returns></returns>
         private void OnSourceWindowDisposed(object sender, EventArgs e)
         {
-            if ( _disposed == false)
+            if (!_disposed)
             {
                 InternalDispose();
             }
@@ -4424,7 +4424,7 @@ namespace System.Windows
         private void DoDialogHide()
         {
 
-            Debug.Assert(_showingAsDialog == true, "_showingAsDialog must be true when DoDialogHide is called");
+            Debug.Assert(_showingAsDialog, "_showingAsDialog must be true when DoDialogHide is called");
 
             bool wasActive = false;
 
@@ -4475,9 +4475,9 @@ namespace System.Windows
             // could have been destroyed by now by some other thread/codepath etc.
             // (BVT BLOCKER: System.ComponentModel.Win32Exception thrown when
             // trying to shutdown app inside a Dialog Window)
-            if ((wasActive == true) &&
+            if ((wasActive) &&
                 (_dialogPreviousActiveHandle != IntPtr.Zero) &&
-                (UnsafeNativeMethods.IsWindow(new HandleRef(this, _dialogPreviousActiveHandle)) == true))
+                (UnsafeNativeMethods.IsWindow(new HandleRef(this, _dialogPreviousActiveHandle))))
             {
                 UnsafeNativeMethods.SetActiveWindow(new HandleRef(this, _dialogPreviousActiveHandle));
             }
@@ -4509,7 +4509,7 @@ namespace System.Windows
             Debug.Assert(ownedWindows.Count == 0, "All owned windows should now be gone");
 
             // Update OwnerWindows of our Owner
-            if (IsOwnerNull == false)
+            if (!IsOwnerNull)
             {
                 // use internal version since we want to update the underlying collection
                 Owner.OwnedWindowsInternal.Remove(this);
@@ -4523,7 +4523,7 @@ namespace System.Windows
                     App.WindowsInternal.Remove(this);
 
                     // Check to see if app should shut down--this behavior really belongs in Application
-                    if (_appShuttingDown == false)
+                    if (!_appShuttingDown)
                     {
                         // If this is the last window that's closing and shutdownmode is onlastwindowclose, or
                         // if this is the main window closing and shutdownmode is onmainwindowclose, shutdown
@@ -4555,7 +4555,7 @@ namespace System.Windows
                 return false;
             }
 
-            if (_disposed == false)
+            if (!_disposed)
             {
                 InternalDispose();
             }
@@ -4894,7 +4894,7 @@ namespace System.Windows
 
             // if IsCompositionTargetInvalid is true, then it means that the CompositionTarget is not available.
             // This can happen at hwnd creation or destruction time.
-            if (IsSourceWindowNull == false && IsCompositionTargetInvalid == false)
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid)
             {
                 //
                 // Get the final MinMax size for this HWND based on Win32 track value and Min/Max setting
@@ -4984,7 +4984,7 @@ namespace System.Windows
 
             GeneralTransform transfromFromWindow = this.TransformToDescendant(_resizeGripControl);
             Point mousePositionWRTResizeGripControl = ptLogicalUnits;
-            if (transfromFromWindow == null || transfromFromWindow.TryTransform(ptLogicalUnits, out mousePositionWRTResizeGripControl) == false)
+            if (transfromFromWindow == null || !transfromFromWindow.TryTransform(ptLogicalUnits, out mousePositionWRTResizeGripControl))
             {
                 return false;
             }
@@ -5081,7 +5081,7 @@ namespace System.Windows
             _icon = newIcon;
 
             // Adding check for IsCompositionTargetInvalid
-            if (IsSourceWindowNull == false && IsCompositionTargetInvalid == false)
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid)
             {
                 UpdateIcon();
             }
@@ -5125,7 +5125,7 @@ namespace System.Windows
             // Case 3 : bet set when CompositionTarget is invalid meaning we're in a bad state
 
             // Adding check for IsCompositionTargetInvalid
-            if ( IsSourceWindowNull == false && IsCompositionTargetInvalid == false)
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid)
             {
                 bool fHideWindow = false;
                 // Win32 bug. For ShowInTaskbar to change dynamically, we need to hide then show the window.
@@ -5186,9 +5186,9 @@ namespace System.Windows
             // window is shown again.
             //
             // Adding check for IsCompositionTargetInvalid
-            if (IsSourceWindowNull == false && IsCompositionTargetInvalid == false)
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid)
             {
-                if (_isVisible == true)
+                if (_isVisible)
                 {
                     HandleRef hr = new HandleRef(this,  Handle);
 
@@ -5303,7 +5303,7 @@ namespace System.Windows
         private void OnWindowStyleChanged(WindowStyle windowStyle)
         {
             // Adding check for IsCompositionTargetInvalid
-            if (IsSourceWindowNull == false && IsCompositionTargetInvalid == false)
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid)
             {
                 using (HwndStyleManager sm = HwndStyleManager.StartManaging(this, StyleFromHwnd, StyleExFromHwnd ))
                 {
@@ -5328,7 +5328,7 @@ namespace System.Windows
             VerifyApiSupported();
 
             // Adding check for IsCompositionTargetInvalid
-            if (IsSourceWindowNull == false  && IsCompositionTargetInvalid == false)
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid)
             {
                 HandleRef hWnd = topmost ? NativeMethods.HWND_TOPMOST : NativeMethods.HWND_NOTOPMOST;
                 UnsafeNativeMethods.SetWindowPos(new HandleRef(null, Handle),
@@ -5376,7 +5376,7 @@ namespace System.Windows
             // _OnVisibilityInvalidated callback.  If a call originates in Show/Hide,
             // we DO NOT want to do anything in the _OnVisibilityCallback since, we
             // synchronously call ShowHelper from Show/Hide
-            if (w._visibilitySetInternally == true)
+            if (w._visibilitySetInternally)
             {
                 return;
             }
@@ -5392,7 +5392,7 @@ namespace System.Windows
         private void SafeCreateWindowDuringShow()
         {
             //this is true the first time the window is created
-            if (IsSourceWindowNull == true)
+            if (IsSourceWindowNull)
             {
                 // _isVisible is false at this moment.  Thus CreateAllStyle
                 // called by CreateSourceWindow does not set WS_VISIBLE style
@@ -5428,7 +5428,7 @@ namespace System.Windows
         {
             // if we set KeyboradNavigation.ShowKeyboardCuesProperty in ShowDialog,
             // set it to false here.
-            if (_resetKeyboardCuesProperty == true)
+            if (_resetKeyboardCuesProperty)
             {
                 _resetKeyboardCuesProperty = false;
                 SetValue(KeyboardNavigation.ShowKeyboardCuesProperty, BooleanBoxes.Box(_previousKeyboardCuesProperty));
@@ -5463,7 +5463,7 @@ namespace System.Windows
             //      ...
             //      window.Close();
             // We should not do anything if the window is already closed.
-            if (_disposed == true)
+            if (_disposed)
             {
                 return null;
             }
@@ -5485,7 +5485,7 @@ namespace System.Windows
             // _isVisible should always be set after calling SafeCreateWindow, because
             // if exception occurs in Loading event (fired as a result of setting Visibility to visible) handler,
             // we set Visibility back to Collapsed. Otherwise we could get into a loop.
-            if (value == true)
+            if (value)
             {
                 if (Application.IsShuttingDown)
                     return null;
@@ -5500,7 +5500,7 @@ namespace System.Windows
 
                 ClearShowKeyboardCueState();
 
-                if (_showingAsDialog == true)
+                if (_showingAsDialog)
                 {
                     DoDialogHide();
                 }
@@ -5510,7 +5510,7 @@ namespace System.Windows
             // we need this check here again, b/c creating the window fires the
             // Activted event and if user closes the window from it, then by
             // the time we get to this point _sourceWindow is already disposed.
-            if ( IsSourceWindowNull == false )
+            if (!IsSourceWindowNull)
             {
 
                 // Specifying an Avalon app to start
@@ -5524,7 +5524,7 @@ namespace System.Windows
                 // If anything else is passed, it does not use nCmd of STARTUPINFO.
 
                 int nCmd = 0;
-                if (value == true)
+                if (value)
                 {
                     // nCmdForShow access WindowState which is inaccessible for RBW.
                     // Thus doing so in a virtual that RBW overrides
@@ -5570,7 +5570,7 @@ namespace System.Windows
 
 
             // dialog functionality; start dispatcher loop to block the call
-            if ((_showingAsDialog == true) && (_isVisible == true))
+            if ((_showingAsDialog) && (_isVisible))
             {
                 //
                 // Since we exited the Context, we need to make sure
@@ -5661,7 +5661,7 @@ namespace System.Windows
             // HwndSource will only update layout if the value has changed.
             //
             // Adding check for IsCompositionTargetInvalid
-            if (IsSourceWindowNull == false && IsCompositionTargetInvalid == false)
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid)
             {
                 HwndSourceSizeToContent = sizeToContent;
             }
@@ -5721,7 +5721,7 @@ namespace System.Windows
             ValidateLengthForHeightWidth(height);
 
             // Adding check for IsCompositionTargetInvalid
-            if (IsSourceWindowNull == false && IsCompositionTargetInvalid == false && !double.IsNaN(height))
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid && !double.IsNaN(height))
             {
                 UpdateHeight(height);
             }
@@ -5747,7 +5747,7 @@ namespace System.Windows
             // If MinHeight is Auto or ActualHeight is greater than MinHeight, there is no need update size of the window.
             //
             // Adding check for IsCompositionTargetInvalid
-            if ((IsSourceWindowNull == false ) && (IsCompositionTargetInvalid == false))
+            if ((!IsSourceWindowNull) && (!IsCompositionTargetInvalid))
             {
                 NativeMethods.RECT rcHwnd = WindowBounds;
                 Point logicalSize = DeviceToLogicalUnits(new Point(rcHwnd.Width, rcHwnd.Height));
@@ -5785,7 +5785,7 @@ namespace System.Windows
             // the HWND's height > MaxHeight
             //
             // Adding check for IsCompositionTargetInvalid
-            if ((IsSourceWindowNull == false) && (IsCompositionTargetInvalid == false))
+            if ((!IsSourceWindowNull) && (!IsCompositionTargetInvalid))
             {
                 NativeMethods.RECT rcHwnd = WindowBounds;
                 Point logicalSize = DeviceToLogicalUnits(new Point(rcHwnd.Width, rcHwnd.Height));
@@ -5819,7 +5819,7 @@ namespace System.Windows
             ValidateLengthForHeightWidth(width);
 
             // Adding check for IsCompositionTargetInvalid
-            if (IsSourceWindowNull == false && IsCompositionTargetInvalid == false && !double.IsNaN(width))
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid && !double.IsNaN(width))
             {
                 UpdateWidth(width);
             }
@@ -5847,7 +5847,7 @@ namespace System.Windows
             // If MinWidth is Auto or ActualWidth is greater than MinWidth, there is no need update size of the window.
             //
             // Adding check for IsCompositionTargetInvalid
-            if ((IsSourceWindowNull == false) && (IsCompositionTargetInvalid == false))
+            if ((!IsSourceWindowNull) && (!IsCompositionTargetInvalid))
             {
                 NativeMethods.RECT rcHwnd = WindowBounds;
                 Point logicalSize = DeviceToLogicalUnits(new Point(rcHwnd.Width, rcHwnd.Height));
@@ -5884,7 +5884,7 @@ namespace System.Windows
             // ActualWidth > MaxWidth
             //
             // Adding check for IsCompositionTargetInvalid
-            if ((IsSourceWindowNull == false ) && (IsCompositionTargetInvalid == false))
+            if ((!IsSourceWindowNull) && (!IsCompositionTargetInvalid))
             {
                 NativeMethods.RECT rcHwnd = WindowBounds;
                 Point logicalSize = DeviceToLogicalUnits(new Point(rcHwnd.Width, rcHwnd.Height));
@@ -6110,11 +6110,11 @@ namespace System.Windows
         private void OnTopChanged(double newTop)
         {
             // Adding check for IsCompositionTargetInvalid
-            if (IsSourceWindowNull == false && IsCompositionTargetInvalid == false)
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid)
             {
                 // NaN is special and indicates using Win32 default,
                 // so we exclude that.
-                if (double.IsNaN(newTop) == false)
+                if (!double.IsNaN(newTop))
                 {
                     if (WindowState == WindowState.Normal)
                     {
@@ -6205,11 +6205,11 @@ namespace System.Windows
         private void OnLeftChanged(double newLeft)
         {
             // Adding check for IsCompositionTargetInvalid
-            if (IsSourceWindowNull == false && IsCompositionTargetInvalid == false)
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid)
             {
                 // NaN is special and indicates using Win32 default,
                 // so we exclude that here.
-                if (double.IsNaN(newLeft) == false)
+                if (!double.IsNaN(newLeft))
                 {
                     if (WindowState == WindowState.Normal)
                     {
@@ -6231,7 +6231,7 @@ namespace System.Windows
 
         private void UpdateHwndPositionOnTopLeftChange(double leftLogicalUnits, double topLogicalUnits)
         {
-            Debug.Assert( IsSourceWindowNull == false , "IsSourceWindowNull cannot be true when calling this function");
+            Debug.Assert(!IsSourceWindowNull, "IsSourceWindowNull cannot be true when calling this function");
 
             Point ptDeviceUnits = LogicalToDeviceUnits(new Point(leftLogicalUnits, topLogicalUnits));
 
@@ -6265,7 +6265,7 @@ namespace System.Windows
             VerifyApiSupported();
 
             // Adding check for IsCompositionTargetInvalid
-            if ( IsSourceWindowNull == false && IsCompositionTargetInvalid == false)
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid)
             {
                 using (HwndStyleManager sm = HwndStyleManager.StartManaging(this, StyleFromHwnd, StyleExFromHwnd  ))
                 {
@@ -6296,7 +6296,7 @@ namespace System.Windows
         private void OnFlowDirectionChanged()
         {
             // Adding check for IsCompositionTargetInvalid
-            if (IsSourceWindowNull == false && IsCompositionTargetInvalid == false)
+            if (!IsSourceWindowNull && !IsCompositionTargetInvalid)
             {
                 using (HwndStyleManager sm = HwndStyleManager.StartManaging(this, StyleFromHwnd, StyleExFromHwnd ))
                 {
@@ -6310,7 +6310,7 @@ namespace System.Windows
             Transform renderTransformValue = (Transform)value;
 
             if ((value == null) ||
-                (renderTransformValue != null && renderTransformValue.Value.IsIdentity == true))
+                (renderTransformValue != null && renderTransformValue.Value.IsIdentity))
             {
                 // setting this value is allowed.
             }
@@ -6328,7 +6328,7 @@ namespace System.Windows
 
         private static object CoerceClipToBounds(DependencyObject d, object value)
         {
-            if ((bool)value != false)
+            if ((bool)value)
             {
                 throw new InvalidOperationException(SR.ClipToBoundsNotSupported);
             }
@@ -6369,7 +6369,7 @@ namespace System.Windows
         /// </summary>
         private void SetTaskbarStatus()
         {
-            if (ShowInTaskbar == false) // don't show in taskbar
+            if (!ShowInTaskbar) // don't show in taskbar
             {
                 // To remove the taskbar button for this window it needs to have a non-null parent
                 // (we'll create a hidden window for this purpose) and not have WS_EX_APPWINDOW
@@ -7442,7 +7442,7 @@ namespace System.Windows
 
                 private NativeMethods.POINT GetWindowScreenLocation(FlowDirection flowDirection)
                 {
-                    Debug.Assert(IsSourceWindowNull != true, "IsSourceWindowNull cannot be true here");
+                    Debug.Assert(!IsSourceWindowNull, "IsSourceWindowNull cannot be true here");
                     NativeMethods.POINT pt = default;
                     if (flowDirection == FlowDirection.RightToLeft)
                     {
@@ -7503,7 +7503,7 @@ namespace System.Windows
                         if (_sourceWindow != null)
                         {
                             HwndTarget compositionTarget = _sourceWindow.CompositionTarget;
-                            if (compositionTarget != null && compositionTarget.IsDisposed == false)
+                            if (compositionTarget != null && !compositionTarget.IsDisposed)
                             {
                                 return compositionTarget;
                             }
@@ -7533,7 +7533,7 @@ namespace System.Windows
                     get
                     {
                         // Should never be called when Handle is non-null
-                        Debug.Assert( IsSourceWindowNull == false , "Should only be invoked when we know Handle is non-null" );
+                        Debug.Assert(!IsSourceWindowNull, "Should only be invoked when we know Handle is non-null" );
                         return UnsafeNativeMethods.GetWindowLong(new HandleRef(this,Handle), NativeMethods.GWL_EXSTYLE);
                     }
                 }
@@ -7543,7 +7543,7 @@ namespace System.Windows
                     get
                     {
                         // Should never be called when Handle is non-null
-                        Debug.Assert( IsSourceWindowNull == false , "Should only be invoked when we know Handle is non-null" );
+                        Debug.Assert(!IsSourceWindowNull, "Should only be invoked when we know Handle is non-null" );
                         return UnsafeNativeMethods.GetWindowLong(new HandleRef(this,Handle), NativeMethods.GWL_STYLE);
                     }
                 }
@@ -7568,7 +7568,7 @@ namespace System.Windows
                 /// </summary>
                 internal Size GetSizeFromHwndInMeasureUnits()
                 {
-                    Debug.Assert( IsSourceWindowNull == false , "IsSourceWindowNull can't be true here");
+                    Debug.Assert(!IsSourceWindowNull, "IsSourceWindowNull can't be true here");
 
                     Point pt = new Point(0,0);
                     NativeMethods.RECT rect = WindowBounds;
@@ -7587,7 +7587,7 @@ namespace System.Windows
                 /// </summary>
                 internal Size GetHwndNonClientAreaSizeInMeasureUnits()
                 {
-                    Debug.Assert( IsSourceWindowNull == false , "IsSourceWindowNull can't be true here");
+                    Debug.Assert(!IsSourceWindowNull, "IsSourceWindowNull can't be true here");
 
                     // Diff the Client and Window sizes to get the dimensions of the frame.
                     NativeMethods.RECT clientRect = ClientBounds;
@@ -7685,7 +7685,7 @@ namespace System.Windows
                 _window = w;
                 _window.Manager = this;
 
-                if ( w.IsSourceWindowNull == false )
+                if (!w.IsSourceWindowNull)
                 {
                     _window._Style    =  Style;
                     _window._StyleEx  = StyleEx;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/InstallationError.xaml.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/InstallationError.xaml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -172,7 +172,7 @@ namespace Microsoft.Internal.DeploymentUI
 
         private void ShowLogFileButton()
         {
-            if (File.Exists(LogFilePath) && ErrorFlag == true)
+            if (File.Exists(LogFilePath) && ErrorFlag)
             {
                 LogFileButton.Visibility = Visibility.Visible;
                 FocusManager.SetFocusedElement(this, LogFileButton);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/FindToolBar.xaml.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/FindToolBar.xaml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Code behind file for the DocumentViewer FindToolBar.
@@ -76,7 +76,7 @@ namespace MS.Internal.Documents
         /// <value></value>
         public bool MatchCase
         {
-            get { return OptionsCaseMenuItem.IsChecked == true; }
+            get { return OptionsCaseMenuItem.IsChecked; }
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace MS.Internal.Documents
         /// <value></value>
         public bool MatchWholeWord
         {
-            get { return OptionsWholeWordMenuItem.IsChecked == true; }
+            get { return OptionsWholeWordMenuItem.IsChecked; }
         }
         /// <summary>
         /// Specifies whether the search should match diacritics.
@@ -94,7 +94,7 @@ namespace MS.Internal.Documents
         /// <value></value>
         public bool MatchDiacritic
         {
-            get { return OptionsDiacriticMenuItem.IsChecked == true; }
+            get { return OptionsDiacriticMenuItem.IsChecked; }
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace MS.Internal.Documents
         /// <value></value>
         public bool MatchKashida
         {
-            get { return OptionsKashidaMenuItem.IsChecked == true; }
+            get { return OptionsKashidaMenuItem.IsChecked; }
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace MS.Internal.Documents
         /// <value></value>
         public bool MatchAlefHamza
         {
-            get { return OptionsAlefHamzaMenuItem.IsChecked == true; }
+            get { return OptionsAlefHamzaMenuItem.IsChecked; }
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/SignatureSummaryDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/SignatureSummaryDialog.cs
@@ -45,7 +45,7 @@ namespace MS.Internal.Documents
             InitializeDialogType();
 
             //Show only the buttons appropriate for the current mode.
-            if (_showRequestDialog == true)
+            if (_showRequestDialog)
             {
                 Text = SR.DigSigRequestTitle;
 
@@ -192,7 +192,7 @@ namespace MS.Internal.Documents
             InitializeColumnHeaders();
 
             //Show only the buttons appropriate for the current mode.
-            if (_showRequestDialog == true)
+            if (_showRequestDialog)
             {
                 Text = SR.DigSigRequestTitle;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/TenFeetInstallationError.xaml.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/TenFeetInstallationError.xaml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -176,7 +176,7 @@ namespace Microsoft.Internal.DeploymentUI
 
         private void ShowLogFileButton()
         {
-            if (File.Exists(LogFilePath) && ErrorFlag == true)
+            if (File.Exists(LogFilePath) && ErrorFlag)
             {
                 LogFileButton.Visibility = Visibility.Visible;
                 FocusManager.SetFocusedElement(this, LogFileButton);

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/FallbackPTProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/FallbackPTProvider.cs
@@ -52,7 +52,7 @@ namespace MS.Internal.Printing.Configuration
             // indicate right away if there was an error in binding the provider
             // to the device.  Doing late binding would mean that any instance
             // method could throw a no such printer exception.
-            if (false == UnsafeNativeMethods.OpenPrinterW(deviceName, out this._deviceHandle, new HandleRef(this, IntPtr.Zero)))
+            if (!UnsafeNativeMethods.OpenPrinterW(deviceName, out this._deviceHandle, new HandleRef(this, IntPtr.Zero)))
             {
                 throw new PrintQueueException(Marshal.GetLastWin32Error(), "PrintConfig.Provider.BindFail", deviceName);
             }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/VisualTreeFlattener.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/VisualTreeFlattener.cs
@@ -501,7 +501,7 @@ namespace System.Windows.Xps.Serialization
                 int dummy;
                 // Some classes like DocumentViewer, in its visual tree, will implicitly generate
                 // some named elements. We will avoid create the duplicate names. 
-                if (_nameList.TryGetValue(fe.Name, out dummy) == false)
+                if (!_nameList.TryGetValue(fe.Name, out dummy))
                 {
                     nameAttr = fe.Name;
                     _nameList.Add(fe.Name, 0);

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/MetroSerializationManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/MetroSerializationManager.cs
@@ -880,7 +880,7 @@ namespace System.Windows.Xps.Serialization
                                                       out serializerTypeForProperty,
                                                       out typeConverterForProperty,
                                                       out defaultValueAttr,
-                                                      out designerSerializationFlagsAttr) == true)
+                                                      out designerSerializationFlagsAttr))
                               {
                                   TypeCacheItem typeCacheItem = GetTypeCacheItem(propertyType);
                                   serializerTypeForProperty = serializerTypeForProperty ?? typeCacheItem.SerializerType;

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/NGCSerializationManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/NGCSerializationManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -491,7 +491,7 @@ namespace System.Windows.Xps.Serialization
 
             if(!_isStartPage)
             {
-                if (_isPrintTicketMerged == false)
+                if (!_isPrintTicketMerged)
                 {
                     XpsSerializationPrintTicketRequiredEventArgs e =
                     new XpsSerializationPrintTicketRequiredEventArgs(PrintTicketLevel.FixedPagePrintTicket,

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/NGCSerializationManagerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/NGCSerializationManagerAsync.cs
@@ -722,7 +722,7 @@ namespace System.Windows.Xps.Serialization
                 bManulStartDoc = true;
             }
 
-            if (_isPrintTicketMerged == false)
+            if (!_isPrintTicketMerged)
             {
                 XpsSerializationPrintTicketRequiredEventArgs e =
                 new XpsSerializationPrintTicketRequiredEventArgs(PrintTicketLevel.FixedPagePrintTicket,

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachDocumentReferenceSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachDocumentReferenceSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -48,7 +48,7 @@ namespace System.Windows.Xps.Serialization
                 // Loads the document
                 FixedDocument document = ((DocumentReference)serializableObjectContext.TargetObject).GetDocument(false);
 
-                if (document.IsInitialized == false)
+                if (!document.IsInitialized)
                 {
                     // Give a parser item a kick
                     document.Dispatcher.Invoke(DispatcherPriority.ApplicationIdle,

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachDocumentReferenceSerializerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachDocumentReferenceSerializerAsync.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -104,7 +104,7 @@ namespace System.Windows.Xps.Serialization
             FixedDocument document = 
             ((DocumentReference)serializableObjectContext.TargetObject).GetDocument(false);
 
-            if (document.IsInitialized == false)
+            if (!document.IsInitialized)
             {
                 // Give a parser item a kick
                 document.Dispatcher.Invoke(DispatcherPriority.ApplicationIdle,

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachSerializationCacheItems.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachSerializationCacheItems.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -113,7 +113,7 @@ namespace System.Windows.Xps.Serialization
                                             out serializerTypeForProperty,
                                             out typeConverterForProperty,
                                             out defaultValueAttr,
-                                            out designerSerializationFlagsAttr) == true)
+                                            out designerSerializationFlagsAttr))
                     {
                         //
                         // Figure out the Serializer or TypeConverter associated with the 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachSerializationUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachSerializationUtils.cs
@@ -1143,8 +1143,8 @@ namespace System.Windows.Xps.Serialization
         {
             Size newSize = ValidateDocumentSize(elementSize, printTicket);
 
-            if (uiElement.IsArrangeValid == false ||
-                uiElement.IsMeasureValid == false ||
+            if (!uiElement.IsArrangeValid ||
+!uiElement.IsMeasureValid ||
                 elementSize != newSize
                 )
             {

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachSerializationUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachSerializationUtils.cs
@@ -1143,10 +1143,7 @@ namespace System.Windows.Xps.Serialization
         {
             Size newSize = ValidateDocumentSize(elementSize, printTicket);
 
-            if (!uiElement.IsArrangeValid ||
-!uiElement.IsMeasureValid ||
-                elementSize != newSize
-                )
+            if (!uiElement.IsArrangeValid || !uiElement.IsMeasureValid || elementSize != newSize)
             {
                 EmitEvent(EventTrace.Event.WClientDRXLayoutBegin);
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsDocumentEvent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsDocumentEvent.cs
@@ -225,7 +225,7 @@ namespace System.Windows.Xps.Serialization
             XpsSerializationCompletedEventArgs e
             )
         {
-            if (e.Cancelled == true)
+            if (e.Cancelled)
             {
                 _documentEvent = XpsDocumentEventType.XpsDocumentCancel;
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/MimeTypeMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/MimeTypeMapper.cs
@@ -23,7 +23,7 @@ namespace MS.Internal
             if (uriSource != null)
             {
                 Uri uri = uriSource;
-                if (uri.IsAbsoluteUri == false)
+                if (!uri.IsAbsoluteUri)
                 {
                       uri = new Uri("http://foo/bar/");
                       uri = new Uri(uri, uriSource);
@@ -135,7 +135,7 @@ namespace MS.Internal
             string extensionWithDot = Path.GetExtension(docString);
             string extension = String.Empty;
 
-            if (String.IsNullOrEmpty(extensionWithDot) == false)
+            if (!String.IsNullOrEmpty(extensionWithDot))
             {
                 extension = extensionWithDot.Substring(1).ToLower(CultureInfo.InvariantCulture);
             }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ResourceIDHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ResourceIDHelper.cs
@@ -44,7 +44,7 @@ namespace MS.Internal
             // If the sourceUri is not relative to baseUri, Emtpy string is returned
             // as resource id.
             //
-            if (baseUri.IsAbsoluteUri == false || sourceUri.IsAbsoluteUri == false)
+            if (!baseUri.IsAbsoluteUri || !sourceUri.IsAbsoluteUri)
             {
                  // 
                  // if any passed Uri is not absolute uri, return empty string here.

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/BindUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/BindUriHelper.cs
@@ -89,7 +89,7 @@ namespace MS.Internal.Utility
             {
                 newUri = null;
             }
-            else if (orgUri.IsAbsoluteUri == false)
+            else if (!orgUri.IsAbsoluteUri)
             {
                 // if the orgUri is an absolute Uri, don't need to resolve it again.
                 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalMap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalMap.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -408,7 +408,7 @@ namespace MS.Utility
         {
             // If we're unsorted and we have entries to sort, do a simple
             // sort.  Sort the pairs (0,1), (1,2) and then (0,1) again.  
-            if ((false == _sorted) && (_count > 1))
+            if ((!_sorted) && (_count > 1))
             {
                 Entry temp;
                 if (_entry0.Key > _entry1.Key)
@@ -912,7 +912,7 @@ namespace MS.Utility
             // If we're unsorted and we have entries to sort, do a simple
             // bubble sort. Sort the pairs, 0..5, and then again until we no
             // longer do any swapping.
-            if ((false == _sorted) && (_count > 1))
+            if ((!_sorted) && (_count > 1))
             {
                 bool swapped;
 
@@ -1215,7 +1215,7 @@ namespace MS.Utility
 
         public override void Sort()
         {
-            if ((false == _sorted) && (_count > 1))
+            if ((!_sorted) && (_count > 1))
             {
                 QSort(0, (_count - 1));
                 _sorted = true;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsCLR.cs
@@ -44,7 +44,7 @@ namespace MS.Win32
 
         internal static void GetMonitorInfo(HandleRef hmonitor, [In, Out] NativeMethods.MONITORINFOEX info)
         {
-            if (SafeNativeMethodsPrivate.IntGetMonitorInfo(hmonitor, info) == false)
+            if (!SafeNativeMethodsPrivate.IntGetMonitorInfo(hmonitor, info))
             {
                 throw new Win32Exception();
             }
@@ -96,7 +96,7 @@ namespace MS.Win32
         internal static bool AdjustWindowRectEx(ref NativeMethods.RECT lpRect, int dwStyle, bool bMenu, int dwExStyle)
         {
             bool returnValue = SafeNativeMethodsPrivate.IntAdjustWindowRectEx(ref lpRect, dwStyle, bMenu, dwExStyle);
-            if (returnValue == false)
+            if (!returnValue)
             {
                 throw new Win32Exception();
             }
@@ -149,7 +149,7 @@ namespace MS.Win32
         {
             bool returnValue = SafeNativeMethodsPrivate.IntReleaseCapture();
 
-            if (returnValue == false)
+            if (!returnValue)
             {
                 throw new Win32Exception();
             }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
@@ -329,7 +329,7 @@ namespace MS.Win32
             // Sometimes Win32 will fail this call, such as if you are
             // not running in the interactive desktop.  For example,
             // a secure screen saver may be running.
-            if (returnValue == false)
+            if (!returnValue)
             {
                 Debug.WriteLine("GetCursorPos failed!");
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsOther.cs
@@ -546,7 +546,7 @@ namespace MS.Win32
 
         internal static void SetWindowText(HandleRef hWnd, string text)
         {
-            if (IntSetWindowText(hWnd, text) == false)
+            if (!IntSetWindowText(hWnd, text))
             {
                 throw new Win32Exception();
             }
@@ -610,7 +610,7 @@ namespace MS.Win32
         // note:  this method exists in UnsafeNativeMethodsCLR.cs, but that method does not have the if/throw implemntation
         internal static void GetWindowPlacement(HandleRef hWnd, ref NativeMethods.WINDOWPLACEMENT placement)
         {
-            if (IntGetWindowPlacement(hWnd, ref placement) == false)
+            if (!IntGetWindowPlacement(hWnd, ref placement))
             {
                 throw new Win32Exception();
             }
@@ -622,7 +622,7 @@ namespace MS.Win32
         // note: this method appears in UnsafeNativeMethodsCLR.cs but does not have the if/throw block
         internal static void SetWindowPlacement(HandleRef hWnd, [In] ref NativeMethods.WINDOWPLACEMENT placement)
         {
-            if (IntSetWindowPlacement(hWnd, ref placement) == false)
+            if (!IntSetWindowPlacement(hWnd, ref placement))
             {
                 throw new Win32Exception();
             }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Media/TypeConverterHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Media/TypeConverterHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -70,7 +70,7 @@ namespace System.Windows.Media
                 uriHolder.OriginalUri = (Uri)inputString;
             }
 
-            if (uriHolder.OriginalUri.IsAbsoluteUri == false)
+            if (!uriHolder.OriginalUri.IsAbsoluteUri)
             {
                 //Debug.Assert (context != null, "Context should not be null");
                 if (context != null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/KeyTipService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/KeyTipService.cs
@@ -391,14 +391,14 @@ namespace Microsoft.Windows.Controls
                 return TreeHelper.FindVisualAncestor(element,
                     delegate(DependencyObject d)
                     {
-                        return ((KeyTipService.GetIsKeyTipScope(d) == true) || (TreeHelper.GetParent(d) == null));
+                        return ((KeyTipService.GetIsKeyTipScope(d)) || (TreeHelper.GetParent(d) == null));
                     });
             }
             else
             {
                 return TreeHelper.FindAncestor(element, delegate(DependencyObject d)
                 {
-                    return ((KeyTipService.GetIsKeyTipScope(d) == true) || (TreeHelper.GetParent(d) == null));
+                    return ((KeyTipService.GetIsKeyTipScope(d)) || (TreeHelper.GetParent(d) == null));
                 });
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonQuickAccessToolBarOverflowPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonQuickAccessToolBarOverflowPanel.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -22,7 +22,7 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
             {
                 UIElement child = Children[i];
                 Debug.Assert(child != null, "child not expected to be null");
-                Debug.Assert(RibbonQuickAccessToolBar.GetIsOverflowItem(child) == true, "child expected to have IsOverflowItem == true");
+                Debug.Assert(RibbonQuickAccessToolBar.GetIsOverflowItem(child), "child expected to have IsOverflowItem == true");
 
                 Size infinity = new Size(Double.PositiveInfinity, availableSize.Height);
                 child.Measure(infinity);

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonQuickAccessToolBarPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonQuickAccessToolBarPanel.cs
@@ -313,9 +313,9 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
                 Debug.Assert(object.ReferenceEquals(InternalChildren[j], GeneratedChildren[j]));
                 UIElement currentChild = InternalChildren[j];
                 Debug.Assert(currentChild != null);
-                Debug.Assert(RibbonQuickAccessToolBar.GetIsOverflowItem(currentChild) == false);
-                Debug.Assert(this.Children.Contains(currentChild) == true);
-                Debug.Assert(QAT.OverflowPanel.Children.Contains(currentChild) == false);
+                Debug.Assert(!RibbonQuickAccessToolBar.GetIsOverflowItem(currentChild));
+                Debug.Assert(this.Children.Contains(currentChild));
+                Debug.Assert(!QAT.OverflowPanel.Children.Contains(currentChild));
                 Debug.Assert(currentChild.IsVisible == this.IsVisible);
                 Debug.Assert(currentChild.DesiredSize.Width > 0.0);
             }
@@ -327,9 +327,9 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
                 Debug.Assert(object.ReferenceEquals(QAT.OverflowPanel.Children[overflowPanelIndex], GeneratedChildren[k]));
                 UIElement currentChild = GeneratedChildren[k];
                 Debug.Assert(currentChild != null);
-                Debug.Assert(RibbonQuickAccessToolBar.GetIsOverflowItem(currentChild) == true);
-                Debug.Assert(this.Children.Contains(currentChild) == false);
-                Debug.Assert(QAT.OverflowPanel.Children.Contains(currentChild) == true);
+                Debug.Assert(RibbonQuickAccessToolBar.GetIsOverflowItem(currentChild));
+                Debug.Assert(!this.Children.Contains(currentChild));
+                Debug.Assert(QAT.OverflowPanel.Children.Contains(currentChild));
             }
         }
 #endif

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Ribbon.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Ribbon.cs
@@ -822,7 +822,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                 // 1. If clicking a tab that is being clicked in its 'selected' state for
                 //    the second time, toggle its 'IsMinimized' behavior.
                 // 2. Otherwise do nothing.
-                if (_selectedTabClicked == true || this.IsMinimized)
+                if (_selectedTabClicked || this.IsMinimized)
                 {
                     IsMinimized = !IsMinimized;
                     IsDropDownOpen = false;
@@ -843,7 +843,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                 //    * Minimize and display the pop-up.
                 // 3. If maximized and the tab was NOT initially selected.
                 //    * Minimize do not display any pop-ups.
-                if (_selectedTabClicked == true)
+                if (_selectedTabClicked)
                 {
                     IsMinimized = !IsMinimized;
                     IsDropDownOpen = false;

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGallery.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGallery.cs
@@ -1317,7 +1317,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                             RibbonComboBox comboBoxParent = LogicalTreeHelper.GetParent(this) as RibbonComboBox;
                             if (comboBoxParent != null &&
                                 this == comboBoxParent.FirstGallery &&
-!comboBoxParent.IsSelectedItemCached)
+                                !comboBoxParent.IsSelectedItemCached)
                             {
                                 comboBoxParent.UpdateSelectionProperties();
                             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGallery.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGallery.cs
@@ -1317,7 +1317,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                             RibbonComboBox comboBoxParent = LogicalTreeHelper.GetParent(this) as RibbonComboBox;
                             if (comboBoxParent != null &&
                                 this == comboBoxParent.FirstGallery &&
-                                comboBoxParent.IsSelectedItemCached == false)
+!comboBoxParent.IsSelectedItemCached)
                             {
                                 comboBoxParent.UpdateSelectionProperties();
                             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonMenuButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonMenuButton.cs
@@ -1480,7 +1480,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                 // If HasPushedMenuMode=true...
                 PropertyInfo property = type.GetProperty("HasPushedMenuMode", BindingFlags.NonPublic | BindingFlags.Instance);
                 Debug.Assert(property != null);
-                if (property != null && (bool)property.GetValue(this, null) == true)
+                if (property != null && (bool)property.GetValue(this, null))
                 {
                     // ...call PopMenuMode.
                     MethodInfo method = type.GetMethod("PopMenuMode", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTab.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTab.cs
@@ -559,7 +559,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                         resizeSuccessful = group.DecreaseGroupSize();
                     }
 
-                    if (resizeSuccessful == true)
+                    if (resizeSuccessful)
                     {
                         _automaticResizeOrder.Add(_groupAutoResizeIndex.Value + 1);
                     }
@@ -571,7 +571,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                         _groupAutoResizeIndex = Items.Count - 1;
                         break;
                     }
-                } while (resizeSuccessful == false);
+                } while (!resizeSuccessful);
 
                 // If we failed to resize during this pass, and we attempted to resize for every
                 // group, then there are no reamining groups to resize.

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -1690,7 +1690,7 @@ namespace System.Xaml
             object parentInstance = ctx.ParentInstance;
             XamlMember parentProperty = ctx.ParentProperty;
 
-            if (parentProperty is not null && parentProperty.IsUnknown == false)
+            if (parentProperty is not null && !parentProperty.IsUnknown)
             {
                 XamlType declaringType = null;
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
@@ -685,7 +685,7 @@ namespace MS.Internal.Automation
             for (int source = 0; source < ach.Length; source++)
             {
                 // get rid of leading spaces
-                if (ach[source] == ' ' && leadingSpace == false)
+                if (ach[source] == ' ' && !leadingSpace)
                 {
                     continue;
                 }
@@ -695,7 +695,7 @@ namespace MS.Internal.Automation
                 }
 
                 // get rid of &
-                if (ach[source] == '&' && amper == false)
+                if (ach[source] == '&' && !amper)
                 {
                     amper = true;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
@@ -439,7 +439,7 @@ namespace MS.Internal.AutomationProxies
             {
                 CPRect r = rectList[i];
 
-                if (r._fNotCovered == true && (r._right - r._left) * (r._bottom - r._top) > 0)
+                if (r._fNotCovered && (r._right - r._left) * (r._bottom - r._top) > 0)
                 {
                     // Skip if the rectangle is empty
                     if (r._right > r._left && r._bottom > r._top)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/MSAANativeProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/MSAANativeProvider.cs
@@ -839,7 +839,7 @@ namespace MS.Internal.AutomationProxies
             }
 
 
-            if (rval == false)
+            if (!rval)
             {
                 // If it's not a recognized role, but does have a default action, support
                 // Invoke as a fallback...

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Misc.cs
@@ -1638,7 +1638,7 @@ namespace MS.Internal.AutomationProxies
             for (int source = 0; source < ach.Length; source++)
             {
                 // get rid of leading spaces
-                if (ach[source] == ' ' && leadingSpace == false)
+                if (ach[source] == ' ' && !leadingSpace)
                 {
                     continue;
                 }
@@ -1648,7 +1648,7 @@ namespace MS.Internal.AutomationProxies
                 }
 
                 // get rid of &
-                if (ach[source] == '&' && amper == false)
+                if (ach[source] == '&' && !amper)
                 {
                     amper = true;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsHyperlink.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsHyperlink.cs
@@ -211,7 +211,7 @@ namespace MS.Internal.AutomationProxies
                 bGetItemResult = XSendMessage.XSend(_hwnd, NativeMethods.LM_HITTEST, IntPtr.Zero, new IntPtr(&HitTestInfo), Marshal.SizeOf(HitTestInfo.GetType()));
             }
 
-            if (bGetItemResult == true && HitTestInfo.item.iLink >= 0 && GetLinkItem (HitTestInfo.item.iLink))
+            if (bGetItemResult && HitTestInfo.item.iLink >= 0 && GetLinkItem (HitTestInfo.item.iLink))
             {
                 return CreateHyperlinkItem (_linkItem, HitTestInfo.item.iLink);
             }
@@ -492,7 +492,7 @@ namespace MS.Internal.AutomationProxies
                             bGetItemResult = XSendMessage.XSend(_hwnd, NativeMethods.LM_HITTEST, IntPtr.Zero, new IntPtr(&HitTestInfo), Marshal.SizeOf(HitTestInfo.GetType()));
                         }
 
-                        if (bGetItemResult == true && HitTestInfo.item.iLink == _item)
+                        if (bGetItemResult && HitTestInfo.item.iLink == _item)
                         {
                             //
                             // N.B. [SEdmison]:

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTab.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTab.cs
@@ -1065,7 +1065,7 @@ namespace MS.Internal.AutomationProxies
                 throw new InvalidOperationException(SR.OperationCannotBePerformed);
             }
 
-            if (((ISelectionItemProvider)this).IsSelected == false)
+            if (!((ISelectionItemProvider)this).IsSelected)
             {
                 Select();
             }
@@ -1093,7 +1093,7 @@ namespace MS.Internal.AutomationProxies
             }
 
             // If multiple selections allowed, add requested selection
-            if (WindowsTab.SupportMultipleSelection(_hwnd) == true)
+            if (WindowsTab.SupportMultipleSelection(_hwnd))
             {
                 // Press ctrl and mouse click tab
                 NativeMethods.Win32Point pt = new NativeMethods.Win32Point();
@@ -1130,7 +1130,7 @@ namespace MS.Internal.AutomationProxies
             }
 
             // If multiple selections allowed, unselect element
-            if (WindowsTab.SupportMultipleSelection(_hwnd) == true)
+            if (WindowsTab.SupportMultipleSelection(_hwnd))
             {
                 NativeMethods.Win32Point pt = new NativeMethods.Win32Point();
                 if (GetClickablePoint(out pt, true))

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Certificate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Certificate.cs
@@ -141,7 +141,7 @@ namespace MS.Internal.IO.Packaging
                 _part = container.GetPart(partName);
 
                 // ensure the part is of the expected type
-                if (_part.ValidatedContentType().AreTypeAndSubTypeEqual(_certificatePartContentType) == false)
+                if (!_part.ValidatedContentType().AreTypeAndSubTypeEqual(_certificatePartContentType))
                     throw new FileFormatException(SR.CertificatePartContentTypeMismatch);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
@@ -502,7 +502,7 @@ namespace MS.Internal.IO.Packaging
 
                 // In addition we need to make sure that the relationship is not created by taking another relationship
                 // as the source of this uri. So XXX/_rels/_rels/YYY.rels.rels would be invalid.
-                if (segments.Length > 3 && result == true)
+                if (segments.Length > 3 && result)
                 {
                     if ((segments[segments.Length - 1]).EndsWith(_relsrelsUpperCaseExtension, StringComparison.Ordinal))
                     {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlDigitalSignatureProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlDigitalSignatureProcessor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -1179,7 +1179,7 @@ namespace MS.Internal.IO.Packaging
                             throw new ArgumentException(SR.PackageSpecificReferenceTagMustBeUnique);
 
                         //If there are more than one package specific tags
-                        if (packageReferenceFound == true)
+                        if (packageReferenceFound)
                             throw new XmlException(SR.MoreThanOnePackageSpecificReference);
                         else
                             packageReferenceFound = true;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ShutDownListener.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ShutDownListener.cs
@@ -116,7 +116,7 @@ namespace MS.Internal
         {
             // The dispatcher and AppDomain events might arrive on separate threads
             // at the same time. The interlock assures that we only do the work once.
-            if (Interlocked.Exchange(ref _inShutDown, true) == false)
+            if (!Interlocked.Exchange(ref _inShutDown, true))
             {
                 // ShutDown is a one-time event.  Stop listening (thus releasing
                 // references to the ShutDownListener).

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AccessibilitySwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AccessibilitySwitches.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
@@ -182,7 +182,7 @@ namespace System.Windows
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void VerifySwitches(Dispatcher dispatcher)
         {
-            if (Interlocked.CompareExchange(ref s_switchesVerified, true, false) == false)
+            if (!Interlocked.CompareExchange(ref s_switchesVerified, true, false))
             {
                 bool netFx47 = UseNetFx47CompatibleAccessibilityFeatures;
                 bool netFx471 = UseNetFx471CompatibleAccessibilityFeatures;
@@ -190,10 +190,10 @@ namespace System.Windows
 
                 // If a flag is set to false, we also must ensure the prior accessibility switches are also false.
                 // Otherwise we should inform the developer, via an exception, to enable all the flags.
-                if (!((netFx47 == false && netFx471 == false && netFx472 == false) ||
-                      (netFx47 == false && netFx471 == false && netFx472 == true) ||
-                      (netFx47 == false && netFx471 == true && netFx472 == true) ||
-                      (netFx47 == true && netFx471 == true && netFx472 == true)))
+                if (!((!netFx47 && !netFx471 && !netFx472) ||
+                      (!netFx47 && !netFx471 && netFx472) ||
+                      (!netFx47 && netFx471 && netFx472) ||
+                      (netFx47 && netFx471 && netFx472)))
                 { 
                     // Dispatch an EventLog and error throw so we get loaded UI, then the crash.
                     // This ensures the WER dialog shows.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
@@ -2639,7 +2639,7 @@ namespace System.Windows
             }
             finally
             {
-                Debug.Assert(CanModifyEffectiveValues == false, "We do not expect re-entrancy here.");
+                Debug.Assert(!CanModifyEffectiveValues, "We do not expect re-entrancy here.");
                 CanModifyEffectiveValues = true;
             }
 
@@ -3109,7 +3109,7 @@ namespace System.Windows
             Debug.Assert(!debugIndex.Found && debugIndex.Index == entryIndex, "Inserting duplicate");
 #endif
 
-            if (CanModifyEffectiveValues == false)
+            if (!CanModifyEffectiveValues)
             {
                 throw new InvalidOperationException(SR.LocalValueEnumerationInvalidated);
             }
@@ -3154,7 +3154,7 @@ namespace System.Windows
             // For thread-safety, sealed DOs can't modify _effectiveValues.
             Debug.Assert(!DO_Sealed, "A Sealed DO cannot be modified");
 
-            if (CanModifyEffectiveValues == false)
+            if (!CanModifyEffectiveValues)
             {
                 throw new InvalidOperationException(SR.LocalValueEnumerationInvalidated);
             }
@@ -3356,7 +3356,7 @@ namespace System.Windows
         {
             Debug.Assert(value != DependencyProperty.UnsetValue, "Value to be set cannot be UnsetValue");
             Debug.Assert(baseValue != DependencyProperty.UnsetValue, "BaseValue to be set cannot be UnsetValue");
-            Debug.Assert(entryIndex.Found == true, "The baseValue for the expression should have been inserted prior to this and hence there should already been an entry for it.");
+            Debug.Assert(entryIndex.Found, "The baseValue for the expression should have been inserted prior to this and hence there should already been an entry for it.");
 
             // For thread-safety, sealed DOs can't modify _effectiveValues.
             Debug.Assert(!DO_Sealed, "A Sealed DO cannot be modified");

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/EffectiveValueEntry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/EffectiveValueEntry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /***************************************************************************\
@@ -413,7 +413,7 @@ namespace System.Windows
             }
             else
             {
-                Debug.Assert(IsExpression == true);
+                Debug.Assert(IsExpression);
 
                 object expressionValue = modifiedValue.ExpressionValue;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Markup/ServiceProviders.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Markup/ServiceProviders.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows.Markup
@@ -38,7 +38,7 @@ namespace System.Windows.Markup
             ArgumentNullException.ThrowIfNull(serviceType);
             ArgumentNullException.ThrowIfNull(service);
 
-            if (_objDict.ContainsKey(serviceType) == false)
+            if (!_objDict.ContainsKey(serviceType))
             {
                 _objDict.Add(serviceType, service);
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
@@ -941,7 +941,7 @@ namespace System.Windows.Threading
                 }
             }
 
-            if (succeeded == true)
+            if (succeeded)
             {
                 // We have enqueued the operation.  Register a callback
                 // with the cancellation token to abort the operation

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherExceptionEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherExceptionEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows.Threading
@@ -55,7 +55,7 @@ namespace System.Windows.Threading
             set
             {
                 // Only allow to be set true.
-                if (value == true)
+                if (value)
                 {
                     _handled = value;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherExceptionFilterEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherExceptionFilterEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows.Threading
@@ -65,7 +65,7 @@ namespace System.Windows.Threading
             set
             {
                 // Only allow to be set false.
-                if (value == false)
+                if (!value)
                 {
                     _requestCatch = value;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/ElementHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/ElementHost.cs
@@ -426,7 +426,7 @@ namespace System.Windows.Forms.Integration
         /// </summary>
         protected override void Select(bool directed, bool forward)
         {
-            if (directed == true)
+            if (directed)
             {
                 SWI.TraversalRequest request = new SWI.TraversalRequest(forward
                                                         ? SWI.FocusNavigationDirection.First


### PR DESCRIPTION
Fixes #10642 

## Description

Avoids using `== false` and `== true` checks, uses `!` for `false` and nothing for `true` on `bool` instead.

## Customer Impact

Cleaner codebase for developers.

## Regression

No.

## Testing

Local testing/build.

## Risk

None, analyzer fix only.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10643)