### PR TITLE
[MilCodeGen] Optimize generated ValueSerializers code style and usings

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/BrushValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/BrushValueSerializer.cs
@@ -9,19 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.KnownBoxes;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
-using System.Windows.Media.Effects;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+using System.Windows.Media;
 using System.Windows.Markup;
-using System.Windows.Media.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Converters
 {
@@ -45,14 +36,7 @@ namespace System.Windows.Media.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // When invoked by the serialization engine we can convert to string only for some instances
-            if (!(value is Brush))
-            {
-                return false;
-            }
-
-            Brush instance  = (Brush) value;
-
-            return instance.CanSerializeToString();
+            return value is Brush brush && brush.CanSerializeToString();
         }
 
         /// <summary>
@@ -60,14 +44,7 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Brush.Parse(value, context );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Brush.Parse(value, context) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -75,19 +52,14 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Brush instance)
+            // When invoked by the serialization engine we can convert to string only for some instances
+            if (value is not Brush brush || !brush.CanSerializeToString())
             {
-                // When invoked by the serialization engine we can convert to string only for some instances
-                if (!instance.CanSerializeToString())
-                {
-                    // Let base throw an exception.
-                    return base.ConvertToString(value, context);
-                }
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return brush.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/CacheModeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/CacheModeValueSerializer.cs
@@ -9,19 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.KnownBoxes;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
-using System.Windows.Media.Effects;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+using System.Windows.Media;
 using System.Windows.Markup;
-using System.Windows.Media.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Converters
 {
@@ -45,14 +36,7 @@ namespace System.Windows.Media.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // When invoked by the serialization engine we can convert to string only for some instances
-            if (!(value is CacheMode))
-            {
-                return false;
-            }
-
-            CacheMode instance  = (CacheMode) value;
-
-            return instance.CanSerializeToString();
+            return value is CacheMode cacheMode && cacheMode.CanSerializeToString();
         }
 
         /// <summary>
@@ -60,14 +44,7 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return CacheMode.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? CacheMode.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -75,19 +52,14 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is CacheMode instance)
+            // When invoked by the serialization engine we can convert to string only for some instances
+            if (value is not CacheMode cacheMode || !cacheMode.CanSerializeToString())
             {
-                // When invoked by the serialization engine we can convert to string only for some instances
-                if (!instance.CanSerializeToString())
-                {
-                    // Let base throw an exception.
-                    return base.ConvertToString(value, context);
-                }
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return cacheMode.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/DoubleCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/DoubleCollectionValueSerializer.cs
@@ -9,19 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.KnownBoxes;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
-using System.Windows.Media.Effects;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+using System.Windows.Media;
 using System.Windows.Markup;
-using System.Windows.Media.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Converters
 {
@@ -45,12 +36,7 @@ namespace System.Windows.Media.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is DoubleCollection))
-            {
-                return false;
-            }
-
-            return true;
+            return value is DoubleCollection;
         }
 
         /// <summary>
@@ -58,14 +44,7 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return DoubleCollection.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? DoubleCollection.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -73,13 +52,13 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is DoubleCollection instance)
+            if (value is not DoubleCollection doubleCollection)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return doubleCollection.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/GeometryValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/GeometryValueSerializer.cs
@@ -9,19 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.KnownBoxes;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
-using System.Windows.Media.Effects;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+using System.Windows.Media;
 using System.Windows.Markup;
-using System.Windows.Media.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Converters
 {
@@ -45,14 +36,7 @@ namespace System.Windows.Media.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // When invoked by the serialization engine we can convert to string only for some instances
-            if (!(value is Geometry))
-            {
-                return false;
-            }
-
-            Geometry instance  = (Geometry) value;
-
-            return instance.CanSerializeToString();
+            return value is Geometry geometry && geometry.CanSerializeToString();
         }
 
         /// <summary>
@@ -60,14 +44,7 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Geometry.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Geometry.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -75,19 +52,14 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Geometry instance)
+            // When invoked by the serialization engine we can convert to string only for some instances
+            if (value is not Geometry geometry || !geometry.CanSerializeToString())
             {
-                // When invoked by the serialization engine we can convert to string only for some instances
-                if (!instance.CanSerializeToString())
-                {
-                    // Let base throw an exception.
-                    return base.ConvertToString(value, context);
-                }
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return geometry.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/Int32CollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/Int32CollectionValueSerializer.cs
@@ -9,19 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.KnownBoxes;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
-using System.Windows.Media.Effects;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+using System.Windows.Media;
 using System.Windows.Markup;
-using System.Windows.Media.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Converters
 {
@@ -45,12 +36,7 @@ namespace System.Windows.Media.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Int32Collection))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Int32Collection;
         }
 
         /// <summary>
@@ -58,14 +44,7 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Int32Collection.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Int32Collection.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -73,13 +52,13 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Int32Collection instance)
+            if (value is not Int32Collection int32Collection)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return int32Collection.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PathFigureCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PathFigureCollectionValueSerializer.cs
@@ -9,19 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.KnownBoxes;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
-using System.Windows.Media.Effects;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+using System.Windows.Media;
 using System.Windows.Markup;
-using System.Windows.Media.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Converters
 {
@@ -45,14 +36,7 @@ namespace System.Windows.Media.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // When invoked by the serialization engine we can convert to string only for some instances
-            if (!(value is PathFigureCollection))
-            {
-                return false;
-            }
-
-            PathFigureCollection instance  = (PathFigureCollection) value;
-
-            return instance.CanSerializeToString();
+            return value is PathFigureCollection pathFigureCollection && pathFigureCollection.CanSerializeToString();
         }
 
         /// <summary>
@@ -60,14 +44,7 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return PathFigureCollection.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? PathFigureCollection.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -75,19 +52,14 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is PathFigureCollection instance)
+            // When invoked by the serialization engine we can convert to string only for some instances
+            if (value is not PathFigureCollection pathFigureCollection || !pathFigureCollection.CanSerializeToString())
             {
-                // When invoked by the serialization engine we can convert to string only for some instances
-                if (!instance.CanSerializeToString())
-                {
-                    // Let base throw an exception.
-                    return base.ConvertToString(value, context);
-                }
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return pathFigureCollection.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PointCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PointCollectionValueSerializer.cs
@@ -9,19 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.KnownBoxes;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
-using System.Windows.Media.Effects;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+using System.Windows.Media;
 using System.Windows.Markup;
-using System.Windows.Media.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Converters
 {
@@ -45,12 +36,7 @@ namespace System.Windows.Media.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is PointCollection))
-            {
-                return false;
-            }
-
-            return true;
+            return value is PointCollection;
         }
 
         /// <summary>
@@ -58,14 +44,7 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return PointCollection.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? PointCollection.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -73,13 +52,13 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is PointCollection instance)
+            if (value is not PointCollection pointCollection)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return pointCollection.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/TransformValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/TransformValueSerializer.cs
@@ -9,19 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.KnownBoxes;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
-using System.Windows.Media.Effects;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+using System.Windows.Media;
 using System.Windows.Markup;
-using System.Windows.Media.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Converters
 {
@@ -45,14 +36,7 @@ namespace System.Windows.Media.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // When invoked by the serialization engine we can convert to string only for some instances
-            if (!(value is Transform))
-            {
-                return false;
-            }
-
-            Transform instance  = (Transform) value;
-
-            return instance.CanSerializeToString();
+            return value is Transform transform && transform.CanSerializeToString();
         }
 
         /// <summary>
@@ -60,14 +44,7 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Transform.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Transform.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -75,19 +52,14 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Transform instance)
+            // When invoked by the serialization engine we can convert to string only for some instances
+            if (value is not Transform transform || !transform.CanSerializeToString())
             {
-                // When invoked by the serialization engine we can convert to string only for some instances
-                if (!instance.CanSerializeToString())
-                {
-                    // Let base throw an exception.
-                    return base.ConvertToString(value, context);
-                }
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return transform.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/VectorCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/VectorCollectionValueSerializer.cs
@@ -9,19 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.KnownBoxes;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
-using System.Windows.Media.Effects;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+using System.Windows.Media;
 using System.Windows.Markup;
-using System.Windows.Media.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Converters
 {
@@ -45,12 +36,7 @@ namespace System.Windows.Media.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is VectorCollection))
-            {
-                return false;
-            }
-
-            return true;
+            return value is VectorCollection;
         }
 
         /// <summary>
@@ -58,14 +44,7 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return VectorCollection.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? VectorCollection.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -73,13 +52,13 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is VectorCollection instance)
+            if (value is not VectorCollection vectorCollection)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return vectorCollection.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Matrix3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Matrix3DValueSerializer.cs
@@ -9,17 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
+using System.Windows.Media.Media3D;
 using System.Windows.Markup;
-using System.Windows.Media.Media3D.Converters;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Media3D.Converters
 {
@@ -43,12 +36,7 @@ namespace System.Windows.Media.Media3D.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Matrix3D))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Matrix3D;
         }
 
         /// <summary>
@@ -56,14 +44,7 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Matrix3D.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Matrix3D.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -71,13 +52,13 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Matrix3D instance)
+            if (value is not Matrix3D matrix3D)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return matrix3D.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DCollectionValueSerializer.cs
@@ -9,17 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
+using System.Windows.Media.Media3D;
 using System.Windows.Markup;
-using System.Windows.Media.Media3D.Converters;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Media3D.Converters
 {
@@ -43,12 +36,7 @@ namespace System.Windows.Media.Media3D.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Point3DCollection))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Point3DCollection;
         }
 
         /// <summary>
@@ -56,14 +44,7 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Point3DCollection.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Point3DCollection.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -71,13 +52,13 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Point3DCollection instance)
+            if (value is not Point3DCollection point3DCollection)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return point3DCollection.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DValueSerializer.cs
@@ -9,17 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
+using System.Windows.Media.Media3D;
 using System.Windows.Markup;
-using System.Windows.Media.Media3D.Converters;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Media3D.Converters
 {
@@ -43,12 +36,7 @@ namespace System.Windows.Media.Media3D.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Point3D))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Point3D;
         }
 
         /// <summary>
@@ -56,14 +44,7 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Point3D.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Point3D.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -71,13 +52,13 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Point3D instance)
+            if (value is not Point3D point3D)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return point3D.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point4DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point4DValueSerializer.cs
@@ -9,17 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
+using System.Windows.Media.Media3D;
 using System.Windows.Markup;
-using System.Windows.Media.Media3D.Converters;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Media3D.Converters
 {
@@ -43,12 +36,7 @@ namespace System.Windows.Media.Media3D.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Point4D))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Point4D;
         }
 
         /// <summary>
@@ -56,14 +44,7 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Point4D.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Point4D.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -71,13 +52,13 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Point4D instance)
+            if (value is not Point4D point4D)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return point4D.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/QuaternionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/QuaternionValueSerializer.cs
@@ -9,17 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
+using System.Windows.Media.Media3D;
 using System.Windows.Markup;
-using System.Windows.Media.Media3D.Converters;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Media3D.Converters
 {
@@ -43,12 +36,7 @@ namespace System.Windows.Media.Media3D.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Quaternion))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Quaternion;
         }
 
         /// <summary>
@@ -56,14 +44,7 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Quaternion.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Quaternion.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -71,13 +52,13 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Quaternion instance)
+            if (value is not Quaternion quaternion)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return quaternion.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Rect3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Rect3DValueSerializer.cs
@@ -9,17 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
+using System.Windows.Media.Media3D;
 using System.Windows.Markup;
-using System.Windows.Media.Media3D.Converters;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Media3D.Converters
 {
@@ -43,12 +36,7 @@ namespace System.Windows.Media.Media3D.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Rect3D))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Rect3D;
         }
 
         /// <summary>
@@ -56,14 +44,7 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Rect3D.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Rect3D.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -71,13 +52,13 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Rect3D instance)
+            if (value is not Rect3D rect3D)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return rect3D.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Size3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Size3DValueSerializer.cs
@@ -9,17 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
+using System.Windows.Media.Media3D;
 using System.Windows.Markup;
-using System.Windows.Media.Media3D.Converters;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Media3D.Converters
 {
@@ -43,12 +36,7 @@ namespace System.Windows.Media.Media3D.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Size3D))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Size3D;
         }
 
         /// <summary>
@@ -56,14 +44,7 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Size3D.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Size3D.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -71,13 +52,13 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Size3D instance)
+            if (value is not Size3D size3D)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return size3D.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DCollectionValueSerializer.cs
@@ -9,17 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
+using System.Windows.Media.Media3D;
 using System.Windows.Markup;
-using System.Windows.Media.Media3D.Converters;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Media3D.Converters
 {
@@ -43,12 +36,7 @@ namespace System.Windows.Media.Media3D.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Vector3DCollection))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Vector3DCollection;
         }
 
         /// <summary>
@@ -56,14 +44,7 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Vector3DCollection.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Vector3DCollection.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -71,13 +52,13 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Vector3DCollection instance)
+            if (value is not Vector3DCollection vector3DCollection)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return vector3DCollection.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DValueSerializer.cs
@@ -9,17 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using MS.Internal.Collections;
-using MS.Utility;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
+using System.Windows.Media.Media3D;
 using System.Windows.Markup;
-using System.Windows.Media.Media3D.Converters;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Composition;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Media3D.Converters
 {
@@ -43,12 +36,7 @@ namespace System.Windows.Media.Media3D.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Vector3D))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Vector3D;
         }
 
         /// <summary>
@@ -56,14 +44,7 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Vector3D.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Vector3D.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -71,13 +52,13 @@ namespace System.Windows.Media.Media3D.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Vector3D instance)
+            if (value is not Vector3D vector3D)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return vector3D.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/Int32RectValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/Int32RectValueSerializer.cs
@@ -9,11 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using System.ComponentModel;
-using System.Globalization;
+using System.Windows;
 using System.Windows.Markup;
-using System.Windows.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Converters
 {
@@ -37,12 +36,7 @@ namespace System.Windows.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Int32Rect))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Int32Rect;
         }
 
         /// <summary>
@@ -50,14 +44,7 @@ namespace System.Windows.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Int32Rect.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Int32Rect.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -65,13 +52,13 @@ namespace System.Windows.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Int32Rect instance)
+            if (value is not Int32Rect int32Rect)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return int32Rect.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/PointValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/PointValueSerializer.cs
@@ -9,11 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using System.ComponentModel;
-using System.Globalization;
+using System.Windows;
 using System.Windows.Markup;
-using System.Windows.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Converters
 {
@@ -37,12 +36,7 @@ namespace System.Windows.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Point))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Point;
         }
 
         /// <summary>
@@ -50,14 +44,7 @@ namespace System.Windows.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Point.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Point.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -65,13 +52,13 @@ namespace System.Windows.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Point instance)
+            if (value is not Point point)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return point.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/RectValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/RectValueSerializer.cs
@@ -9,11 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using System.ComponentModel;
-using System.Globalization;
+using System.Windows;
 using System.Windows.Markup;
-using System.Windows.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Converters
 {
@@ -37,12 +36,7 @@ namespace System.Windows.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Rect))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Rect;
         }
 
         /// <summary>
@@ -50,14 +44,7 @@ namespace System.Windows.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Rect.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Rect.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -65,13 +52,13 @@ namespace System.Windows.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Rect instance)
+            if (value is not Rect rect)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return rect.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/SizeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/SizeValueSerializer.cs
@@ -9,11 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using System.ComponentModel;
-using System.Globalization;
+using System.Windows;
 using System.Windows.Markup;
-using System.Windows.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Converters
 {
@@ -37,12 +36,7 @@ namespace System.Windows.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Size))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Size;
         }
 
         /// <summary>
@@ -50,14 +44,7 @@ namespace System.Windows.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Size.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Size.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -65,13 +52,13 @@ namespace System.Windows.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Size instance)
+            if (value is not Size size)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return size.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/VectorValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/VectorValueSerializer.cs
@@ -9,11 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using System.ComponentModel;
-using System.Globalization;
+using System.Windows;
 using System.Windows.Markup;
-using System.Windows.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Converters
 {
@@ -37,12 +36,7 @@ namespace System.Windows.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Vector))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Vector;
         }
 
         /// <summary>
@@ -50,14 +44,7 @@ namespace System.Windows.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Vector.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Vector.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -65,13 +52,13 @@ namespace System.Windows.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Vector instance)
+            if (value is not Vector vector)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return vector.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Converters/Generated/MatrixValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Converters/Generated/MatrixValueSerializer.cs
@@ -9,11 +9,10 @@
 // Please see MilCodeGen.html for more information.
 //
 
-using MS.Internal;
-using System.ComponentModel;
-using System.Globalization;
+using System.Windows.Media;
 using System.Windows.Markup;
-using System.Windows.Media.Converters;
+
+using ConverterHelper = System.Windows.Markup.TypeConverterHelper;
 
 namespace System.Windows.Media.Converters
 {
@@ -37,12 +36,7 @@ namespace System.Windows.Media.Converters
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if (!(value is Matrix))
-            {
-                return false;
-            }
-
-            return true;
+            return value is Matrix;
         }
 
         /// <summary>
@@ -50,14 +44,7 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext context)
         {
-            if (value != null)
-            {
-                return Matrix.Parse(value );
-            }
-            else
-            {
-                return base.ConvertFromString( value, context );
-            }
+            return value is not null ? Matrix.Parse(value) : base.ConvertFromString(value, context);
         }
 
         /// <summary>
@@ -65,13 +52,13 @@ namespace System.Windows.Media.Converters
         /// </summary>
         public override string ConvertToString(object value, IValueSerializerContext context)
         {
-            if (value is Matrix instance)
+            if (value is not Matrix matrix)
             {
-
-                return instance.ConvertToString(null, System.Windows.Markup.TypeConverterHelper.InvariantEnglishUS);
+                // Let base throw an exception.
+                return base.ConvertToString(value, context);
             }
 
-            return base.ConvertToString(value, context);
+            return matrix.ConvertToString(null, ConverterHelper.InvariantEnglishUS);
         }
     }
 }


### PR DESCRIPTION
## Description

Resolves numerous IDE warnings and reflects more closely current code-style in derived ValueSerializers. 

Also removes redundant usings. Instead of using the collection from the resource tree, we only really need the managed namespace for the resource itself and `System.Windows.Markup` for `ValueSerializer`, this is static dependency so the definition doesn't need to be in the resource model itself (same thing as `System.Windows.Markup.TypeConverterHelper` is directly linked in generator code).

Reviewing `ManagedStruct.cs` shall be enough to get the grip of the changes, also the changes are always consistent per-folder so 1 file gives you overview of full set of changes for that particular set of resources.

## Customer Impact

Cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low.
