### PR TITLE
Fix measuring passes in AdornerLayer of the underlying Adorner elements

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/AdornerLayer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/AdornerLayer.cs
@@ -528,12 +528,12 @@ namespace System.Windows.Documents
         /// Clean all the dynamically-updated data from the Adorner
         /// </summary>
         /// <param name="adornerInfo">AdornerInfo to scrub</param>
-        internal void InvalidateAdorner(AdornerInfo adornerInfo)
+        internal static void InvalidateAdorner(AdornerInfo adornerInfo)
         {
             Debug.Assert(adornerInfo != null, "Adorner should not be null");
             adornerInfo.Adorner.InvalidateMeasure();
             adornerInfo.Adorner.InvalidateVisual();
-            adornerInfo.RenderSize = new Size(Double.NaN, Double.NaN);
+            adornerInfo.RenderSize = new Size(double.NaN, double.NaN);
             adornerInfo.Transform = null;
         }
 
@@ -742,13 +742,23 @@ namespace System.Windows.Documents
                     transform.AffineTransform.Value != adornerInfo.Transform.AffineTransform.Value ||
                     clipChanged)
                 {
-                    InvalidateAdorner(adornerInfo);
+                    adornerInfo.Adorner.InvalidateMeasure();
+                    adornerInfo.Adorner.InvalidateVisual();
+
                     adornerInfo.RenderSize = size;
                     adornerInfo.Transform = transform;
+
                     if (adornerInfo.Adorner.IsClipEnabled)
                     {
                         adornerInfo.Clip = clip;
                     }
+
+                    dirty = true;
+                }
+                else if (adornerInfo.Adorner.ArrangeDirty)
+                {
+                    adornerInfo.Adorner.InvalidateMeasure();
+
                     dirty = true;
                 }
             }


### PR DESCRIPTION
Fixes #10640 

## Description

Marks `AdornerLayer` dirty when any of the `Adorners` is dirty and forces a measure pass so that the position is updated.

Due to the aggressive performance optimization to only re-render when size/position changes (including transforms),
a case such as this has been overlooked so the position of the respective Adorner's is wrong while all flags are correct.

This could have been workarounded via synchronous `UpdateLayout` pass called by the user or invoking visual re-invalidation but due to its asynchronous nature this would only work the second time around.

I have also removed the redundant assigment of cached `RenderSize`/`Transform` and in-lined the two calls instead.

This shall not add any unnecessary overhead according to my testing.

## Customer Impact

If the fix is not taken, customers will continue to observe unwanted behaviour and will be requires to use computionally expensive and synchronous updates to receive the correct position for Adorners upon adorned `UIElement` changes.

## Regression

Not according to my tests, this seems to be present both on `.NET Core` and `NETFX`.

## Testing

Local build, repro tests, tests with adorners.

## Risk

Medium, it would be beneficial to test more real-life examples of adorners.
