### PR TITLE
Fix Indeterminate Progress Bar animation with Cache Mode set up

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ProgressBar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ProgressBar.cs
@@ -274,7 +274,11 @@ namespace System.Windows.Controls
         {
             // We change the visual state to determinate when not IsVisible for performance reasons.
             // By default, the animation for the Indeterminate state will continue even when the progress bar is not visible.
-            if (!IsIndeterminate || !IsVisible)
+
+            // However, we can only allow ourselves to do that if the ProgressBar is not being cached, since when the UIElement is defined within
+            // resources, IsVisible property will always evaluate to false as the UIElement is not a part of the visual tree at that point. (#8960)
+
+            if (!IsIndeterminate || (!IsVisible && CacheMode is null))
             {
                 VisualStateManager.GoToState(this, VisualStates.StateDeterminate, useTransitions);
             }


### PR DESCRIPTION
Fixes #8960 

## Description

Adjusts the logic behind transitioning to `Determinate` state to avoid background animation to exclude when a `CacheMode` is set up on the `ProgressBar` and the ProgressBar is not a part of the visual tree (`IsVisible` evaluates to `false`).

## Customer Impact

Customers will not be able to cache their indeterminate progress bars.

## Regression

Yeah, broken in #6266.

## Testing

Local build, repro in #8960 and #6264.

## Risk

Medium, we should have more test cases covering these kinda changes.