### PR TITLE
[Cleanup] Use named arguments in PresentationFramework

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
@@ -399,7 +399,7 @@ namespace MS.Internal.Annotations.Anchoring
                 ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(offset, realLocator.Parts.Count);
             }
 
-            return InternalResolveLocator(locator, offset, startNode, false /*skipStartNode*/, out attachmentLevel);
+            return InternalResolveLocator(locator, offset, startNode, skipStartNode: false, out attachmentLevel);
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
@@ -538,7 +538,7 @@ namespace MS.Internal.Annotations.Anchoring
                 {
                     // Now we try to resolve.  If any locator parts were matched to the startNode we want to 
                     // start resolving with its children, skipping a revisit to the startNode.
-                    anchor = InternalResolveLocator(locator, locatorPartIdx, startNode, locatorPartIdx != 0 /*skipStartNode*/, out attachmentLevel);
+                    anchor = InternalResolveLocator(locator, locatorPartIdx, startNode, skipStartNode: locatorPartIdx != 0, out attachmentLevel);
                 }
 
                 // If nothing was returned, we base our return values on the results

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppSecurityManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppSecurityManager.cs
@@ -91,12 +91,12 @@ namespace MS.Internal.AppModel
                     // assumed safe - because we're only allowing this for mailto urls. 
                     // 
 
-                    UnsafeNativeMethods.ShellExecute(new HandleRef(null, IntPtr.Zero), /*hwnd*/
-                                                      null, /*operation*/
-                                                      BindUriHelper.UriToString(destinationUri), /*file*/
-                                                      null, /*parameters*/
-                                                      null, /*directory*/
-                                                      0); /*nShowCmd*/
+                    UnsafeNativeMethods.ShellExecute(hwnd: new HandleRef(null, IntPtr.Zero),
+                                                      lpOperation: null,
+                                                      lpFile: BindUriHelper.UriToString(destinationUri),
+                                                      lpParameters: null,
+                                                      lpDirectory: null,
+                                                      nShowCmd: 0);
                     launched = LaunchResult.Launched;
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CompositeCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CompositeCollectionView.cs
@@ -33,7 +33,7 @@ namespace MS.Internal.Data
 
         // create the new CompositeCollectionView for a CompositeCollection
         internal CompositeCollectionView(CompositeCollection collection)
-            : base(collection, -1 /* don't move to first */)    // base.ctor also subscribes to CollectionChanged event of CompositeCollection
+            : base(collection, moveToFirst: -1)    // base.ctor also subscribes to CollectionChanged event of CompositeCollection
         {
             _collection = collection;
             _collection.ContainedCollectionChanged += new NotifyCollectionChangedEventHandler(OnContainedCollectionChanged);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DefaultValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DefaultValueConverter.cs
@@ -555,7 +555,7 @@ namespace MS.Internal.Data
 
         public ObjectTargetConverter(Type sourceType, DataBindEngine engine) :
             base(null, sourceType, typeof(object),
-                 true /* shouldConvertFrom */, false /* shouldConvertTo */, engine)
+                 shouldConvertFrom: true, shouldConvertTo: false, engine)
         {
         }
 
@@ -602,7 +602,7 @@ namespace MS.Internal.Data
 
         public ObjectSourceConverter(Type targetType, DataBindEngine engine) :
             base(null, typeof(object), targetType,
-                 true /* shouldConvertFrom */, false /* shouldConvertTo */, engine)
+                 shouldConvertFrom: true, shouldConvertTo: false, engine)
         {
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/BamlTreeUpdater.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/BamlTreeUpdater.cs
@@ -88,8 +88,8 @@ namespace MS.Internal.Globalization
                             BamlStartElementNode newNode = new BamlStartElementNode(
                                 treeMap.Resolver.ResolveAssemblyFromClass(key.ClassName),
                                 key.ClassName,
-                                false, /*isInjected*/
-                                false /*CreateUsingTypeConverter*/
+                                isInjected: false,
+                                useTypeConverter: false
                                 );
 
                             // create new x:Uid node for this element node
@@ -514,8 +514,8 @@ namespace MS.Internal.Globalization
                     bamlNode = new BamlStartElementNode(
                         assemblyName,
                         className,
-                        false, /*isInjected*/
-                        false /*CreateUsingTypeConverter*/
+                        isInjected: false,
+                        useTypeConverter: false
                         );
 
                     if (tagUid != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
@@ -961,7 +961,7 @@ namespace MS.Internal
                     // for "fake" properties (no corresponding DP - e.g. VSP's desired-size),
                     // set the property directly into the effective value table
                     EntryIndex entryIndex = container.LookupEntry(dpIndex);
-                    container.SetEffectiveValue(entryIndex, null /*dp*/, dpIndex, null /*metadata*/, value, BaseValueSourceInternal.Local);
+                    container.SetEffectiveValue(entryIndex, dp: null, dpIndex, metadata: null, value, BaseValueSourceInternal.Local);
                 }
             }
         }
@@ -1314,7 +1314,7 @@ namespace MS.Internal
         /// <param name="pathEndElement">ancestor to stop invalidation at</param>
         internal static void InvalidateMeasureOnPath(DependencyObject pathStartElement, DependencyObject pathEndElement, bool duringMeasure)
         {
-            InvalidateMeasureOnPath(pathStartElement, pathEndElement, duringMeasure, false /*includePathEnd*/);
+            InvalidateMeasureOnPath(pathStartElement, pathEndElement, duringMeasure, includePathEnd: false);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/XamlFilter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/XamlFilter.cs
@@ -981,7 +981,7 @@ namespace MS.Internal.IO.Packaging
         /// The default content descriptor has content in child nodes, no title, and block-type content.
         /// </summary>
         private readonly ContentDescriptor _defaultContentDescriptor  =
-            new ContentDescriptor(true /*hasIndexableContent*/, false /*isInline*/, null, null);
+            new ContentDescriptor(hasIndexableContent: true, isInline: false, null, null);
 
         private readonly ContentDescriptor _nonIndexableElementDescriptor =
             new ContentDescriptor(false);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/EditingCoordinator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/EditingCoordinator.cs
@@ -91,7 +91,7 @@ namespace MS.Internal.Ink
                     //we pass true for userInitiated because we've simply consulted the InputDevice
                     //(and only StylusDevice or MouseDevice) for the current position of the device
                     InitializeCapture(inputDevice, (IStylusEditing)dynamicBehavior, 
-                        true /*userInitiated*/, false/*Don't reset the RTI*/);
+                        userInitiated: true, false/*Don't reset the RTI*/);
                     fSucceeded = true;
                 }
                 finally

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/EraserBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/EraserBehavior.cs
@@ -123,7 +123,7 @@ namespace MS.Internal.Ink
                             && newBehavior != null )
                         {
                             // Now add the previous points to the lasso behavior
-                            newBehavior.AddStylusPoints(cachedPoints, false/*userInitiated*/);
+                            newBehavior.AddStylusPoints(cachedPoints, userInitiated: false);
                         }
 
                         break;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/InkCanvasSelection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/InkCanvasSelection.cs
@@ -484,7 +484,7 @@ namespace MS.Internal.Ink
 
         internal void TransformStrokes(StrokeCollection strokes, Matrix matrix)
         {
-            strokes.Transform(matrix, false /*Don't apply the transform to StylusTip*/);
+            strokes.Transform(matrix, applyToStylusTip: false);
         }
 
         internal InkCanvasSelectionHitResult HitTestSelection(Point pointOnInkCanvas)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/InkCollectionBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/InkCollectionBehavior.cs
@@ -145,7 +145,7 @@ namespace MS.Internal.Ink
                             // Now add the previous points to the lasso behavior
                             // The SelectionBehavior doesn't check userInitiated, pass false
                             // even if our _userInitiated flag is true
-                            newBehavior.AddStylusPoints(cachedPoints, false/*userInitiated*/);
+                            newBehavior.AddStylusPoints(cachedPoints, userInitiated: false);
                         }
 
                         break;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/PenCursorManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/PenCursorManager.cs
@@ -89,7 +89,7 @@ namespace MS.Internal.Ink
             }
 
             // Forward to GetPenCursor.
-            return GetPenCursor(da, true, false/*isRightToLeft*/, dpiScaleX, dpiScaleY);
+            return GetPenCursor(da, true, isRightToLeft: false, dpiScaleX, dpiScaleY);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/BackgroundFormatInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/BackgroundFormatInfo.cs
@@ -195,7 +195,7 @@ namespace MS.Internal.PtsHost
 
             if (_pendingBackgroundFormatter != null)
             {
-                BackgroundFormat(_pendingBackgroundFormatter, true /* ignoreThrottle */);
+                BackgroundFormat(_pendingBackgroundFormatter, ignoreThrottle: true);
                 _pendingBackgroundFormatter = null;
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/LineBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/LineBase.cs
@@ -93,7 +93,7 @@ namespace MS.Internal.PtsHost
             // Extract the aggregated properties into something that the textrun can use.
             //      For properties that can be applied to Highlight services, need to use 'textHighlights'.
             //      Right now only background is properly retrieved.
-            TextProperties textProps = new TextProperties(element, position, false /* inline objects */, true /* get background */,
+            TextProperties textProps = new TextProperties(element, position, inlineObjects: false, getBackground: true,
                 _paraClient.Paragraph.StructuralCache.TextFormatterHost.PixelsPerDip);
 
             // Calculate the end of the run by finding either:
@@ -163,7 +163,7 @@ namespace MS.Internal.PtsHost
                 // Empty TextElement should affect line metrics.
                 // TextFormatter does not support this feature right now, so as workaround
                 // TextRun with ZERO WIDTH SPACE is used.
-                TextProperties textProps = new TextProperties(element, position, false /* inline objects */, true /* get background */,
+                TextProperties textProps = new TextProperties(element, position, inlineObjects: false, getBackground: true,
                     _paraClient.Paragraph.StructuralCache.TextFormatterHost.PixelsPerDip);
 
                 char[] textBuffer = new char[_elementEdgeCharacterLength * 2];
@@ -304,7 +304,7 @@ namespace MS.Internal.PtsHost
             if (embeddedObject is UIElement)
             {
                 // Extract the aggregated properties into something that the textrun can use.
-                TextRunProperties textProps = new TextProperties(embeddedObject, position, true /* inline objects */, true /* get background */,
+                TextRunProperties textProps = new TextProperties(embeddedObject, position, inlineObjects: true, getBackground: true,
                     _paraClient.Paragraph.StructuralCache.TextFormatterHost.PixelsPerDip);
 
                 // Create inline object run.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/ListParaClient.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/ListParaClient.cs
@@ -59,7 +59,7 @@ namespace MS.Internal.PtsHost
             
             // This textProperties object is eventually used in creation of LineProperties, which leads to creation of a TextMarkerSource. TextMarkerSource relies on PixelsPerDip
             // from TextProperties, therefore it must be set here properly.
-            TextProperties textProperties = new TextProperties(Paragraph.Element, StaticTextPointer.Null, false /* inline objects */, false /* get background */,
+            TextProperties textProperties = new TextProperties(Paragraph.Element, StaticTextPointer.Null, inlineObjects: false, getBackground: false,
                 Paragraph.StructuralCache.TextFormatterHost.PixelsPerDip);
 
             // There might be possibility to get empty sub-track, skip the sub-track in such case.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsHost.cs
@@ -1437,7 +1437,7 @@ namespace MS.Internal.PtsHost
                 TextParaClient paraClient = PtsContext.HandleToObject(pfsparaclient) as TextParaClient;
                 PTS.ValidateHandle(paraClient);
                 para.FormatLine(paraClient, iArea, dcp, pbrlineIn, fswdir, urStartLine, durLine, urStartTrack, durTrack, urPageLeftMargin, 
-                    true/*fAllowHyphenation*/, PTS.ToBoolean(fClearOnLeft), PTS.ToBoolean(fClearOnRight), PTS.ToBoolean(fTreatAsFirstInPara), PTS.ToBoolean(fTreatAsLastInPara), 
+                    fAllowHyphenation: true, PTS.ToBoolean(fClearOnLeft), PTS.ToBoolean(fClearOnRight), PTS.ToBoolean(fTreatAsFirstInPara), PTS.ToBoolean(fTreatAsLastInPara), 
                     PTS.ToBoolean(fSuppressTopSpace), out pfsline, out dcpLine, out ppbrlineOut, out fForcedBrokenIgnore, out fsflres, 
                     out dvrAscent, out dvrDescent, out urBBox, out durBBox,  out dcpDepend, 
                     out fReformatNeighborsAsLastLineIgnore);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsPage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsPage.cs
@@ -169,7 +169,7 @@ namespace MS.Internal.PtsHost
                     // Update structural cache info. The DestroyStructureCache parameter is set to true if
                     // the name table is not preserved. If the name table is to be preserved, e.g. for highlight
                     // changed, we do not clear structure cache
-                    _section.StructuralCache.ClearUpdateInfo(/*destroy structure cache:*/ _section.StructuralCache.DestroyStructure);
+                    _section.StructuralCache.ClearUpdateInfo(destroyStructureCache: _section.StructuralCache.DestroyStructure);
                 } 
                 // If there is DRT list, invalidate entire NameTable starting from the 
                 // position of the first DTR.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsPage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsPage.cs
@@ -257,7 +257,7 @@ namespace MS.Internal.PtsHost
 
             if (formattingOwner.Formatter is FlowDocumentFormatter)
             {
-                _section.StructuralCache.BackgroundFormatInfo.BackgroundFormat(formattingOwner.BottomlessFormatter, false /* ignoreThrottle */);
+                _section.StructuralCache.BackgroundFormatInfo.BackgroundFormat(formattingOwner.BottomlessFormatter, ignoreThrottle: false);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParagraph.cs
@@ -1490,7 +1490,7 @@ namespace MS.Internal.PtsHost
                 // This textProperties object is eventually used in creation of LineProperties, which leads to creation of a TextMarkerSource. TextMarkerSource relies on PixelsPerDip
                 // from TextProperties, therefore it must be set here properly.
 
-                TextProperties defaultTextProperties = new TextProperties(Element, StaticTextPointer.Null, false /* inline objects */, false /* get background */,
+                TextProperties defaultTextProperties = new TextProperties(Element, StaticTextPointer.Null, inlineObjects: false, getBackground: false,
                     StructuralCache.TextFormatterHost.PixelsPerDip);
                 
                 _lineProperties = new LineProperties(Element, StructuralCache.FormattingOwner, defaultTextProperties, null); // No marker properties

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/ComplexLine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/ComplexLine.cs
@@ -345,7 +345,7 @@ namespace MS.Internal.Text
             //      For properties that can be applied to Highlight services,
             //      need to use 'textHighlights'.
             //      Right now only background is properly retrieved.
-            TextRunProperties textProps = new TextProperties(element, position, false /* inline objects */, true /* get background */, PixelsPerDip);
+            TextRunProperties textProps = new TextProperties(element, position, inlineObjects: false, getBackground: true, PixelsPerDip);
 
             // Calculate the end of the run by finding either:
             //      a) the next intersection of highlight ranges, or
@@ -394,7 +394,7 @@ namespace MS.Internal.Text
                 // Empty TextElement should affect line metrics.
                 // TextFormatter does not support this feature right now, so as workaround
                 // TextRun with ZERO WIDTH SPACE is used.
-                TextRunProperties textProps = new TextProperties(element, position, false /* inline objects */, true /* get background */, PixelsPerDip);
+                TextRunProperties textProps = new TextProperties(element, position, inlineObjects: false, getBackground: true, PixelsPerDip);
                 char[] textBuffer = new char[_elementEdgeCharacterLength * 2];
                 textBuffer[0] = (char)0x200B;
                 textBuffer[1] = (char)0x200B;
@@ -527,7 +527,7 @@ namespace MS.Internal.Text
             {
                 //  Need to Handle visibility collapsed.
 
-                TextRunProperties textProps = new TextProperties(element, position, true /* inline objects */, true /* get background */, PixelsPerDip);
+                TextRunProperties textProps = new TextProperties(element, position, inlineObjects: true, getBackground: true, PixelsPerDip);
 
                 // Create object run.
                 run = new InlineObject(dcp, TextContainerHelper.EmbeddedObjectLength, (UIElement)element, textProps, _owner);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentGrid.cs
@@ -469,7 +469,7 @@ namespace MS.Internal.Documents
             EventTrace.EasyTraceEvent(EventTrace.Keyword.KeywordXPS, EventTrace.Event.WClientDRXLayoutBegin);
 
             QueueUpdateDocumentLayout(
-                new DocumentLayout(1 /* one column */, ViewMode.PageWidth));
+                new DocumentLayout(columns: 1, ViewMode.PageWidth));
         }
 
         /// <summary>
@@ -481,7 +481,7 @@ namespace MS.Internal.Documents
             EventTrace.EasyTraceEvent(EventTrace.Keyword.KeywordXPS, EventTrace.Event.WClientDRXLayoutBegin);
 
             QueueUpdateDocumentLayout(
-                new DocumentLayout(1 /* one column */, ViewMode.PageHeight));
+                new DocumentLayout(columns: 1, ViewMode.PageHeight));
         }
 
         /// <summary>
@@ -494,7 +494,7 @@ namespace MS.Internal.Documents
             EventTrace.EasyTraceEvent(EventTrace.Keyword.KeywordXPS, EventTrace.Event.WClientDRXLayoutBegin);
 
             QueueUpdateDocumentLayout(
-                new DocumentLayout(1 /* one column, arbitrary */, ViewMode.Thumbnails));
+                new DocumentLayout(columns: 1 /* arbitrary */, ViewMode.Thumbnails));
         }
 
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentGrid.cs
@@ -700,7 +700,7 @@ namespace MS.Internal.Documents
 
                     //Clear out our visual collection so that the old pages (pointing to old content)
                     //will be replaced with new ones on the next Measure/Arrange pass.
-                    ResetVisualTree(false /*pruneOnly*/);
+                    ResetVisualTree(pruneOnly: false);
                     ResetPageViewCollection();
 
                     //Reset our visible pages.
@@ -1336,7 +1336,7 @@ namespace MS.Internal.Documents
             //If not, we can just clear our visual collection and return.
             if (_rowCache.RowCount == 0)
             {
-                ResetVisualTree(false /*pruneOnly*/);
+                ResetVisualTree(pruneOnly: false);
                 ResetPageViewCollection();
                 _firstVisibleRow = 0;
                 _visibleRowCount = 0;
@@ -1361,7 +1361,7 @@ namespace MS.Internal.Documents
             //Do we have no visible rows at all?  Then clear the Visual collection and return.
             if (newVisibleRowCount == 0)
             {
-                ResetVisualTree(false /*pruneOnly*/);
+                ResetVisualTree(pruneOnly: false);
                 ResetPageViewCollection();
                 _firstVisibleRow = 0;
                 _visibleRowCount = 0;
@@ -1453,7 +1453,7 @@ namespace MS.Internal.Documents
                 //the MultiPageTextView's list of visible DocumentPageViews.
                 //First, prune our visual tree so it only contains the set of pages that are visible
                 //before and after the layout change.
-                ResetVisualTree(true /*pruneOnly*/);
+                ResetVisualTree(pruneOnly: true);
 
                 Collection<DocumentPageView> documentPageViews =
                     new Collection<DocumentPageView>();
@@ -1812,7 +1812,7 @@ namespace MS.Internal.Documents
                     Rect boundingRect = (data.Rect != Rect.Empty) ? data.Rect : data.Visual.VisualContentBounds;
 
                     Rect offsetRect = transform.TransformBounds(boundingRect);
-                    MakeRectVisible(offsetRect, false /* alwaysCenter */);
+                    MakeRectVisible(offsetRect, alwaysCenter: false);
                 }
             }
             else if (data.ContentPosition != null)
@@ -1823,7 +1823,7 @@ namespace MS.Internal.Documents
                 //we can make the TextPointer's Rect visible...
                 if (TextViewContains(tp))
                 {
-                    MakeRectVisible(TextView.GetRectangleFromTextPosition(tp), false /* alwaysCenter */);
+                    MakeRectVisible(TextView.GetRectangleFromTextPosition(tp), alwaysCenter: false);
                 }
             }
             else
@@ -2852,7 +2852,7 @@ namespace MS.Internal.Documents
             {
                 //Now we make the selection visible.
                 MakeRectVisible(TextView.GetRectangleFromTextPosition(
-                    selection), true /* alwaysCenter */);
+                    selection), alwaysCenter: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentPageTextView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentPageTextView.cs
@@ -423,7 +423,7 @@ namespace MS.Internal.Documents
 
                     while (this.IsValid && !Contains(position))
                     {
-                        backgroundFormatInfo.BackgroundFormat(formatter, true /* ignoreThrottle */);
+                        backgroundFormatInfo.BackgroundFormat(formatter, ignoreThrottle: true);
                         _owner.UpdateLayout(); // May invalidate the view.
 
                         // Break if background layout is not progressing.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/MultiPageTextView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/MultiPageTextView.cs
@@ -985,7 +985,7 @@ namespace MS.Internal.Documents
                     Point point = TransformToDescendant(pageTextView.RenderScope, suggestedOffset);
 
                     // Query inner TextView for requested page to find position at that point. 
-                    positionOut = newPageTextView.GetTextPositionFromPoint(point, /*snapToText*/true);
+                    positionOut = newPageTextView.GetTextPositionFromPoint(point, snapToText: true);
                     if (positionOut != null)
                     {
                         Rect rect = newPageTextView.GetRectangleFromTextPosition(positionOut);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/RowCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/RowCache.cs
@@ -675,7 +675,7 @@ namespace MS.Internal.Documents
             while (currentPage > 0)
             {
                 //Create our row, specifying a backwards direction
-                RowInfo newRow = CreateDynamicRow(currentPage - 1, pivotRowWidth, false /* backwards */);
+                RowInfo newRow = CreateDynamicRow(currentPage - 1, pivotRowWidth, createForward: false);
                 currentPage = newRow.FirstPage;
                 tempRows.Add(newRow);
             }
@@ -699,7 +699,7 @@ namespace MS.Internal.Documents
             while (currentPage < PageCache.PageCount)
             {
                 //Create our row, specifying a forward direction
-                RowInfo newRow = CreateDynamicRow(currentPage, pivotRowWidth, true /*forwards */);
+                RowInfo newRow = CreateDynamicRow(currentPage, pivotRowWidth, createForward: true);
                 currentPage += newRow.PageCount;
                 AddRow(newRow);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextDocumentView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextDocumentView.cs
@@ -754,7 +754,7 @@ namespace MS.Internal.Documents
                 Invariant.Assert(nestedParagraphs != null, "Paragraph collection is null.");
                 if (nestedParagraphs.Count > 0)
                 {
-                    position = GetTextPositionFromPoint(nestedParagraphs, _emptyParagraphCollection, point, snapToText, /* snap to text for floating elements*/ false);
+                    position = GetTextPositionFromPoint(nestedParagraphs, _emptyParagraphCollection, point, snapToText, snapToTextInFloatingElements: false);
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonDialog.cs
@@ -275,8 +275,8 @@ namespace Microsoft.Win32
                     NativeMethods.RECT dialogRect = new NativeMethods.RECT();
                     SafeNativeMethods.GetWindowRect(hWnd, ref dialogRect);
 
-                    Size dialogSize = new Size((dialogRect.right - dialogRect.left),  /*width*/
-                                               (dialogRect.bottom - dialogRect.top)); /*height*/
+                    Size dialogSize = new Size(width: (dialogRect.right - dialogRect.left),
+                                               height: (dialogRect.bottom - dialogRect.top));
 
                     // create variables that will receive the new position of the dialog
                     double x = 0;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -320,7 +320,7 @@ namespace System.Windows
         internal object FindResourceInternal(object resourceKey)
         {
             // Call Forwarded
-            return FindResourceInternal(resourceKey, false /*allowDeferredResourceReference*/, false /*mustReturnDeferredResourceReference*/);
+            return FindResourceInternal(resourceKey, allowDeferredResourceReference: false, mustReturnDeferredResourceReference: false);
         }
 
         internal object FindResourceInternal(object resourceKey, bool allowDeferredResourceReference, bool mustReturnDeferredResourceReference)
@@ -714,7 +714,7 @@ namespace System.Windows
         /// </Remarks>
         public static string GetCookie(Uri uri)
         {
-            return CookieHandler.GetCookie(uri, true/*throwIfNoCookie*/);
+            return CookieHandler.GetCookie(uri, throwIfNoCookie: true);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/CalendarAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/CalendarAutomationPeer.cs
@@ -149,7 +149,7 @@ namespace System.Windows.Automation.Peers
                     if (owningButton != null && owningButton.DataContext is DateTime)
                     {
                         date = (DateTime)owningButton.DataContext;
-                        peer = GetOrCreateDateTimeAutomationPeer(date, OwningCalendar.DisplayMode, /*addParentInfo*/ false);
+                        peer = GetOrCreateDateTimeAutomationPeer(date, OwningCalendar.DisplayMode, addParentInfo: false);
                         peers.Add(peer);
 
                         DateTimeCalendarModePair key = new DateTimeCalendarModePair(date, OwningCalendar.DisplayMode);
@@ -190,7 +190,7 @@ namespace System.Windows.Automation.Peers
                         focusedDate = owner.DisplayDate;
                     }
 
-                    DateTimeAutomationPeer focusedItem = GetOrCreateDateTimeAutomationPeer(focusedDate, owner.DisplayMode, /*addParentInfo*/ false);
+                    DateTimeAutomationPeer focusedItem = GetOrCreateDateTimeAutomationPeer(focusedDate, owner.DisplayMode, addParentInfo: false);
                     FrameworkElement focusedButton = focusedItem.OwningButton;
 
                     if (focusedButton == null || !focusedButton.IsKeyboardFocused)
@@ -211,7 +211,7 @@ namespace System.Windows.Automation.Peers
 
         private DateTimeAutomationPeer GetOrCreateDateTimeAutomationPeer(DateTime date, CalendarMode buttonMode)
         {
-            return GetOrCreateDateTimeAutomationPeer(date, buttonMode, /*addParentInfo*/ true);
+            return GetOrCreateDateTimeAutomationPeer(date, buttonMode, addParentInfo: true);
         }
         
         private DateTimeAutomationPeer GetOrCreateDateTimeAutomationPeer(DateTime date, CalendarMode buttonMode, bool addParentInfo)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DataGridCellItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DataGridCellItemAutomationPeer.cs
@@ -632,7 +632,7 @@ namespace System.Windows.Automation.Peers
                     }
 
                     // other cells may need to be de-selected, let the DataGrid handle that.
-                    this.OwningDataGrid.HandleSelectionForCellInput(cell, /* startDragging = */ false, /* allowsExtendSelect = */ false, /* allowsMinimalSelect = */ false);
+                    this.OwningDataGrid.HandleSelectionForCellInput(cell, startDragging: false, allowsExtendSelect: false, allowsMinimalSelect: false);
 
                     // the cell is now the datagrid's "current" cell, so BeginEdit will put
                     // it into edit mode
@@ -903,7 +903,7 @@ namespace System.Windows.Automation.Peers
                     DataGridAutomationPeer dataGridPeer = FrameworkElementAutomationPeer.CreatePeerForElement(OwningDataGrid) as DataGridAutomationPeer;
                     if (dataGridPeer != null)
                     {
-                        return dataGridPeer.GetExistingPeerByItem(Item, /*checkInWeakRefStorage*/ true) as DataGridItemAutomationPeer;
+                        return dataGridPeer.GetExistingPeerByItem(Item, checkInWeakRefStorage: true) as DataGridItemAutomationPeer;
                     }
                 }
                 return null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DataGridItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DataGridItemAutomationPeer.cs
@@ -447,7 +447,7 @@ namespace System.Windows.Automation.Peers
 
                     if (column != null)
                     {
-                        DataGridCellItemAutomationPeer peer = GetOrCreateCellItemPeer(column,/*addParentInfo*/ false );
+                        DataGridCellItemAutomationPeer peer = GetOrCreateCellItemPeer(column,addParentInfo: false);
                         children.Add(peer);
                         newChildren[column] = peer;
                     }
@@ -461,7 +461,7 @@ namespace System.Windows.Automation.Peers
 
         internal DataGridCellItemAutomationPeer GetOrCreateCellItemPeer(DataGridColumn column)
         {
-            return GetOrCreateCellItemPeer(column, /*addParentInfo*/ true);
+            return GetOrCreateCellItemPeer(column, addParentInfo: true);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/SelectorItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/SelectorItemAutomationPeer.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Automation.Peers
                 throw new InvalidOperationException(SR.UIA_OperationCannotBePerformed);
             }
 
-            parentSelector.SelectionChange.SelectJustThisItem(parentSelector.NewItemInfo(Item), true /* assumeInItemsCollection */);
+            parentSelector.SelectionChange.SelectJustThisItem(parentSelector.NewItemInfo(Item), assumeInItemsCollection: true);
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/BroadcastEventHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/BroadcastEventHelper.cs
@@ -267,7 +267,7 @@ namespace System.Windows
             {
                 DependencyObject d = eventRoute[i];
                 RoutedEventArgs args = new RoutedEventArgs(routedEvent, d);
-                FrameworkObject fo = new FrameworkObject(d, true /*throwIfNeither*/);
+                FrameworkObject fo = new FrameworkObject(d, throwIfNeither: true);
 
                 if (routedEvent == FrameworkElement.LoadedEvent)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/AccessText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/AccessText.cs
@@ -508,7 +508,7 @@ namespace System.Windows.Controls
         /// </summary>
         private void CreateTextBlock()
         {
-            _textContainer = new TextContainer(this, false /* plainTextOnly */);
+            _textContainer = new TextContainer(this, plainTextOnly: false);
             _textBlock = new TextBlock();
             AddVisualChild(_textBlock);
             _textBlock.IsContentPresenterContainer = true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Border.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Border.cs
@@ -720,10 +720,10 @@ namespace System.Windows.Controls
             //
             //  create the border geometry
             //
-            ctx.BeginFigure(topLeft, true /* is filled */, true /* is closed */);
+            ctx.BeginFigure(topLeft, isFilled: true, isClosed: true);
 
             // Top line
-            ctx.LineTo(topRight, true /* is stroked */, false /* is smooth join */);
+            ctx.LineTo(topRight, isStroked: true, isSmoothJoin: false);
 
             // Upper-right corner
             double radiusX = rect.TopRight.X - topRight.X;
@@ -735,7 +735,7 @@ namespace System.Windows.Controls
             }
 
             // Right line
-            ctx.LineTo(rightBottom, true /* is stroked */, false /* is smooth join */);
+            ctx.LineTo(rightBottom, isStroked: true, isSmoothJoin: false);
 
             // Lower-right corner
             radiusX = rect.BottomRight.X - bottomRight.X;
@@ -747,7 +747,7 @@ namespace System.Windows.Controls
             }
 
             // Bottom line
-            ctx.LineTo(bottomLeft, true /* is stroked */, false /* is smooth join */);
+            ctx.LineTo(bottomLeft, isStroked: true, isSmoothJoin: false);
 
             // Lower-left corner
             radiusX = bottomLeft.X - rect.BottomLeft.X;
@@ -759,7 +759,7 @@ namespace System.Windows.Controls
             }
 
             // Left line
-            ctx.LineTo(leftTop, true /* is stroked */, false /* is smooth join */);
+            ctx.LineTo(leftTop, isStroked: true, isSmoothJoin: false);
 
             // Upper-left corner
             radiusX = topLeft.X - rect.TopLeft.X;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Calendar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Calendar.cs
@@ -550,7 +550,7 @@ namespace System.Windows.Controls
                 {
                     if (!addedDate.HasValue)
                     {
-                        c.SelectedDates.ClearInternal(true /*fireChangeNotification*/);
+                        c.SelectedDates.ClearInternal(fireChangeNotification: true);
                     }
                     else
                     {
@@ -627,7 +627,7 @@ namespace System.Windows.Controls
             Debug.Assert(c != null);
 
             c.HoverStart = c.HoverEnd = null;
-            c.SelectedDates.ClearInternal(true /*fireChangeNotification*/);
+            c.SelectedDates.ClearInternal(fireChangeNotification: true);
             c.OnSelectionModeChanged(EventArgs.Empty);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ComboBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ComboBox.cs
@@ -256,7 +256,7 @@ namespace System.Windows.Controls
                         ComboBox cb = (ComboBox)arg;
                         if (cb.IsItemsHostVisible)
                         {
-                            cb.NavigateToItem(cb.InternalSelectedInfo, ItemNavigateArgs.Empty, true /* alwaysAtTopOfViewport */);
+                            cb.NavigateToItem(cb.InternalSelectedInfo, ItemNavigateArgs.Empty, alwaysAtTopOfViewport: true);
                         }
                         return null;
                     },
@@ -1250,7 +1250,7 @@ namespace System.Windows.Controls
             object item = ItemContainerGenerator.ItemFromContainer(comboBoxItem);
             if (item != null)
             {
-                SelectionChange.SelectJustThisItem(NewItemInfo(item, comboBoxItem), true /* assumeInItemsCollection */);
+                SelectionChange.SelectJustThisItem(NewItemInfo(item, comboBoxItem), assumeInItemsCollection: true);
             }
 
             Close();
@@ -1336,7 +1336,7 @@ namespace System.Windows.Controls
                     handled = true;
                     if ((e.KeyboardDevice.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt)
                     {
-                        KeyboardToggleDropDown(true /* commitSelection */);
+                        KeyboardToggleDropDown(commitSelection: true);
                     }
                     else
                     {
@@ -1358,7 +1358,7 @@ namespace System.Windows.Controls
                     handled = true;
                     if ((e.KeyboardDevice.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt)
                     {
-                        KeyboardToggleDropDown(true /* commitSelection */);
+                        KeyboardToggleDropDown(commitSelection: true);
                     }
                     else
                     {
@@ -1377,7 +1377,7 @@ namespace System.Windows.Controls
                 case Key.F4:
                     if ((e.KeyboardDevice.Modifiers & ModifierKeys.Alt) == 0)
                     {
-                        KeyboardToggleDropDown(true /* commitSelection */);
+                        KeyboardToggleDropDown(commitSelection: true);
                         handled = true;
                     }
                     break;
@@ -1385,7 +1385,7 @@ namespace System.Windows.Controls
                 case Key.Escape:
                     if (IsDropDownOpen)
                     {
-                        KeyboardCloseDropDown(false /* commitSelection */);
+                        KeyboardCloseDropDown(commitSelection: false);
                         handled = true;
                     }
                     break;
@@ -1393,7 +1393,7 @@ namespace System.Windows.Controls
                 case Key.Enter:
                     if (IsDropDownOpen)
                     {
-                        KeyboardCloseDropDown(true /* commitSelection */);
+                        KeyboardCloseDropDown(commitSelection: true);
                         handled = true;
                     }
                     break;
@@ -1569,7 +1569,7 @@ namespace System.Windows.Controls
                 DependencyObject container = ItemContainerGenerator.ContainerFromIndex(i);
                 if (IsSelectableHelper(item) && IsSelectableHelper(container))
                 {
-                    SelectionChange.SelectJustThisItem(NewItemInfo(item, container, i), true /* assumeInItemsCollection */);
+                    SelectionChange.SelectJustThisItem(NewItemInfo(item, container, i), assumeInItemsCollection: true);
                     break;
                 }
             }
@@ -1830,7 +1830,7 @@ namespace System.Windows.Controls
         /// </summary>
         private void KeyboardCloseDropDown(bool commitSelection)
         {
-            KeyboardToggleDropDown(false /* openDropDown */, commitSelection);
+            KeyboardToggleDropDown(openDropDown: false, commitSelection);
         }
 
         private void KeyboardToggleDropDown(bool openDropDown, bool commitSelection)
@@ -1849,7 +1849,7 @@ namespace System.Windows.Controls
 
             if (openDropDown == false && commitSelection && (infoToSelect != null))
             {
-                SelectionChange.SelectJustThisItem(infoToSelect, true /* assumeInItemsCollection */);
+                SelectionChange.SelectJustThisItem(infoToSelect, assumeInItemsCollection: true);
             }
         }
 
@@ -1858,7 +1858,7 @@ namespace System.Windows.Controls
             ItemInfo infoToSelect = HighlightedInfo;
             if (infoToSelect != null)
             {
-                SelectionChange.SelectJustThisItem(infoToSelect, true /* assumeInItemsCollection */);
+                SelectionChange.SelectJustThisItem(infoToSelect, assumeInItemsCollection: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ContextMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ContextMenu.cs
@@ -44,7 +44,7 @@ namespace System.Windows.Controls
             KeyboardNavigation.DirectionalNavigationProperty.OverrideMetadata(typeof(ContextMenu), new FrameworkPropertyMetadata(KeyboardNavigationMode.Cycle));
 
             // Disable the default focus visual for ContextMenu
-            FocusVisualStyleProperty.OverrideMetadata(typeof(ContextMenu), new FrameworkPropertyMetadata((object)null /* default value */));
+            FocusVisualStyleProperty.OverrideMetadata(typeof(ContextMenu), new FrameworkPropertyMetadata(defaultValue: null));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -225,17 +225,17 @@ namespace System.Windows.Controls
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    UpdateDataGridReference(e.NewItems, /* clear = */ false);
+                    UpdateDataGridReference(e.NewItems, clear: false);
                     UpdateColumnSizeConstraints(e.NewItems);
                     break;
 
                 case NotifyCollectionChangedAction.Remove:
-                    UpdateDataGridReference(e.OldItems, /* clear = */ true);
+                    UpdateDataGridReference(e.OldItems, clear: true);
                     break;
 
                 case NotifyCollectionChangedAction.Replace:
-                    UpdateDataGridReference(e.OldItems, /* clear = */ true);
-                    UpdateDataGridReference(e.NewItems, /* clear = */ false);
+                    UpdateDataGridReference(e.OldItems, clear: true);
+                    UpdateDataGridReference(e.NewItems, clear: false);
                     UpdateColumnSizeConstraints(e.NewItems);
                     break;
 
@@ -1804,7 +1804,7 @@ namespace System.Windows.Controls
                         if (row != null)
                         {
                             _hasAutoScrolled = true;
-                            HandleSelectionForRowHeaderAndDetailsInput(row, /* startDragging = */ false);
+                            HandleSelectionForRowHeaderAndDetailsInput(row, startDragging: false);
                             SetCurrentItem(info.Item);
                             return true;
                         }
@@ -1817,7 +1817,7 @@ namespace System.Windows.Controls
                         if (cell != null)
                         {
                             _hasAutoScrolled = true;
-                            HandleSelectionForCellInput(cell, /* startDragging = */ false, /* allowsExtendSelect = */ true, /* allowsMinimalSelect = */ true);
+                            HandleSelectionForCellInput(cell, startDragging: false, allowsExtendSelect: true, allowsMinimalSelect: true);
                             cell.Focus();
                             return true;
                         }
@@ -2225,7 +2225,7 @@ namespace System.Windows.Controls
                         CancelRowItem();
 
                         // Display the new item placeholder again
-                        UpdateNewItemPlaceholder(/* isAddingNewItem = */ false);
+                        UpdateNewItemPlaceholder(isAddingNewItem: false);
 
                         // Put focus back on the placeholder
                         SetCurrentItemToPlaceholder();
@@ -2316,7 +2316,7 @@ namespace System.Windows.Controls
         /// </summary>
         protected virtual void OnCanExecuteCommitEdit(CanExecuteRoutedEventArgs e)
         {
-            if (CanEndEdit(e, /* commit = */ true))
+            if (CanEndEdit(e, commit: true))
             {
                 e.CanExecute = true;
                 e.Handled = true;
@@ -2484,7 +2484,7 @@ namespace System.Windows.Controls
         /// </summary>
         protected virtual void OnCanExecuteCancelEdit(CanExecuteRoutedEventArgs e)
         {
-            if (CanEndEdit(e, /* commit = */ false))
+            if (CanEndEdit(e, commit: false))
             {
                 e.CanExecute = true;
                 e.Handled = true;
@@ -2689,7 +2689,7 @@ namespace System.Windows.Controls
                         if (cell != null)
                         {
                             _selectionAnchor = null;
-                            HandleSelectionForCellInput(cell, /* startDragging = */ false, /* allowsExtendSelect = */ false, /* allowsMinimalSelect = */ false);
+                            HandleSelectionForCellInput(cell, startDragging: false, allowsExtendSelect: false, allowsMinimalSelect: false);
                         }
                     }
                 }
@@ -3138,7 +3138,7 @@ namespace System.Windows.Controls
         /// <returns>true if the current cell or row enters edit mode, false otherwise.</returns>
         public bool BeginEdit()
         {
-            return BeginEdit(/* editingEventArgs = */ null);
+            return BeginEdit(editingEventArgs: null);
         }
 
         /// <summary>
@@ -3286,12 +3286,12 @@ namespace System.Windows.Controls
             if (IsAddingNewItem || IsEditingRowItem)
             {
                 // There is a row edit in progress, commit it, which will also commit the cell edit.
-                return CommitEdit(DataGridEditingUnit.Row, /* exitEditingMode = */ true);
+                return CommitEdit(DataGridEditingUnit.Row, exitEditingMode: true);
             }
             else if (IsEditingCurrentCell)
             {
                 // Commit the current cell edit.
-                return CommitEdit(DataGridEditingUnit.Cell, /* exitEditingMode = */ true);
+                return CommitEdit(DataGridEditingUnit.Cell, exitEditingMode: true);
             }
 
             return true;
@@ -3435,12 +3435,12 @@ namespace System.Windows.Controls
 
         private static void OnCanUserAddRowsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            ((DataGrid)d).UpdateNewItemPlaceholder(/* isAddingNewItem = */ false);
+            ((DataGrid)d).UpdateNewItemPlaceholder(isAddingNewItem: false);
         }
 
         private static object OnCoerceCanUserAddRows(DependencyObject d, object baseValue)
         {
-            return OnCoerceCanUserAddOrDeleteRows((DataGrid)d, (bool)baseValue, /* canUserAddRowsProperty = */ true);
+            return OnCoerceCanUserAddOrDeleteRows((DataGrid)d, (bool)baseValue, canUserAddRowsProperty: true);
         }
 
         private static bool OnCoerceCanUserAddOrDeleteRows(DataGrid dataGrid, bool baseValue, bool canUserAddRowsProperty)
@@ -3491,7 +3491,7 @@ namespace System.Windows.Controls
 
         private static object OnCoerceCanUserDeleteRows(DependencyObject d, object baseValue)
         {
-            return OnCoerceCanUserAddOrDeleteRows((DataGrid)d, (bool)baseValue, /* canUserAddRowsProperty = */ false);
+            return OnCoerceCanUserAddOrDeleteRows((DataGrid)d, (bool)baseValue, canUserAddRowsProperty: false);
         }
 
         /// <summary>
@@ -3544,7 +3544,7 @@ namespace System.Windows.Controls
             Debug.Assert(!IsAddingNewItem, "AddNewItem called when a pending add is taking place.");
 
             // Hide the placeholder
-            UpdateNewItemPlaceholder(/* isAddingNewItem = */ true);
+            UpdateNewItemPlaceholder(isAddingNewItem: true);
 
             // Create the new item (with app's help, or not)
             object newItem = null;
@@ -3602,7 +3602,7 @@ namespace System.Windows.Controls
                 EditableItems.CommitNew();
 
                 // Show the placeholder again
-                UpdateNewItemPlaceholder(/* isAddingNewItem = */ false);
+                UpdateNewItemPlaceholder(isAddingNewItem: false);
             }
         }
 
@@ -3658,7 +3658,7 @@ namespace System.Windows.Controls
                 EditableItems.CancelNew();
 
                 // Show the placeholder again
-                UpdateNewItemPlaceholder(/* isAddingNewItem = */ false);
+                UpdateNewItemPlaceholder(isAddingNewItem: false);
 
                 if (wasCurrent)
                 {
@@ -4510,7 +4510,7 @@ namespace System.Windows.Controls
                     for (int i = 0; i < count; i++)
                     {
                         ItemInfo rowInfo = e.RemovedInfos[i];
-                        UpdateSelectionOfCellsInRow(rowInfo, /* isSelected = */ false);
+                        UpdateSelectionOfCellsInRow(rowInfo, isSelected: false);
                     }
 
                     // Add cells of rows that were selected
@@ -4518,7 +4518,7 @@ namespace System.Windows.Controls
                     for (int i = 0; i < count; i++)
                     {
                         ItemInfo rowInfo = e.AddedInfos[i];
-                        UpdateSelectionOfCellsInRow(rowInfo, /* isSelected = */ true);
+                        UpdateSelectionOfCellsInRow(rowInfo, isSelected: true);
                     }
                 }
             }
@@ -4540,8 +4540,8 @@ namespace System.Windows.Controls
 
         private void UpdateIsSelected()
         {
-            UpdateIsSelected(_pendingUnselectedCells, /* isSelected = */ false);
-            UpdateIsSelected(_pendingSelectedCells, /* isSelected = */ true);
+            UpdateIsSelected(_pendingUnselectedCells, isSelected: false);
+            UpdateIsSelected(_pendingSelectedCells, isSelected: true);
         }
 
         /// <summary>
@@ -4752,7 +4752,7 @@ namespace System.Windows.Controls
             // Select a row when the mode is not None and the unit allows selecting rows
             if (CanSelectRows)
             {
-                MakeFullRowSelection(rowInfo, /* allowsExtendSelect = */ true, /* allowsMinimalSelect = */ true);
+                MakeFullRowSelection(rowInfo, allowsExtendSelect: true, allowsMinimalSelect: true);
 
                 if (startDragging)
                 {
@@ -5450,11 +5450,11 @@ namespace System.Windows.Controls
                         cell.Focus();
                         if (ShouldSelectRowHeader)
                         {
-                            HandleSelectionForRowHeaderAndDetailsInput(cell.RowOwner, /* startDragging = */ false);
+                            HandleSelectionForRowHeaderAndDetailsInput(cell.RowOwner, startDragging: false);
                         }
                         else
                         {
-                            HandleSelectionForCellInput(cell, /* startDragging = */ false, /* allowsExtendSelect = */ false, /* allowsMinimalSelect = */ false);
+                            HandleSelectionForCellInput(cell, startDragging: false, allowsExtendSelect: false, allowsMinimalSelect: false);
                         }
                     }
                 }
@@ -5825,7 +5825,7 @@ namespace System.Windows.Controls
                         ((startElement != null) && startElement.MoveFocus(request)) ||
                         ((startContentElement != null) && startContentElement.MoveFocus(request)))
                     {
-                        SelectAndEditOnFocusMove(e, currentCellContainer, wasEditing, /* allowsExtendSelect = */ true, /* ignoreControlKey = */ true);
+                        SelectAndEditOnFocusMove(e, currentCellContainer, wasEditing, allowsExtendSelect: true, ignoreControlKey: true);
                     }
                 }
             }
@@ -5928,7 +5928,7 @@ namespace System.Windows.Controls
 
                         // When doing TAB and SHIFT+TAB focus movement, don't confuse the selection
                         // code, which also relies on SHIFT to know whether to extend selection or not.
-                        SelectAndEditOnFocusMove(e, currentCellContainer, wasEditing, /* allowsExtendSelect = */ false, /* ignoreControlKey = */ true);
+                        SelectAndEditOnFocusMove(e, currentCellContainer, wasEditing, allowsExtendSelect: false, ignoreControlKey: true);
                     }
                 }
             }
@@ -5968,7 +5968,7 @@ namespace System.Windows.Controls
                             SetCurrentValueInternal(CurrentCellProperty, new DataGridCellInfo(rowInfo, column, this));
 
                             // Will never edit on ENTER, so just say that the old cell wasn't in edit mode
-                            SelectAndEditOnFocusMove(e, currentCellContainer, /* wasEditing = */ false, /* allowsExtendSelect = */ false, /* ignoreControlKey = */ true);
+                            SelectAndEditOnFocusMove(e, currentCellContainer, wasEditing: false, allowsExtendSelect: false, ignoreControlKey: true);
                         }
                         else
                         {
@@ -6005,11 +6005,11 @@ namespace System.Windows.Controls
                 {
                     if (ShouldSelectRowHeader && allowsExtendSelect)
                     {
-                        HandleSelectionForRowHeaderAndDetailsInput(newCell.RowOwner, /* startDragging = */ false);
+                        HandleSelectionForRowHeaderAndDetailsInput(newCell.RowOwner, startDragging: false);
                     }
                     else
                     {
-                        HandleSelectionForCellInput(newCell, /* startDragging = */ false, allowsExtendSelect, /* allowsMinimalSelect = */ false);
+                        HandleSelectionForCellInput(newCell, startDragging: false, allowsExtendSelect, allowsMinimalSelect: false);
                     }
                 }
 
@@ -6063,11 +6063,11 @@ namespace System.Windows.Controls
                     cell.Focus();
                     if (ShouldSelectRowHeader)
                     {
-                        HandleSelectionForRowHeaderAndDetailsInput(cell.RowOwner, /* startDragging = */ false);
+                        HandleSelectionForRowHeaderAndDetailsInput(cell.RowOwner, startDragging: false);
                     }
                     else
                     {
-                        HandleSelectionForCellInput(cell, /* startDragging = */ false, /* allowsExtendSelect = */ true, /* allowsMinimalSelect = */ false);
+                        HandleSelectionForCellInput(cell, startDragging: false, allowsExtendSelect: true, allowsMinimalSelect: false);
                     }
                 }
             }
@@ -6117,11 +6117,11 @@ namespace System.Windows.Controls
                                 cell.Focus();
                                 if (ShouldSelectRowHeader)
                                 {
-                                    HandleSelectionForRowHeaderAndDetailsInput(cell.RowOwner, /* startDragging = */ false);
+                                    HandleSelectionForRowHeaderAndDetailsInput(cell.RowOwner, startDragging: false);
                                 }
                                 else
                                 {
-                                    HandleSelectionForCellInput(cell, /* startDragging = */ false, /* allowsExtendSelect = */ true, /* allowsMinimalSelect = */ false);
+                                    HandleSelectionForCellInput(cell, startDragging: false, allowsExtendSelect: true, allowsMinimalSelect: false);
                                 }
                             }
                         }
@@ -6181,11 +6181,11 @@ namespace System.Windows.Controls
                                 cell.Focus();
                                 if (ShouldSelectRowHeader)
                                 {
-                                    HandleSelectionForRowHeaderAndDetailsInput(cell.RowOwner, /* startDragging = */ false);
+                                    HandleSelectionForRowHeaderAndDetailsInput(cell.RowOwner, startDragging: false);
                                 }
                                 else
                                 {
-                                    HandleSelectionForCellInput(cell, /* startDragging = */ false, /* allowsExtendSelect = */ true, /* allowsMinimalSelect = */ false);
+                                    HandleSelectionForCellInput(cell, startDragging: false, allowsExtendSelect: true, allowsMinimalSelect: false);
                                 }
                             }
                         }
@@ -6230,7 +6230,7 @@ namespace System.Windows.Controls
                                 if ((row != null) && (row.Item != CurrentItem))
                                 {
                                     // Continue a row header drag to the given row
-                                    HandleSelectionForRowHeaderAndDetailsInput(row, /* startDragging = */ false);
+                                    HandleSelectionForRowHeaderAndDetailsInput(row, startDragging: false);
                                     SetCurrentItem(row.Item);
                                     e.Handled = true;
                                 }
@@ -6252,7 +6252,7 @@ namespace System.Windows.Controls
 
                                 if ((cell != null) && (cell != CurrentCellContainer))
                                 {
-                                    HandleSelectionForCellInput(cell, /* startDragging = */ false, /* allowsExtendSelect = */ true, /* allowsMinimalSelect = */ true);
+                                    HandleSelectionForCellInput(cell, startDragging: false, allowsExtendSelect: true, allowsMinimalSelect: true);
                                     cell.Focus();
                                     e.Handled = true;
                                 }
@@ -6268,7 +6268,7 @@ namespace System.Windows.Controls
                                 if ((row != null) && (row.Item != CurrentItem))
                                 {
                                     // The mouse is directly to the left or right of the row
-                                    HandleSelectionForRowHeaderAndDetailsInput(row, /* startDragging = */ false);
+                                    HandleSelectionForRowHeaderAndDetailsInput(row, startDragging: false);
                                     SetCurrentItem(row.Item);
                                     e.Handled = true;
                                 }
@@ -6348,7 +6348,7 @@ namespace System.Windows.Controls
             if ((cell != null) && !cell.IsSelected && !cell.IsKeyboardFocusWithin)
             {
                 cell.Focus();
-                HandleSelectionForCellInput(cell, /* startDragging = */ false, /* allowsExtendSelect = */ true, /* allowsMinimalSelect = */ true);
+                HandleSelectionForCellInput(cell, startDragging: false, allowsExtendSelect: true, allowsMinimalSelect: true);
             }
 
             if (rowHeader != null)
@@ -6356,7 +6356,7 @@ namespace System.Windows.Controls
                 DataGridRow parentRow = rowHeader.ParentRow;
                 if (parentRow != null && !parentRow.IsSelected)
                 {
-                    HandleSelectionForRowHeaderAndDetailsInput(parentRow, /* startDragging = */ false);
+                    HandleSelectionForRowHeaderAndDetailsInput(parentRow, startDragging: false);
                 }
             }
         }
@@ -6726,12 +6726,12 @@ namespace System.Windows.Controls
 
         internal void SetCellAutomationValue(object item, DataGridColumn column, string value)
         {
-            SetCellValue(item, column, value, false /*clipboard*/);
+            SetCellValue(item, column, value, clipboard: false);
         }
 
         internal void SetCellClipboardValue(object item, DataGridColumn column, object value)
         {
-            SetCellValue(item, column, value, true /*clipboard*/);
+            SetCellValue(item, column, value, clipboard: true);
         }
 
         private void SetCellValue(object item, DataGridColumn column, object value, bool clipboard)
@@ -7516,7 +7516,7 @@ namespace System.Windows.Controls
 
                 // We need to call this in case CanUserAddRows has remained true (the default value)
                 // since startup and no one has set the placeholder position.
-                UpdateNewItemPlaceholder(/* isAddingNewItem = */ false);
+                UpdateNewItemPlaceholder(isAddingNewItem: false);
 
                 // always use an ItemBindingGroup
                 EnsureItemBindingGroup();
@@ -7626,7 +7626,7 @@ namespace System.Windows.Controls
 
             ResetRowHeaderActualWidth();
 
-            UpdateNewItemPlaceholder(/* isAddingNewItem = */ false);
+            UpdateNewItemPlaceholder(isAddingNewItem: false);
 
             HasCellValidationError = false;
             HasRowValidationError = false;
@@ -8285,7 +8285,7 @@ namespace System.Windows.Controls
 
             foreach (string format in formats)
             {
-                dataObject.SetData(format, dataGridStringBuilders[format].ToString(), false /*autoConvert*/);
+                dataObject.SetData(format, dataGridStringBuilders[format].ToString(), autoConvert: false);
             }
 
             try

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -2893,12 +2893,12 @@ namespace System.Windows.Controls
                 {
                     // There is a row edit pending and the current cell changed to another row.
                     // Commit the row, which also commits the cell.
-                    dataGrid.EndEdit(CommitEditCommand, dataGrid._currentCellContainer, DataGridEditingUnit.Row, /* exitEditingMode = */ true);
+                    dataGrid.EndEdit(CommitEditCommand, dataGrid._currentCellContainer, DataGridEditingUnit.Row, exitEditMode: true);
                 }
                 else if (dataGrid._currentCellContainer.IsEditing)
                 {
                     // Only the cell needs to commit.
-                    dataGrid.EndEdit(CommitEditCommand, dataGrid._currentCellContainer, DataGridEditingUnit.Cell, /* exitEditingMode = */ true);
+                    dataGrid.EndEdit(CommitEditCommand, dataGrid._currentCellContainer, DataGridEditingUnit.Cell, exitEditMode: true);
                 }
             }
 
@@ -4744,7 +4744,7 @@ namespace System.Windows.Controls
                     if (_currentCellContainer != null && _currentCellContainer.IsEditing)
                     {
                         // End the pending edit even for the same row
-                        EndEdit(CommitEditCommand, _currentCellContainer, DataGridEditingUnit.Cell, /* exitEditingMode = */ true);
+                        EndEdit(CommitEditCommand, _currentCellContainer, DataGridEditingUnit.Cell, exitEditMode: true);
                     }
                 }
             }
@@ -5176,7 +5176,7 @@ namespace System.Windows.Controls
                 }
             }
 
-            UpdateSelectedItems(info, /* Add = */ true);
+            UpdateSelectedItems(info, add: true);
         }
 
         private void UnselectItem(ItemInfo info)
@@ -5191,7 +5191,7 @@ namespace System.Windows.Controls
                 }
             }
 
-            UpdateSelectedItems(info, /*Add = */ false);
+            UpdateSelectedItems(info, add: false);
         }
 
         /// <summary>
@@ -7079,8 +7079,7 @@ namespace System.Windows.Controls
             {
                 DefaultSort(
                     eventArgs.Column,
-                    /* clearExistinSortDescriptions */
-                    (Keyboard.Modifiers & ModifierKeys.Shift) != ModifierKeys.Shift);
+                    clearExistingSortDescriptions: (Keyboard.Modifiers & ModifierKeys.Shift) != ModifierKeys.Shift);
             }
         }
 
@@ -8250,7 +8249,7 @@ namespace System.Windows.Controls
                 // Add column headers if enabled
                 if (ClipboardCopyMode == DataGridClipboardCopyMode.IncludeHeader)
                 {
-                    DataGridRowClipboardEventArgs preparingRowClipboardContentEventArgs = new DataGridRowClipboardEventArgs(null, minColumnDisplayIndex, maxColumnDisplayIndex, true /*IsColumnHeadersRow*/);
+                    DataGridRowClipboardEventArgs preparingRowClipboardContentEventArgs = new DataGridRowClipboardEventArgs(null, minColumnDisplayIndex, maxColumnDisplayIndex, isColumnHeadersRow: true);
                     OnCopyingRowClipboardContent(preparingRowClipboardContentEventArgs);
 
                     foreach (string format in formats)
@@ -8267,7 +8266,7 @@ namespace System.Windows.Controls
                     // Row has a selecion
                     if (_selectedCells.Intersects(i))
                     {
-                        DataGridRowClipboardEventArgs preparingRowClipboardContentEventArgs = new DataGridRowClipboardEventArgs(row, minColumnDisplayIndex, maxColumnDisplayIndex, false /*IsColumnHeadersRow*/, i);
+                        DataGridRowClipboardEventArgs preparingRowClipboardContentEventArgs = new DataGridRowClipboardEventArgs(row, minColumnDisplayIndex, maxColumnDisplayIndex, isColumnHeadersRow: false, i);
                         OnCopyingRowClipboardContent(preparingRowClipboardContentEventArgs);
 
                         foreach (string format in formats)
@@ -8290,7 +8289,7 @@ namespace System.Windows.Controls
 
             try
             {
-                Clipboard.CriticalSetDataObject(dataObject, true /* Copy */);
+                Clipboard.CriticalSetDataObject(dataObject, copy: true);
             }
             catch (ExternalException)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -778,20 +778,20 @@ namespace System.Windows.Controls
             // Remove space from the constraint (since it implicitly includes the GridLine's thickness),
             // call the base implementation, and add the thickness back for the returned size.
             DataGrid dataGridOwner = DataGridOwner;
-            bool horizontalLinesVisible = DataGridHelper.IsGridLineVisible(dataGridOwner, /*isHorizontal = */ true);
-            bool verticalLinesVisible = DataGridHelper.IsGridLineVisible(dataGridOwner, /*isHorizontal = */ false);
+            bool horizontalLinesVisible = DataGridHelper.IsGridLineVisible(dataGridOwner, isHorizontal: true);
+            bool verticalLinesVisible = DataGridHelper.IsGridLineVisible(dataGridOwner, isHorizontal: false);
             double horizontalLineThickness = 0;
             double verticalLineThickness = 0;
 
             if (horizontalLinesVisible)
             {
                 horizontalLineThickness = dataGridOwner.HorizontalGridLineThickness;
-                constraint = DataGridHelper.SubtractFromSize(constraint, horizontalLineThickness, /*height = */ true);
+                constraint = DataGridHelper.SubtractFromSize(constraint, horizontalLineThickness, height: true);
             }
             if (verticalLinesVisible)
             {
                 verticalLineThickness = dataGridOwner.VerticalGridLineThickness;
-                constraint = DataGridHelper.SubtractFromSize(constraint, verticalLineThickness, /*height = */ false);
+                constraint = DataGridHelper.SubtractFromSize(constraint, verticalLineThickness, height: false);
             }
             Size desiredSize = base.MeasureOverride(constraint);
             if (horizontalLinesVisible)
@@ -814,19 +814,19 @@ namespace System.Windows.Controls
             // We don't need to adjust the Arrange position of the content.  By default it is arranged at 0,0 and we're
             // adding a line to the right and bottom.  All we have to do is compress and extend the size, just like Measure.
             DataGrid dataGridOwner = DataGridOwner;
-            bool horizontalLinesVisible = DataGridHelper.IsGridLineVisible(dataGridOwner, /*isHorizontal = */ true);
-            bool verticalLinesVisible = DataGridHelper.IsGridLineVisible(dataGridOwner, /*isHorizontal = */ false);
+            bool horizontalLinesVisible = DataGridHelper.IsGridLineVisible(dataGridOwner, isHorizontal: true);
+            bool verticalLinesVisible = DataGridHelper.IsGridLineVisible(dataGridOwner, isHorizontal: false);
             double horizontalLineThickness = 0;
             double verticalLineThickness = 0;
             if (horizontalLinesVisible)
             {
                 horizontalLineThickness = dataGridOwner.HorizontalGridLineThickness;
-                arrangeSize = DataGridHelper.SubtractFromSize(arrangeSize, horizontalLineThickness, /*height = */ true);
+                arrangeSize = DataGridHelper.SubtractFromSize(arrangeSize, horizontalLineThickness, height: true);
             }
             if (verticalLinesVisible)
             {
                 verticalLineThickness = dataGridOwner.VerticalGridLineThickness;
-                arrangeSize = DataGridHelper.SubtractFromSize(arrangeSize, verticalLineThickness, /*height = */ false);
+                arrangeSize = DataGridHelper.SubtractFromSize(arrangeSize, verticalLineThickness, height: false);
             }
             Size returnSize = base.ArrangeOverride(arrangeSize);
             if (horizontalLinesVisible)
@@ -849,7 +849,7 @@ namespace System.Windows.Controls
             base.OnRender(drawingContext);
             DataGrid dataGrid = DataGridOwner;
 
-            if (DataGridHelper.IsGridLineVisible(dataGrid, /*isHorizontal = */ false))
+            if (DataGridHelper.IsGridLineVisible(dataGrid, isHorizontal: false))
             {
                 double thickness = DataGridOwner.VerticalGridLineThickness;
                 Rect rect = new Rect(new Size(thickness, RenderSize.Height))
@@ -860,7 +860,7 @@ namespace System.Windows.Controls
                 drawingContext.DrawRectangle(DataGridOwner.VerticalGridLinesBrush, null, rect);
             }
 
-            if (DataGridHelper.IsGridLineVisible(dataGrid, /*isHorizontal = */ true))
+            if (DataGridHelper.IsGridLineVisible(dataGrid, isHorizontal: true))
             {
                 double thickness = dataGrid.HorizontalGridLineThickness;
                 Rect rect = new Rect(new Size(RenderSize.Width, thickness))
@@ -898,7 +898,7 @@ namespace System.Windows.Controls
                 {
                     // The cell was clicked, which means that other cells may
                     // need to be de-selected, let the DataGrid handle that.
-                    dataGridOwner.HandleSelectionForCellInput(this, /* startDragging = */ false, /* allowsExtendSelect = */ true, /* allowsMinimalSelect = */ false);
+                    dataGridOwner.HandleSelectionForCellInput(this, startDragging: false, allowsExtendSelect: true, allowsMinimalSelect: false);
 
                     if (!IsEditing && !IsReadOnly)
                     {
@@ -922,7 +922,7 @@ namespace System.Windows.Controls
 
                 DataGrid dataGridOwner = DataGridOwner;
                 // Let the DataGrid process selection
-                dataGridOwner?.HandleSelectionForCellInput(this, /* startDragging = */ Mouse.Captured == null, /* allowsExtendSelect = */ true, /* allowsMinimalSelect = */ true);
+                dataGridOwner?.HandleSelectionForCellInput(this, startDragging: Mouse.Captured == null, allowsExtendSelect: true, allowsMinimalSelect: true);
 
                 e.Handled = true;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCheckBoxColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCheckBoxColumn.cs
@@ -90,7 +90,7 @@ namespace System.Windows.Controls
         /// </summary>
         protected override FrameworkElement GenerateElement(DataGridCell cell, object dataItem)
         {
-            return GenerateCheckBox(/* isEditing = */ false, cell);
+            return GenerateCheckBox(isEditing: false, cell);
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace System.Windows.Controls
         /// </summary>
         protected override FrameworkElement GenerateEditingElement(DataGridCell cell, object dataItem)
         {
-            return GenerateCheckBox(/* isEditing = */ true, cell);
+            return GenerateCheckBox(isEditing: true, cell);
         }
 
         private CheckBox GenerateCheckBox(bool isEditing, DataGridCell cell)
@@ -111,7 +111,7 @@ namespace System.Windows.Controls
 
             checkBox.IsThreeState = IsThreeState;
 
-            ApplyStyle(isEditing, /* defaultToElementStyle = */ true, checkBox);
+            ApplyStyle(isEditing, defaultToElementStyle: true, checkBox);
             ApplyBinding(checkBox, CheckBox.IsCheckedProperty);
 
             return checkBox;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumn.cs
@@ -1044,12 +1044,12 @@ namespace System.Windows.Controls
             var column = d as DataGridColumn;
 
             bool basePropertyHasModifiers;
-            BaseValueSourceInternal baseValueSource = column.GetValueSource(CanUserSortProperty, /*metadata*/ null, out basePropertyHasModifiers);
+            BaseValueSourceInternal baseValueSource = column.GetValueSource(CanUserSortProperty, metadata: null, out basePropertyHasModifiers);
 
             if (column.DataGridOwner != null)
             {
                 bool parentPropertyHasModifiers;
-                BaseValueSourceInternal parentValueSource = column.DataGridOwner.GetValueSource(DataGrid.CanUserSortColumnsProperty, /*metadata*/ null, out parentPropertyHasModifiers);
+                BaseValueSourceInternal parentValueSource = column.DataGridOwner.GetValueSource(DataGrid.CanUserSortColumnsProperty, metadata: null, out parentPropertyHasModifiers);
                 if (parentValueSource == baseValueSource && !basePropertyHasModifiers && parentPropertyHasModifiers)
                 {
                     return column.DataGridOwner.GetValue(DataGrid.CanUserSortColumnsProperty);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumnCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumnCollection.cs
@@ -1965,7 +1965,7 @@ namespace System.Windows.Controls
         private double GiveAwayWidthToColumns(DataGridColumn ignoredColumn, double giveAwayWidth, bool recomputeStars)
         {
             double originalGiveAwayWidth = giveAwayWidth;
-            giveAwayWidth = GiveAwayWidthToScrollViewerExcess(giveAwayWidth, /*includedInColumnsWidth*/ ignoredColumn != null);
+            giveAwayWidth = GiveAwayWidthToScrollViewerExcess(giveAwayWidth, includedInColumnsWidth: ignoredColumn != null);
             giveAwayWidth = GiveAwayWidthToNonStarColumns(ignoredColumn, giveAwayWidth);
 
             if (DoubleUtil.GreaterThanZero(giveAwayWidth) || recomputeStars)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridComboBoxColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridComboBoxColumn.cs
@@ -486,7 +486,7 @@ namespace System.Windows.Controls
         {
             TextBlockComboBox comboBox = new TextBlockComboBox();
 
-            ApplyStyle(/* isEditing = */ false, /* defaultToElementStyle = */ false, comboBox);
+            ApplyStyle(isEditing: false, defaultToElementStyle: false, comboBox);
             ApplyColumnProperties(comboBox);
 
             DataGridHelper.RestoreFlowDirection(comboBox, cell);
@@ -501,7 +501,7 @@ namespace System.Windows.Controls
         {
             ComboBox comboBox = new ComboBox();
 
-            ApplyStyle(/* isEditing = */ true, /* defaultToElementStyle = */ false, comboBox);
+            ApplyStyle(isEditing: true, defaultToElementStyle: false, comboBox);
             ApplyColumnProperties(comboBox);
 
             DataGridHelper.RestoreFlowDirection(comboBox, cell);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridHyperlinkColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridHyperlinkColumn.cs
@@ -173,7 +173,7 @@ namespace System.Windows.Controls
 
             link.TargetName = TargetName;
 
-            ApplyStyle(/* isEditing = */ false, /* defaultToElementStyle = */ false, outerBlock);
+            ApplyStyle(isEditing: false, defaultToElementStyle: false, outerBlock);
             ApplyBinding(link, Hyperlink.NavigateUriProperty);
             ApplyContentBinding(innerContentPresenter, ContentPresenter.ContentProperty);
 
@@ -189,7 +189,7 @@ namespace System.Windows.Controls
         {
             TextBox textBox = new TextBox();
 
-            ApplyStyle(/* isEditing = */ true, /* defaultToElementStyle = */ false, textBox);
+            ApplyStyle(isEditing: true, defaultToElementStyle: false, textBox);
             ApplyBinding(textBox, TextBox.TextProperty);
 
             DataGridHelper.RestoreFlowDirection(textBox, cell);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridRowClipboardEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridRowClipboardEventArgs.cs
@@ -68,7 +68,7 @@ namespace System.Windows.Controls
             int count = ClipboardRowContent.Count;
             for (int i = 0; i < count; i++)
             {
-                DataGridClipboardHelper.FormatCell(ClipboardRowContent[i].Content, i == 0 /* firstCell */, i == count - 1 /* lastCell */, sb, format);
+                DataGridClipboardHelper.FormatCell(ClipboardRowContent[i].Content, firstCell: i == 0, lastCell: i == count - 1, sb, format);
             }
 
             return sb.ToString();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridTemplateColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridTemplateColumn.cs
@@ -179,7 +179,7 @@ namespace System.Windows.Controls
         /// </summary>
         protected override FrameworkElement GenerateElement(DataGridCell cell, object dataItem)
         {
-            return LoadTemplateContent(/* isEditing = */ false, dataItem, cell);
+            return LoadTemplateContent(isEditing: false, dataItem, cell);
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace System.Windows.Controls
         /// </summary>
         protected override FrameworkElement GenerateEditingElement(DataGridCell cell, object dataItem)
         {
-            return LoadTemplateContent(/* isEditing = */ true, dataItem, cell);
+            return LoadTemplateContent(isEditing: true, dataItem, cell);
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridTextColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridTextColumn.cs
@@ -82,7 +82,7 @@ namespace System.Windows.Controls
 
             SyncProperties(textBlock);
 
-            ApplyStyle(/* isEditing = */ false, /* defaultToElementStyle = */ false, textBlock);
+            ApplyStyle(isEditing: false, defaultToElementStyle: false, textBlock);
             ApplyBinding(textBlock, TextBlock.TextProperty);
 
             DataGridHelper.RestoreFlowDirection(textBlock, cell);
@@ -99,7 +99,7 @@ namespace System.Windows.Controls
 
             SyncProperties(textBox);
 
-            ApplyStyle(/* isEditing = */ true, /* defaultToElementStyle = */ false, textBox);
+            ApplyStyle(isEditing: true, defaultToElementStyle: false, textBox);
             ApplyBinding(textBox, TextBox.TextProperty);
 
             DataGridHelper.RestoreFlowDirection(textBox, cell);
@@ -235,7 +235,7 @@ namespace System.Windows.Controls
 
         private static bool PlaceCaretOnTextBox(TextBox textBox, Point position)
         {
-            int characterIndex = textBox.GetCharacterIndexFromPoint(position, /* snapToText = */ false);
+            int characterIndex = textBox.GetCharacterIndexFromPoint(position, snapToText: false);
             if (characterIndex >= 0)
             {
                 textBox.Select(characterIndex, 0);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Expander.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Expander.cs
@@ -93,7 +93,7 @@ namespace System.Windows.Controls
                         typeof(ExpandDirection),
                         typeof(Expander),
                         new FrameworkPropertyMetadata(
-                                ExpandDirection.Down /* default value */,
+                                defaultValue: ExpandDirection.Down,
                                 FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
                                 new PropertyChangedCallback(OnVisualStatePropertyChanged)),
                         new ValidateValueCallback(IsValidExpandDirection));
@@ -118,7 +118,7 @@ namespace System.Windows.Controls
                         typeof(bool),
                         typeof(Expander),
                         new FrameworkPropertyMetadata(
-                                BooleanBoxes.FalseBox /* default value */,
+                                defaultValue: BooleanBoxes.FalseBox,
                                 FrameworkPropertyMetadataOptions.BindsTwoWayByDefault | FrameworkPropertyMetadataOptions.Journal,
                                 new PropertyChangedCallback(OnIsExpandedChanged)));
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/FlowDocumentScrollViewer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/FlowDocumentScrollViewer.cs
@@ -1324,7 +1324,7 @@ namespace System.Windows.Controls
             _commandLineRight = new RoutedUICommand(String.Empty, "FDSV_LineRight", typeof(FlowDocumentScrollViewer));
 
             // Register editing command handlers
-            TextEditor.RegisterCommandHandlers(typeof(FlowDocumentScrollViewer), /*acceptsRichContent:*/true, /*readOnly:*/!IsEditingEnabled, /*registerEventListeners*/true);
+            TextEditor.RegisterCommandHandlers(typeof(FlowDocumentScrollViewer), acceptsRichContent: true, readOnly: !IsEditingEnabled, registerEventListeners: true);
 
             // Command: ApplicationCommands.Find
             CommandHelpers.RegisterCommandHandler(typeof(FlowDocumentScrollViewer), ApplicationCommands.Find,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Frame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Frame.cs
@@ -1318,7 +1318,7 @@ namespace System.Windows.Controls
             if (_ownJournalScope == null)
             {
                 // Entries created for this frame in the parent's journal have to be removed.
-                JournalNavigationScope parentJns = GetParentJournal(false/*don't create*/);
+                JournalNavigationScope parentJns = GetParentJournal(create: false);
                 parentJns?.Journal.RemoveEntries(_navigationService.GuidId);
 
                 _ownJournalScope = new JournalNavigationScope(this);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Frame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Frame.cs
@@ -269,7 +269,7 @@ namespace System.Windows.Controls
 
                 // Calling the internal Navigate from Frame and NavWin's Source DP's property changed callbacks
                 // We would not set value back in this case.
-                frame._navigationService.Navigate(uriToNavigate, null, false, true/* navigateOnSourceChanged */);
+                frame._navigationService.Navigate(uriToNavigate, null, false, navigateOnSourceChanged: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridView.cs
@@ -367,8 +367,7 @@ namespace System.Windows.Controls
                     "AllowsColumnReorder",
                     typeof(bool),
                     typeof(GridView),
-                    new FrameworkPropertyMetadata(BooleanBoxes.TrueBox  /* default value */
-                        )
+                    new FrameworkPropertyMetadata(defaultValue: BooleanBoxes.TrueBox)
                 );
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumn.cs
@@ -378,7 +378,7 @@ namespace System.Windows.Controls
             FrameworkElement.WidthProperty.AddOwner(
                 typeof(GridViewColumn),
                 new PropertyMetadata(
-                    Double.NaN /* default value */,
+                    defaultValue: Double.NaN,
                     new PropertyChangedCallback(OnWidthChanged))
             );
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumnCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumnCollection.cs
@@ -390,7 +390,7 @@ namespace System.Windows.Controls
 
             ((INotifyPropertyChanged)column).PropertyChanged += new PropertyChangedEventHandler(ColumnPropertyChanged);
 
-            return new GridViewColumnCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, column, index, count /* actual index*/);
+            return new GridViewColumnCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, column, index, actualIndex: count);
         }
 
         // This[index] = newColumn

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewHeaderRowPresenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewHeaderRowPresenter.cs
@@ -1382,8 +1382,8 @@ namespace System.Windows.Controls
 
             for (int i = 0, n = s_DPList[0].Length; i < n; i++)
             {
-                UpdateHeaderProperty(header, s_DPList[2][i] /* header */,
-                    s_DPList[1][i] /* column */, s_DPList[0][i] /* GV */);
+                UpdateHeaderProperty(header, targetDP: s_DPList[2][i],
+                    columnDP: s_DPList[1][i], gvDP: s_DPList[0][i]);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GroupItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GroupItem.cs
@@ -80,7 +80,7 @@ namespace System.Windows.Controls
                         // remeasure the sub tree through the ItemsPresenter leading up to the
                         // ItemsHost panel. If we didnt do this the offsets could get skewed.
                         groupItem.InvalidateMeasure();
-                        Helper.InvalidateMeasureOnPath(itemsHostPresenter, groupItem, false /*duringMeasure*/);
+                        Helper.InvalidateMeasureOnPath(itemsHostPresenter, groupItem, duringMeasure: false);
                     }
                 }
             }
@@ -163,7 +163,7 @@ namespace System.Windows.Controls
                 }
                 else
                 {
-                    Generator.RemoveAllInternal(true /*saveRecycleQueue*/);
+                    Generator.RemoveAllInternal(saveRecycleQueue: true);
                 }
             }
 
@@ -249,7 +249,7 @@ namespace System.Windows.Controls
                 VirtualizingPanel vp = _itemsHost as VirtualizingPanel;
                 vp?.OnClearChildrenInternal();
 
-                Generator.RemoveAllInternal(true /*saveRecycleQueue*/);
+                Generator.RemoveAllInternal(saveRecycleQueue: true);
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/InkCanvas.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/InkCanvas.cs
@@ -137,7 +137,7 @@ namespace System.Windows.Controls
             StyleProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(defaultStyle));
             DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(typeof(InkCanvas)));
 
-            FocusVisualStyleProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata((object)null /* default value */));
+            FocusVisualStyleProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(defaultValue: (object)null));
         }
 
         /// <summary>
@@ -1317,7 +1317,7 @@ namespace System.Windows.Controls
         {
             Debug.Assert(e != null, "EventArg can not be null");
 
-            _editingCoordinator.UpdateEditingState(false /* EditingMode */);
+            _editingCoordinator.UpdateEditingState(inverted: false);
 
             this.OnEditingModeChanged(e);
         }
@@ -1371,7 +1371,7 @@ namespace System.Windows.Controls
         {
             Debug.Assert(e != null, "EventArg can not be null");
 
-            _editingCoordinator.UpdateEditingState(true /* EditingModeInverted */);
+            _editingCoordinator.UpdateEditingState(inverted: true);
 
             this.OnEditingModeInvertedChanged(e);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemContainerGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemContainerGenerator.cs
@@ -490,7 +490,7 @@ namespace System.Windows.Controls
 
         void IRecyclingItemContainerGenerator.Recycle(GeneratorPosition position, int count)
         {
-            Remove(position, count, /*isRecyling = */ true);
+            Remove(position, count, isRecycling: true);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemContainerGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemContainerGenerator.cs
@@ -261,7 +261,7 @@ namespace System.Windows.Controls
         /// </summary>
         void IItemContainerGenerator.Remove(GeneratorPosition position, int count)
         {
-            Remove(position, count, /*isRecycling = */ false);
+            Remove(position, count, isRecycling: false);
         }
 
         /// <summary>
@@ -427,7 +427,7 @@ namespace System.Windows.Controls
         /// </summary>
         void IItemContainerGenerator.RemoveAll()
         {
-            RemoveAllInternal(false /*saveRecycleQueue*/);
+            RemoveAllInternal(saveRecycleQueue: false);
         }
 
         internal void RemoveAllInternal(bool saveRecycleQueue)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
@@ -1873,7 +1873,7 @@ namespace System.Windows.Controls
                 direction,
                 startingElement,
                 itemNavigateArgs,
-                false /*shouldFocus*/,
+                shouldFocus: false,
                 out container);
         }
 
@@ -1913,7 +1913,7 @@ namespace System.Windows.Controls
                 direction,
                 startingElement,
                 itemNavigateArgs,
-                true /*shouldFocus*/,
+                shouldFocus: true,
                 out container);
         }
 
@@ -1998,7 +1998,7 @@ namespace System.Windows.Controls
                                 ElementViewportPosition elementPosition = GetElementViewportPosition(viewport,
                                     TryGetTreeViewItemHeader(nextElement) as FrameworkElement,
                                     direction,
-                                    false /*fullyVisible*/,
+                                    fullyVisible: false,
                                     out currentRect);
                                 if (elementPosition == ElementViewportPosition.CompletelyInViewport ||
                                     elementPosition == ElementViewportPosition.PartiallyInViewport)
@@ -2013,7 +2013,7 @@ namespace System.Windows.Controls
                                         GetElementViewportPosition(viewport,
                                             startingElement,
                                             direction,
-                                            false /*fullyVisible*/,
+                                            fullyVisible: false,
                                             out startingRect);
                                         bool isInDirection = IsInDirectionForLineNavigation(startingRect, currentRect, direction, isHorizontal);
                                         if (isInDirection)
@@ -2160,7 +2160,7 @@ namespace System.Windows.Controls
             // start navigating again, scroll it back into view.
             if (startingElement != null)
             {
-                MakeVisible(startingElement, direction, /*alwaysAtTopOfViewport*/ false);
+                MakeVisible(startingElement, direction, alwaysAtTopOfViewport: false);
             }
             else
             {
@@ -2174,7 +2174,7 @@ namespace System.Windows.Controls
                 direction,
                 startingElement,
                 itemNavigateArgs,
-                false /*shouldFocus*/,
+                shouldFocus: false,
                 out container);
         }
 
@@ -2206,7 +2206,7 @@ namespace System.Windows.Controls
             // start navigating again, scroll it back into view.
             if (startingElement != null)
             {
-                MakeVisible(startingElement, direction, /*alwaysAtTopOfViewport*/ false);
+                MakeVisible(startingElement, direction, alwaysAtTopOfViewport: false);
             }
             else
             {
@@ -2221,7 +2221,7 @@ namespace System.Windows.Controls
                 direction,
                 startingElement,
                 itemNavigateArgs,
-                true /*shouldFocus*/,
+                shouldFocus: true,
                 out container);
         }
 
@@ -2326,7 +2326,7 @@ namespace System.Windows.Controls
         internal void NavigateToStart(ItemNavigateArgs itemNavigateArgs)
         {
             FrameworkElement container;
-            NavigateToStartInternal(itemNavigateArgs, true /*shouldFocus*/, out container);
+            NavigateToStartInternal(itemNavigateArgs, shouldFocus: true, out container);
         }
 
         internal bool NavigateToStartInternal(ItemNavigateArgs itemNavigateArgs, bool shouldFocus, out FrameworkElement container)
@@ -2364,7 +2364,7 @@ namespace System.Windows.Controls
                 }
 
                 FrameworkElement firstElement;
-                FrameworkElement hopefulFirstElement = FindEndFocusableLeafContainer(ItemsHost, false /*last*/);
+                FrameworkElement hopefulFirstElement = FindEndFocusableLeafContainer(ItemsHost, last: false);
                 object firstItem = GetFirstItemOnCurrentPage(hopefulFirstElement,
                     FocusNavigationDirection.Up,
                     out firstElement);
@@ -2392,7 +2392,7 @@ namespace System.Windows.Controls
         internal void NavigateToEnd(ItemNavigateArgs itemNavigateArgs)
         {
             FrameworkElement container;
-            NavigateToEndInternal(itemNavigateArgs, true /*shouldFocus*/, out container);
+            NavigateToEndInternal(itemNavigateArgs, shouldFocus: true, out container);
         }
 
         internal bool NavigateToEndInternal(ItemNavigateArgs itemNavigateArgs, bool shouldFocus, out FrameworkElement container)
@@ -2430,7 +2430,7 @@ namespace System.Windows.Controls
                 }
 
                 FrameworkElement lastElement;
-                FrameworkElement hopefulLastElement = FindEndFocusableLeafContainer(ItemsHost, true /*last*/);
+                FrameworkElement hopefulLastElement = FindEndFocusableLeafContainer(ItemsHost, last: true);
                 object lastItem = GetFirstItemOnCurrentPage(hopefulLastElement,
                     FocusNavigationDirection.Down,
                     out lastElement);
@@ -2514,12 +2514,12 @@ namespace System.Windows.Controls
 
         internal void NavigateToItem(object item, ItemNavigateArgs itemNavigateArgs)
         {
-            NavigateToItem(item, -1, itemNavigateArgs, false /* alwaysAtTopOfViewport */);
+            NavigateToItem(item, -1, itemNavigateArgs, alwaysAtTopOfViewport: false);
         }
 
         internal void NavigateToItem(object item, int itemIndex, ItemNavigateArgs itemNavigateArgs)
         {
-            NavigateToItem(item, itemIndex, itemNavigateArgs, false /* alwaysAtTopOfViewport */);
+            NavigateToItem(item, itemIndex, itemNavigateArgs, alwaysAtTopOfViewport: false);
         }
 
         internal void NavigateToItem(object item, ItemNavigateArgs itemNavigateArgs, bool alwaysAtTopOfViewport)
@@ -2659,12 +2659,12 @@ namespace System.Windows.Controls
         {
             if (info != null)
             {
-                MakeVisible(info.Index, direction, false /*alwaysAtTopOfViewport*/, out container);
+                MakeVisible(info.Index, direction, alwaysAtTopOfViewport: false, out container);
                 info.Container = container;
             }
             else
             {
-                MakeVisible(-1, direction, false /*alwaysAtTopOfViewport*/, out container);
+                MakeVisible(-1, direction, alwaysAtTopOfViewport: false, out container);
             }
         }
 
@@ -2680,7 +2680,7 @@ namespace System.Windows.Controls
 
                 FrameworkElement viewportElement = GetViewportElement();
 
-                while (container != null && !IsOnCurrentPage(viewportElement, container, direction, false /*fullyVisible*/))
+                while (container != null && !IsOnCurrentPage(viewportElement, container, direction, fullyVisible: false))
                 {
                     oldHorizontalOffset = ScrollHost.HorizontalOffset;
                     oldVerticalOffset = ScrollHost.VerticalOffset;
@@ -2833,7 +2833,7 @@ namespace System.Windows.Controls
                     ElementViewportPosition elementPosition = GetElementViewportPosition(viewportElement,
                         startingElement,
                         direction,
-                        false /*fullyVisible*/);
+                        fullyVisible: false);
                     if (elementPosition == ElementViewportPosition.CompletelyInViewport ||
                         elementPosition == ElementViewportPosition.PartiallyInViewport)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
@@ -451,7 +451,7 @@ namespace System.Windows.Controls
                                     else if ((Keyboard.Modifiers & (ModifierKeys.Control | ModifierKeys.Shift)) == ModifierKeys.Shift)
                                     {
                                         // Only SHIFT
-                                        MakeAnchorSelection(source, true /* clearCurrent */);
+                                        MakeAnchorSelection(source, clearCurrent: true);
                                     }
                                     else if ((Keyboard.Modifiers & ModifierKeys.Shift) == 0)
                                     {
@@ -794,7 +794,7 @@ namespace System.Windows.Controls
             {
                 ItemInfo info = ItemInfoFromContainer(listItem);
 
-                SelectionChange.SelectJustThisItem(info, true /* assumeInItemsCollection */);
+                SelectionChange.SelectJustThisItem(info, assumeInItemsCollection: true);
 
                 listItem.Focus();
 
@@ -880,7 +880,7 @@ namespace System.Windows.Controls
                     enumerator.MoveNext();
                     if (index >= start)
                     {
-                        SelectionChange.Select(NewItemInfo(enumerator.Current, null, index), true /* assumeInItemsCollection */);
+                        SelectionChange.Select(NewItemInfo(enumerator.Current, null, index), assumeInItemsCollection: true);
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -181,7 +181,7 @@ namespace System.Windows.Controls
             KeyboardNavigation.DirectionalNavigationProperty.OverrideMetadata(typeof(MenuItem), new FrameworkPropertyMetadata(KeyboardNavigationMode.None));
 
             // Disable default focus visual for MenuItem.
-            FocusVisualStyleProperty.OverrideMetadata(typeof(MenuItem), new FrameworkPropertyMetadata((object)null /* default value */));
+            FocusVisualStyleProperty.OverrideMetadata(typeof(MenuItem), new FrameworkPropertyMetadata(defaultValue: (object)null));
 
 
             // While the menu is opened, Input Method should be suspended.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Panel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Panel.cs
@@ -340,7 +340,7 @@ namespace System.Windows.Controls
                     if (_uiElementCollection == null)
                     {
                         // First access on a regular panel
-                        EnsureEmptyChildren(/* logicalParent = */ this);
+                        EnsureEmptyChildren(logicalParent: this);
                     }
                 }
 
@@ -618,7 +618,7 @@ namespace System.Windows.Controls
                 ConnectToGenerator();
 
                 // Children of this panel should not have their logical parent reset
-                EnsureEmptyChildren(/* logicalParent = */ null);
+                EnsureEmptyChildren(logicalParent: null);
 
                 GenerateChildren();
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordBox.cs
@@ -831,7 +831,7 @@ namespace System.Windows.Controls
             // We don't use the static ctor because there are cases
             // where another control will want to alias our properties
             // but doesn't need this overhead.
-            TextEditor.RegisterCommandHandlers(typeof(PasswordBox), /*acceptsRichContent:*/false, /*readOnly*/false, /*registerEventListeners*/false);
+            TextEditor.RegisterCommandHandlers(typeof(PasswordBox), acceptsRichContent: false, readOnly: false, registerEventListeners: false);
 
             // Create TextContainer
             InitializeTextContainer(new PasswordTextContainer(this));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordTextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordTextContainer.cs
@@ -148,7 +148,7 @@ namespace System.Windows.Controls
         /// </summary>
         internal void EndChange()
         {
-            EndChange(false /* skipEvents */);
+            EndChange(skipEvents: false);
         }
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace System.Windows.Controls
         /// </summary>
         void ITextContainer.EndChange()
         {
-            EndChange(false /* skipEvents */);
+            EndChange(skipEvents: false);
         }
 
         /// <summary>
@@ -634,7 +634,7 @@ namespace System.Windows.Controls
                 _changes = new TextContainerChangedEventArgs();
             }
 
-            _changes.AddChange(precursorTextChange, startPosition.Offset, symbolCount, false /* collectTextChanges */);
+            _changes.AddChange(precursorTextChange, startPosition.Offset, symbolCount, collectTextChanges: false);
 
             if (this.Change != null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
@@ -966,7 +966,7 @@ namespace System.Windows.Controls
         private bool RaiseContextMenuOpeningEvent(IInputElement source, double x, double y,bool userInitiated)
         {
             // Fire the event
-            ContextMenuEventArgs args = new ContextMenuEventArgs(source, true /* opening */, x, y);
+            ContextMenuEventArgs args = new ContextMenuEventArgs(source, opening: true, x, y);
             DependencyObject sourceDO = source as DependencyObject;
             if (userInitiated && sourceDO != null)
             {
@@ -1054,7 +1054,7 @@ namespace System.Windows.Controls
                         if (!IsPresentationSourceNull(uie))
                         {
                             IInputElement inputElement = (o is ContentElement || o is UIElement3D) ? (IInputElement)o : (IInputElement)uie;
-                            ContextMenuEventArgs args = new ContextMenuEventArgs(inputElement, false /*opening */);
+                            ContextMenuEventArgs args = new ContextMenuEventArgs(inputElement, opening: false);
                             inputElement.RaiseEvent(args);
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/CalendarItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/CalendarItem.cs
@@ -599,7 +599,7 @@ namespace System.Windows.Controls.Primitives
                     case CalendarSelectionMode.SingleRange:
                         {
                             DateTime? lastDate = this.Owner.CurrentDate;
-                            this.Owner.SelectedDates.ClearInternal(true /*fireChangeNotification*/);
+                            this.Owner.SelectedDates.ClearInternal(fireChangeNotification: true);
                             if (shift && lastDate.HasValue)
                             {
                                 this.Owner.SelectedDates.AddRangeInternal(lastDate.Value, clickedDate);
@@ -618,7 +618,7 @@ namespace System.Windows.Controls.Primitives
                         {
                             if (!ctrl)
                             {
-                                this.Owner.SelectedDates.ClearInternal(true /*fireChangeNotification*/);
+                                this.Owner.SelectedDates.ClearInternal(fireChangeNotification: true);
                             }
 
                             if (shift)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridCellsPresenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridCellsPresenter.cs
@@ -394,11 +394,11 @@ namespace System.Windows.Controls.Primitives
                 }
                 else if (string.Equals(propertyName, "RealizedColumnsBlockListForNonVirtualizedRows", StringComparison.Ordinal))
                 {
-                    InvalidateDataGridCellsPanelMeasureAndArrange(/* withColumnVirtualization */ false);
+                    InvalidateDataGridCellsPanelMeasureAndArrange(withColumnVirtualization: false);
                 }
                 else if (string.Equals(propertyName, "RealizedColumnsBlockListForVirtualizedRows", StringComparison.Ordinal))
                 {
-                    InvalidateDataGridCellsPanelMeasureAndArrange(/* withColumnVirtualization */ true);
+                    InvalidateDataGridCellsPanelMeasureAndArrange(withColumnVirtualization: true);
                 }
                 else if (e.Property == DataGrid.RowHeightProperty || e.Property == HeightProperty)
                 {
@@ -472,7 +472,7 @@ namespace System.Windows.Controls.Primitives
                 return;
             }
 
-            if (DataGridHelper.IsGridLineVisible(dataGrid, /*isHorizontal = */ true))
+            if (DataGridHelper.IsGridLineVisible(dataGrid, isHorizontal: true))
             {
                 double thickness = dataGrid.HorizontalGridLineThickness;
                 Rect rect = new Rect(new Size(RenderSize.Width, thickness))
@@ -538,7 +538,7 @@ namespace System.Windows.Controls.Primitives
                     DataGrid dataGrid = DataGridOwner;
                     if(dataGrid != null && dataGrid.InternalItemsHost != null)
                     {
-                        Helper.InvalidateMeasureOnPath(_internalItemsHost, dataGrid.InternalItemsHost, false/*duringMeasure*/, true/*includePathEnd*/);
+                        Helper.InvalidateMeasureOnPath(_internalItemsHost, dataGrid.InternalItemsHost, duringMeasure: false, includePathEnd: true);
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridCellsPresenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridCellsPresenter.cs
@@ -380,7 +380,7 @@ namespace System.Windows.Controls.Primitives
                 {
                     if (((DataGridColumn)d).IsVisible)
                     {
-                        InvalidateDataGridCellsPanelMeasureAndArrangeImpl((e.Property == DataGridColumn.WidthProperty)/*invalidateMeasureUptoRowsPresenter*/);
+                        InvalidateDataGridCellsPanelMeasureAndArrangeImpl(invalidateMeasureUptoRowsPresenter: (e.Property == DataGridColumn.WidthProperty));
                     }
                 }
                 else if (e.Property == DataGrid.FrozenColumnCountProperty ||

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridColumnHeadersPresenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridColumnHeadersPresenter.cs
@@ -309,11 +309,11 @@ namespace System.Windows.Controls.Primitives
                 }
                 else if (string.Equals(propertyName, "RealizedColumnsBlockListForNonVirtualizedRows", StringComparison.Ordinal))
                 {
-                    InvalidateDataGridCellsPanelMeasureAndArrange(/* withColumnVirtualization */ false);
+                    InvalidateDataGridCellsPanelMeasureAndArrange(withColumnVirtualization: false);
                 }
                 else if (string.Equals(propertyName, "RealizedColumnsBlockListForVirtualizedRows", StringComparison.Ordinal))
                 {
-                    InvalidateDataGridCellsPanelMeasureAndArrange(/* withColumnVirtualization */ true);
+                    InvalidateDataGridCellsPanelMeasureAndArrange(withColumnVirtualization: true);
                 }
                 else if (e.Property == DataGrid.CellsPanelActualWidthProperty)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridDetailsPresenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridDetailsPresenter.cs
@@ -131,7 +131,7 @@ namespace System.Windows.Controls.Primitives
                     dataGridOwner.ScrollIntoView(rowOwner.Item, dataGridOwner.ColumnFromDisplayIndex(0));
                 }
 
-                dataGridOwner.HandleSelectionForRowHeaderAndDetailsInput(rowOwner, /* startDragging = */ Mouse.Captured == null);
+                dataGridOwner.HandleSelectionForRowHeaderAndDetailsInput(rowOwner, startDragging: Mouse.Captured == null);
             }
         }
 
@@ -217,10 +217,10 @@ namespace System.Windows.Controls.Primitives
             }
 
             if (row.DetailsPresenterDrawsGridLines && 
-                DataGridHelper.IsGridLineVisible(dataGrid, /*isHorizontal = */ true))
+                DataGridHelper.IsGridLineVisible(dataGrid, isHorizontal: true))
             {
                 double thickness = dataGrid.HorizontalGridLineThickness;
-                Size desiredSize = base.MeasureOverride(DataGridHelper.SubtractFromSize(availableSize, thickness, /*height = */ true));
+                Size desiredSize = base.MeasureOverride(DataGridHelper.SubtractFromSize(availableSize, thickness, height: true));
                 desiredSize.Height += thickness;
                 return desiredSize;
             }
@@ -251,10 +251,10 @@ namespace System.Windows.Controls.Primitives
             }
 
             if (row.DetailsPresenterDrawsGridLines &&
-                DataGridHelper.IsGridLineVisible(dataGrid, /*isHorizontal = */ true))
+                DataGridHelper.IsGridLineVisible(dataGrid, isHorizontal: true))
             {
                 double thickness = dataGrid.HorizontalGridLineThickness;
-                Size returnSize = base.ArrangeOverride(DataGridHelper.SubtractFromSize(finalSize, thickness, /*height = */ true));
+                Size returnSize = base.ArrangeOverride(DataGridHelper.SubtractFromSize(finalSize, thickness, height: true));
                 returnSize.Height += thickness;
                 return returnSize;
             }
@@ -285,7 +285,7 @@ namespace System.Windows.Controls.Primitives
             }
 
             if (row.DetailsPresenterDrawsGridLines &&
-                DataGridHelper.IsGridLineVisible(dataGrid, /*isHorizontal = */ true))
+                DataGridHelper.IsGridLineVisible(dataGrid, isHorizontal: true))
             {
                 double thickness = dataGrid.HorizontalGridLineThickness;
                 Rect rect = new Rect(new Size(RenderSize.Width, thickness))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridRowHeader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridRowHeader.cs
@@ -561,7 +561,7 @@ namespace System.Windows.Controls.Primitives
             DataGridRow parentRow = ParentRow;
             if ((dataGridOwner != null) && (parentRow != null))
             {
-                dataGridOwner.HandleSelectionForRowHeaderAndDetailsInput(parentRow, /* startDragging = */ true);
+                dataGridOwner.HandleSelectionForRowHeaderAndDetailsInput(parentRow, startDragging: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DocumentViewerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DocumentViewerBase.cs
@@ -1456,7 +1456,7 @@ namespace System.Windows.Controls.Primitives
                 executedHandler, canExecuteHandler); // no key gesture
 
             // Register editing command handlers - After our commands to let editor handle them first
-            TextEditor.RegisterCommandHandlers(typeof(DocumentViewerBase), /*acceptsRichContent:*/true, /*readOnly:*/!IsEditingEnabled, /*registerEventListeners*/true);
+            TextEditor.RegisterCommandHandlers(typeof(DocumentViewerBase), acceptsRichContent: true, readOnly: !IsEditingEnabled, registerEventListeners: true);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/GridViewRowPresenterBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/GridViewRowPresenterBase.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Controls.Primitives
                 typeof(GridViewColumnCollection),
                 typeof(GridViewRowPresenterBase),
                 new FrameworkPropertyMetadata(
-                    (GridViewColumnCollection)null /* default value */,
+                    defaultValue: (GridViewColumnCollection)null,
                     FrameworkPropertyMetadataOptions.AffectsMeasure,
                     new PropertyChangedCallback(ColumnsPropertyChanged))
             );
@@ -225,7 +225,7 @@ namespace System.Windows.Controls.Primitives
             {
                 if (_uiElementCollection == null) //nobody used it yet
                 {
-                    _uiElementCollection = new UIElementCollection(this /* visual parent */, this /* logical parent */);
+                    _uiElementCollection = new UIElementCollection(visualParent: this, logicalParent: this);
                 }
 
                 return _uiElementCollection;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/MenuBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/MenuBase.cs
@@ -220,7 +220,7 @@ namespace System.Windows.Controls.Primitives
             if (!menu.IsKeyboardFocusWithin && !menu.HasPushedMenuMode)
             {
                 // Call PushMenuMode just before focus enters the menu...
-                menu.PushMenuMode(/*isAcquireFocusMenuMode*/ true);
+                menu.PushMenuMode(isAcquireFocusMenuMode: true);
             }
         }
 
@@ -817,7 +817,7 @@ namespace System.Windows.Controls.Primitives
                             // is set within the menu), push it now.
                             if (!HasPushedMenuMode)
                             {
-                                PushMenuMode(/*isAcquireFocusMenuMode*/ false);
+                                PushMenuMode(isAcquireFocusMenuMode: false);
                             }
                             
                             RaiseClrEvent(InternalMenuModeChangedKey, EventArgs.Empty);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
@@ -355,7 +355,7 @@ namespace System.Windows.Controls.Primitives
 
                     // Cancel any pending async create requests, we're creating now
                     popup.CancelAsyncCreate();
-                    popup.CreateWindow(false /*asyncCall*/);
+                    popup.CreateWindow(asyncCall: false);
 
                     // It is possible that the popup is destroyed by CreateWindow or one of its callbacks
                     if (popup._secHelper.IsWindowAlive())
@@ -1461,7 +1461,7 @@ namespace System.Windows.Controls.Primitives
         {
             Popup popup = (Popup)arg;
             popup._asyncCreate = null;
-            popup.CreateWindow(true /*asyncCall*/);
+            popup.CreateWindow(asyncCall: true);
 
             return null;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ScrollBar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ScrollBar.cs
@@ -143,7 +143,7 @@ namespace System.Windows.Controls.Primitives
                 double newValue = Track.ValueFromPoint(pt);
                 if (System.Windows.Shapes.Shape.IsDoubleFinite(newValue))
                 {
-                    ChangeValue(newValue, false /* defer */);
+                    ChangeValue(newValue, defer: false);
                 }
 
                 if (Track.Thumb != null && Track.Thumb.IsMouseOver)
@@ -345,7 +345,7 @@ namespace System.Windows.Controls.Primitives
                     if (!DoubleUtil.AreClose(currentValue, newValue))
                     {
                         _hasScrolled = true;
-                        ChangeValue(newValue, true /* defer */);
+                        ChangeValue(newValue, defer: true);
                         RaiseScrollEvent(ScrollEventType.ThumbTrack);
                     }
                 }
@@ -399,7 +399,7 @@ namespace System.Windows.Controls.Primitives
             if (command.CanExecute(value, target))
             {
                 // If we were reporting drag commands, we need to give a final scroll command
-                ChangeValue(value, false /* defer */);
+                ChangeValue(value, defer: false);
             }
         }
         
@@ -453,7 +453,7 @@ namespace System.Windows.Controls.Primitives
                 double newValue = Track.ValueFromPoint(_latestRightButtonClickPoint);
                 if (System.Windows.Shapes.Shape.IsDoubleFinite(newValue))
                 {
-                    ChangeValue(newValue, false /* defer */);
+                    ChangeValue(newValue, defer: false);
                     _latestRightButtonClickPoint = pt;
                     RaiseScrollEvent(ScrollEventType.ThumbPosition);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Selector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Selector.cs
@@ -335,7 +335,7 @@ namespace System.Windows.Controls.Primitives
             if (!s.SelectionChange.IsActive)
             {
                 int newIndex = (int) e.NewValue;
-                s.SelectionChange.SelectJustThisItem(s.ItemInfoFromIndex(newIndex), true /* assumeInItemsCollection */);
+                s.SelectionChange.SelectJustThisItem(s.ItemInfoFromIndex(newIndex), assumeInItemsCollection: true);
             }
         }
 
@@ -387,7 +387,7 @@ namespace System.Windows.Controls.Primitives
 
             if (!s.SelectionChange.IsActive)
             {
-                s.SelectionChange.SelectJustThisItem(s.NewItemInfo(e.NewValue), false /* assumeInItemsCollection */);
+                s.SelectionChange.SelectJustThisItem(s.NewItemInfo(e.NewValue), assumeInItemsCollection: false);
             }
         }
 
@@ -497,7 +497,7 @@ namespace System.Windows.Controls.Primitives
 
                     // We can assume it's in the collection because we just searched
                     // through the collection to find it.
-                    SelectionChange.SelectJustThisItem(NewItemInfo(item, null, index), true /* assumeInItemsCollection */);
+                    SelectionChange.SelectJustThisItem(NewItemInfo(item, null, index), assumeInItemsCollection: true);
                 }
                 else
                 {
@@ -827,7 +827,7 @@ namespace System.Windows.Controls.Primitives
                         // Make sure that we can select every items.
                         foreach (object item in selectedItems)
                         {
-                            if (!SelectionChange.Select(NewUnresolvedItemInfo(item), false /* assumeInItemsCollection */))
+                            if (!SelectionChange.Select(NewUnresolvedItemInfo(item), assumeInItemsCollection: false))
                             {
                                 SelectionChange.Cancel();
                                 return false;
@@ -873,7 +873,7 @@ namespace System.Windows.Controls.Primitives
                         if (e.NewItems.Count != 1)
                             throw new NotSupportedException(SR.RangeActionsNotSupported);
 
-                        SelectionChange.Select(NewUnresolvedItemInfo(e.NewItems[0]), false /* assumeInItemsCollection */);
+                        SelectionChange.Select(NewUnresolvedItemInfo(e.NewItems[0]), assumeInItemsCollection: false);
                         break;
 
                     case NotifyCollectionChangedAction.Remove:
@@ -894,7 +894,7 @@ namespace System.Windows.Controls.Primitives
 
                         for (int i = 0; i < userSelectedItems.Count; i++)
                         {
-                            SelectionChange.Select(NewUnresolvedItemInfo(userSelectedItems[i]), false /* assumeInItemsCollection */);
+                            SelectionChange.Select(NewUnresolvedItemInfo(userSelectedItems[i]), assumeInItemsCollection: false);
                         }
                         break;
 
@@ -903,7 +903,7 @@ namespace System.Windows.Controls.Primitives
                             throw new NotSupportedException(SR.RangeActionsNotSupported);
 
                         SelectionChange.Unselect(NewUnresolvedItemInfo(e.OldItems[0]));
-                        SelectionChange.Select(NewUnresolvedItemInfo(e.NewItems[0]), false /* assumeInItemsCollection */);
+                        SelectionChange.Select(NewUnresolvedItemInfo(e.NewItems[0]), assumeInItemsCollection: false);
                         break;
 
                     case NotifyCollectionChangedAction.Move:
@@ -1042,7 +1042,7 @@ namespace System.Windows.Controls.Primitives
                 foreach (object current in Items)
                 {
                     ItemInfo info = NewItemInfo(current, null, index++);
-                    SelectionChange.Select(info, true /* assumeInItemsCollection */);
+                    SelectionChange.Select(info, assumeInItemsCollection: true);
                 }
             }
             finally
@@ -1147,7 +1147,7 @@ namespace System.Windows.Controls.Primitives
                         // If we added something, see if it was set be selected and sync.
                         if (InfoGetIsSelected(info))
                         {
-                            SelectionChange.Select(info, true /* assumeInItemsCollection */);
+                            SelectionChange.Select(info, assumeInItemsCollection: true);
                         }
                     }
                     finally
@@ -1226,7 +1226,7 @@ namespace System.Windows.Controls.Primitives
                                     {
                                         if (!_selectedItems.Contains(info))
                                         {
-                                            SelectionChange.Select(info, true /* assumeInItemsCollection */);
+                                            SelectionChange.Select(info, assumeInItemsCollection: true);
                                         }
                                     }
                                 }
@@ -1438,7 +1438,7 @@ namespace System.Windows.Controls.Primitives
 
                 if (selected)
                 {
-                    SelectionChange.Select(info, true /* assumeInItemsCollection */);
+                    SelectionChange.Select(info, assumeInItemsCollection: true);
                 }
                 else
                 {
@@ -1532,7 +1532,7 @@ namespace System.Windows.Controls.Primitives
 
                     if (item != null && ItemGetIsSelectable(item))
                     {
-                        SelectionChange.SelectJustThisItem(NewItemInfo(item, null, Items.CurrentPosition), true /* assumeInItemsCollection */);
+                        SelectionChange.SelectJustThisItem(NewItemInfo(item, null, Items.CurrentPosition), assumeInItemsCollection: true);
                     }
                     else
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/TextBoxBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/TextBoxBase.cs
@@ -491,7 +491,7 @@ namespace System.Windows.Controls.Primitives
                         "AcceptsTab", // Property name
                         typeof(bool), // Property type
                         typeof(TextBoxBase), // Property owner
-                        new FrameworkPropertyMetadata(false /*default value*/));
+                        new FrameworkPropertyMetadata(defaultValue: false));
 
         /// <summary>
         /// Whether or not the Textbox accepts tabs

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ToolBarPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ToolBarPanel.cs
@@ -251,14 +251,14 @@ namespace System.Windows.Controls.Primitives
                 // whether they're going into the overflow or not.
                 // overflowExtent will be the size of the Always elements, which is not actually
                 // needed for subsequent calculations.
-                bool hasAlwaysOverflowItems = MeasureGeneratedItems(/* asNeeded = */ false, layoutSlotSize, horizontal, maxExtent, ref stackDesiredSize, out overflowExtent);
+                bool hasAlwaysOverflowItems = MeasureGeneratedItems(asNeededPass: false, layoutSlotSize, horizontal, maxExtent, ref stackDesiredSize, out overflowExtent);
 
                 // At this point, the desired size is the minimum size of the ToolBar.
                 MinLength = horizontal ? stackDesiredSize.Width : stackDesiredSize.Height;
 
                 // This second call will measure all of the AsNeeded elements and place
                 // them in the appropriate location.
-                bool hasAsNeededOverflowItems = MeasureGeneratedItems(/* asNeeded = */ true, layoutSlotSize, horizontal, maxExtent, ref stackDesiredSize, out overflowExtent);
+                bool hasAsNeededOverflowItems = MeasureGeneratedItems(asNeededPass: true, layoutSlotSize, horizontal, maxExtent, ref stackDesiredSize, out overflowExtent);
 
                 // At this point, the desired size is complete. The desired size plus overflowExtent
                 // is the maximum size of the ToolBar.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RichTextBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RichTextBox.cs
@@ -91,7 +91,7 @@ namespace System.Windows.Controls
             // We don't use the static ctor because there are cases
             // where another control will want to alias our properties
             // but doesn't need this overhead.
-            TextEditor.RegisterCommandHandlers(typeof(RichTextBox), /*acceptsRichContent:*/true, /*readOnly*/false, /*registerEventListeners*/false);
+            TextEditor.RegisterCommandHandlers(typeof(RichTextBox), acceptsRichContent: true, readOnly: false, registerEventListeners: false);
 
             // Create TextContainer and TextEditor associated with it
             if (document == null)
@@ -576,7 +576,7 @@ namespace System.Windows.Controls
                 {
                     throw new ArgumentException(SR.RichTextBox_PointerNotInSameDocument, nameof(value));
                 }
-                Selection.SetCaretToPosition(value, value.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/false);
+                Selection.SetCaretToPosition(value, value.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: false);
             }
         }
         

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/SelectedDatesCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/SelectedDatesCollection.cs
@@ -137,7 +137,7 @@ namespace System.Windows.Controls
             // Turn off highlight
             this._owner.HoverStart = null;
 
-            ClearInternal(true /*fireChangeNotification*/);
+            ClearInternal(fireChangeNotification: true);
         }
 
         /// <summary>
@@ -341,7 +341,7 @@ namespace System.Windows.Controls
 
         internal void ClearInternal()
         {
-            ClearInternal(false /*fireChangeNotification*/);
+            ClearInternal(fireChangeNotification: false);
         }
 
         internal void ClearInternal(bool fireChangeNotification)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/SelectedItemCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/SelectedItemCollection.cs
@@ -80,7 +80,7 @@ namespace System.Windows.Controls
                 // For defered selection we should allow only Add method
                 if (index == Count)
                 {
-                    _selector.SelectionChange.Select(_selector.NewItemInfo(item), true /* assumeInItemsCollection */);
+                    _selector.SelectionChange.Select(_selector.NewItemInfo(item), assumeInItemsCollection: true);
                 }
                 else
                 {
@@ -226,7 +226,7 @@ namespace System.Windows.Controls
                 throw new InvalidOperationException(SR.DeferSelectionNotActive);
             }
 
-            _selector.SelectionChange.Select(info, true /* assumeInItemsCollection */);
+            _selector.SelectionChange.Select(info, assumeInItemsCollection: true);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -135,7 +135,7 @@ namespace System.Windows.Controls
             Type valueType = value.GetType();
 
             // Do implicit conversion to allowed inline type - if possible
-            if (!TextSchema.IsValidChildOfContainer(parentType, /*childType*/valueType))
+            if (!TextSchema.IsValidChildOfContainer(parentType, childType: valueType))
             {
                 if (value is UIElement)
                 {
@@ -425,7 +425,7 @@ namespace System.Windows.Controls
         {
             get
             {
-                return new InlineCollection(this, /*isOwnerParent*/true);
+                return new InlineCollection(this, isOwnerParent: true);
             }
         }
 
@@ -2864,7 +2864,7 @@ Debug.Assert(lineCount == LineCount);
             {
                 if (textContainer == null)
                 {
-                    textContainer = new TextContainer(IsContentPresenterContainer ? null : this, false /* plainTextOnly */);
+                    textContainer = new TextContainer(IsContentPresenterContainer ? null : this, plainTextOnly: false);
                 }
 
                 _complexContent = new ComplexContent(this, textContainer, false, Text);
@@ -3910,7 +3910,7 @@ Debug.Assert(lineCount == LineCount);
                 // Add content
                 if (content != null && content.Length > 0)
                 {
-                    TextBlock.InsertTextRun(this.TextContainer.End, content, /*whitespacesIgnorable:*/false);
+                    TextBlock.InsertTextRun(this.TextContainer.End, content, whitespacesIgnorable: false);
                 }
 
                 // Create TextView associated with TextContainer.
@@ -4096,7 +4096,7 @@ Debug.Assert(lineCount == LineCount);
                     try
                     {
                         ((TextContainer)text._complexContent.TextContainer).DeleteContentInternal((TextPointer)text._complexContent.TextContainer.Start, (TextPointer)text._complexContent.TextContainer.End);
-                        InsertTextRun(text._complexContent.TextContainer.End, newText, /*whitespacesIgnorable:*/true);
+                        InsertTextRun(text._complexContent.TextContainer.End, newText, whitespacesIgnorable: true);
                         exceptionThrown = false;
                     }
                     finally

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBlock.cs
@@ -1269,7 +1269,7 @@ namespace System.Windows.Controls
                     {
                         // Format line. Set showParagraphEllipsis flag to false because we do not know whether or not the line will have
                         // paragraph ellipsis at this time. Since TextBlock is auto-sized we do not know the RenderSize until we finish Measure
-                        line.Format(dcp, contentSize.Width, GetLineProperties(dcp == 0, lineProperties), textLineBreakIn, _textBlockCache._textRunCache, /*Show paragraph ellipsis*/ false);
+                        line.Format(dcp, contentSize.Width, GetLineProperties(dcp == 0, lineProperties), textLineBreakIn, _textBlockCache._textRunCache, showParagraphEllipsis: false);
 
                         double lineHeight = CalcLineAdvance(line.Height, lineProperties);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBox.cs
@@ -83,10 +83,10 @@ namespace System.Windows.Controls
             // We don't use the static ctor because there are cases
             // where another control will want to alias our properties
             // but doesn't need this overhead.
-            TextEditor.RegisterCommandHandlers(typeof(TextBox), /*acceptsRichContent:*/false, /*readOnly*/false, /*registerEventListeners*/false);
+            TextEditor.RegisterCommandHandlers(typeof(TextBox), acceptsRichContent: false, readOnly: false, registerEventListeners: false);
 
             // Create TextContainer and TextEditor associated with it
-            TextContainer container = new TextContainer(this, true /* plainTextOnly */)
+            TextContainer container = new TextContainer(this, plainTextOnly: true)
             {
                 CollectTextChanges = true
             };
@@ -418,7 +418,7 @@ namespace System.Windows.Controls
         /// <returns>leading edge rectangle of the given character, or Rect.Empty if no layout information is available.</returns>
         public Rect GetRectFromCharacterIndex(int charIndex)
         {
-            return GetRectFromCharacterIndex(charIndex, /*trailingEdge*/false);
+            return GetRectFromCharacterIndex(charIndex, trailingEdge: false);
         }
 
         /// <summary>
@@ -456,7 +456,7 @@ namespace System.Windows.Controls
 
             // NB: rect will be Rect.Empty if no layout is available.
             Rect rect;
-            GetRectangleFromTextPositionInternal(textPointer, /*relativeToTextBox*/true, out rect);
+            GetRectangleFromTextPositionInternal(textPointer, relativeToTextBox: true, out rect);
             return rect;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBox.cs
@@ -688,8 +688,8 @@ namespace System.Windows.Controls
                         "CharacterCasing", // Property name
                         typeof(CharacterCasing), // Property type
                         typeof(TextBox), // Property owner
-                        new FrameworkPropertyMetadata(CharacterCasing.Normal /*default value*/),
-                        new ValidateValueCallback(CharacterCasingValidateValue) /*validation callback*/);
+                        new FrameworkPropertyMetadata(defaultValue: CharacterCasing.Normal),
+                        validateValueCallback: new ValidateValueCallback(CharacterCasingValidateValue));
 
         /// <summary>
         /// Character casing of the TextBox
@@ -723,7 +723,7 @@ namespace System.Windows.Controls
                     "MaxLength", // Property name
                     typeof(int), // Property type
                     typeof(TextBox), // Property owner
-                    new FrameworkPropertyMetadata(0), /*default value*/
+                    new FrameworkPropertyMetadata(defaultValue: 0),
                     new ValidateValueCallback(MaxLengthValidateValue));
 
 
@@ -1440,7 +1440,7 @@ namespace System.Windows.Controls
 
             if (TextEditor.GetTextView(this.RenderScope).Validate(point))
             {
-                textPointer = (TextPointer)TextEditor.GetTextView(this.RenderScope).GetTextPositionFromPoint(point, /* snap to text */ true);
+                textPointer = (TextPointer)TextEditor.GetTextView(this.RenderScope).GetTextPositionFromPoint(point, snapToText: true);
                 textPointer = (TextPointer)TextEditor.GetTextView(this.RenderScope).GetLineRange(textPointer).Start.CreatePointer(textPointer.LogicalDirection);
             }
             else
@@ -1469,7 +1469,7 @@ namespace System.Windows.Controls
 
             if (TextEditor.GetTextView(this.RenderScope).Validate(point))
             {
-                textPointer = (TextPointer)TextEditor.GetTextView(this.RenderScope).GetTextPositionFromPoint(point, /* snap to text */ true);
+                textPointer = (TextPointer)TextEditor.GetTextView(this.RenderScope).GetTextPositionFromPoint(point, snapToText: true);
                 textPointer = (TextPointer)TextEditor.GetTextView(this.RenderScope).GetLineRange(textPointer).End.CreatePointer(textPointer.LogicalDirection);
 
                 // Hit testing ignores line breaks, so the position returned will be between the last visible character

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextSearch.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextSearch.cs
@@ -68,7 +68,7 @@ namespace System.Windows.Controls
         /// </summary>
         public static readonly DependencyProperty TextPathProperty
             = DependencyProperty.RegisterAttached("TextPath", typeof(string), typeof(TextSearch),
-                                                  new FrameworkPropertyMetadata(String.Empty /* default value */));
+                                                  new FrameworkPropertyMetadata(defaultValue: String.Empty));
 
         /// <summary>
         ///     Writes the attached property to the given element.
@@ -154,7 +154,7 @@ namespace System.Windows.Controls
         /// </summary>
         private static readonly DependencyPropertyKey TextSearchInstancePropertyKey =
             DependencyProperty.RegisterAttachedReadOnly("TextSearchInstance", typeof(TextSearch), typeof(TextSearch),
-                                                new FrameworkPropertyMetadata((object)null /* default value */));
+                                                new FrameworkPropertyMetadata(defaultValue: (object)null));
 
         /// <summary>
         ///     Instance of TextSearch -- attached property so that the instance can be stored on the element

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TreeView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TreeView.cs
@@ -610,14 +610,14 @@ namespace System.Windows.Controls
         private bool FocusFirstItem()
         {
             FrameworkElement container;
-            return NavigateToStartInternal(new ItemNavigateArgs(Keyboard.PrimaryDevice, Keyboard.Modifiers), true /*shouldFocus*/, out container);
+            return NavigateToStartInternal(new ItemNavigateArgs(Keyboard.PrimaryDevice, Keyboard.Modifiers), shouldFocus: true, out container);
         }
 
 
         private bool FocusLastItem()
         {
             FrameworkElement container;
-            return NavigateToEndInternal(new ItemNavigateArgs(Keyboard.PrimaryDevice, Keyboard.Modifiers), true /*shouldFocus*/, out container);
+            return NavigateToEndInternal(new ItemNavigateArgs(Keyboard.PrimaryDevice, Keyboard.Modifiers), shouldFocus: true, out container);
         }
 
         private bool HandleScrollKeys(Key key)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TreeViewItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TreeViewItem.cs
@@ -106,7 +106,7 @@ namespace System.Windows.Controls
                 // sub tree through the ItemsPresenter leading up to the ItemsHost
                 // panel. If we didnt do this the offsets could get skewed.
                 item.InvalidateMeasure();
-                Helper.InvalidateMeasureOnPath(itemsHostPresenter, item, false /*duringMeasure*/);
+                Helper.InvalidateMeasureOnPath(itemsHostPresenter, item, duringMeasure: false);
             }
 
             TreeViewItemAutomationPeer peer = UIElementAutomationPeer.FromElement(item) as TreeViewItemAutomationPeer;
@@ -913,7 +913,7 @@ namespace System.Windows.Controls
                 VirtualizingPanel vp = ItemsHost as VirtualizingPanel;
                 vp?.OnClearChildrenInternal();
 
-                ItemContainerGenerator.RemoveAllInternal(true /*saveRecycleQueue*/);
+                ItemContainerGenerator.RemoveAllInternal(saveRecycleQueue: true);
             }
 
             // this container is going away - forget about its selection

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizedCellInfoCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizedCellInfoCollection.cs
@@ -822,7 +822,7 @@ namespace System.Windows.Controls
 
         internal void AddRegion(int rowIndex, int columnIndex, int rowCount, int columnCount)
         {
-            AddRegion(rowIndex, columnIndex, rowCount, columnCount, /* notify = */ true);
+            AddRegion(rowIndex, columnIndex, rowCount, columnCount, notify: true);
         }
 
         private void AddRegion(int rowIndex, int columnIndex, int rowCount, int columnCount, bool notify)
@@ -992,7 +992,7 @@ namespace System.Windows.Controls
                     for (int i = 0; i < numKeptRegions; i++)
                     {
                         CellRegion keptRegion = keepRegions[i];
-                        AddRegion(keptRegion.Top + 1, keptRegion.Left, keptRegion.Height, keptRegion.Width, /* notify = */ false);
+                        AddRegion(keptRegion.Top + 1, keptRegion.Left, keptRegion.Height, keptRegion.Width, notify: false);
                     }
                 }
             }
@@ -1024,7 +1024,7 @@ namespace System.Windows.Controls
                     for (int i = 0; i < numKeptRegions; i++)
                     {
                         CellRegion keptRegion = keepRegions[i];
-                        AddRegion(keptRegion.Top - 1, keptRegion.Left, keptRegion.Height, keptRegion.Width, /* notify = */ false);
+                        AddRegion(keptRegion.Top - 1, keptRegion.Left, keptRegion.Height, keptRegion.Width, notify: false);
                     }
                 }
 
@@ -1080,7 +1080,7 @@ namespace System.Windows.Controls
                     for (int i = 0; i < numKeptRegions; i++)
                     {
                         CellRegion keptRegion = slideRegions[i];
-                        AddRegion(keptRegion.Top - 1, keptRegion.Left, keptRegion.Height, keptRegion.Width, /* notify = */ false);
+                        AddRegion(keptRegion.Top - 1, keptRegion.Left, keptRegion.Height, keptRegion.Width, notify: false);
                     }
                 }
 
@@ -1096,7 +1096,7 @@ namespace System.Windows.Controls
                     for (int i = 0; i < numMovedRegions; i++)
                     {
                         CellRegion movedRegion = movedRegions[i];
-                        AddRegion(newIndex, movedRegion.Left, movedRegion.Height, movedRegion.Width, /* notify = */ false);
+                        AddRegion(newIndex, movedRegion.Left, movedRegion.Height, movedRegion.Width, notify: false);
                     }
                 }
 
@@ -1108,7 +1108,7 @@ namespace System.Windows.Controls
                     for (int i = 0; i < numKeptRegions; i++)
                     {
                         CellRegion keptRegion = slideRegions[i];
-                        AddRegion(keptRegion.Top + 1, keptRegion.Left, keptRegion.Height, keptRegion.Width, /* notify = */ false);
+                        AddRegion(keptRegion.Top + 1, keptRegion.Left, keptRegion.Height, keptRegion.Width, notify: false);
                     }
                 }
             }
@@ -1165,11 +1165,11 @@ namespace System.Windows.Controls
                     for (int i = 0; i < numKeptRegions; i++)
                     {
                         CellRegion keptRegion = keepRegions[i];
-                        AddRegion(keptRegion.Top, keptRegion.Left + 1, keptRegion.Height, keptRegion.Width, /* notify = */ false);
+                        AddRegion(keptRegion.Top, keptRegion.Left + 1, keptRegion.Height, keptRegion.Width, notify: false);
                     }
                 }
 
-                FillInFullRowRegions(selectedRows, columnIndex, /* notify = */ true);
+                FillInFullRowRegions(selectedRows, columnIndex, notify: true);
             }
         }
 
@@ -1212,7 +1212,7 @@ namespace System.Windows.Controls
                     for (int i = 0; i < numKeptRegions; i++)
                     {
                         CellRegion keptRegion = keepRegions[i];
-                        AddRegion(keptRegion.Top, keptRegion.Left - 1, keptRegion.Height, keptRegion.Width, /* notify = */ false);
+                        AddRegion(keptRegion.Top, keptRegion.Left - 1, keptRegion.Height, keptRegion.Width, notify: false);
                     }
                 }
 
@@ -1241,7 +1241,7 @@ namespace System.Windows.Controls
             }
 
             // Restore cells in full rows belonging to the new column
-            FillInFullRowRegions(selectedRows, columnIndex, /* notify = */ true);
+            FillInFullRowRegions(selectedRows, columnIndex, notify: true);
         }
 
         private void OnMoveColumn(int oldIndex, int newIndex)
@@ -1271,7 +1271,7 @@ namespace System.Windows.Controls
                     for (int i = 0; i < numKeptRegions; i++)
                     {
                         CellRegion keptRegion = slideRegions[i];
-                        AddRegion(keptRegion.Top, keptRegion.Left - 1, keptRegion.Height, keptRegion.Width, /* notify = */ false);
+                        AddRegion(keptRegion.Top, keptRegion.Left - 1, keptRegion.Height, keptRegion.Width, notify: false);
                     }
                 }
 
@@ -1286,7 +1286,7 @@ namespace System.Windows.Controls
                     for (int i = 0; i < numMovedRegions; i++)
                     {
                         CellRegion movedRegion = movedRegions[i];
-                        AddRegion(movedRegion.Top, newIndex, movedRegion.Height, movedRegion.Width, /* notify = */ false);
+                        AddRegion(movedRegion.Top, newIndex, movedRegion.Height, movedRegion.Width, notify: false);
                     }
                 }
 
@@ -1298,7 +1298,7 @@ namespace System.Windows.Controls
                     for (int i = 0; i < numKeptRegions; i++)
                     {
                         CellRegion keptRegion = slideRegions[i];
-                        AddRegion(keptRegion.Top, keptRegion.Left + 1, keptRegion.Height, keptRegion.Width, /* notify = */ false);
+                        AddRegion(keptRegion.Top, keptRegion.Left + 1, keptRegion.Height, keptRegion.Width, notify: false);
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingPanel.cs
@@ -523,7 +523,7 @@ namespace System.Windows.Controls
 
             OnItemsChanged(sender, args);
 
-            return ShouldItemsChangeAffectLayout(true /*areItemChangesLocal*/, args);
+            return ShouldItemsChangeAffectLayout(areItemChangesLocal: true, args);
         }
 
         internal override void OnClearChildrenInternal()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
@@ -470,7 +470,7 @@ namespace System.Windows.Controls
                     "delta:", offset - HorizontalOffset);
             }
 
-            ClearAnchorInformation(true /*shouldAbort*/);
+            ClearAnchorInformation(shouldAbort: true);
             SetHorizontalOffsetImpl(offset, setAnchorInformation:false);
         }
 
@@ -598,7 +598,7 @@ namespace System.Windows.Controls
                     "delta:", offset - VerticalOffset);
             }
 
-            ClearAnchorInformation(true /*shouldAbort*/);
+            ClearAnchorInformation(shouldAbort: true);
             SetVerticalOffsetImpl(offset, setAnchorInformation:false);
         }
 
@@ -761,7 +761,7 @@ namespace System.Windows.Controls
                                     //
                                     // Retry the pending AnchorOperation
                                     //
-                                    OnAnchorOperation(true /*isAnchorOperationPending*/);
+                                    OnAnchorOperation(isAnchorOperationPending: true);
 
                                     //
                                     // Adjust offsets
@@ -833,7 +833,7 @@ namespace System.Windows.Controls
             ItemsControl.GetItemsOwnerInternal(this, out itemsControl);
             if (itemsControl == null || !VisualTreeHelper.IsAncestorOf(this, _scrollData._firstContainerInViewport))
             {
-                ClearAnchorInformation(isAnchorOperationPending /*shouldAbort*/);
+                ClearAnchorInformation(shouldAbort: isAnchorOperationPending);
                 return;
             }
 
@@ -960,7 +960,7 @@ namespace System.Windows.Controls
                 // If we are at the right position with respect to the anchor then
                 // we dont need the anchor element any more. So clear it.
                 //
-                ClearAnchorInformation(isAnchorOperationPending /*shouldAbort*/);
+                ClearAnchorInformation(shouldAbort: isAnchorOperationPending);
 
                 if (isTracing)
                 {
@@ -1076,7 +1076,7 @@ namespace System.Windows.Controls
                 }
                 else
                 {
-                    ClearAnchorInformation(isAnchorOperationPending /*shouldAbort*/);
+                    ClearAnchorInformation(shouldAbort: isAnchorOperationPending);
                 }
             }
         }
@@ -1195,8 +1195,8 @@ namespace System.Windows.Controls
                             viewportElement,
                             fe,
                             direction,
-                            false /*fullyVisible*/,
-                            !isVSP45Compat /*ignorePerpendicularAxis*/,
+                            fullyVisible: false,
+                            ignorePerpendicularAxis: !isVSP45Compat,
                             out elementRect,
                             out layoutRect);
 
@@ -1476,7 +1476,7 @@ namespace System.Windows.Controls
         // Note: This code presently assumes we/children are layout clean.  See work item 22269 for more detail.
         public Rect MakeVisible(Visual visual, Rect rectangle)
         {
-            ClearAnchorInformation(true /*shouldAbort*/);
+            ClearAnchorInformation(shouldAbort: true);
 
             Vector newOffset = new Vector();
             Rect newRect = new Rect();
@@ -1692,7 +1692,7 @@ namespace System.Windows.Controls
                 child = generator.GenerateNext(out newlyRealized) as UIElement;
                 if (child != null)
                 {
-                    visualOrderChanged = AddContainerFromGenerator(childIndex, child, newlyRealized, false /*isBeforeViewport*/);
+                    visualOrderChanged = AddContainerFromGenerator(childIndex, child, newlyRealized, isBeforeViewport: false);
 
                     if (visualOrderChanged)
                     {
@@ -2170,7 +2170,7 @@ namespace System.Windows.Controls
                     //
                     // Fetch the owner for this panel. That could either be an ItemsControl or a GroupItem.
                     //
-                    GetOwners(true /*shouldSetVirtualizationState*/, isHorizontal, out itemsControl, out groupItem, out itemStorageProvider, out virtualizationInfoProvider, out parentItem, out parentItemStorageProvider, out mustDisableVirtualization);
+                    GetOwners(shouldSetVirtualizationState: true, isHorizontal, out itemsControl, out groupItem, out itemStorageProvider, out virtualizationInfoProvider, out parentItem, out parentItemStorageProvider, out mustDisableVirtualization);
 
                     // ===================================================================================
                     // ===================================================================================
@@ -2450,8 +2450,8 @@ namespace System.Windows.Controls
                                                 (i < firstItemInViewportIndex) || isAlwaysBeforeFirstItem,
                                                 isAlwaysAfterFirstItem,
                                                 isAlwaysAfterLastItem,
-                                                false /*skipActualMeasure*/,
-                                                false /*skipGeneration*/,
+                                                skipActualMeasure: false,
+                                                skipGeneration: false,
                                                 ref hasBringIntoViewContainerBeenMeasured,
                                                 ref hasVirtualizingChildren);
 
@@ -2483,7 +2483,7 @@ namespace System.Windows.Controls
                                                         ref uniformOrAverageContainerSize,
                                                         ref hasAverageContainerSizeChanged,
                                                         isHorizontal,
-                                                        false /* evaluateAreContainersUniformlySized */);
+                                                        evaluateAreContainersUniformlySized: false);
                                                 }
                                                 else
                                                 {
@@ -2501,7 +2501,7 @@ namespace System.Windows.Controls
                                                         ref uniformOrAverageContainerPixelSize,
                                                         ref hasAverageContainerSizeChanged,
                                                         isHorizontal,
-                                                        false /* evaluateAreContainersUniformlySized */);
+                                                        evaluateAreContainersUniformlySized: false);
                                                 }
 
                                                 ComputeFirstItemInViewportIndexAndOffset(items, itemCount, itemStorageProvider, viewport, cacheSize,
@@ -2547,11 +2547,11 @@ namespace System.Windows.Controls
                                                             ref stackLogicalSizeInCacheBeforeViewport,
                                                             ref stackLogicalSizeInCacheAfterViewport,
                                                             ref mustDisableVirtualization,
-                                                            false /*isBeforeFirstItem*/,
-                                                            false /*isAfterFirstItem*/,
-                                                            false /*isAfterLastItem*/,
-                                                            true /*skipActualMeasure*/,
-                                                            true /*skipGeneration*/,
+                                                            isBeforeFirstItem: false,
+                                                            isAfterFirstItem: false,
+                                                            isAfterLastItem: false,
+                                                            skipActualMeasure: true,
+                                                            skipGeneration: true,
                                                             ref hasBringIntoViewContainerBeenMeasured,
                                                             ref hasVirtualizingChildren);
 
@@ -2753,8 +2753,8 @@ namespace System.Windows.Controls
                                             isAlwaysBeforeFirstItem,
                                             (i > firstItemInViewportIndex) || isAlwaysAfterFirstItem,
                                             (i > lastItemInViewportIndex) || isAlwaysAfterLastItem,
-                                            false /*skipActualMeasure*/,
-                                            false /*skipGeneration*/,
+                                            skipActualMeasure: false,
+                                            skipGeneration: false,
                                             ref hasBringIntoViewContainerBeenMeasured,
                                             ref hasVirtualizingChildren);
 
@@ -2901,7 +2901,7 @@ namespace System.Windows.Controls
                             ref uniformOrAverageContainerSize,
                             ref hasAverageContainerSizeChanged,
                             isHorizontal,
-                            false /* evaluateAreContainersUniformlySized */);
+                            evaluateAreContainersUniformlySized: false);
                     }
                     else
                     {
@@ -2919,7 +2919,7 @@ namespace System.Windows.Controls
                             ref uniformOrAverageContainerPixelSize,
                             ref hasAverageContainerSizeChanged,
                             isHorizontal,
-                            false /* evaluateAreContainersUniformlySized */);
+                            evaluateAreContainersUniformlySized: false);
                     }
 
                     if (IsVirtualizing)
@@ -2950,7 +2950,7 @@ namespace System.Windows.Controls
                             _firstItemInExtendedViewportIndex,
                             _firstItemInExtendedViewportChildIndex,
                             firstItemInViewportIndex,
-                            true /*before */);
+                            before: true);
 
                         ExtendPixelAndLogicalSizes(
                             children,
@@ -3193,7 +3193,7 @@ namespace System.Windows.Controls
                             }
                             else
                             {
-                                EnsureCleanupOperation(false /*delay*/);
+                                EnsureCleanupOperation(delay: false);
                             }
                         }
                         HasVirtualizingChildren = hasVirtualizingChildren;
@@ -3323,7 +3323,7 @@ namespace System.Windows.Controls
                     //
                     // Fetch the owner for this panel. That could either be an ItemsControl or a GroupItem.
                     //
-                    GetOwners(false /*shouldSetVirtualizationState*/, isHorizontal, out itemsControl, out groupItem, out itemStorageProvider, out virtualizationInfoProvider, out parentItem, out parentItemStorageProvider, out mustDisableVirtualization);
+                    GetOwners(shouldSetVirtualizationState: false, isHorizontal, out itemsControl, out groupItem, out itemStorageProvider, out virtualizationInfoProvider, out parentItem, out parentItemStorageProvider, out mustDisableVirtualization);
 
                     if (ScrollTracer.IsEnabled && ScrollTracer.IsTracing(this))
                     {
@@ -3438,7 +3438,7 @@ namespace System.Windows.Controls
                                         itemStorageProvider,
                                         areContainersUniformlySized,
                                         uniformOrAverageContainerSize,
-                                        true /*beforeExtendedViewport*/,
+                                        beforeExtendedViewport: true,
                                         ref rcChildBeforeViewport,
                                         ref previousChildSizeBeforeViewport,
                                         ref previousChildOffsetBeforeViewport,
@@ -3488,7 +3488,7 @@ namespace System.Windows.Controls
                                 itemStorageProvider,
                                 areContainersUniformlySized,
                                 uniformOrAverageContainerSize,
-                                false /*beforeExtendedViewport*/,
+                                beforeExtendedViewport: false,
                                 ref rcChild,
                                 ref previousChildSize,
                                 ref previousChildOffset,
@@ -3741,11 +3741,11 @@ namespace System.Windows.Controls
                             UpdateExtent(areItemChangesLocal);
 
                             IItemContainerGenerator generator = vp.ItemContainerGenerator;
-                            int index = ((ItemContainerGenerator)generator).IndexFromContainer(itemsOwner, true /*returnLocalIndex*/);
+                            int index = ((ItemContainerGenerator)generator).IndexFromContainer(itemsOwner, returnLocalIndex: true);
                             ItemsChangedEventArgs newArgs = new ItemsChangedEventArgs(NotifyCollectionChangedAction.Reset,
                                 generator.GeneratorPositionFromIndex(index), 1, 1);
 
-                            shouldItemsChangeAffectLayout = vp.ShouldItemsChangeAffectLayout(false /*areItemChangesLocal*/, newArgs);
+                            shouldItemsChangeAffectLayout = vp.ShouldItemsChangeAffectLayout(areItemChangesLocal: false, newArgs);
                         }
                         else
                         {
@@ -3776,7 +3776,7 @@ namespace System.Windows.Controls
             IContainItemStorage parentItemStorageProvider;
             bool mustDisableVirtualization;
 
-            GetOwners(false /*shouldSetVirtualizationState*/, isHorizontal,
+            GetOwners(shouldSetVirtualizationState: false, isHorizontal,
                 out itemsControl, out groupItem, out itemStorageProvider,
                 out virtualizationInfoProvider, out parentItem,
                 out parentItemStorageProvider, out mustDisableVirtualization);
@@ -3820,7 +3820,7 @@ namespace System.Windows.Controls
                         ref uniformOrAverageContainerSize,
                         ref hasAverageContainerSizeChanged,
                         isHorizontal,
-                        true /* evaluateAreContainersUniformlySized */);
+                        evaluateAreContainersUniformlySized: true);
                 }
                 else
                 {
@@ -3839,7 +3839,7 @@ namespace System.Windows.Controls
                         ref uniformOrAverageContainerPixelSize,
                         ref hasAverageContainerSizeChanged,
                         isHorizontal,
-                        true /* evaluateAreContainersUniformlySized */);
+                        evaluateAreContainersUniformlySized: true);
                 }
 
                 if (hasAverageContainerSizeChanged && !IsVSP45Compat)
@@ -5903,7 +5903,7 @@ namespace System.Windows.Controls
                 double pixelDistance;
                 ComputeDistance(items, itemStorageProvider, isHorizontal, areContainersUniformlySized,
                     uniformOrAverageContainerSize,
-                    1.0 /*uniformOrAverageContainerPixelSize*/, // dummy - pixelDistance not used
+                    uniformOrAverageContainerPixelSize: 1.0, // dummy - pixelDistance not used
                     startIndex, itemCount, out distance, out pixelDistance);
                 return;
             }
@@ -6024,7 +6024,7 @@ namespace System.Windows.Controls
                 GetContainerSizeForItem(itemStorageProvider, item, isHorizontal,
                     areContainersUniformlySized,
                     uniformOrAverageContainerSize,
-                    1.0 /*uniformOrAverageContainerPixelSize*/, // dummy - pixelSize not used
+                    uniformOrAverageContainerPixelSize: 1.0, // dummy - pixelSize not used
                     out containerSize,
                     out containerPixelSize);
                 return;
@@ -6818,7 +6818,7 @@ namespace System.Windows.Controls
             Panel childItemsHost = virtualizingChild.ItemsHost;
             if (childItemsHost != null)
             {
-                Helper.InvalidateMeasureOnPath(childItemsHost, this, true /*duringMeasure*/);
+                Helper.InvalidateMeasureOnPath(childItemsHost, this, duringMeasure: true);
 
                 if (!(childItemsHost is VirtualizingStackPanel))
                 {
@@ -8591,7 +8591,7 @@ namespace System.Windows.Controls
 
                 if (IsPixelBased)
                 {
-                    int currChildItemIndex = ((ItemContainerGenerator)generator).IndexFromContainer(child, true /*returnLocalIndex*/);
+                    int currChildItemIndex = ((ItemContainerGenerator)generator).IndexFromContainer(child, returnLocalIndex: true);
                     double distance;
 
                     if (beforeExtendedViewport)
@@ -8644,7 +8644,7 @@ namespace System.Windows.Controls
 
                 if (IsPixelBased)
                 {
-                    int currChildItemIndex = ((ItemContainerGenerator)generator).IndexFromContainer(child, true /*returnLocalIndex*/);
+                    int currChildItemIndex = ((ItemContainerGenerator)generator).IndexFromContainer(child, returnLocalIndex: true);
                     double distance;
 
                     if (beforeExtendedViewport)
@@ -9008,8 +9008,8 @@ namespace System.Windows.Controls
             CleanupContainers(firstItemInExtendedViewportIndex,
                 itemsInExtendedViewportCount,
                 itemsControl,
-                false /*timeBound*/,
-                0 /*startTickCount*/);
+                timeBound: false,
+                startTickCount: 0);
         }
 
         /// <summary>
@@ -9362,7 +9362,7 @@ namespace System.Windows.Controls
 
             if (needsMoreCleanup)
             {
-                EnsureCleanupOperation(true /* delay */);
+                EnsureCleanupOperation(delay: true);
             }
 
             return null;
@@ -9409,7 +9409,7 @@ namespace System.Windows.Controls
                     needsMoreCleanup = CleanupContainers(_firstItemInExtendedViewportIndex,
                         _actualItemsInExtendedViewportCount,
                         itemsControl,
-                        true /*timeBound*/,
+                        timeBound: true,
                         startMilliseconds);
                 }
             }
@@ -10984,11 +10984,11 @@ namespace System.Windows.Controls
             IContainItemStorage parentItemStorageProvider;
             bool mustDisableVirtualization;
 
-            GetOwners(false /*shouldSetVirtualizationState*/, isHorizontal, out itemsControl, out groupItem, out itemStorageProvider, out virtualizationInfoProvider,out parentItem, out parentItemStorageProvider, out mustDisableVirtualization);
+            GetOwners(shouldSetVirtualizationState: false, isHorizontal, out itemsControl, out groupItem, out itemStorageProvider, out virtualizationInfoProvider,out parentItem, out parentItemStorageProvider, out mustDisableVirtualization);
 
             ItemContainerGenerator generator = (ItemContainerGenerator)Generator;
             IList items = generator.ItemsInternal;
-            int itemIndex = generator.IndexFromContainer(child, true /*returnLocalIndex*/);
+            int itemIndex = generator.IndexFromContainer(child, returnLocalIndex: true);
 
             double distance = 0;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
@@ -417,11 +417,11 @@ namespace System.Windows.Controls
             // find the top container(s)
             double firstContainerOffsetFromViewport;
             FrameworkElement deepestTopContainer = ComputeFirstContainerInViewport(
-                this,   /* viewportElement */
+                viewportElement: this,
                 isHorizontal ? FocusNavigationDirection.Right : FocusNavigationDirection.Down,
-                this,   /* itemsHost */
-                null,   /* action callback */
-                true,   /* findTopContainer */
+                itemsHost: this,
+                action: null,
+                findTopContainer: true,
                 out firstContainerOffsetFromViewport);
 
             // there are two cases where we can still use the simple approach:
@@ -541,11 +541,11 @@ namespace System.Windows.Controls
                             {
                                 double topContainerOffset;
                                 FrameworkElement deepestTopContainer = ComputeFirstContainerInViewport(
-                                    this,   /* viewportElement */
+                                    viewportElement: this,
                                     FocusNavigationDirection.Right,
-                                    this,   /* itemsHost */
-                                    null,   /* action callback */
-                                    true,   /* findTopContainer */
+                                    itemsHost: this,
+                                    action: null,
+                                    findTopContainer: true,
                                     out topContainerOffset);
 
                                 if (topContainerOffset > 0.0)
@@ -669,11 +669,11 @@ namespace System.Windows.Controls
                             {
                                 double topContainerOffset;
                                 FrameworkElement deepestTopContainer = ComputeFirstContainerInViewport(
-                                    this,   /* viewportElement */
+                                    viewportElement: this,
                                     FocusNavigationDirection.Down,
-                                    this,   /* itemsHost */
-                                    null,   /* action callback */
-                                    true,   /* findTopContainer */
+                                    itemsHost: this,
+                                    action: null,
+                                    findTopContainer: true,
                                     out topContainerOffset);
 
                                 if (topContainerOffset > 0.0)
@@ -788,7 +788,7 @@ namespace System.Windows.Controls
                                             // the leaf container that will serve as an anchor for the current scroll operation.
                                             d.SetCurrentValue(VirtualizingPanel.IsContainerVirtualizableProperty, false);
                                         },
-                                        false,  /* findTopContainer */
+                                        findTopContainer: false,
                                         out _scrollData._firstContainerOffsetFromViewport);
 
                                     if (_scrollData._firstContainerInViewport != null)
@@ -882,7 +882,7 @@ namespace System.Windows.Controls
                 isHorizontal ? FocusNavigationDirection.Right : FocusNavigationDirection.Down,
                 this,
                 null,
-                false,   /* findTopContainer */
+                findTopContainer: false,
                 out currFirstContainerOffsetFromViewport);
             Debug.Assert(currFirstContainerInViewport != null, "Cannot find container in viewport");
             double currFirstContainerOffset = FindScrollOffset(currFirstContainerInViewport);
@@ -905,7 +905,7 @@ namespace System.Windows.Controls
                         isHorizontal ? FocusNavigationDirection.Right : FocusNavigationDirection.Down,
                         this,
                         null,
-                        true,   /* findTopContainer*/
+                        findTopContainer: true,
                         out topContainerOffset);
                     double diff = actualDistanceBetweenViewports - _scrollData._expectedDistanceBetweenViewports;
                     success = (!LayoutDoubleUtil.LessThan(diff, 0.0) &&
@@ -2966,7 +2966,7 @@ namespace System.Windows.Controls
                             _firstItemInExtendedViewportIndex + _actualItemsInExtendedViewportCount,
                             _firstItemInExtendedViewportChildIndex + _actualItemsInExtendedViewportCount,
                             -1,                     // firstItemInViewportIndex - ignored in 'after' call
-                            false /*before */);
+                            before: false);
                     }
 
                     // ===================================================================================

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/WebBrowser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/WebBrowser.cs
@@ -143,7 +143,7 @@ namespace System.Windows.Controls
             object objHeaders = (object)additionalHeaders;
 
             Uri uri = new Uri(source);
-            DoNavigate(uri, ref objTargetFrameName, ref objPostData, ref objHeaders, true /* ignoreEscaping */);
+            DoNavigate(uri, ref objTargetFrameName, ref objPostData, ref objHeaders, ignoreEscaping: true);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
@@ -1003,7 +1003,7 @@ namespace System.Windows.Data
             if (ShouldUpdateWithCurrentValue(target, out currentValue))
             {
                 initialTransferIsUpdate = true;
-                ChangeValue(currentValue, /*notify*/false);
+                ChangeValue(currentValue, notify: false);
                 NeedsUpdate = true;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
@@ -1637,7 +1637,7 @@ namespace System.Windows.Data
 
             if (bindingGroup != null)
             {
-                JoinBindingGroup(bindingGroup, /*explicit*/false);
+                JoinBindingGroup(bindingGroup, explicitJoin: false);
             }
         }
 
@@ -1679,7 +1679,7 @@ namespace System.Windows.Data
                 root.LeaveBindingGroup();
                 if (newBindingGroup != null)
                 {
-                    JoinBindingGroup(newBindingGroup, /*explicit*/false);
+                    JoinBindingGroup(newBindingGroup, explicitJoin: false);
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
@@ -1799,7 +1799,7 @@ namespace System.Windows.Data
                 root = bindingExpr;
 
                 // bindings in a group update Explicitly, unless declared otherwise
-                bindingExpr.OnBindingGroupChanged(/*joining*/true);
+                bindingExpr.OnBindingGroupChanged(joining: true);
 
                 bg.AddToValueTable(bindingExpr);
             }
@@ -2003,7 +2003,7 @@ namespace System.Windows.Data
                 if (_value == DefaultValueObject)
                 {
                     // don't notify listeners.  This isn't a real value change.
-                    ChangeValue(UseFallbackValue(), false /*notify*/);
+                    ChangeValue(UseFallbackValue(), notify: false);
                 }
                 return _value;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingGroup.cs
@@ -1349,7 +1349,7 @@ namespace System.Windows.Data
             // tell each expression it is leaving the group
             foreach (BindingExpressionBase expr in list)
             {
-                expr.OnBindingGroupChanged(/*joining*/ false);
+                expr.OnBindingGroupChanged(joining: false);
 
                 // also remove the expression from our collection.  Normally this is
                 // a no-op, as we only get here after the expression has been removed,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingGroup.cs
@@ -1302,7 +1302,7 @@ namespace System.Windows.Data
             {
                 case NotifyCollectionChangedAction.Add:
                     bindingExpr = e.NewItems[0] as BindingExpressionBase;
-                    bindingExpr.JoinBindingGroup(this, /*explicit*/ true);
+                    bindingExpr.JoinBindingGroup(this, explicitJoin: true);
                     break;
                 case NotifyCollectionChangedAction.Remove:
                     bindingExpr = e.OldItems[0] as BindingExpressionBase;
@@ -1314,7 +1314,7 @@ namespace System.Windows.Data
                     bindingExpr = e.OldItems[0] as BindingExpressionBase;
                     RemoveBindingExpression(bindingExpr);
                     bindingExpr = e.NewItems[0] as BindingExpressionBase;
-                    bindingExpr.JoinBindingGroup(this, /*explicit*/ true);
+                    bindingExpr.JoinBindingGroup(this, explicitJoin: true);
                     break;
                 case NotifyCollectionChangedAction.Reset:
                     // the only way this collection can raise Reset is due to Clear()
@@ -1452,7 +1452,7 @@ namespace System.Windows.Data
                         // reassign error's owner to this BindingGroup
                         ValidationError newError = new ValidationError(
                                         validationError.RuleInError,
-                                        this,   /* bindingInError */
+                                        bindingInError: this,
                                         validationError.ErrorContent,
                                         validationError.Exception);
                         AddValidationError(newError);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingListCollectionView.cs
@@ -527,12 +527,12 @@ namespace System.Windows.Data
                         if (oldIndex >= 0)
                         {
                             int index = (oldIndex == 0) ? 0 : _group.Items.Count - 1;
-                            _group.RemoveSpecialItem(index, NewItemPlaceholder, false /*loading*/);
+                            _group.RemoveSpecialItem(index, NewItemPlaceholder, loading: false);
                         }
                         if (newIndex >= 0)
                         {
                             int index = (newIndex == 0) ? 0 : _group.Items.Count;
-                            _group.InsertSpecialItem(index, NewItemPlaceholder, false /*loading*/);
+                            _group.InsertSpecialItem(index, NewItemPlaceholder, loading: false);
                         }
                     }
 
@@ -814,7 +814,7 @@ namespace System.Windows.Data
             object newItem = EndAddNew(false);
 
             // remove item from its temporary position
-            _group.RemoveSpecialItem(index, newItem, false /*loading*/);
+            _group.RemoveSpecialItem(index, newItem, loading: false);
 
             // add it to the groups
             AddItemToGroups(newItem);
@@ -2258,10 +2258,10 @@ namespace System.Windows.Data
             // into groups (with special cases for placeholder and new item)
             if (NewItemPlaceholderPosition == NewItemPlaceholderPosition.AtBeginning)
             {
-                _group.InsertSpecialItem(0, NewItemPlaceholder, true /*loading*/);
+                _group.InsertSpecialItem(0, NewItemPlaceholder, loading: true);
                 if (IsAddingNew)
                 {
-                    _group.InsertSpecialItem(1, _newItem, true /*loading*/);
+                    _group.InsertSpecialItem(1, _newItem, loading: true);
                 }
             }
 
@@ -2275,17 +2275,17 @@ namespace System.Windows.Data
 
                 if (!IsAddingNew || !System.Windows.Controls.ItemsControl.EqualsEx(_newItem, item))
                 {
-                    _group.AddToSubgroups(item, lsi, true /*loading*/);
+                    _group.AddToSubgroups(item, lsi, loading: true);
                 }
             }
 
             if (IsAddingNew && NewItemPlaceholderPosition != NewItemPlaceholderPosition.AtBeginning)
             {
-                _group.InsertSpecialItem(_group.Items.Count, _newItem, true /*loading*/);
+                _group.InsertSpecialItem(_group.Items.Count, _newItem, loading: true);
             }
             if (NewItemPlaceholderPosition == NewItemPlaceholderPosition.AtEnd)
             {
-                _group.InsertSpecialItem(_group.Items.Count, NewItemPlaceholder, true /*loading*/);
+                _group.InsertSpecialItem(_group.Items.Count, NewItemPlaceholder, loading: true);
             }
         }
 
@@ -2343,11 +2343,11 @@ namespace System.Windows.Data
                         break;
                 }
 
-                _group.InsertSpecialItem(index, item, false /*loading*/);
+                _group.InsertSpecialItem(index, item, loading: false);
             }
             else
             {
-                _group.AddToSubgroups(item, null, false /*loading*/);
+                _group.AddToSubgroups(item, null, loading: false);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
@@ -640,12 +640,12 @@ namespace System.Windows.Data
                         if (oldIndex >= 0)
                         {
                             int index = (oldIndex == 0) ? 0 : _group.Items.Count - 1;
-                            _group.RemoveSpecialItem(index, NewItemPlaceholder, false /*loading*/);
+                            _group.RemoveSpecialItem(index, NewItemPlaceholder, loading: false);
                         }
                         if (newIndex >= 0)
                         {
                             int index = (newIndex == 0) ? 0 : _group.Items.Count;
-                            _group.InsertSpecialItem(index, NewItemPlaceholder, false /*loading*/);
+                            _group.InsertSpecialItem(index, NewItemPlaceholder, loading: false);
                         }
                     }
 
@@ -921,7 +921,7 @@ namespace System.Windows.Data
             object newItem = EndAddNew(false);
 
             // remove item from its temporary position
-            _group.RemoveSpecialItem(index, newItem, false /*loading*/);
+            _group.RemoveSpecialItem(index, newItem, loading: false);
 
             // now pretend it just got added to the collection.  This will add it
             // to the internal list with sort/filter, and to the groups
@@ -2950,10 +2950,10 @@ namespace System.Windows.Data
             // into groups (with special cases for placeholder and new item)
             if (NewItemPlaceholderPosition == NewItemPlaceholderPosition.AtBeginning)
             {
-                _group.InsertSpecialItem(0, NewItemPlaceholder, true /*loading*/);
+                _group.InsertSpecialItem(0, NewItemPlaceholder, loading: true);
                 if (IsAddingNew)
                 {
-                    _group.InsertSpecialItem(1, _newItem, true /*loading*/);
+                    _group.InsertSpecialItem(1, _newItem, loading: true);
                 }
             }
 
@@ -2967,17 +2967,17 @@ namespace System.Windows.Data
 
                 if (!IsAddingNew || !System.Windows.Controls.ItemsControl.EqualsEx(_newItem, item))
                 {
-                    _group.AddToSubgroups(item, lsi, true /*loading*/);
+                    _group.AddToSubgroups(item, lsi, loading: true);
                 }
             }
 
             if (IsAddingNew && NewItemPlaceholderPosition != NewItemPlaceholderPosition.AtBeginning)
             {
-                _group.InsertSpecialItem(_group.Items.Count, _newItem, true /*loading*/);
+                _group.InsertSpecialItem(_group.Items.Count, _newItem, loading: true);
             }
             if (NewItemPlaceholderPosition == NewItemPlaceholderPosition.AtEnd)
             {
-                _group.InsertSpecialItem(_group.Items.Count, NewItemPlaceholder, true /*loading*/);
+                _group.InsertSpecialItem(_group.Items.Count, NewItemPlaceholder, loading: true);
             }
         }
 
@@ -3036,11 +3036,11 @@ namespace System.Windows.Data
                         break;
                 }
 
-                _group.InsertSpecialItem(index, item, false /*loading*/);
+                _group.InsertSpecialItem(index, item, loading: false);
             }
             else
             {
-                _group.AddToSubgroups(item, lsi, false /*loading*/);
+                _group.AddToSubgroups(item, lsi, loading: false);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/MultiBindingExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/MultiBindingExpression.cs
@@ -233,7 +233,7 @@ namespace System.Windows.Data
         if (ShouldUpdateWithCurrentValue(target, out currentValue))
         {
             initialTransferIsUpdate = true;
-            ChangeValue(currentValue, /*notify*/false);
+            ChangeValue(currentValue, notify: false);
             NeedsUpdate = true;
         }
 
@@ -367,7 +367,7 @@ namespace System.Windows.Data
         // attach to things that need tree context.  Do it synchronously
         // if possible, otherwise post a task.  This gives the parser et al.
         // a chance to assemble the tree before we start walking it.
-        AttachToContext(false /* lastChance */);
+        AttachToContext(lastChance: false);
         if (TransferIsDeferred)
         {
             Engine.AddTask(this, TaskOps.AttachToContext);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/AnchoredBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/AnchoredBlock.cs
@@ -80,7 +80,7 @@ namespace System.Windows.Documents
         {
             get
             {
-                return new BlockCollection(this, /*isOwnerParent*/true);
+                return new BlockCollection(this, isOwnerParent: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Block.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Block.cs
@@ -432,19 +432,19 @@ namespace System.Windows.Documents
         internal static bool IsValidMargin(object o)
         {
             Thickness t = (Thickness)o;
-            return IsValidThickness(t, /*allow NaN*/true);
+            return IsValidThickness(t, allowNaN: true);
         }
 
         internal static bool IsValidPadding(object o)
         {
             Thickness t = (Thickness)o;
-            return IsValidThickness(t, /*allow NaN*/true);
+            return IsValidThickness(t, allowNaN: true);
         }
 
         internal static bool IsValidBorderThickness(object o)
         {
             Thickness t = (Thickness)o;
-            return IsValidThickness(t, /*allow NaN*/false);
+            return IsValidThickness(t, allowNaN: false);
         }
 
         #endregion Internal Methods

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Block.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Block.cs
@@ -44,7 +44,7 @@ namespace System.Windows.Documents
                     return null;
                 }
 
-                return new BlockCollection(this, /*isOwnerParent*/false);
+                return new BlockCollection(this, isOwnerParent: false);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CaretElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CaretElement.cs
@@ -985,7 +985,7 @@ namespace System.Windows.Documents
                     // so that Win32 application will have the compatibility who listen the caret event.
                     // Specified height with the current caret height will sync the win32 caret which
                     // Win32 Magnifer rely on the caret height to scroll their window.
-                    NativeMethods.BitmapHandle bitmap = UnsafeNativeMethods.CreateBitmap(width: 1, /*height*/ ConvertToInt32(deviceHeight), /*panels*/ 1, bitsPerPixel: 1, /*bits*/ null);
+                    NativeMethods.BitmapHandle bitmap = UnsafeNativeMethods.CreateBitmap(width: 1, height: ConvertToInt32(deviceHeight), planes: 1, bitsPerPixel: 1, lpvBits: null);
 
                     // Specified width and height as zero since they will be ignored by setting the bitmap.
                     bool returnValue = UnsafeNativeMethods.CreateCaret(new HandleRef(null, hwnd), bitmap, width: 0, height: 0);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CaretElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CaretElement.cs
@@ -521,7 +521,7 @@ namespace System.Windows.Documents
                 InvalidateVisual();
 
                 // Skip the animation if the animation isn't set. E.g. DragDrop caret.
-                SetBlinking(/*isBlinkEnabled:*/false);
+                SetBlinking(isBlinkEnabled: false);
 
                 // Destroy Win32 caret
                 Win32DestroyCaret();
@@ -571,7 +571,7 @@ namespace System.Windows.Documents
         // Removes this CaretElement from its AdornerLayer.
         internal void DetachFromView()
         {
-            SetBlinking(/*isBlinkEnabled:*/false);
+            SetBlinking(isBlinkEnabled: false);
 
             if (_adornerLayer != null)
             {
@@ -985,10 +985,10 @@ namespace System.Windows.Documents
                     // so that Win32 application will have the compatibility who listen the caret event.
                     // Specified height with the current caret height will sync the win32 caret which
                     // Win32 Magnifer rely on the caret height to scroll their window.
-                    NativeMethods.BitmapHandle bitmap = UnsafeNativeMethods.CreateBitmap(/*width*/ 1, /*height*/ ConvertToInt32(deviceHeight), /*panels*/ 1, /*bitsPerPixel*/ 1, /*bits*/ null);
+                    NativeMethods.BitmapHandle bitmap = UnsafeNativeMethods.CreateBitmap(width: 1, /*height*/ ConvertToInt32(deviceHeight), /*panels*/ 1, bitsPerPixel: 1, /*bits*/ null);
 
                     // Specified width and height as zero since they will be ignored by setting the bitmap.
-                    bool returnValue = UnsafeNativeMethods.CreateCaret(new HandleRef(null, hwnd), bitmap, /*width*/ 0, /*height*/ 0);
+                    bool returnValue = UnsafeNativeMethods.CreateCaret(new HandleRef(null, hwnd), bitmap, width: 0, height: 0);
 
                     int win32Error = Marshal.GetLastWin32Error();
                     if (returnValue)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ChildDocumentBlock.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ChildDocumentBlock.cs
@@ -225,7 +225,7 @@ namespace System.Windows.Documents
 
                 DocumentsTrace.FixedDocumentSequence.TextOM.Trace($"Loading TextContainer {_docRef}");
                 // Load the TextContainer
-                IDocumentPaginatorSource idp = _docRef.GetDocument(false /*forceReload*/);
+                IDocumentPaginatorSource idp = _docRef.GetDocument(forceReload: false);
                 IServiceProvider isp = idp as IServiceProvider;
                 if (isp != null)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequence.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequence.cs
@@ -561,7 +561,7 @@ namespace System.Windows.Documents
             }
             else
             {
-                document = docRef.GetDocument(false /*forceReload*/);
+                document = docRef.GetDocument(forceReload: false);
                 if (document != null)
                 {
                     paginator = document.DocumentPaginator as DynamicDocumentPaginator;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextContainer.cs
@@ -63,7 +63,7 @@ namespace System.Windows.Documents
 
         void ITextContainer.EndChange()
         {
-            ((ITextContainer)this).EndChange(false /* skipEvents */);
+            ((ITextContainer)this).EndChange(skipEvents: false);
         }
 
         /// <summary>
@@ -552,7 +552,7 @@ namespace System.Windows.Documents
                     _changes = new TextContainerChangedEventArgs();
                 }
 
-                _changes.AddChange(precursorTextChange, DocumentSequenceTextPointer.GetOffsetToPosition(_start, startPosition), symbolCount, false /* collectTextChanges */);
+                _changes.AddChange(precursorTextChange, DocumentSequenceTextPointer.GetOffsetToPosition(_start, startPosition), symbolCount, collectTextChanges: false);
 
                 if (this.Change != null)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedDocument.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedDocument.cs
@@ -328,7 +328,7 @@ namespace System.Windows.Documents
                 //
                 // If we are not out of bound, try next page
                 //
-                FixedPage page = SyncGetPage(pageNumber, false/*forceReload*/);
+                FixedPage page = SyncGetPage(pageNumber, forceReload: false);
 
                 if (page == null)
                 {
@@ -639,7 +639,7 @@ namespace System.Windows.Documents
         {
             if (IsValidPageIndex(index))
             {
-                return SyncGetPage(index, false /*forceReload*/);
+                return SyncGetPage(index, forceReload: false);
             }
             DocumentsTrace.FixedFormat.FixedDocument.Trace($"SyncGetPageWithCheck {index} is invalid page");
             return null;
@@ -729,7 +729,7 @@ namespace System.Windows.Documents
                 FixedPage p = null;
                 if (!_pendingPages.Contains(Pages[pageNumber]))
                 {
-                    p = SyncGetPage(pageNumber, false /*forceReload*/);
+                    p = SyncGetPage(pageNumber, forceReload: false);
                 }
 #if DEBUG
                 else
@@ -1169,7 +1169,7 @@ namespace System.Windows.Documents
 
             foreach (int i in dirtyPages)
             {
-                HighlightVisual hv = HighlightVisual.GetHighlightVisual(SyncGetPage(i, false /*forceReload*/));
+                HighlightVisual hv = HighlightVisual.GetHighlightVisual(SyncGetPage(i, forceReload: false));
 
                 hv?.InvalidateHighlights();
             }
@@ -1191,7 +1191,7 @@ namespace System.Windows.Documents
                 _pendingPages.Add(pc);
                 // Initiate an async loading of the page
                 pc.GetPageRootCompleted += new GetPageRootCompletedEventHandler(OnGetPageRootCompleted);
-                pc.GetPageRootAsync(false /*forceReload*/);
+                pc.GetPageRootAsync(forceReload: false);
                 if (asyncRequest.Cancelled)
                 {
                     pc.GetPageRootAsyncCancel();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextContainer.cs
@@ -65,7 +65,7 @@ namespace System.Windows.Documents
         /// </summary>
         void ITextContainer.EndChange()
         {
-            ((ITextContainer)this).EndChange(false /* skipEvents */);
+            ((ITextContainer)this).EndChange(skipEvents: false);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FlowDocument.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FlowDocument.cs
@@ -146,7 +146,7 @@ namespace System.Windows.Documents
         {
             get
             {
-                return new BlockCollection(this, /*isOwnerParent*/true);
+                return new BlockCollection(this, isOwnerParent: true);
             }
         }
 
@@ -1213,7 +1213,7 @@ namespace System.Windows.Documents
             if (textContainer == null)
             {
                 // Create text tree that contains content of the element.
-                textContainer = new TextContainer(this, false /* plainTextOnly */);
+                textContainer = new TextContainer(this, plainTextOnly: false);
             }
 
             // Create structural cache object
@@ -1625,7 +1625,7 @@ namespace System.Windows.Documents
         {
             ArgumentNullException.ThrowIfNull(value);
 
-            if (!TextSchema.IsValidChildOfContainer(/*parentType:*/_typeofThis, /*childType:*/value.GetType()))
+            if (!TextSchema.IsValidChildOfContainer(parentType: _typeofThis, childType: value.GetType()))
             {
                 throw new ArgumentException(SR.Format(SR.TextSchema_ChildTypeIsInvalid, _typeofThis.Name, value.GetType().Name));
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FlowDocument.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FlowDocument.cs
@@ -1402,7 +1402,7 @@ namespace System.Windows.Documents
                 // We DTR invalidate if we're using a formatter as well for incremental update.
                 if (_formatter == null || !(_formatter is FlowDocumentFormatter))
                 {
-                    _structuralCache.InvalidateFormatCache(/*Clear structure*/ false);
+                    _structuralCache.InvalidateFormatCache(destroyStructure: false);
                 }
 
                 // Notify formatter about content invalidation.
@@ -1497,7 +1497,7 @@ namespace System.Windows.Documents
                 else
                 {
                     // Clear format caches.
-                    _structuralCache.InvalidateFormatCache(/*Clear structure*/ false);
+                    _structuralCache.InvalidateFormatCache(destroyStructure: false);
                 }
 
                 // Notify formatter about content invalidation.
@@ -1559,7 +1559,7 @@ namespace System.Windows.Documents
         private static bool IsValidPagePadding(object o)
         {
             Thickness value = (Thickness)o;
-            return Block.IsValidThickness(value, /*allow NaN*/true);
+            return Block.IsValidThickness(value, allowNaN: true);
         }
 
         private static bool IsValidColumnRuleWidth(object o)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ImmComposition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ImmComposition.cs
@@ -978,7 +978,7 @@ namespace System.Windows.Documents
             }
 
             // UpdateCompositionText raises a PUBLIC EVENT....
-            UpdateCompositionText(composition, resultLength, true /* includeResultText */, out _startComposition, out _endComposition);
+            UpdateCompositionText(composition, resultLength, includeResultText: true, out _startComposition, out _endComposition);
 
             if (_compositionModifiedByEventListener)
             {
@@ -1008,7 +1008,7 @@ namespace System.Windows.Documents
             }
 
             // UpdateCompositionText raises a PUBLIC EVENT....
-            UpdateCompositionText(composition, resultLength, false /* includeResultText */, out _startComposition, out _endComposition);
+            UpdateCompositionText(composition, resultLength, includeResultText: false, out _startComposition, out _endComposition);
 
             if (_compositionModifiedByEventListener)
             {
@@ -1048,8 +1048,7 @@ namespace System.Windows.Documents
             ITextPointer start;
             ITextPointer end;
 
-            UpdateCompositionText(composition, 0, true /* includeResultText */
-                                                                              , out start, out end);
+            UpdateCompositionText(composition, 0, includeResultText: true, out start, out end);
         }
 
         // Inserts composition text into the document.
@@ -1095,7 +1094,7 @@ namespace System.Windows.Documents
                         //
                         // If we're here it means composition is being finalized
                         //
-                        range = new TextRange(composition._ResultStart, composition._ResultEnd, true /* ignoreTextUnitBoundaries */);
+                        range = new TextRange(composition._ResultStart, composition._ResultEnd, ignoreTextUnitBoundaries: true);
                         text = this._editor._FilterText(composition.Text, range);
                         isTextFiltered = (text != composition.Text);
                         if (isTextFiltered)
@@ -1109,7 +1108,7 @@ namespace System.Windows.Documents
                     }
                     else
                     {
-                        range = new TextRange(composition._CompositionStart, composition._CompositionEnd, true /* ignoreTextUnitBoundaries */);
+                        range = new TextRange(composition._CompositionStart, composition._CompositionEnd, ignoreTextUnitBoundaries: true);
                         text = composition.CompositionText;
                     }
 
@@ -1218,7 +1217,7 @@ namespace System.Windows.Documents
                                 }
 
                                 // Need to pass the foreground and background color of the composition
-                                _highlightLayer.Add(startClause, endClause, /*TextDecorationCollection:*/null);
+                                _highlightLayer.Add(startClause, endClause, TextDecorationCollection: null);
 #endif
 
                     TextServicesDisplayAttribute textServiceDisplayAttribute = new TextServicesDisplayAttribute(displayAttribute);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Inline.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Inline.cs
@@ -55,7 +55,7 @@ namespace System.Windows.Documents
                     return null;
                 }
 
-                return new InlineCollection(this, /*isOwnerParent*/false);
+                return new InlineCollection(this, isOwnerParent: false);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/InlineCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/InlineCollection.cs
@@ -58,7 +58,7 @@ namespace System.Windows.Documents
 
             if (text != null)
             {
-                index = AddText(text, true /* returnIndex */);
+                index = AddText(text, returnIndex: true);
             }
             else
             {
@@ -69,7 +69,7 @@ namespace System.Windows.Documents
 
                     if (uiElement != null)
                     {
-                        index = AddUIElement(uiElement, true /* returnIndex */);
+                        index = AddUIElement(uiElement, returnIndex: true);
                     }
                     else
                     {
@@ -92,7 +92,7 @@ namespace System.Windows.Documents
         /// </param>
         public void Add(string text)
         {
-            AddText(text, false /* returnIndex */);
+            AddText(text, returnIndex: false);
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace System.Windows.Documents
         /// </param>
         public void Add(UIElement uiElement)
         {
-            AddUIElement(uiElement, false /* returnIndex */);
+            AddUIElement(uiElement, returnIndex: false);
         }
 
         #endregion Public Methods
@@ -159,7 +159,7 @@ namespace System.Windows.Documents
 
             if (this.Parent is TextElement)
             {
-                TextSchema.ValidateChild((TextElement)this.Parent, child, true /* throwIfIllegalChild */, true /* throwIfIllegalHyperlinkDescendent */);
+                TextSchema.ValidateChild((TextElement)this.Parent, child, throwIfIllegalChild: true, throwIfIllegalHyperlinkDescendent: true);
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/List.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/List.cs
@@ -78,7 +78,7 @@ namespace System.Windows.Documents
         {
             get
             {
-                return new ListItemCollection(this, /*isOwnerParent*/true);
+                return new ListItemCollection(this, isOwnerParent: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ListItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ListItem.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Documents
         {
             get
             {
-                return  new BlockCollection(this, /*isOwnerParent*/true);
+                return  new BlockCollection(this, isOwnerParent: true);
             }
         }
 
@@ -103,7 +103,7 @@ namespace System.Windows.Documents
                     return null;
                 }
 
-                return new ListItemCollection(this, /*isOwnerParent*/false);
+                return new ListItemCollection(this, isOwnerParent: false);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/NullTextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/NullTextContainer.cs
@@ -65,7 +65,7 @@ namespace System.Windows.Documents
         /// </summary>
         void ITextContainer.EndChange()
         {
-            ((ITextContainer)this).EndChange(false /* skipEvents */);
+            ((ITextContainer)this).EndChange(skipEvents: false);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Paragraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Paragraph.cs
@@ -72,7 +72,7 @@ namespace System.Windows.Documents
         {
             get
             {
-                return new InlineCollection(this, /*isOwnerParent*/true);
+                return new InlineCollection(this, isOwnerParent: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlLexer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlLexer.cs
@@ -162,7 +162,7 @@ namespace System.Windows.Documents
             RtfToken token = new RtfToken();
             while (nSkip > 0 && rtfToXamlError == RtfToXamlError.None)
             {
-                rtfToXamlError = Next(token, /*formatState:*/null);
+                rtfToXamlError = Next(token, formatState: null);
 
                 if (rtfToXamlError != RtfToXamlError.None)
                     break;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Section.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Section.cs
@@ -92,7 +92,7 @@ namespace System.Windows.Documents
         {
             get
             {
-                return new BlockCollection(this, /*isOwnerParent*/true);
+                return new BlockCollection(this, isOwnerParent: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Span.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Span.cs
@@ -142,7 +142,7 @@ namespace System.Windows.Documents
                 }
 
                 Invariant.Assert(start.Parent == end.Parent);
-                Invariant.Assert(TextSchema.IsValidChild(/*position*/start, /*childType*/typeof(Span)));
+                Invariant.Assert(TextSchema.IsValidChild(position: start, /*childType*/typeof(Span)));
 
                 this.Reposition(start, end);
             }
@@ -170,7 +170,7 @@ namespace System.Windows.Documents
         {
             get
             {
-                return new InlineCollection(this, /*isOwnerParent*/true);
+                return new InlineCollection(this, isOwnerParent: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Span.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Span.cs
@@ -142,7 +142,7 @@ namespace System.Windows.Documents
                 }
 
                 Invariant.Assert(start.Parent == end.Parent);
-                Invariant.Assert(TextSchema.IsValidChild(position: start, /*childType*/typeof(Span)));
+                Invariant.Assert(TextSchema.IsValidChild(position: start, childType: typeof(Span)));
 
                 this.Reposition(start, end);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Speller.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Speller.cs
@@ -165,7 +165,7 @@ namespace System.Windows.Documents
                 position = endPosition.CreateDynamicTextPointer(direction);
             }
 
-            SpellingError spellingError = GetError(position, direction, false /* forceEvaluation */);
+            SpellingError spellingError = GetError(position, direction, forceEvaluation: false);
             return spellingError?.Start;
         }
 
@@ -701,8 +701,8 @@ namespace System.Windows.Documents
             _spellerInterop.Mode = SpellerInteropBase.SpellerMode.WordBreaking;
 
             XmlLanguage language = GetCurrentLanguage(caretPosition);
-            wordBreakLeft = SearchForWordBreaks(caretPosition, LogicalDirection.Backward, language, 1, false /* stopOnError */);
-            wordBreakRight = SearchForWordBreaks(caretPosition, LogicalDirection.Forward, language, 1, false /* stopOnError */);
+            wordBreakLeft = SearchForWordBreaks(caretPosition, LogicalDirection.Backward, language, 1, stopOnError: false);
+            wordBreakRight = SearchForWordBreaks(caretPosition, LogicalDirection.Forward, language, 1, stopOnError: false);
 
             textMap = new TextMap(wordBreakLeft, wordBreakRight, caretPosition, caretPosition);
             segments = new ArrayList(2);
@@ -1112,11 +1112,11 @@ namespace System.Windows.Documents
 
             // 1. Search outward, into surrounding text.  We need MinWordBreaksForContext
             // word breaks to handle multi-word errors.
-            outwardPosition = SearchForWordBreaks(position, direction, language, MinWordBreaksForContext, true /* stopOnError */);
+            outwardPosition = SearchForWordBreaks(position, direction, language, MinWordBreaksForContext, stopOnError: true);
 
             // 2. Search inward, towards content.  We just need one word break inward.
             inwardDirection = direction == LogicalDirection.Forward ? LogicalDirection.Backward : LogicalDirection.Forward;
-            inwardPosition = SearchForWordBreaks(position, inwardDirection, language, 1, false /* stopOnError */);
+            inwardPosition = SearchForWordBreaks(position, inwardDirection, language, 1, stopOnError: false);
 
             // Get combined word breaks.  This may not be the same as we calculated
             // in two parts above, since we don't know yet whether or not position is
@@ -1474,7 +1474,7 @@ namespace System.Windows.Documents
                 end = position;
             }
 
-            ScanRange(start, end, Int64.MaxValue /* timeLimit */);
+            ScanRange(start, end, timeLimit: Int64.MaxValue);
         }
 
         // Returns the XmlLanguage of the parent element at position.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SplayTreeNode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SplayTreeNode.cs
@@ -354,7 +354,7 @@ namespace System.Windows.Documents
             if (edge == ElementEdge.BeforeStart || edge == ElementEdge.AfterEnd)
             {
                 // Insert to this node's tree.
-                InsertAtNode(positionNode, edge == ElementEdge.BeforeStart /* insertBefore */);
+                InsertAtNode(positionNode, insertBefore: edge == ElementEdge.BeforeStart);
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Table.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Table.cs
@@ -281,7 +281,7 @@ namespace System.Windows.Documents
         /// </summary>
         internal void InvalidateColumns()
         {
-            NotifyTypographicPropertyChanged(true /* affectsMeasureOrArrange */, true /* localValueChanged */, null);
+            NotifyTypographicPropertyChanged(affectsMeasureOrArrange: true, localValueChanged: true, null);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TableCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TableCell.cs
@@ -120,7 +120,7 @@ namespace System.Windows.Documents
         {
             get
             {
-                return new BlockCollection(this, /*isOwnerParent*/true);
+                return new BlockCollection(this, isOwnerParent: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextContainer.cs
@@ -326,19 +326,19 @@ namespace System.Windows.Documents
 
         internal void BeginChange()
         {
-            BeginChange(true /* undo */);
+            BeginChange(undo: true);
         }
 
         internal void BeginChangeNoUndo()
         {
-            BeginChange(false /* undo */);
+            BeginChange(undo: false);
         }
 
         /// <summary>
         /// </summary>
         internal void EndChange()
         {
-            EndChange(false /* skipEvents */);
+            EndChange(skipEvents: false);
         }
 
         /// <summary>
@@ -413,7 +413,7 @@ namespace System.Windows.Documents
         /// </summary>
         void ITextContainer.EndChange()
         {
-            EndChange(false /* skipEvents */);
+            EndChange(skipEvents: false);
         }
 
         /// <summary>
@@ -485,7 +485,7 @@ namespace System.Windows.Documents
             DemandCreatePositionState();
 
             // Add +1 to offset because we're converting from external to internal offsets.
-            GetNodeAndEdgeAtOffset(offset + 1, false /* splitNode */, out node, out edge);
+            GetNodeAndEdgeAtOffset(offset + 1, splitNode: false, out node, out edge);
 
             nodeOffset = (offset + 1) - node.GetSymbolOffset(this.Generation);
 
@@ -764,7 +764,7 @@ namespace System.Windows.Documents
                              textChange != PrecursorTextChangeType.ElementExtracted,
                              "Need second TextPointer for ElementAdded/Extracted operations!");
 
-            AddChange(startPosition, null, symbolCount, /* leftEdgeCharCount */ 0, charCount, textChange, property, affectsRenderOnly);
+            AddChange(startPosition, null, symbolCount, leftEdgeCharCount: 0, charCount, textChange, property, affectsRenderOnly);
         }
 
         // Adds a change to the current change block.
@@ -904,7 +904,7 @@ namespace System.Windows.Documents
 
             // Update the symbol counts.
             textNode.SymbolCount += textLength; // This simultaneously updates textNode.IMECharCount.
-            UpdateContainerSymbolCount(containingNode, /* symbolCount */ textLength, /* charCount */ textLength);
+            UpdateContainerSymbolCount(containingNode, symbolCount: textLength, charCount: textLength);
 
             // Insert the raw text.
             symbolOffset = textNode.GetSymbolOffset(this.Generation);
@@ -914,9 +914,9 @@ namespace System.Windows.Documents
             TextTreeUndo.CreateInsertUndoUnit(this, symbolOffset, textLength);
 
             // Announce the change.
-            NextGeneration(false /* deletedContent */);
+            NextGeneration(deletedContent: false);
 
-            AddChange(originalPosition, /* symbolCount */ textLength, /* charCount */ textLength, PrecursorTextChangeType.ContentAdded);
+            AddChange(originalPosition, symbolCount: textLength, charCount: textLength, PrecursorTextChangeType.ContentAdded);
 
             // Notify the TextElement of a content change.
             TextElement textElement = position.Parent as TextElement;
@@ -976,7 +976,7 @@ namespace System.Windows.Documents
                 {
                     // ExtractElementInternal will raise LogicalTree events which
                     // could raise exceptions from external code.
-                    elementText = element.TextContainer.ExtractElementInternal(element, true /* deep */, out extractChangeEventArgs);
+                    elementText = element.TextContainer.ExtractElementInternal(element, deep: true, out extractChangeEventArgs);
                     exceptionThrown = false;
                 }
                 finally
@@ -1083,7 +1083,7 @@ namespace System.Windows.Documents
                 TextTreeText.InsertText(_rootNode.RootTextBlock, symbolOffset, elementText);
             }
 
-            NextGeneration(false /* deletedContent */);
+            NextGeneration(deletedContent: false);
 
             // Handle undo.
             TextTreeUndo.CreateInsertElementUndoUnit(this, symbolOffset, elementText != null /* deep */);
@@ -1189,7 +1189,7 @@ namespace System.Windows.Documents
             symbolOffset = objectNode.GetSymbolOffset(this.Generation);
             TextTreeText.InsertObject(_rootNode.RootTextBlock, symbolOffset);
 
-            NextGeneration(false /* deletedContent */);
+            NextGeneration(deletedContent: false);
 
             // Handle undo.
             TextTreeUndo.CreateInsertUndoUnit(this, symbolOffset, 1);
@@ -1268,7 +1268,7 @@ namespace System.Windows.Documents
 
         internal void GetNodeAndEdgeAtOffset(int offset, out SplayTreeNode node, out ElementEdge edge)
         {
-            GetNodeAndEdgeAtOffset(offset, true /* splitNode */, out node, out edge);
+            GetNodeAndEdgeAtOffset(offset, splitNode: true, out node, out edge);
         }
 
         // Finds a node/edge pair matching a given symbol offset in the tree.
@@ -1569,7 +1569,7 @@ namespace System.Windows.Documents
         {
             ExtractChangeEventArgs extractChangeEventArgs;
 
-            ExtractElementInternal(element, false /* deep */, out extractChangeEventArgs);
+            ExtractElementInternal(element, deep: false, out extractChangeEventArgs);
         }
 
         // Wrapper for this.TextView.IsAtCaretUnitBoundary, adds a cache.
@@ -2295,7 +2295,7 @@ namespace System.Windows.Documents
             {
                 if (newFirstIMEVisibleNode)
                 {
-                    UpdateContainerSymbolCount(containingNode, /* symbolCount */ 0, /* charCount */ -1);
+                    UpdateContainerSymbolCount(containingNode, symbolCount: 0, charCount: -1);
                 }
                 charCount = 0;
                 return 0;
@@ -2371,7 +2371,7 @@ namespace System.Windows.Documents
 
                 UpdateContainerSymbolCount(containingNode, -symbolCount, -charCount + nextNodeCharDelta);
                 TextTreeText.RemoveText(_rootNode.RootTextBlock, symbolOffset, symbolCount);
-                NextGeneration(true /* deletedContent */);
+                NextGeneration(deletedContent: true);
 
                 // Notify the TextElement of a content change. Note that any full TextElements
                 // between startPosition and endPosition will be handled by CutTopLevelLogicalNodes,
@@ -2437,17 +2437,17 @@ namespace System.Windows.Documents
                     // textElementNode.TextElement's TextElementNode will be updated
                     // with a deep copy of all contained nodes. We need a deep copy
                     // to ensure the new element/tree has no TextPointer references.
-                    ExtractElementFromSiblingTree(containingNode, elementNode, true /* deep */);
+                    ExtractElementFromSiblingTree(containingNode, elementNode, deep: true);
                     // Assert that the TextElement now points to a new TextElementNode, not the original one.
                     Invariant.Assert(elementNode.TextElement.TextElementNode != elementNode);
                     // We want to start referring to the copied node, update elementNode.
                     elementNode = elementNode.TextElement.TextElementNode;
 
                     UpdateContainerSymbolCount(containingNode, -elementNode.SymbolCount, -imeCharCountInOriginalContainer);
-                    NextGeneration(true /* deletedContent */);
+                    NextGeneration(deletedContent: true);
 
                     // Stick it in a private tree so it's safe for the outside world to play with.
-                    tree = new TextContainer(null, false /* plainTextOnly */);
+                    tree = new TextContainer(null, plainTextOnly: false);
                     newTreeStart = tree.Start;
 
                     tree.InsertElementToSiblingTree(newTreeStart, newTreeStart, elementNode);
@@ -2455,7 +2455,7 @@ namespace System.Windows.Documents
                     tree.UpdateContainerSymbolCount(elementNode.GetContainingNode(), elementNode.SymbolCount, elementNode.IMECharCount);
                     tree.DemandCreateText();
                     TextTreeText.InsertText(tree.RootTextBlock, 1 /* symbolOffset */, elementText);
-                    tree.NextGeneration(false /* deletedContent */);
+                    tree.NextGeneration(deletedContent: false);
 
                     currentLogicalChild = elementNode.TextElement;
 
@@ -2875,10 +2875,10 @@ namespace System.Windows.Documents
             }
             else
             {
-                UpdateContainerSymbolCount(containingNode, /* symbolCount */ -2, /* charCount */ -imeLeftEdgeCharCount + nextNodeCharDelta + containedNodeCharDelta);
+                UpdateContainerSymbolCount(containingNode, symbolCount: -2, charCount: -imeLeftEdgeCharCount + nextNodeCharDelta + containedNodeCharDelta);
             }
 
-            NextGeneration(true /* deletedContent */);
+            NextGeneration(deletedContent: true);
 
             undoUnit?.SetTreeHashCode();
 
@@ -2889,7 +2889,7 @@ namespace System.Windows.Documents
             }
             else if (empty)
             {
-                AddChange(startPosition, /* symbolCount */ 2, /* charCount */ imeCharCount, PrecursorTextChangeType.ContentRemoved);
+                AddChange(startPosition, symbolCount: 2, charCount: imeCharCount, PrecursorTextChangeType.ContentRemoved);
             }
             else
             {
@@ -3405,7 +3405,7 @@ namespace System.Windows.Documents
 
             // Next node was the old first node.  Its IMECharCount
             // just bumped up, report that.
-            AddChange(startEdgePosition, /* symbolCount */ 0, /* IMECharCount */ 1, PrecursorTextChangeType.ContentAdded);
+            AddChange(startEdgePosition, symbolCount: 0, /* IMECharCount */ 1, PrecursorTextChangeType.ContentAdded);
         }
 
         // Fires Change events for IMELeftEdgeCharCount deltas to a node after it
@@ -3417,7 +3417,7 @@ namespace System.Windows.Documents
 
             // node was the old second node.  Its IMECharCount
             // just dropped down, report that.
-            AddChange(startEdgePosition, /* symbolCount */ 0, /* IMECharCount */ 1, PrecursorTextChangeType.ContentRemoved);
+            AddChange(startEdgePosition, symbolCount: 0, /* IMECharCount */ 1, PrecursorTextChangeType.ContentRemoved);
         }
 
         // Sets boolean state.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextContainer.cs
@@ -1068,7 +1068,7 @@ namespace System.Windows.Documents
             }
 
             // Ancester nodes gain the two edge symbols.
-            UpdateContainerSymbolCount(elementNode.GetContainingNode(), /* symbolCount */ elementText == null ? 2 : elementText.Length, deltaCharCount + formerFirstIMEVisibleNodeCharDelta + newFirstIMEVisibleNodeCharDelta);
+            UpdateContainerSymbolCount(elementNode.GetContainingNode(), symbolCount: elementText == null ? 2 : elementText.Length, deltaCharCount + formerFirstIMEVisibleNodeCharDelta + newFirstIMEVisibleNodeCharDelta);
 
             symbolOffset = elementNode.GetSymbolOffset(this.Generation);
 
@@ -1086,7 +1086,7 @@ namespace System.Windows.Documents
             NextGeneration(deletedContent: false);
 
             // Handle undo.
-            TextTreeUndo.CreateInsertElementUndoUnit(this, symbolOffset, elementText != null /* deep */);
+            TextTreeUndo.CreateInsertElementUndoUnit(this, symbolOffset, deep: elementText != null);
 
             // If we extracted the TextElement from another tree, raise that event now.
             // We can't raise this event any earlier, because prior to now _this_ tree
@@ -1148,7 +1148,7 @@ namespace System.Windows.Documents
             // We only need to do this if we created a new element node.
             if (newElementNode)
             {
-                ReparentLogicalChildren(elementNode, elementNode.TextElement, parentLogicalNode /* oldParent */);
+                ReparentLogicalChildren(elementNode, elementNode.TextElement, oldParentLogicalNode: parentLogicalNode);
             }
 
             // Notify the TextElement of a content change if it was moved to parent new content. This 
@@ -2454,7 +2454,7 @@ namespace System.Windows.Documents
                     Invariant.Assert(elementText.Length == elementNode.SymbolCount);
                     tree.UpdateContainerSymbolCount(elementNode.GetContainingNode(), elementNode.SymbolCount, elementNode.IMECharCount);
                     tree.DemandCreateText();
-                    TextTreeText.InsertText(tree.RootTextBlock, 1 /* symbolOffset */, elementText);
+                    TextTreeText.InsertText(tree.RootTextBlock, offset: 1, elementText);
                     tree.NextGeneration(deletedContent: false);
 
                     currentLogicalChild = elementNode.TextElement;
@@ -2916,7 +2916,7 @@ namespace System.Windows.Documents
 
             if (!deep && !empty)
             {
-                ReparentLogicalChildren(firstContainedChildNode, lastContainedChildNode, oldLogicalParent /* new parent */, element /* old parent */);
+                ReparentLogicalChildren(firstContainedChildNode, lastContainedChildNode, newParentLogicalNode: oldLogicalParent, oldParentLogicalNode: element);
             }
 
             //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditor.cs
@@ -120,7 +120,7 @@ namespace System.Windows.Documents
         {
             // Detach TextStore that TextStore will be unregisted from Cicero.
             // And clean all reference of the native resources.
-            DetachTextStore(true /* finalizer */);
+            DetachTextStore(finalizer: true);
         }
 
         #endregion Finalizer
@@ -178,7 +178,7 @@ namespace System.Windows.Documents
             _pendingTextStoreInit = false;
 
             // Shut down the Cicero.
-            DetachTextStore(false /* finalizer */);
+            DetachTextStore(finalizer: false);
 
             // Shut down IMM32.
             if (_immCompositionForDetach != null)
@@ -1909,7 +1909,7 @@ namespace System.Windows.Documents
             internal override void OnShutDown(object target, object sender, EventArgs e)
             {
                 TextEditor editor = (TextEditor)target;
-                editor.DetachTextStore(false /* finalizer */);
+                editor.DetachTextStore(finalizer: false);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorCharacters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorCharacters.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Documents
         // Creates undo unit for this action.
         internal static void _OnApplyProperty(TextEditor This, DependencyProperty formattingProperty, object propertyValue)
         {
-            _OnApplyProperty(This, formattingProperty, propertyValue, /*applyToParagraphs*/false, PropertyValueAction.SetValue);
+            _OnApplyProperty(This, formattingProperty, propertyValue, applyToParagraphs: false, PropertyValueAction.SetValue);
         }
 
         internal static void _OnApplyProperty(TextEditor This, DependencyProperty formattingProperty, object propertyValue, bool applyToParagraphs)
@@ -314,7 +314,7 @@ namespace System.Windows.Documents
             else
             {
                 // Apply font size in incremental mode to a nonempty selection
-                TextEditorCharacters._OnApplyProperty(This, TextElement.FontSizeProperty, OneFontPoint, /*applyToParagraphs:*/false, PropertyValueAction.IncreaseByAbsoluteValue);
+                TextEditorCharacters._OnApplyProperty(This, TextElement.FontSizeProperty, OneFontPoint, applyToParagraphs: false, PropertyValueAction.IncreaseByAbsoluteValue);
             }
         }
 
@@ -355,7 +355,7 @@ namespace System.Windows.Documents
             else
             {
                 // Apply font size in decremental mode to a nonempty selection
-                TextEditorCharacters._OnApplyProperty(This, TextElement.FontSizeProperty, OneFontPoint, /*applyToParagraphs:*/false, PropertyValueAction.DecreaseByAbsoluteValue);
+                TextEditorCharacters._OnApplyProperty(This, TextElement.FontSizeProperty, OneFontPoint, applyToParagraphs: false, PropertyValueAction.DecreaseByAbsoluteValue);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorContextMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorContextMenu.cs
@@ -118,7 +118,7 @@ namespace System.Windows.Documents
                         // If we're not over the selection, move the caret.
                         if (!This.Selection.Contains(renderScopeMouseDownPoint))
                         {
-                            TextEditorMouse.SetCaretPositionOnMouseEvent(This, renderScopeMouseDownPoint, MouseButton.Right, 1 /* clickCount */);
+                            TextEditorMouse.SetCaretPositionOnMouseEvent(This, renderScopeMouseDownPoint, MouseButton.Right, clickCount: 1);
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorCopyPaste.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorCopyPaste.cs
@@ -99,7 +99,7 @@ namespace System.Windows.Documents
                     // and will be not created when there is no images in the range.
 
                     // Create in-memory wpf package, and serialize the content of selection into it
-                    string xamlTextWithImages = WpfPayload.SaveRange(This.Selection, ref wpfContainerMemory, /*useFlowDocumentAsRoot:*/false);
+                    string xamlTextWithImages = WpfPayload.SaveRange(This.Selection, ref wpfContainerMemory, useFlowDocumentAsRoot: false);
 
                     if (xamlTextWithImages.Length > 0)
                     {
@@ -133,7 +133,7 @@ namespace System.Windows.Documents
                 // Need to re-serialize xaml to avoid image references within a container:
                 StringWriter stringWriter = new StringWriter(CultureInfo.InvariantCulture);
                 XmlTextWriter xmlWriter = new XmlTextWriter(stringWriter);
-                TextRangeSerialization.WriteXaml(xmlWriter, This.Selection, /*useFlowDocumentAsRoot:*/false, /*wpfPayload:*/null);
+                TextRangeSerialization.WriteXaml(xmlWriter, This.Selection, useFlowDocumentAsRoot: false, wpfPayload: null);
                 string xamlText = stringWriter.ToString();
                 //  Use WpfPayload.SaveRangeAsXaml method to produce correct image.Source properties.
 
@@ -149,7 +149,7 @@ namespace System.Windows.Documents
             }
 
             // Notify application about our data object preparation completion
-            DataObjectCopyingEventArgs dataObjectCopyingEventArgs = new DataObjectCopyingEventArgs(dataObject, /*isDragDrop:*/isDragDrop);
+            DataObjectCopyingEventArgs dataObjectCopyingEventArgs = new DataObjectCopyingEventArgs(dataObject, isDragDrop: isDragDrop);
             This.UiScope.RaiseEvent(dataObjectCopyingEventArgs);
             if (dataObjectCopyingEventArgs.CommandCancelled)
             {
@@ -279,7 +279,7 @@ namespace System.Windows.Documents
                 // Copy content onto the clipboard
 
                 // Note: _CreateDataObject raises a public event which might throw a recoverable exception.
-                DataObject dataObject = TextEditorCopyPaste._CreateDataObject(This, /*isDragDrop:*/false);
+                DataObject dataObject = TextEditorCopyPaste._CreateDataObject(This, isDragDrop: false);
 
                 if (dataObject != null)
                 {
@@ -325,7 +325,7 @@ namespace System.Windows.Documents
             if (This.Selection != null && !This.Selection.IsEmpty)
             {
                 // Note: _CreateDataObject raises a public event which might throw a recoverable exception.
-                DataObject dataObject = TextEditorCopyPaste._CreateDataObject(This, /*isDragDrop:*/false);
+                DataObject dataObject = TextEditorCopyPaste._CreateDataObject(This, isDragDrop: false);
 
                 if (dataObject != null)
                 {
@@ -391,11 +391,11 @@ namespace System.Windows.Documents
                     TextEditorSelection._ClearSuggestedX(This);
 
                     // _DoPaste raises a public event -- could raise recoverable exception.
-                    if (TextEditorCopyPaste._DoPaste(This, dataObject, /*isDragDrop:*/false))
+                    if (TextEditorCopyPaste._DoPaste(This, dataObject, isDragDrop: false))
                     {
                         // Collapse selection to the end
                         // Use backward direction to stay oriented towards pasted content
-                        This.Selection.SetCaretToPosition(This.Selection.End, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/true);
+                        This.Selection.SetCaretToPosition(This.Selection.End, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: true);
 
                         // Clear springload formatting
                         if (This.Selection is TextSelection)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorDragDrop.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorDragDrop.cs
@@ -124,7 +124,7 @@ namespace System.Windows.Documents
                     if (this.TextView.IsValid)
                     {
                         Point mouseDownPoint = e.GetPosition(_textEditor.TextView.RenderScope);
-                        ITextPointer cursorPosition = this.TextView.GetTextPositionFromPoint(mouseDownPoint, /*snapToText:*/true);
+                        ITextPointer cursorPosition = this.TextView.GetTextPositionFromPoint(mouseDownPoint, snapToText: true);
                         if (cursorPosition != null)
                         {
                             _textEditor.Selection.SetSelectionByMouse(cursorPosition, mouseDownPoint);
@@ -168,7 +168,7 @@ namespace System.Windows.Documents
                 // Prepare data object (including side effects from application customization)
 
                 // Note: _CreateDataObject raises a public event which might throw a recoverable exception.
-                IDataObject dataObject = TextEditorCopyPaste._CreateDataObject(_textEditor, /*isDragDrop:*/true);
+                IDataObject dataObject = TextEditorCopyPaste._CreateDataObject(_textEditor, isDragDrop: true);
 
                 if (dataObject != null) // null would mean that application cancelled the command
                 {
@@ -281,7 +281,7 @@ namespace System.Windows.Documents
 
                     // Add the caret.
                     // Create caret to show it during the dragging operation.
-                    _caretDragDrop = new CaretElement(_textEditor, /*isBlinkEnabled:*/false);
+                    _caretDragDrop = new CaretElement(_textEditor, isBlinkEnabled: false);
 
                     // Initialize the caret.
                     // (psarrett) Understand why this call is so important for AdornerLayer.
@@ -415,7 +415,7 @@ namespace System.Windows.Documents
                             Brush caretBrush = TextSelection.GetCaretBrush(_textEditor);
 
                             // Show the caret on the dropable position.
-                            _caretDragDrop.Update(/*visible:*/true, caretRectangle, caretBrush, 0.5, italic, CaretScrollMethod.None, /*wordWrappingPosition*/ double.NaN);
+                            _caretDragDrop.Update(visible: true, caretRectangle, caretBrush, 0.5, italic, CaretScrollMethod.None, /*wordWrappingPosition*/ double.NaN);
                         }
                     }
                 }
@@ -445,7 +445,7 @@ namespace System.Windows.Documents
                     transform.TryTransform(point, out point); 
                 }
 
-                ITextPointer dropPosition = this.TextView.GetTextPositionFromPoint(point, /*snapToText:*/true);
+                ITextPointer dropPosition = this.TextView.GetTextPositionFromPoint(point, snapToText: true);
                 
                 // For rich text content we adjust drop position to word boundary
                 if (dropPosition != null)
@@ -461,7 +461,7 @@ namespace System.Windows.Documents
                             // The drop position must be before of end of line
                             dropPosition.CompareTo(lineRange.End) < 0 &&
                             // We check if we are not at word boundary already:
-                            !TextPointerBase.IsAtWordBoundary(dropPosition, /*insideWordDirection:*/LogicalDirection.Forward) &&
+                            !TextPointerBase.IsAtWordBoundary(dropPosition, insideWordDirection: LogicalDirection.Forward) &&
                             // We do not do it if the source range was not on word boundaries from both ends
                             _dragSourceTextRange != null && //
                             TextPointerBase.IsAtWordBoundary(_dragSourceTextRange.Start, LogicalDirection.Forward) && //
@@ -545,7 +545,7 @@ namespace System.Windows.Documents
                         // nothing happened.
 
                         // Set caret to this position.
-                        selection.SetCaretToPosition(dropPosition, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/true);
+                        selection.SetCaretToPosition(dropPosition, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: true);
 
                         // Indicate the resulting effect of an action
                         // Note that dropResult may stay equal to DragDropResult.Drop
@@ -573,10 +573,10 @@ namespace System.Windows.Documents
                             // When we drop outside of selection,
                             // we should ignore current selection and
                             // move ip into dropping point.
-                            selection.SetCaretToPosition(dropPosition, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/true);
+                            selection.SetCaretToPosition(dropPosition, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: true);
 
                             // _DoPaste raises a public event -- could raise recoverable exception.
-                            e.Handled = TextEditorCopyPaste._DoPaste(_textEditor, e.Data, /*isDragDrop:*/true);
+                            e.Handled = TextEditorCopyPaste._DoPaste(_textEditor, e.Data, isDragDrop: true);
                             //  So we consider a case when we pasted nothing as non-handled. This is inconsistent with otherwise "static" approach to event handling across editing. Need to revisit this.
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorLists.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorLists.cs
@@ -236,7 +236,7 @@ namespace System.Windows.Documents
                     if (paragraphOrBlockUIContainer is BlockUIContainer)
                     {
                         // Increment BlockUIContainer's leading margin.
-                        TextRangeEdit.IncrementParagraphLeadingMargin(thisSelection, /*increment:*/20, PropertyValueAction.IncreaseByAbsoluteValue);
+                        TextRangeEdit.IncrementParagraphLeadingMargin(thisSelection, increment: 20, PropertyValueAction.IncreaseByAbsoluteValue);
                     }
                     else
                     {
@@ -259,14 +259,14 @@ namespace System.Windows.Documents
                         else
                         {
                             // Increment paragraph leading margin.
-                            TextRangeEdit.IncrementParagraphLeadingMargin(thisSelection, /*increment:*/20, PropertyValueAction.IncreaseByAbsoluteValue);
+                            TextRangeEdit.IncrementParagraphLeadingMargin(thisSelection, increment: 20, PropertyValueAction.IncreaseByAbsoluteValue);
                         }
                     }
                 }
                 else
                 {
                     // For non-empty selection, always increment paragraph margin.
-                    TextRangeEdit.IncrementParagraphLeadingMargin(thisSelection, /*increment:*/20, PropertyValueAction.IncreaseByAbsoluteValue);
+                    TextRangeEdit.IncrementParagraphLeadingMargin(thisSelection, increment: 20, PropertyValueAction.IncreaseByAbsoluteValue);
                 }
             }
         }
@@ -291,7 +291,7 @@ namespace System.Windows.Documents
                     if (paragraphOrBlockUIContainer is BlockUIContainer)
                     {
                         // Decrement BlockUIContainer's leading margin.
-                        TextRangeEdit.IncrementParagraphLeadingMargin(thisSelection, /*increment:*/20, PropertyValueAction.DecreaseByAbsoluteValue);
+                        TextRangeEdit.IncrementParagraphLeadingMargin(thisSelection, increment: 20, PropertyValueAction.DecreaseByAbsoluteValue);
                     }
                     else
                     {
@@ -315,14 +315,14 @@ namespace System.Windows.Documents
                         else
                         {
                             // Decrement paragraph leading margin.
-                            TextRangeEdit.IncrementParagraphLeadingMargin(thisSelection, /*increment:*/20, PropertyValueAction.DecreaseByAbsoluteValue);
+                            TextRangeEdit.IncrementParagraphLeadingMargin(thisSelection, increment: 20, PropertyValueAction.DecreaseByAbsoluteValue);
                         }
                     }
                 }
                 else
                 {
                     // For non-empty selection, always decrement paragraph margin.
-                    TextRangeEdit.IncrementParagraphLeadingMargin(thisSelection, /*increment:*/20, PropertyValueAction.DecreaseByAbsoluteValue);
+                    TextRangeEdit.IncrementParagraphLeadingMargin(thisSelection, increment: 20, PropertyValueAction.DecreaseByAbsoluteValue);
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorMouse.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorMouse.cs
@@ -62,7 +62,7 @@ namespace System.Windows.Documents
         internal static void SetCaretPositionOnMouseEvent(TextEditor This, Point mouseDownPoint, MouseButton changedButton, int clickCount)
         {
             // Get the character position of the mouse event.
-            ITextPointer cursorPosition = This.TextView.GetTextPositionFromPoint(mouseDownPoint, /*snapToText:*/true);
+            ITextPointer cursorPosition = This.TextView.GetTextPositionFromPoint(mouseDownPoint, snapToText: true);
 
             if (cursorPosition == null)
             {
@@ -481,7 +481,7 @@ namespace System.Windows.Documents
                 Invariant.Assert(This.Selection != null);
 
                 // Find a text position for this mouse point
-                ITextPointer snappedCursorPosition = This.TextView.GetTextPositionFromPoint(mouseMovePoint, /*snapToText:*/true);
+                ITextPointer snappedCursorPosition = This.TextView.GetTextPositionFromPoint(mouseMovePoint, snapToText: true);
 
                 // For bug 1547567, remove when resolved.
                 Invariant.Assert(This.Selection != null);
@@ -521,13 +521,13 @@ namespace System.Windows.Documents
                             {
                                 Rect targetRect = This.TextView.GetRectangleFromTextPosition(snappedCursorPosition);
                                 targetPoint = new Point(targetPoint.X, targetRect.Bottom - pageHeight);
-                                acceleratedCursorPosition = This.TextView.GetTextPositionFromPoint(targetPoint, /*snapToText:*/true);
+                                acceleratedCursorPosition = This.TextView.GetTextPositionFromPoint(targetPoint, snapToText: true);
                             }
                             else if (pointScroller.Y > pageHeight + slowAreaDelta)
                             {
                                 Rect targetRect = This.TextView.GetRectangleFromTextPosition(snappedCursorPosition);
                                 targetPoint = new Point(targetPoint.X, targetRect.Top + pageHeight);
-                                acceleratedCursorPosition = This.TextView.GetTextPositionFromPoint(targetPoint, /*snapToText:*/true);
+                                acceleratedCursorPosition = This.TextView.GetTextPositionFromPoint(targetPoint, snapToText: true);
                             }
 
                             double pageWidth = (double)((TextBoxBase)This.UiScope).ViewportWidth;
@@ -537,12 +537,12 @@ namespace System.Windows.Documents
                             if (pointScroller.X < 0)
                             {
                                 targetPoint = new Point(targetPoint.X - slowAreaDelta, targetPoint.Y);
-                                acceleratedCursorPosition = This.TextView.GetTextPositionFromPoint(targetPoint, /*snapToText:*/true);
+                                acceleratedCursorPosition = This.TextView.GetTextPositionFromPoint(targetPoint, snapToText: true);
                             }
                             else if (pointScroller.X > pageWidth)
                             {
                                 targetPoint = new Point(targetPoint.X + slowAreaDelta, targetPoint.Y);
-                                acceleratedCursorPosition = This.TextView.GetTextPositionFromPoint(targetPoint, /*snapToText:*/true);
+                                acceleratedCursorPosition = This.TextView.GetTextPositionFromPoint(targetPoint, snapToText: true);
                             }
 
                             // Use acceleratedcursorPosition instead of real one to make scrolling reasonable faster
@@ -710,7 +710,7 @@ namespace System.Windows.Documents
         // Return a UIElement when mouseMovePoint is within the ui element's bounding Rect. Null otherwise.
         private static UIElement GetUIElementWhenMouseOver(TextEditor This, Point mouseMovePoint)
         {
-            ITextPointer mouseMovePosition = This.TextView.GetTextPositionFromPoint(mouseMovePoint, /*snapToText:*/false);
+            ITextPointer mouseMovePosition = This.TextView.GetTextPositionFromPoint(mouseMovePoint, snapToText: false);
             if (mouseMovePosition == null)
             {
                 return null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorParagraphs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorParagraphs.cs
@@ -69,7 +69,7 @@ namespace System.Windows.Documents
                 return;
             }
 
-            TextEditorCharacters._OnApplyProperty(This, Block.TextAlignmentProperty, TextAlignment.Left, /*applyToParagraphs*/true);
+            TextEditorCharacters._OnApplyProperty(This, Block.TextAlignmentProperty, TextAlignment.Left, applyToParagraphs: true);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace System.Windows.Documents
                 return;
             }
 
-            TextEditorCharacters._OnApplyProperty(This, Block.TextAlignmentProperty, TextAlignment.Center, /*applyToParagraphs*/true);
+            TextEditorCharacters._OnApplyProperty(This, Block.TextAlignmentProperty, TextAlignment.Center, applyToParagraphs: true);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace System.Windows.Documents
                 return;
             }
 
-            TextEditorCharacters._OnApplyProperty(This, Block.TextAlignmentProperty, TextAlignment.Right, /*applyToParagraphs*/true);
+            TextEditorCharacters._OnApplyProperty(This, Block.TextAlignmentProperty, TextAlignment.Right, applyToParagraphs: true);
         }
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace System.Windows.Documents
                 return;
             }
 
-            TextEditorCharacters._OnApplyProperty(This, Block.TextAlignmentProperty, TextAlignment.Justify, /*applyToParagraphs*/true);
+            TextEditorCharacters._OnApplyProperty(This, Block.TextAlignmentProperty, TextAlignment.Justify, applyToParagraphs: true);
         }
 
         private static void OnApplySingleSpace(object sender, ExecutedRoutedEventArgs e)
@@ -139,7 +139,7 @@ namespace System.Windows.Documents
         {
             TextEditor This = TextEditor._GetTextEditor(sender);
             TextEditorCharacters._OnApplyProperty(This, FrameworkElement.FlowDirectionProperty,
-                FlowDirection.LeftToRight, /*applyToParagraphs*/true);
+                FlowDirection.LeftToRight, applyToParagraphs: true);
         }
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace System.Windows.Documents
         {
             TextEditor This = TextEditor._GetTextEditor(sender);
             TextEditorCharacters._OnApplyProperty(This, FrameworkElement.FlowDirectionProperty,
-                FlowDirection.RightToLeft, /*applyToParagraphs*/true);
+                FlowDirection.RightToLeft, applyToParagraphs: true);
         }
 
         // ----------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorSelection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorSelection.cs
@@ -152,7 +152,7 @@ namespace System.Windows.Documents
 
             TextEditorTyping._FlushPendingInputItems(This);
 
-            using (This.Selection.DeclareChangeBlock(true /* disableScroll */))
+            using (This.Selection.DeclareChangeBlock(disableScroll: true))
             {
                 This.Selection.Select(This.TextContainer.Start, This.TextContainer.End);
 
@@ -186,7 +186,7 @@ namespace System.Windows.Documents
             }
 
             LogicalDirection movementDirection = IsFlowDirectionRightToLeftThenTopToBottom(This) ? LogicalDirection.Backward : LogicalDirection.Forward;
-            MoveToCharacterLogicalDirection(This, movementDirection, /*extend:*/false);
+            MoveToCharacterLogicalDirection(This, movementDirection, extend: false);
         }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace System.Windows.Documents
             }
 
             LogicalDirection movementDirection = IsFlowDirectionRightToLeftThenTopToBottom(This) ? LogicalDirection.Forward : LogicalDirection.Backward;
-            MoveToCharacterLogicalDirection(This, movementDirection, /*extend:*/false);
+            MoveToCharacterLogicalDirection(This, movementDirection, extend: false);
         }
 
 
@@ -267,7 +267,7 @@ namespace System.Windows.Documents
                     // for LineEnd condition - choose inner position within a line.
                     ITextPointer position = TextEditorSelection.GetEndInner(This);
 
-                    This.Selection.SetCaretToPosition(position, position.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                    This.Selection.SetCaretToPosition(position, position.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: true);
                     TextEditorSelection._ClearSuggestedX(This); // So that when we will request suggestedX below it will take it from the new moving position
                 }
                 Invariant.Assert(This.Selection.IsEmpty);
@@ -296,7 +296,7 @@ namespace System.Windows.Documents
                     TextEditorSelection.UpdateSuggestedXOnColumnOrPageBoundary(This, newSuggestedX);
 
                     // Move insertion point to next or previous line
-                    This.Selection.SetCaretToPosition(newMovingPosition, newMovingPosition.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                    This.Selection.SetCaretToPosition(newMovingPosition, newMovingPosition.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: true);
                 }
                 else
                 {
@@ -312,7 +312,7 @@ namespace System.Windows.Documents
                         ITextPointer lineEndPosition = GetPositionAtLineEnd(originalMovingPosition);
                         ITextPointer nextPosition = lineEndPosition.GetNextInsertionPosition(LogicalDirection.Forward);
                         This.Selection.SetCaretToPosition(nextPosition ?? lineEndPosition,
-                            originalMovingPosition.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                            originalMovingPosition.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: true);
                     }
                     else if (IsPaginated(This.TextView))
                     {
@@ -356,7 +356,7 @@ namespace System.Windows.Documents
                     // It is Word behavior for setting a cratet on moving down from nonempty selection.
                     ITextPointer position = TextEditorSelection.GetStartInner(This);
 
-                    This.Selection.SetCaretToPosition(position, position.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                    This.Selection.SetCaretToPosition(position, position.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: true);
                     TextEditorSelection._ClearSuggestedX(This); // So that when we will request suggestedX below it will take it from the new moving position
                 }
                 Invariant.Assert(This.Selection.IsEmpty);
@@ -386,7 +386,7 @@ namespace System.Windows.Documents
 
                     // Move insertion point to next or previous line
                     //  position must be normalized not randomly here (bug)
-                    This.Selection.SetCaretToPosition(newMovingPosition, newMovingPosition.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                    This.Selection.SetCaretToPosition(newMovingPosition, newMovingPosition.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: true);
                 }
                 else
                 {
@@ -402,7 +402,7 @@ namespace System.Windows.Documents
                         ITextPointer lineStartPosition = GetPositionAtLineStart(originalMovingPosition);
                         ITextPointer previousPosition = lineStartPosition.GetNextInsertionPosition(LogicalDirection.Backward);
                         This.Selection.SetCaretToPosition(previousPosition ?? lineStartPosition,
-                            originalMovingPosition.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                            originalMovingPosition.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: true);
                     }
                     else if (IsPaginated(This.TextView))
                     {
@@ -453,7 +453,7 @@ namespace System.Windows.Documents
                     // for LineEnd condition - choose inner position within a line.
                     ITextPointer position = TextEditorSelection.GetEndInner(This);
 
-                    This.Selection.SetCaretToPosition(position, position.LogicalDirection, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                    This.Selection.SetCaretToPosition(position, position.LogicalDirection, allowStopAtLineEnd: false, allowStopNearSpace: false);
                 }
 
                 ITextPointer movingPointer = This.Selection.MovingPosition.CreatePointer();
@@ -465,12 +465,12 @@ namespace System.Windows.Documents
                 {
                     // Next paragraph found. Set selection to its start
                     paragraphRange.SelectParagraph(movingPointer);
-                    This.Selection.SetCaretToPosition(paragraphRange.Start, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                    This.Selection.SetCaretToPosition(paragraphRange.Start, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: false);
                 }
                 else
                 {
                     // Next paragraph does not exist. Set selectionn to the end of current paragraph
-                    This.Selection.SetCaretToPosition(paragraphRange.End, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                    This.Selection.SetCaretToPosition(paragraphRange.End, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: false);
                 }
             }
         }
@@ -505,7 +505,7 @@ namespace System.Windows.Documents
                     // It is Word behavior for setting a cratet on moving down from nonempty selection.
                     ITextPointer position = TextEditorSelection.GetStartInner(This);
 
-                    This.Selection.SetCaretToPosition(position, position.LogicalDirection, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                    This.Selection.SetCaretToPosition(position, position.LogicalDirection, allowStopAtLineEnd: false, allowStopNearSpace: false);
                 }
                 ITextPointer movingPointer = This.Selection.MovingPosition.CreatePointer();
                 ITextRange paragraphRange = new TextRange(movingPointer, movingPointer);
@@ -514,7 +514,7 @@ namespace System.Windows.Documents
                 if (This.Selection.Start.CompareTo(paragraphRange.Start) > 0)
                 {
                     // We are in the middle of a paragraph. Move to its start
-                    This.Selection.SetCaretToPosition(paragraphRange.Start, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                    This.Selection.SetCaretToPosition(paragraphRange.Start, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: false);
                 }
                 else
                 {
@@ -523,7 +523,7 @@ namespace System.Windows.Documents
                     {
                         // Previous paragraph found. Set selection to its start
                         paragraphRange.SelectParagraph(movingPointer);
-                        This.Selection.SetCaretToPosition(paragraphRange.Start, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                        This.Selection.SetCaretToPosition(paragraphRange.Start, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: false);
                     }
                 }
             }
@@ -558,7 +558,7 @@ namespace System.Windows.Documents
                     // for LineEnd condition - choose inner position within a line.
                     ITextPointer position = TextEditorSelection.GetEndInner(This);
 
-                    This.Selection.SetCaretToPosition(position, position.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                    This.Selection.SetCaretToPosition(position, position.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: true);
                 }
 
                 ITextPointer movingPosition;
@@ -600,7 +600,7 @@ namespace System.Windows.Documents
                             TextEditorSelection.UpdateSuggestedXOnColumnOrPageBoundary(This, newSuggestedX);
 
                             // If shift key isn't down, collapse the range.
-                            This.Selection.SetCaretToPosition(targetPosition, targetPosition.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/false);
+                            This.Selection.SetCaretToPosition(targetPosition, targetPosition.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: false);
                         }
                         else if (IsPaginated(This.TextView))
                         {
@@ -615,7 +615,7 @@ namespace System.Windows.Documents
                     // Calculate target position - at a specified distance from current movingPosition
                     Rect targetRect = This.TextView.GetRectangleFromTextPosition(movingPosition);
                     Point targetPoint = new Point(GetViewportXOffset(This.TextView, suggestedX), targetRect.Top + pageHeight);
-                    targetPosition = This.TextView.GetTextPositionFromPoint(targetPoint, /*snapToText:*/true);
+                    targetPosition = This.TextView.GetTextPositionFromPoint(targetPoint, snapToText: true);
 
                     if (targetPosition == null)
                     {
@@ -638,7 +638,7 @@ namespace System.Windows.Documents
                     This.TextView.RenderScope.UpdateLayout();
 
                     // If shift key isn't down, collapse the range.
-                    This.Selection.SetCaretToPosition(targetPosition, targetPosition.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/false);
+                    This.Selection.SetCaretToPosition(targetPosition, targetPosition.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: false);
                 }
 
                 // Discard typing undo unit merging
@@ -675,7 +675,7 @@ namespace System.Windows.Documents
                     // It is Word behavior for setting a cratet on moving down from nonempty selection.
                     ITextPointer position = TextEditorSelection.GetStartInner(This);
 
-                    This.Selection.SetCaretToPosition(position, position.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                    This.Selection.SetCaretToPosition(position, position.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: true);
                 }
 
                 ITextPointer movingPosition;
@@ -714,7 +714,7 @@ namespace System.Windows.Documents
                             TextEditorSelection.UpdateSuggestedXOnColumnOrPageBoundary(This, newSuggestedX);
 
                             // If shift key isn't down, collapse the range.
-                            This.Selection.SetCaretToPosition(targetPosition, targetPosition.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/false);
+                            This.Selection.SetCaretToPosition(targetPosition, targetPosition.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: false);
                         }
                         else if (IsPaginated(This.TextView))
                         {
@@ -729,7 +729,7 @@ namespace System.Windows.Documents
                     // Calculate target position - at a specified distance from current movingPosition
                     Rect targetRect = This.TextView.GetRectangleFromTextPosition(movingPosition);
                     Point targetPoint = new Point(GetViewportXOffset(This.TextView, suggestedX), targetRect.Bottom - pageHeight);
-                    targetPosition = This.TextView.GetTextPositionFromPoint(targetPoint, /*snapToText:*/true);
+                    targetPosition = This.TextView.GetTextPositionFromPoint(targetPoint, snapToText: true);
 
                     if (targetPosition == null)
                     {
@@ -752,8 +752,7 @@ namespace System.Windows.Documents
                     This.TextView.RenderScope.UpdateLayout();
 
                     // If shift key isn't down, collapse the range.
-                    This.Selection.SetCaretToPosition(targetPosition, targetPosition.LogicalDirection, /*allowStopAtLineEnd:*/
-                                                      true, /*allowStopNearSpace:*/false);
+                    This.Selection.SetCaretToPosition(targetPosition, targetPosition.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: false);
                 }
 
                 // Discard typing undo unit merging
@@ -803,7 +802,7 @@ namespace System.Windows.Documents
                 ITextPointer caretPosition = lineRange.Start.GetFrozenPointer(LogicalDirection.Forward);
 
                 // Set caret to beginning of a line
-                This.Selection.SetCaretToPosition(caretPosition, LogicalDirection.Forward, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                This.Selection.SetCaretToPosition(caretPosition, LogicalDirection.Forward, allowStopAtLineEnd: true, allowStopNearSpace: true);
 
                 // Forget previously suggested horizontal position
                 TextEditorSelection._ClearSuggestedX(This);
@@ -855,7 +854,7 @@ namespace System.Windows.Documents
                 ITextPointer caretPosition = lineRange.End.GetFrozenPointer(orientation);
 
                 // Set caret to the end of line
-                This.Selection.SetCaretToPosition(caretPosition, orientation, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                This.Selection.SetCaretToPosition(caretPosition, orientation, allowStopAtLineEnd: true, allowStopNearSpace: true);
 
                 // Forget previously suggested horizontal position
                 TextEditorSelection._ClearSuggestedX(This);
@@ -883,7 +882,7 @@ namespace System.Windows.Documents
 
             using (This.Selection.DeclareChangeBlock())
             {
-                This.Selection.SetCaretToPosition(This.TextContainer.Start, LogicalDirection.Forward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                This.Selection.SetCaretToPosition(This.TextContainer.Start, LogicalDirection.Forward, allowStopAtLineEnd: false, allowStopNearSpace: false);
 
                 // Forget previously suggested horizontal position
                 TextEditorSelection._ClearSuggestedX(This);
@@ -912,7 +911,7 @@ namespace System.Windows.Documents
             using (This.Selection.DeclareChangeBlock())
             {
                 // Orientation is standard - forward, because text cannot wrap by flow at this position
-                This.Selection.SetCaretToPosition(This.TextContainer.End, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                This.Selection.SetCaretToPosition(This.TextContainer.End, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: false);
 
                 // Forget previously suggested horizontal position
                 TextEditorSelection._ClearSuggestedX(This);
@@ -944,7 +943,7 @@ namespace System.Windows.Documents
             }
 
             LogicalDirection movementDirection = IsFlowDirectionRightToLeftThenTopToBottom(This) ? LogicalDirection.Backward : LogicalDirection.Forward;
-            MoveToCharacterLogicalDirection(This, movementDirection, /*extend:*/true);
+            MoveToCharacterLogicalDirection(This, movementDirection, extend: true);
         }
 
         /// <summary>
@@ -960,7 +959,7 @@ namespace System.Windows.Documents
             }
 
             LogicalDirection movementDirection = IsFlowDirectionRightToLeftThenTopToBottom(This) ? LogicalDirection.Forward : LogicalDirection.Backward;
-            MoveToCharacterLogicalDirection(This, movementDirection, /*extend:*/true);
+            MoveToCharacterLogicalDirection(This, movementDirection, extend: true);
         }
 
         /// <summary>
@@ -1443,7 +1442,7 @@ namespace System.Windows.Documents
                     // Calculate target position - at a specified distance from current movingPosition
                     Rect targetRect = This.TextView.GetRectangleFromTextPosition(movingPosition);
                     Point targetPoint = new Point(GetViewportXOffset(This.TextView, suggestedX), targetRect.Top + pageHeight);
-                    targetPosition = This.TextView.GetTextPositionFromPoint(targetPoint, /*snapToText:*/true);
+                    targetPosition = This.TextView.GetTextPositionFromPoint(targetPoint, snapToText: true);
 
                     if (targetPosition == null)
                     {
@@ -1539,7 +1538,7 @@ namespace System.Windows.Documents
                     // Calculate target position - at a specified distance from current movingPosition
                     Rect targetRect = This.TextView.GetRectangleFromTextPosition(movingPosition);
                     Point targetPoint = new Point(GetViewportXOffset(This.TextView, suggestedX), targetRect.Bottom - pageHeight);
-                    targetPosition = This.TextView.GetTextPositionFromPoint(targetPoint, /*snapToText:*/true);
+                    targetPosition = This.TextView.GetTextPositionFromPoint(targetPoint, snapToText: true);
 
                     if (targetPosition == null)
                     {
@@ -1782,7 +1781,7 @@ namespace System.Windows.Documents
                     TextEditorSelection.UpdateSuggestedXOnColumnOrPageBoundary(This, e.NewSuggestedX);
 
                     // Move insertion point to next or previous line
-                    This.Selection.SetCaretToPosition(e.NewPosition, e.NewPosition.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                    This.Selection.SetCaretToPosition(e.NewPosition, e.NewPosition.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: true);
                 }
             }
         }
@@ -1812,7 +1811,7 @@ namespace System.Windows.Documents
                     TextEditorSelection.UpdateSuggestedXOnColumnOrPageBoundary(This, e.NewSuggestedOffset.X);
 
                     // Move insertion point to next or previous page
-                    This.Selection.SetCaretToPosition(e.NewPosition, e.NewPosition.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                    This.Selection.SetCaretToPosition(e.NewPosition, e.NewPosition.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: true);
                 }
             }
         }
@@ -2074,7 +2073,7 @@ namespace System.Windows.Documents
                         // This means that when we pass a space by keyboard we will respect its formatting,
                         // while when we click next to a space we always ignore space's formatting
                         // and prefer neighboring non-space character formatting instead.
-                        textEditor.Selection.SetCaretToPosition(movingEnd, contentDirection, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                        textEditor.Selection.SetCaretToPosition(movingEnd, contentDirection, allowStopAtLineEnd: false, allowStopNearSpace: false);
                     }
                 }
 
@@ -2118,7 +2117,7 @@ namespace System.Windows.Documents
                     if (!textEditor.Selection.IsEmpty && TextPointerBase.IsAtWordBoundary(textEditor.Selection.End, LogicalDirection.Forward))
                     {
                         // If the selection is non-empty and ends on a word boundary, collapse it to that boundary.
-                        textEditor.Selection.SetCaretToPosition(textEditor.Selection.End, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                        textEditor.Selection.SetCaretToPosition(textEditor.Selection.End, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: false);
                         // Note that we are using a "smart" version of SetCaretToPosition
                         // to choose caret orientation on formattinng switches appropriately.
                     }
@@ -2127,7 +2126,7 @@ namespace System.Windows.Documents
                         ITextPointer wordBoundary = textEditor.Selection.End.CreatePointer();
                         TextPointerBase.MoveToNextWordBoundary(wordBoundary, LogicalDirection.Forward);
 
-                        textEditor.Selection.SetCaretToPosition(wordBoundary, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                        textEditor.Selection.SetCaretToPosition(wordBoundary, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: false);
                         // Note that we are using a "smart" version of SetCaretToPosition
                         // to choose caret orientation on formattinng switches appropriately.
                     }
@@ -2138,7 +2137,7 @@ namespace System.Windows.Documents
                     if (!textEditor.Selection.IsEmpty && TextPointerBase.IsAtWordBoundary(textEditor.Selection.Start, LogicalDirection.Forward))
                     {
                         // If the selection is non-empty and starts at word boundary, collapse it to that boundary.
-                        textEditor.Selection.SetCaretToPosition(textEditor.Selection.Start, LogicalDirection.Forward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                        textEditor.Selection.SetCaretToPosition(textEditor.Selection.Start, LogicalDirection.Forward, allowStopAtLineEnd: false, allowStopNearSpace: false);
                         // Note that we are using a "smart" version of SetCaretToPosition
                         // to choose caret orientation on formattinng switches appropriately.
                     }
@@ -2147,7 +2146,7 @@ namespace System.Windows.Documents
                         ITextPointer wordBoundary = textEditor.Selection.Start.CreatePointer();
                         TextPointerBase.MoveToNextWordBoundary(wordBoundary, LogicalDirection.Backward);
 
-                        textEditor.Selection.SetCaretToPosition(wordBoundary, LogicalDirection.Forward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                        textEditor.Selection.SetCaretToPosition(wordBoundary, LogicalDirection.Forward, allowStopAtLineEnd: false, allowStopNearSpace: false);
                         // Note that we are using a "smart" version of SetCaretToPosition
                         // to choose caret orientation on formattinng switches appropriately.
                     }
@@ -2396,7 +2395,7 @@ namespace System.Windows.Documents
                 ITextPointer position = This.Selection.Start.GetNextInsertionPosition(LogicalDirection.Backward);
                 if (position != null)
                 {
-                    This.Selection.SetCaretToPosition(position, LogicalDirection.Forward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                    This.Selection.SetCaretToPosition(position, LogicalDirection.Forward, allowStopAtLineEnd: false, allowStopNearSpace: false);
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorSpelling.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorSpelling.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Documents
         // Worker for TextBox/RichTextBox.GetSpellingErrorAtPosition.
         internal static SpellingError GetSpellingErrorAtPosition(TextEditor This, ITextPointer position, LogicalDirection direction)
         {
-            return This.Speller?.GetError(position, direction, true /* forceEvaluation */);
+            return This.Speller?.GetError(position, direction, forceEvaluation: true);
         }
 
         // Returns the error (if any) at the current selection.
@@ -59,13 +59,13 @@ namespace System.Windows.Documents
             LogicalDirection direction = This.Selection.IsEmpty ? This.Selection.Start.LogicalDirection : LogicalDirection.Forward;
 
             char character;
-            ITextPointer position = GetNextTextPosition(This.Selection.Start, null /* limit */, direction, out character);
+            ITextPointer position = GetNextTextPosition(This.Selection.Start, limit: null, direction, out character);
             if (position == null)
             {
                 // There is no next character -- flip direction.
                 // This is the end-of-document or end-of-paragraph case.
                 direction = (direction == LogicalDirection.Forward) ? LogicalDirection.Backward : LogicalDirection.Forward;
-                position = GetNextTextPosition(This.Selection.Start, null /* limit */, direction, out character);
+                position = GetNextTextPosition(This.Selection.Start, limit: null, direction, out character);
             }
             else if (Char.IsWhiteSpace(character))
             {
@@ -80,7 +80,7 @@ namespace System.Windows.Documents
                 if (This.Selection.IsEmpty)
                 {
                     direction = (direction == LogicalDirection.Forward) ? LogicalDirection.Backward : LogicalDirection.Forward;
-                    position = GetNextTextPosition(This.Selection.Start, null /* limit */, direction, out character);
+                    position = GetNextTextPosition(This.Selection.Start, limit: null, direction, out character);
                 }
                 else
                 {
@@ -89,12 +89,12 @@ namespace System.Windows.Documents
                     if (position == null)
                     {
                         direction = LogicalDirection.Backward;
-                        position = GetNextTextPosition(This.Selection.Start, null /* limit */, direction, out character);
+                        position = GetNextTextPosition(This.Selection.Start, limit: null, direction, out character);
                     }
                 }
             }
 
-            return (position == null) ? null : This.Speller.GetError(position, direction, false /* forceEvaluation */);
+            return (position == null) ? null : This.Speller.GetError(position, direction, forceEvaluation: false);
         }
 
         // Worker for TextBox/RichTextBox.GetNextSpellingErrorPosition.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorTables.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorTables.cs
@@ -66,7 +66,7 @@ namespace System.Windows.Documents
             // Execute the command
             if (args.Command == EditingCommands.InsertTable)
             {
-                ((TextSelection)This.Selection).InsertTable(/*rowCount:*/4, /*columnCount:*/4);
+                ((TextSelection)This.Selection).InsertTable(rowCount: 4, columnCount: 4);
             }
             else if (args.Command == EditingCommands.InsertRows)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorTyping.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorTyping.cs
@@ -63,8 +63,8 @@ namespace System.Windows.Documents
             var onQueryStatusNYI = new CanExecuteRoutedEventHandler(OnQueryStatusNYI);
             var onQueryStatusEnterBreak = new CanExecuteRoutedEventHandler(OnQueryStatusEnterBreak);
             
-            EventManager.RegisterClassHandler(controlType, Mouse.MouseMoveEvent, new MouseEventHandler(OnMouseMove), true /* handledEventsToo */);
-            EventManager.RegisterClassHandler(controlType, Mouse.MouseLeaveEvent, new MouseEventHandler(OnMouseLeave), true /* handledEventsToo */);
+            EventManager.RegisterClassHandler(controlType, Mouse.MouseMoveEvent, new MouseEventHandler(OnMouseMove), handledEventsToo: true);
+            EventManager.RegisterClassHandler(controlType, Mouse.MouseLeaveEvent, new MouseEventHandler(OnMouseLeave), handledEventsToo: true);
 
             CommandHelpers.RegisterCommandHandler(controlType, ApplicationCommands.CorrectionList   , new ExecutedRoutedEventHandler(OnCorrectionList)       , new CanExecuteRoutedEventHandler(OnQueryStatusCorrectionList)       , nameof(SR.KeyCorrectionList),   nameof(SR.KeyCorrectionListDisplayString)         );
             CommandHelpers.RegisterCommandHandler(controlType, EditingCommands.ToggleInsert         , new ExecutedRoutedEventHandler(OnToggleInsert)         , onQueryStatusNYI                  , KeyGesture.CreateFromResourceStrings(KeyToggleInsert,     nameof(SR.KeyToggleInsertDisplayString)           ));
@@ -393,7 +393,7 @@ namespace System.Windows.Documents
                 // We'll delay the event handling, batching it up with other
                 // input if layout is too slow to keep up with the input stream.
                 KeyboardDevice keyboard = e.Device as KeyboardDevice;
-                TextEditorTyping.ScheduleInput(This, new TextInputItem(This, e.Text, /*isInsertKeyToggled:*/keyboard != null ? keyboard.IsKeyToggled(Key.Insert) : false));
+                TextEditorTyping.ScheduleInput(This, new TextInputItem(This, e.Text, isInsertKeyToggled: keyboard != null ? keyboard.IsKeyToggled(Key.Insert) : false));
             }
         }
 
@@ -428,7 +428,7 @@ namespace System.Windows.Documents
             if (This.TextStore != null)
             {
                 // Don't do actual reconversion, it just checks if the current selection is reconvertable.
-                args.CanExecute = This.TextStore.QueryRangeOrReconvertSelection( /*fDoReconvert:*/ false);
+                args.CanExecute = This.TextStore.QueryRangeOrReconvertSelection( fDoReconvert: false);
             }
             else
             {
@@ -449,7 +449,7 @@ namespace System.Windows.Documents
                 return;
             }
 
-            This.TextStore?.QueryRangeOrReconvertSelection( /*fDoReconvert:*/ true);
+            This.TextStore?.QueryRangeOrReconvertSelection( fDoReconvert: true);
         }
 
         /// <summary>
@@ -600,7 +600,7 @@ namespace System.Windows.Documents
                         TextRangeEditLists.ConvertListItemsToParagraphs((TextRange)This.Selection);
                     }
                     else if (This.AcceptsRichContent &&
-                             (IsAtListItemChildStart(position, false /* emptyChildOnly */) || IsAtIndentedParagraphOrBlockUIContainerStart(This.Selection.Start)))
+                             (IsAtListItemChildStart(position, emptyChildOnly: false) || IsAtIndentedParagraphOrBlockUIContainerStart(This.Selection.Start)))
                     {
                         // Unindent the list by one level.
                         TextEditorLists.DecreaseIndentation(This);
@@ -711,7 +711,7 @@ namespace System.Windows.Documents
                 // because we want to appear close to previous character.
                 // However, we do not allow to stop at end of line.
                 // We alow to stop next to space - to be consistent with typing behavior.
-                This.Selection.SetCaretToPosition(position, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/true);
+                This.Selection.SetCaretToPosition(position, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: true);
             }
         }
 
@@ -759,7 +759,7 @@ namespace System.Windows.Documents
             }
 
             // Set caret position.
-            This.Selection.SetCaretToPosition(deletePosition, directionOfDelete, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/true);
+            This.Selection.SetCaretToPosition(deletePosition, directionOfDelete, allowStopAtLineEnd: false, allowStopNearSpace: true);
 
             if (directionOfDelete == LogicalDirection.Backward)
             {
@@ -1069,7 +1069,7 @@ namespace System.Windows.Documents
                 if (wasSelectionChanged)
                 {
                     // Position the caret.
-                    This.Selection.SetCaretToPosition(This.Selection.End, LogicalDirection.Forward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                    This.Selection.SetCaretToPosition(This.Selection.End, LogicalDirection.Forward, allowStopAtLineEnd: false, allowStopNearSpace: false);
 
                     // Forget previously suggested horizontal position
                     TextEditorSelection._ClearSuggestedX(This);
@@ -1109,7 +1109,7 @@ namespace System.Windows.Documents
                     }
                     else
                     {
-                        newEnd = TextRangeEdit.InsertParagraphBreak(newEnd, /*moveIntoSecondParagraph*/true);
+                        newEnd = TextRangeEdit.InsertParagraphBreak(newEnd, moveIntoSecondParagraph: true);
                     }
                 }
                 else if (command == EditingCommands.EnterLineBreak)
@@ -1160,10 +1160,10 @@ namespace System.Windows.Documents
             {
                 // For both ParagraphBreak and LineBreak commands, insert a new row after the current one
                 TextRange range = ((TextSelection)This.Selection).InsertRows(+1);
-                This.Selection.SetCaretToPosition(range.Start, LogicalDirection.Forward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                This.Selection.SetCaretToPosition(range.Start, LogicalDirection.Forward, allowStopAtLineEnd: false, allowStopNearSpace: false);
             }
             else if (This.Selection.IsEmpty &&
-                     (TextPointerBase.IsInEmptyListItem(position) || IsAtListItemChildStart(position, true /* emptyChildOnly */)) &&
+                     (TextPointerBase.IsInEmptyListItem(position) || IsAtListItemChildStart(position, emptyChildOnly: true)) &&
                      command == EditingCommands.EnterParagraphBreak)
             {
                 // Unindent the list by one level.
@@ -1213,7 +1213,7 @@ namespace System.Windows.Documents
                     if (This.AcceptsRichContent && (This.Selection is TextSelection))
                     {
                         // NOTE: We do not call OnApplyProperty to avoid recursion for FlushPendingInput
-                        ((TextSelection)This.Selection).ApplyPropertyValue(FlowDocument.FlowDirectionProperty, FlowDirection.LeftToRight, /*applyToParagraphs*/true);
+                        ((TextSelection)This.Selection).ApplyPropertyValue(FlowDocument.FlowDirectionProperty, FlowDirection.LeftToRight, applyToParagraphs: true);
                     }
                     else
                     {
@@ -1229,7 +1229,7 @@ namespace System.Windows.Documents
                     if (This.AcceptsRichContent && (This.Selection is TextSelection))
                     {
                         // NOTE: We do not call OnApplyProperty to avoid recursion for FlushPendingInput
-                        ((TextSelection)This.Selection).ApplyPropertyValue(FlowDocument.FlowDirectionProperty, FlowDirection.RightToLeft, /*applyToParagraphs*/true);
+                        ((TextSelection)This.Selection).ApplyPropertyValue(FlowDocument.FlowDirectionProperty, FlowDirection.RightToLeft, applyToParagraphs: true);
                     }
                     else
                     {
@@ -1276,7 +1276,7 @@ namespace System.Windows.Documents
 
             This.TextView?.ThrottleBackgroundTasksForUserInput();
 
-            ScheduleInput(This, new TextInputItem(This, " ", /*isInsertKeyToggled:*/!This._OvertypeMode));
+            ScheduleInput(This, new TextInputItem(This, " ", isInsertKeyToggled: !This._OvertypeMode));
         }
 
         // ...........................................................................
@@ -1344,7 +1344,7 @@ namespace System.Windows.Documents
             else
             {
                 // In plain text we treat tab as a characters always
-                DoTextInput(This, "\t", /*isInsertKeyToggled:*/!This._OvertypeMode, /*acceptControlCharacters:*/true);
+                DoTextInput(This, "\t", isInsertKeyToggled: !This._OvertypeMode, acceptControlCharacters: true);
             }
         }
 
@@ -1376,7 +1376,7 @@ namespace System.Windows.Documents
             else
             {
                 // In plain text we treat tab as a characters always
-                DoTextInput(This, "\t", /*isInsertKeyToggled:*/!This._OvertypeMode, /*acceptControlCharacters:*/true);
+                DoTextInput(This, "\t", isInsertKeyToggled: !This._OvertypeMode, acceptControlCharacters: true);
             }
         }
 
@@ -1393,7 +1393,7 @@ namespace System.Windows.Documents
             {
                 // When table cell range is selected, Tab simply collapses
                 // a selection to a content of a first cell
-                This.Selection.SetCaretToPosition(This.Selection.Start, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                This.Selection.SetCaretToPosition(This.Selection.Start, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: false);
                 return true;
             }
 
@@ -1544,7 +1544,7 @@ namespace System.Windows.Documents
                     ITextPointer caretPosition = This.Selection.End.CreatePointer(LogicalDirection.Backward);
 
                     // Set selection at the end of input content
-                    This.Selection.SetCaretToPosition(caretPosition, LogicalDirection.Backward, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                    This.Selection.SetCaretToPosition(caretPosition, LogicalDirection.Backward, allowStopAtLineEnd: true, allowStopNearSpace: true);
                     // Note: Using explicit backward orientation we keep formatting with
                     // a previous character during typing.
 
@@ -1704,7 +1704,7 @@ namespace System.Windows.Documents
                     return;
                 }
 
-                DoTextInput(TextEditor, _text, _isInsertKeyToggled, /*acceptControlCharacters:*/false);
+                DoTextInput(TextEditor, _text, _isInsertKeyToggled, acceptControlCharacters: false);
             }
 
             // Text to input.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElement.cs
@@ -793,7 +793,7 @@ namespace System.Windows.Documents
 
             if (te != null)
             {
-                TextSchema.ValidateChild(/*parent:*/this, /*child:*/te, true /* throwIfIllegalChild */, true /* throwIfIllegalHyperlinkDescendent */);
+                TextSchema.ValidateChild(parent: this, child: te, throwIfIllegalChild: true, throwIfIllegalHyperlinkDescendent: true);
                 Append(te);
             }
             else
@@ -825,7 +825,7 @@ namespace System.Windows.Documents
                         }
                         else
                         {
-                            if (TextSchema.IsValidChild(/*parent:*/this, /*childType:*/typeof(InlineUIContainer)))
+                            if (TextSchema.IsValidChild(parent: this, childType: typeof(InlineUIContainer)))
                             {
                                 // Create implicit InlineUIContainer wrapper for this UIElement
                                 InlineUIContainer implicitInlineUIContainer = Inline.CreateImplicitInlineUIContainer(this);
@@ -859,14 +859,14 @@ namespace System.Windows.Documents
 
             // Check if text run is allowed in this element,
             // and create implicit Run if possible.
-            if (TextSchema.IsValidChild(/*parent:*/this, /*childType:*/typeof(string)))
+            if (TextSchema.IsValidChild(parent: this, childType: typeof(string)))
             {
                 Append(text);
             }
             else
             {
                 // Implicit Run creation
-                if (TextSchema.IsValidChild(/*parent:*/this, /*childType:*/typeof(Run)))
+                if (TextSchema.IsValidChild(parent: this, childType: typeof(Run)))
                 {
                     // NOTE: Do not use new Run(text) constructor to avoid TextContainer creation
                     // which would hit parser perf
@@ -1552,7 +1552,7 @@ namespace System.Windows.Documents
             }
             else
             {
-                tree = new TextContainer(null, false /* plainTextOnly */);
+                tree = new TextContainer(null, plainTextOnly: false);
                 start = tree.Start;
 
                 tree.BeginChange();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElementCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElementCollection.cs
@@ -440,7 +440,7 @@ namespace System.Windows.Documents
 
         int IList.IndexOf(object value)
         {
-            return IndexOfInternal(value, false /* isCacheSafePreviousIndex */);
+            return IndexOfInternal(value, isCacheSafePreviousIndex: false);
         }
 
         void IList.Insert(int index, object value)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextFindEngine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextFindEngine.cs
@@ -338,7 +338,7 @@ namespace System.Windows.Documents
                                 nextPosition,
                                 position.CreatePointer() /* need unfrozen pointer */,
                                 LogicalDirection.Forward,
-                                false /* matchLast */,
+                                matchLast: false,
                                 findText,
                                 findTextPositionMap);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextPointer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextPointer.cs
@@ -1437,7 +1437,7 @@ namespace System.Windows.Documents
             _tree.BeginChange();
             try
             {
-                position = TextRangeEdit.InsertParagraphBreak(this, /*moveIntoSecondParagraph:*/true);
+                position = TextRangeEdit.InsertParagraphBreak(this, moveIntoSecondParagraph: true);
             }
             finally
             {
@@ -3538,7 +3538,7 @@ namespace System.Windows.Documents
             TextPointer position = this;
 
             // Check for hyperlink schema validity first -- we'll throw on an illegal Hyperlink descendent insert.
-            bool isValidChild = TextSchema.ValidateChild(position, /*childType*/inline.GetType(), false /* throwIfIllegalChild */, true /* throwIfIllegalHyperlinkDescendent */);
+            bool isValidChild = TextSchema.ValidateChild(position, /*childType*/inline.GetType(), throwIfIllegalChild: false, throwIfIllegalHyperlinkDescendent: true);
 
             // Now, it is safe to assume that !isValidChild will be the case of incomplete content.
             if (!isValidChild)
@@ -3562,7 +3562,7 @@ namespace System.Windows.Documents
                 else
                 {
                     // Position is parented by Run, split formatting elements to prepare for inserting inline at this position.
-                    position = TextRangeEdit.SplitFormattingElement(position, /*keepEmptyFormatting:*/false);
+                    position = TextRangeEdit.SplitFormattingElement(position, keepEmptyFormatting: false);
                 }
 
                 Invariant.Assert(TextSchema.IsValidChild(position, /*childType*/inline.GetType()));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextPointer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextPointer.cs
@@ -3538,7 +3538,7 @@ namespace System.Windows.Documents
             TextPointer position = this;
 
             // Check for hyperlink schema validity first -- we'll throw on an illegal Hyperlink descendent insert.
-            bool isValidChild = TextSchema.ValidateChild(position, /*childType*/inline.GetType(), throwIfIllegalChild: false, throwIfIllegalHyperlinkDescendent: true);
+            bool isValidChild = TextSchema.ValidateChild(position, childType: inline.GetType(), throwIfIllegalChild: false, throwIfIllegalHyperlinkDescendent: true);
 
             // Now, it is safe to assume that !isValidChild will be the case of incomplete content.
             if (!isValidChild)
@@ -3565,7 +3565,7 @@ namespace System.Windows.Documents
                     position = TextRangeEdit.SplitFormattingElement(position, keepEmptyFormatting: false);
                 }
 
-                Invariant.Assert(TextSchema.IsValidChild(position, /*childType*/inline.GetType()));
+                Invariant.Assert(TextSchema.IsValidChild(position, childType: inline.GetType()));
             }
 
             inline.RepositionWithContent(position);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextPointerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextPointerBase.cs
@@ -177,7 +177,7 @@ namespace System.Windows.Documents
         {
             Invariant.Assert(backwardPosition.HasEqualScope(forwardPosition));
 
-            if (TextSchema.IsValidChild(position: backwardPosition, /*childType*/typeof(Run)))
+            if (TextSchema.IsValidChild(position: backwardPosition, childType: typeof(Run)))
             {
                 Type forwardType = forwardPosition.GetElementType(LogicalDirection.Forward);
                 Type backwardType = backwardPosition.GetElementType(LogicalDirection.Backward);
@@ -1303,7 +1303,7 @@ namespace System.Windows.Documents
                 // The inner edge of a Hyperlink is not a valid insertion position.
                 return false;
             }
-            else if (TextSchema.IsValidChild(position: position, /*childType*/typeof(string)))
+            else if (TextSchema.IsValidChild(position: position, childType: typeof(string)))
             {
                 return respectCaretUnitBoundaries ? IsAtCaretUnitBoundary(position) : true;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextPointerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextPointerBase.cs
@@ -119,7 +119,7 @@ namespace System.Windows.Documents
         // IsAtInsertionPosition when only formatting scopes are important.
         internal static bool IsAtFormatNormalizedPosition(ITextPointer position)
         {
-            return IsAtNormalizedPosition(position, false /* respectCaretUnitBoundaries */);
+            return IsAtNormalizedPosition(position, respectCaretUnitBoundaries: false);
         }
 #endif
 
@@ -131,7 +131,7 @@ namespace System.Windows.Documents
         /// </value>
         internal static bool IsAtInsertionPosition(ITextPointer position)
         {
-            return IsAtNormalizedPosition(position, true /* respectCaretUnitBoundaries */);
+            return IsAtNormalizedPosition(position, respectCaretUnitBoundaries: true);
         }
 
         // Tests if a position is between structural symbols where Run is potentially insertable,
@@ -177,7 +177,7 @@ namespace System.Windows.Documents
         {
             Invariant.Assert(backwardPosition.HasEqualScope(forwardPosition));
 
-            if (TextSchema.IsValidChild(/*position*/backwardPosition, /*childType*/typeof(Run)))
+            if (TextSchema.IsValidChild(position: backwardPosition, /*childType*/typeof(Run)))
             {
                 Type forwardType = forwardPosition.GetElementType(LogicalDirection.Forward);
                 Type backwardType = backwardPosition.GetElementType(LogicalDirection.Backward);
@@ -401,12 +401,12 @@ namespace System.Windows.Documents
 
         internal static bool IsAtFormatNormalizedPosition(ITextPointer position, LogicalDirection direction)
         {
-            return IsAtNormalizedPosition(position, direction, false /* respectCaretUnitBoundaries */);
+            return IsAtNormalizedPosition(position, direction, respectCaretUnitBoundaries: false);
         }
 
         internal static bool IsAtInsertionPosition(ITextPointer position, LogicalDirection direction)
         {
-            return IsAtNormalizedPosition(position, direction, true /* respectCaretUnitBoundaries */);
+            return IsAtNormalizedPosition(position, direction, respectCaretUnitBoundaries: true);
         }
 
         internal static bool IsAtNormalizedPosition(ITextPointer position, LogicalDirection direction, bool respectCaretUnitBoundaries)
@@ -542,7 +542,7 @@ namespace System.Windows.Documents
 
             // Find the corresponding word start edge.
             ITextPointer wordStart;
-            if (moved && IsAtWordBoundary(thisPosition, /*insideWordDirection:*/LogicalDirection.Forward))
+            if (moved && IsAtWordBoundary(thisPosition, insideWordDirection: LogicalDirection.Forward))
             {
                 wordStart = thisPosition;
             }
@@ -619,7 +619,7 @@ namespace System.Windows.Documents
         internal static bool IsNextToPlainLineBreak(ITextPointer thisPosition, LogicalDirection direction)
         {
             char[] textBuffer = new char[2];
-            int actualCount = thisPosition.GetTextInRun(direction, textBuffer, /*startIndex:*/0, /*count:*/2);
+            int actualCount = thisPosition.GetTextInRun(direction, textBuffer, startIndex: 0, count: 2);
 
             return
                 (actualCount == 1 && IsCharUnicodeNewLine(textBuffer[0]))
@@ -795,7 +795,7 @@ namespace System.Windows.Documents
         //resulting in infinite loops, no line navigation etc.
         internal static int MoveToLineBoundary(ITextPointer thisPointer, ITextView textView, int count)
         {
-            return MoveToLineBoundary(thisPointer, textView, count, false /* respectNonMeargeableInlineStart */);
+            return MoveToLineBoundary(thisPointer, textView, count, respectNonMeargeableInlineStart: false);
         }
 
         // <see cref="System.Windows.Documents.TextPointer.MoveToLineBoundary"/>
@@ -853,7 +853,7 @@ namespace System.Windows.Documents
 
         internal static Rect GetCharacterRect(ITextPointer thisPointer, LogicalDirection direction)
         {
-            return GetCharacterRect(thisPointer, direction, /*transformToUiScope*/true);
+            return GetCharacterRect(thisPointer, direction, transformToUiScope: true);
         }
 
         // <see cref="TextPointer.GetCharacterRect"/>
@@ -894,7 +894,7 @@ namespace System.Windows.Documents
                 }
                 else if (thisPointer.TextContainer.Parent is Visual)
                 {
-                    Invariant.Assert(textView.RenderScope == thisPointer.TextContainer.Parent || ((Visual)thisPointer.TextContainer.Parent).IsAncestorOf( /*descendant:*/textView.RenderScope),
+                    Invariant.Assert(textView.RenderScope == thisPointer.TextContainer.Parent || ((Visual)thisPointer.TextContainer.Parent).IsAncestorOf( descendant: textView.RenderScope),
                         "Unexpected location of RenderScope within visual tree");
                     templatedParent = (Visual)thisPointer.TextContainer.Parent;
                 }
@@ -903,10 +903,10 @@ namespace System.Windows.Documents
                     templatedParent = null;
                 }
 
-                if (templatedParent != null && templatedParent.IsAncestorOf( /*descendant:*/textView.RenderScope))
+                if (templatedParent != null && templatedParent.IsAncestorOf( descendant: textView.RenderScope))
                 {
                     // translate the rect from renderscope to uiscope coordinate system (from FlowDocumentView to RichTextBox)
-                    GeneralTransform transformFromRenderToUiScope = textView.RenderScope.TransformToAncestor(/*ancestor:*/templatedParent);
+                    GeneralTransform transformFromRenderToUiScope = textView.RenderScope.TransformToAncestor(ancestor: templatedParent);
 
                     rect = transformFromRenderToUiScope.TransformBounds(rect);
                 }
@@ -920,7 +920,7 @@ namespace System.Windows.Documents
         // MoveToNextInsertionPosition when only formatting scopes are important.
         internal static bool MoveToFormatNormalizedPosition(ITextPointer thisNavigator, LogicalDirection direction)
         {
-            return NormalizePosition(thisNavigator, direction, false /* respectCaretUnitBoundaries */);
+            return NormalizePosition(thisNavigator, direction, respectCaretUnitBoundaries: false);
         }
 
         /// <summary>
@@ -933,7 +933,7 @@ namespace System.Windows.Documents
         /// </summary>
         internal static bool MoveToInsertionPosition(ITextPointer thisNavigator, LogicalDirection direction)
         {
-            return NormalizePosition(thisNavigator, direction, true /* respectCaretUnitBoundaries */);
+            return NormalizePosition(thisNavigator, direction, respectCaretUnitBoundaries: true);
         }
 
         /// <summary>
@@ -1083,7 +1083,7 @@ namespace System.Windows.Documents
                     break;
                 }
 
-                if (IsAtWordBoundary(thisNavigator, /*insideWordDirection:*/LogicalDirection.Forward))
+                if (IsAtWordBoundary(thisNavigator, insideWordDirection: LogicalDirection.Forward))
                 {
                     // Note that we always use Forward direction for word orientation.
                     break;
@@ -1303,7 +1303,7 @@ namespace System.Windows.Documents
                 // The inner edge of a Hyperlink is not a valid insertion position.
                 return false;
             }
-            else if (TextSchema.IsValidChild(/*position*/position, /*childType*/typeof(string)))
+            else if (TextSchema.IsValidChild(position: position, /*childType*/typeof(string)))
             {
                 return respectCaretUnitBoundaries ? IsAtCaretUnitBoundary(position) : true;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRange.cs
@@ -54,7 +54,7 @@ namespace System.Windows.Documents
         }
 
         internal TextRange(ITextPointer position1, ITextPointer position2)
-            : this(position1, position2, false /* ignoreTextUnitBoundaries */)
+            : this(position1, position2, ignoreTextUnitBoundaries: false)
         {
         }
 
@@ -242,7 +242,7 @@ namespace System.Windows.Documents
         {
             // ATTENTION: This implementation *must* be pure redirect to TextRangeBase. Otherwise TextSelection extensibility is broken
             // DO NOT ANY CODE IN THIS METHOD!
-            TextRangeBase.EndChange(this, false /* disableScroll */, false /* skipEvents */);
+            TextRangeBase.EndChange(this, disableScroll: false, skipEvents: false);
         }
 
         /// <summary>
@@ -260,7 +260,7 @@ namespace System.Windows.Documents
         /// </summary>
         IDisposable ITextRange.DeclareChangeBlock()
         {
-            return new ChangeBlock(this, false /* disableScroll */);
+            return new ChangeBlock(this, disableScroll: false);
         }
 
         /// <summary>
@@ -729,7 +729,7 @@ namespace System.Windows.Documents
         /// </remarks>
         public void ApplyPropertyValue(DependencyProperty formattingProperty, object value)
         {
-            this.ApplyPropertyValue(formattingProperty, value, /*applyToParagraphs*/false, PropertyValueAction.SetValue);
+            this.ApplyPropertyValue(formattingProperty, value, applyToParagraphs: false, PropertyValueAction.SetValue);
         }
 
         /// <summary>
@@ -1599,7 +1599,7 @@ namespace System.Windows.Documents
                     {
                         // Use InlineUIContainer
                         InlineUIContainer inlineUIContainer = new InlineUIContainer(embeddedElement);
-                        TextPointer insertionPosition = TextRangeEdit.SplitFormattingElements(this.Start, /*keepEmptyFormatting:*/false);
+                        TextPointer insertionPosition = TextRangeEdit.SplitFormattingElements(this.Start, keepEmptyFormatting: false);
                         insertionPosition.InsertTextElement(inlineUIContainer);
                         this.Select(inlineUIContainer.ElementStart, inlineUIContainer.ElementEnd);
                     }
@@ -1847,7 +1847,7 @@ namespace System.Windows.Documents
 
             void IDisposable.Dispose()
             {
-                _range.EndChange(_disableScroll, false /* skipEvents */);
+                _range.EndChange(_disableScroll, skipEvents: false);
                 GC.SuppressFinalize(this);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeBase.cs
@@ -112,7 +112,7 @@ namespace System.Windows.Documents
         /// </param>
         internal static void Select(ITextRange thisRange, ITextPointer position1, ITextPointer position2)
         {
-            Select(thisRange, position1, position2, /*includeCellAtMovingPosition:*/false);
+            Select(thisRange, position1, position2, includeCellAtMovingPosition: false);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace System.Windows.Documents
             {
                 // This is initializing call from TextRange constructor.
                 // No need in change notifications, no need in position verification.
-                TextRangeBase.SelectPrivate(thisRange, position1, position2, includeCellAtMovingPosition, /*markRangeChanged*/false);
+                TextRangeBase.SelectPrivate(thisRange, position1, position2, includeCellAtMovingPosition, markRangeChanged: false);
             }
             else
             {
@@ -165,7 +165,7 @@ namespace System.Windows.Documents
                 TextRangeBase.BeginChange(thisRange);
                 try
                 {
-                    TextRangeBase.SelectPrivate(thisRange, position1, position2, includeCellAtMovingPosition, /*markRangeChanged*/true);
+                    TextRangeBase.SelectPrivate(thisRange, position1, position2, includeCellAtMovingPosition, markRangeChanged: true);
                 }
                 finally
                 {
@@ -557,7 +557,7 @@ namespace System.Windows.Documents
         /// </summary>
         internal static void EndChange(ITextRange thisRange)
         {
-            EndChange(thisRange, false /* disableScroll */, false /* skipEvents */ );
+            EndChange(thisRange, disableScroll: false, skipEvents: false);
         }
 
         /// <summary>
@@ -1354,7 +1354,7 @@ namespace System.Windows.Documents
                     // Store the fact that implicit paragraph was inserted to exclude ane extra paragraph break
                     // from the end of pasted fragment
                     bool implicitParagraphInserted = insertPosition is TextPointer &&
-                        TextSchema.IsValidChild(/*position*/insertPosition, /*childType*/typeof(Block)) &&
+                        TextSchema.IsValidChild(position: insertPosition, /*childType*/typeof(Block)) &&
                         (insertPosition.GetPointerContext(LogicalDirection.Backward) == TextPointerContext.None ||
                         insertPosition.GetPointerContext(LogicalDirection.Backward) == TextPointerContext.ElementStart) &&
                         (insertPosition.GetPointerContext(LogicalDirection.Forward) == TextPointerContext.None ||
@@ -1444,7 +1444,7 @@ namespace System.Windows.Documents
                     }
 
                     // Select the range
-                    TextRangeBase.SelectPrivate(thisRange, newStart, newEnd, /*includeCellAtMovingPosition:*/false, /*markRangeChanged*/true);
+                    TextRangeBase.SelectPrivate(thisRange, newStart, newEnd, includeCellAtMovingPosition: false, markRangeChanged: true);
                 }
             }
             finally
@@ -1461,7 +1461,7 @@ namespace System.Windows.Documents
             StringWriter stringWriter = new StringWriter(CultureInfo.InvariantCulture);
             XmlTextWriter xmlWriter = new XmlTextWriter(stringWriter);
 
-            TextRangeSerialization.WriteXaml(xmlWriter, thisRange, /*useFlowDocumentAsRoot:*/false, /*wpfPayload:*/null);
+            TextRangeSerialization.WriteXaml(xmlWriter, thisRange, useFlowDocumentAsRoot: false, wpfPayload: null);
 
             return stringWriter.ToString();
         }
@@ -1512,21 +1512,21 @@ namespace System.Windows.Documents
                 XmlTextWriter xamlXmlWriter = new XmlTextWriter(xamlStreamWriter);
                 // Passing null as wpfPayload parameter we request to produce
                 // xaml without images - all of them will be repllaced by whitespaces.
-                TextRangeSerialization.WriteXaml(xamlXmlWriter, thisRange, /*useFlowDocumentAsRoot:*/false, /*wpfPayload:*/null, preserveTextElements);
+                TextRangeSerialization.WriteXaml(xamlXmlWriter, thisRange, useFlowDocumentAsRoot: false, wpfPayload: null, preserveTextElements);
                 xamlXmlWriter.Flush();
             }
             else if (dataFormat == DataFormats.XamlPackage)
             {
                 // Non-null stream here means unconditional request to create a WPF package for the range
                 // independently whether there are images in it or not.
-                WpfPayload.SaveRange(thisRange, ref stream, /*useFlowDocumentAsRoot:*/false, preserveTextElements);
+                WpfPayload.SaveRange(thisRange, ref stream, useFlowDocumentAsRoot: false, preserveTextElements);
             }
             else if (dataFormat == DataFormats.Rtf)
             {
                 Stream wpfPayloadMemory = null;
                 // Passing null as a wpfPayloadStream we allow to not create wpf package
                 // when it is not needed (there is no images in the range)
-                string xamlText = WpfPayload.SaveRange(thisRange, ref wpfPayloadMemory, /*useFlowDocumentAsRoot:*/false);
+                string xamlText = WpfPayload.SaveRange(thisRange, ref wpfPayloadMemory, useFlowDocumentAsRoot: false);
                 // Convert xaml to rtf text to set rtf data into data object.
                 string rtfText = TextEditorCopyPaste.ConvertXamlToRtf(xamlText, wpfPayloadMemory);
                 StreamWriter rtfStreamWriter = new StreamWriter(stream);
@@ -1927,7 +1927,7 @@ namespace System.Windows.Documents
 
                 // We cannot open a change block here (even though the content of thisRange may change),
                 // because it will cause another normalization request, leading to stack overflow.
-                SelectPrivate(thisRange, start, end, /*includeCellAtMovingPosition:*/false, /*markRangeChanged*/false);
+                SelectPrivate(thisRange, start, end, includeCellAtMovingPosition: false, markRangeChanged: false);
             }
             else
             {
@@ -1989,8 +1989,8 @@ namespace System.Windows.Documents
             if (position1 is TextPointer)
             {
                 textSegments = TextRangeEditTables.BuildTableRange(
-                    /*anchorPosition:*/(TextPointer)position1, 
-                    /*movingPosition:*/(TextPointer)position2, 
+                    anchorPosition: (TextPointer)position1, 
+                    movingPosition: (TextPointer)position2, 
                     includeCellAtMovingPosition, 
                     out isTableCellRange);
             }
@@ -2046,9 +2046,9 @@ namespace System.Windows.Documents
                         // position1/position2.
                         // Note: we use includeCellAtMovingPosition=false here because the movingPosition is taken from a constructed table range, not from input
                         textSegments = TextRangeEditTables.BuildTableRange(
-                            /*anchorPosition:*/(TextPointer)finalStart, 
-                            /*movingPosition:*/(TextPointer)finalEnd, 
-                            /*includeCellAtMovingPosition:*/false, 
+                            anchorPosition: (TextPointer)finalStart, 
+                            movingPosition: (TextPointer)finalEnd, 
+                            includeCellAtMovingPosition: false, 
                             out isTableCellRange);
                         if (textSegments != null)
                         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeBase.cs
@@ -1354,7 +1354,7 @@ namespace System.Windows.Documents
                     // Store the fact that implicit paragraph was inserted to exclude ane extra paragraph break
                     // from the end of pasted fragment
                     bool implicitParagraphInserted = insertPosition is TextPointer &&
-                        TextSchema.IsValidChild(position: insertPosition, /*childType*/typeof(Block)) &&
+                        TextSchema.IsValidChild(position: insertPosition, childType: typeof(Block)) &&
                         (insertPosition.GetPointerContext(LogicalDirection.Backward) == TextPointerContext.None ||
                         insertPosition.GetPointerContext(LogicalDirection.Backward) == TextPointerContext.ElementStart) &&
                         (insertPosition.GetPointerContext(LogicalDirection.Forward) == TextPointerContext.None ||

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeEdit.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeEdit.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Documents
 
         internal static TextPointer SplitFormattingElements(TextPointer splitPosition, bool keepEmptyFormatting)
         {
-            return SplitFormattingElements(splitPosition, keepEmptyFormatting, /*limitingAncestor*/null);
+            return SplitFormattingElements(splitPosition, keepEmptyFormatting, limitingAncestor: null);
         }
 
         internal static TextPointer SplitFormattingElement(TextPointer splitPosition, bool keepEmptyFormatting)
@@ -409,8 +409,8 @@ namespace System.Windows.Documents
             if (start.CompareTo(end) < 0)
             {
                 // Split formatting elements at range boundaries
-                start = SplitFormattingElements(start, /*keepEmptyFormatting:*/false, /*preserveStructuralFormatting*/true, /*limitingAncestor*/null);
-                end = SplitFormattingElements(end, /*keepEmptyFormatting:*/false, /*preserveStructuralFormatting*/true, /*limitingAncestor*/null);
+                start = SplitFormattingElements(start, keepEmptyFormatting: false, preserveStructuralFormatting: true, limitingAncestor: null);
+                end = SplitFormattingElements(end, keepEmptyFormatting: false, preserveStructuralFormatting: true, limitingAncestor: null);
 
                 while (start.CompareTo(end) < 0)
                 {
@@ -633,7 +633,7 @@ namespace System.Windows.Documents
             TextPointer breakPosition = position;
 
             // Split all inline elements up to this paragraph
-            breakPosition = SplitFormattingElements(breakPosition, /*keepEmptyFormatting:*/true);
+            breakPosition = SplitFormattingElements(breakPosition, keepEmptyFormatting: true);
             Invariant.Assert(breakPosition.Parent == paragraph, "breakPosition must be in paragraph scope after splitting formatting elements");
 
             // Decide whether we need to split ListItem around this paragraph (if any).
@@ -677,7 +677,7 @@ namespace System.Windows.Documents
         /// </returns>
         internal static TextPointer InsertLineBreak(TextPointer position)
         {
-            if (!TextSchema.IsValidChild(/*position*/position, /*childType*/typeof(LineBreak)))
+            if (!TextSchema.IsValidChild(position: position, /*childType*/typeof(LineBreak)))
             {
                 // Ensure insertion position, in case position's parent is not a paragraph/span element.
                 position = TextRangeEditTables.EnsureInsertionPosition(position);
@@ -689,7 +689,7 @@ namespace System.Windows.Documents
                 position = SplitElement(position);
             }
 
-            Invariant.Assert(TextSchema.IsValidChild(/*position*/position, /*childType*/typeof(LineBreak)), 
+            Invariant.Assert(TextSchema.IsValidChild(position: position, /*childType*/typeof(LineBreak)), 
                 "position must be in valid scope now to insert a LineBreak element");
 
             LineBreak lineBreak = new LineBreak();
@@ -1232,9 +1232,9 @@ namespace System.Windows.Documents
                     // Swap left and right values
                     object newValue = new Thickness(
                         /*left*/((Thickness)value).Right, 
-                        /*top:*/((Thickness)value).Top,
-                        /*right:*/((Thickness)value).Left, 
-                        /*bottom:*/((Thickness)value).Bottom);
+                        top: ((Thickness)value).Top,
+                        right: ((Thickness)value).Left, 
+                        bottom: ((Thickness)value).Bottom);
 
                     SetPropertyValue(block, Block.MarginProperty, value, newValue);
                 }
@@ -1714,7 +1714,7 @@ namespace System.Windows.Documents
 
         private static TextPointer SplitFormattingElements(TextPointer splitPosition, bool keepEmptyFormatting, TextElement limitingAncestor)
         {
-            return SplitFormattingElements(splitPosition, keepEmptyFormatting, /*preserveStructuralFormatting*/false, limitingAncestor);
+            return SplitFormattingElements(splitPosition, keepEmptyFormatting, preserveStructuralFormatting: false, limitingAncestor);
         }
 
         /// <summary>
@@ -1869,8 +1869,8 @@ namespace System.Windows.Documents
         private static void SetNonStructuralInlineProperty(TextPointer start, TextPointer end, DependencyProperty formattingProperty, object value, PropertyValueAction propertyValueAction)
         {
             // Split formatting elements at range boundaries
-            start = SplitFormattingElements(start, /*keepEmptyFormatting:*/false, /*preserveStructuralFormatting*/true, /*limitingAncestor*/null);
-            end = SplitFormattingElements(end, /*keepEmptyFormatting:*/false, /*preserveStructuralFormatting*/true, /*limitingAncestor*/null);
+            start = SplitFormattingElements(start, keepEmptyFormatting: false, preserveStructuralFormatting: true, limitingAncestor: null);
+            end = SplitFormattingElements(end, keepEmptyFormatting: false, preserveStructuralFormatting: true, limitingAncestor: null);
 
             Run run = TextRangeEdit.GetNextRun(start, end);
 
@@ -2047,8 +2047,8 @@ namespace System.Windows.Documents
             if (conflictingParent != null)
             {
                 TextElement limit = (TextElement)conflictingParent.Parent;
-                SplitFormattingElements(child.ElementStart, /*keepEmptyFormatting*/false, limit);
-                TextPointer end = SplitFormattingElements(child.ElementEnd, /*keepEmptyFormatting*/false, limit);
+                SplitFormattingElements(child.ElementStart, keepEmptyFormatting: false, limit);
+                TextPointer end = SplitFormattingElements(child.ElementEnd, keepEmptyFormatting: false, limit);
 
                 Span parent = (Span)end.GetAdjacentElement(LogicalDirection.Backward);
 
@@ -2143,8 +2143,8 @@ namespace System.Windows.Documents
             else
             {
                 // Split elements at start and end boundaries.
-                start = SplitFormattingElements(start, /*keepEmptyFormatting:*/false, /*limitingAncestor*/run.Parent as TextElement);
-                end = SplitFormattingElements(end, /*keepEmptyFormatting:*/false, /*limitingAncestor*/run.Parent as TextElement);
+                start = SplitFormattingElements(start, keepEmptyFormatting: false, limitingAncestor: run.Parent as TextElement);
+                end = SplitFormattingElements(end, keepEmptyFormatting: false, limitingAncestor: run.Parent as TextElement);
 
                 run = (Run)start.GetAdjacentElement(LogicalDirection.Forward);
                 run.SetValue(formattingProperty, value);
@@ -2156,8 +2156,8 @@ namespace System.Windows.Documents
 
         private static void ApplyStructuralInlinePropertyAcrossInline(TextPointer start, TextPointer end, TextElement commonAncestor, DependencyProperty formattingProperty, object value)
         {
-            start = SplitFormattingElements(start, /*keepEmptyFormatting:*/false, commonAncestor);
-            end = SplitFormattingElements(end, /*keepEmptyFormatting:*/false, commonAncestor);
+            start = SplitFormattingElements(start, keepEmptyFormatting: false, commonAncestor);
+            end = SplitFormattingElements(end, keepEmptyFormatting: false, commonAncestor);
 
             DependencyObject forwardElement = start.GetAdjacentElement(LogicalDirection.Forward);
             DependencyObject backwardElement = end.GetAdjacentElement(LogicalDirection.Backward);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeEdit.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeEdit.cs
@@ -677,7 +677,7 @@ namespace System.Windows.Documents
         /// </returns>
         internal static TextPointer InsertLineBreak(TextPointer position)
         {
-            if (!TextSchema.IsValidChild(position: position, /*childType*/typeof(LineBreak)))
+            if (!TextSchema.IsValidChild(position: position, childType: typeof(LineBreak)))
             {
                 // Ensure insertion position, in case position's parent is not a paragraph/span element.
                 position = TextRangeEditTables.EnsureInsertionPosition(position);
@@ -689,7 +689,7 @@ namespace System.Windows.Documents
                 position = SplitElement(position);
             }
 
-            Invariant.Assert(TextSchema.IsValidChild(position: position, /*childType*/typeof(LineBreak)), 
+            Invariant.Assert(TextSchema.IsValidChild(position: position, childType: typeof(LineBreak)), 
                 "position must be in valid scope now to insert a LineBreak element");
 
             LineBreak lineBreak = new LineBreak();
@@ -1231,7 +1231,7 @@ namespace System.Windows.Documents
                 {
                     // Swap left and right values
                     object newValue = new Thickness(
-                        /*left*/((Thickness)value).Right, 
+                        left: ((Thickness)value).Right, 
                         top: ((Thickness)value).Top,
                         right: ((Thickness)value).Left, 
                         bottom: ((Thickness)value).Bottom);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeEditTables.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeEditTables.cs
@@ -193,7 +193,7 @@ namespace System.Windows.Documents
 
             return IdentifyTableElements((
                 TextPointer)anchorPosition, (TextPointer)movingPosition,
-                /*includeCellAtMovingPosition:*/true,
+                includeCellAtMovingPosition: true,
                 out anchorCell, out movingCell,
                 out anchorRow, out movingRow,
                 out anchorRowGroup, out movingRowGroup,
@@ -436,7 +436,7 @@ namespace System.Windows.Documents
             TableCell anchorCell;
             TableCell movingCell;
             if (TextRangeEditTables.IsTableCellRange(selection.AnchorPosition, (TextPointer)movingPosition,
-                /*includeCellAtMovingPosition:*/false,
+                includeCellAtMovingPosition: false,
                 out anchorCell, out movingCell))
             {
                 // anchorCell is a corner cell of a table where selection has been started.
@@ -687,10 +687,10 @@ namespace System.Windows.Documents
         private static Thickness GetCellBorder(double thickness, int rowIndex, int columnIndex, int rowSpan, int columnSpan, int rowCount, int columnCount)
         {
             return new Thickness(
-                /*left:*/thickness,
-                /*top:*/thickness,
-                /*right:*/columnIndex + columnSpan < columnCount ? 0 : thickness,
-                /*bottom:*/rowIndex + rowSpan < rowCount ? 0 : thickness);
+                left: thickness,
+                top: thickness,
+                right: columnIndex + columnSpan < columnCount ? 0 : thickness,
+                bottom: rowIndex + rowSpan < rowCount ? 0 : thickness);
         }
 
         #endregion Table Insertion
@@ -873,13 +873,13 @@ namespace System.Windows.Documents
             }
 
             TextPointer insertionPosition;
-            if (TextSchema.IsValidChild(/*position:*/position, /*childType:*/typeof(Inline)))
+            if (TextSchema.IsValidChild(position: position, childType: typeof(Inline)))
             {
                 insertionPosition = CreateImplicitRun(position);
             }
             else
             {
-                Invariant.Assert(TextSchema.IsValidChild(/*position:*/position, /*childType:*/typeof(Block)), "Expecting valid parent-child relationship");
+                Invariant.Assert(TextSchema.IsValidChild(position: position, childType: typeof(Block)), "Expecting valid parent-child relationship");
                 insertionPosition = CreateImplicitParagraph(position);
             }
 
@@ -963,8 +963,8 @@ namespace System.Windows.Documents
                 start.CompareTo(end) < 0
                 &&
                 IdentifyTableElements(
-                    /*anchorPosition:*/start, /*movingPosition:*/end,
-                    /*includeCellAtMovingPosition:*/false,
+                    anchorPosition: start, movingPosition: end,
+                    includeCellAtMovingPosition: false,
                     out startCell, out endCell,
                     out startRow, out endRow,
                     out startRowGroup, out endRowGroup,
@@ -974,9 +974,9 @@ namespace System.Windows.Documents
                 {
                     bool isTableCellRange;
                     List<TextSegment> textSegments = TextRangeEditTables.BuildTableRange(
-                        /*anchorPosition:*/start,
-                        /*movingPosition:*/end,
-                        /*includeCellAtMovingPosition*/false,
+                        anchorPosition: start,
+                        movingPosition: end,
+                        includeCellAtMovingPosition: false,
                         out isTableCellRange);
 
                     if (isTableCellRange && textSegments != null)
@@ -1180,7 +1180,7 @@ namespace System.Windows.Documents
                     {
                         // Create new cell and transfer all formatting properties to it from a source cell.
                         // All properties except for RowSpan will be transferred.
-                        AddCellCopy(newRow, currentCell, -1/*negative means at the endPosition*/, /*copyRowSpan:*/false, /*copyColumnSpan:*/true);
+                        AddCellCopy(newRow, currentCell, -1/*negative means at the endPosition*/, copyRowSpan: false, copyColumnSpan: true);
                     }
                 }
 
@@ -1332,7 +1332,7 @@ namespace System.Windows.Documents
                             {
                                 cellIndex++;
                             }
-                            TableCell newCell = AddCellCopy(nextRow, spannedCell, cellIndex, /*copyRowSpan:*/false, /*copyColumnSpan:*/true);
+                            TableCell newCell = AddCellCopy(nextRow, spannedCell, cellIndex, copyRowSpan: false, copyColumnSpan: true);
                             Invariant.Assert(spannedCell.RowSpan - (nextRow.Index - spannedCell.Row.Index) > 0, "expecting: spannedCell.RowSpan - (nextRow.Index - spannedCell.Row.Index) > 0");
                             newCell.ContentStart.TextContainer.SetValue(newCell.ContentStart, TableCell.RowSpanProperty, spannedCell.RowSpan - (nextRow.Index - spannedCell.Row.Index));
                             cellIndex++;
@@ -1439,7 +1439,7 @@ namespace System.Windows.Documents
             TableRowGroup endRowGroup;
             Table startTable;
             Table endTable;
-            if (!IdentifyTableElements(textRange.Start, textRange.End, /*includeCellAtMovingPosition:*/false, out startCell, out endCell, out startRow, out endRow, out startRowGroup, out endRowGroup, out startTable, out endTable))
+            if (!IdentifyTableElements(textRange.Start, textRange.End, includeCellAtMovingPosition: false, out startCell, out endCell, out startRow, out endRow, out startRowGroup, out endRowGroup, out startTable, out endTable))
             {
                 if (textRange.IsTableCellRange)
                 {
@@ -1541,7 +1541,7 @@ namespace System.Windows.Documents
 
             if (!IsTableCellRange(
                 textRange.Start, textRange.End,
-                /*includeCellAtMovingPosition:*/false,
+                includeCellAtMovingPosition: false,
                 out startCell, out endCell))
             {
                 return false;
@@ -1833,7 +1833,7 @@ namespace System.Windows.Documents
             TableRowGroup endRowGroup;
             Table startTable;
             Table endTable;
-            if (!IdentifyTableElements(textRange.Start, textRange.End, /*includeCellAtMovingPosition:*/false, out startCell, out endCell, out startRow, out endRow, out startRowGroup, out endRowGroup, out startTable, out endTable))
+            if (!IdentifyTableElements(textRange.Start, textRange.End, includeCellAtMovingPosition: false, out startCell, out endCell, out startRow, out endRow, out startRowGroup, out endRowGroup, out startTable, out endTable))
             {
                 return null;
             }
@@ -1884,7 +1884,7 @@ namespace System.Windows.Documents
             TableRowGroup endRowGroup;
             Table startTable;
             Table endTable;
-            if (!IdentifyTableElements(textRange.Start, textRange.End, /*includeCellAtMovingPosition:*/false, out startCell, out endCell, out startRow, out endRow, out startRowGroup, out endRowGroup, out startTable, out endTable))
+            if (!IdentifyTableElements(textRange.Start, textRange.End, includeCellAtMovingPosition: false, out startCell, out endCell, out startRow, out endRow, out startRowGroup, out endRowGroup, out startTable, out endTable))
             {
                 return null;
             }
@@ -1921,7 +1921,7 @@ namespace System.Windows.Documents
             // Perform a split horizontally
             while (splitCountHorizontal > 0)
             {
-                AddCellCopy(startCell.Row, startCell, startCellIndex + 1, /*copyRowSpan:*/true, /*copyColumnSpan:*/false);
+                AddCellCopy(startCell.Row, startCell, startCellIndex + 1, copyRowSpan: true, copyColumnSpan: false);
                 startCell.ContentStart.TextContainer.SetValue(startCell.ContentStart, TableCell.ColumnSpanProperty, startCell.ColumnSpan - 1);
                 if (startCell.ColumnSpan == 1)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeSerialization.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeSerialization.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Documents
 
             // Start counting tags needed to be closed.
             // EmptyDocumentDepth==1 - counts FlowDocument opened in WriteRootFlowDocument above.
-            int elementLevel = EmptyDocumentDepth + WriteOpeningTags(range, range.Start, commonAncestor, xmlWriter, xamlTypeMapper, /*reduceElement:*/wpfPayload == null, out ignoreWriteHyperlinkEnd, ref ignoreList, preserveTextElements);
+            int elementLevel = EmptyDocumentDepth + WriteOpeningTags(range, range.Start, commonAncestor, xmlWriter, xamlTypeMapper, reduceElement: wpfPayload == null, out ignoreWriteHyperlinkEnd, ref ignoreList, preserveTextElements);
 
             if (range.IsTableCellRange)
             {
@@ -253,7 +253,7 @@ namespace System.Windows.Documents
 
                         elementLevel++;
                         textReader.MoveToNextContextPosition(LogicalDirection.Forward);
-                        WriteStartXamlElement(/*range:*/null, textReader, xmlWriter, xamlTypeMapper, /*reduceElement:*/wpfPayload == null, preserveTextElements);
+                        WriteStartXamlElement(range: null, textReader, xmlWriter, xamlTypeMapper, reduceElement: wpfPayload == null, preserveTextElements);
 
                         break;
 
@@ -361,7 +361,7 @@ namespace System.Windows.Documents
 
                     ITextRange textRange = new TextRange(textSegment.Start, textSegment.End);
 
-                    elementLevel += WriteOpeningTags(textRange, textSegment.Start, pointer, xmlWriter, xamlTypeMapper, /*reduceElement:*/wpfPayload == null, out ignoreWriteHyperlinkEnd, ref ignoreList, preserveTextElements);
+                    elementLevel += WriteOpeningTags(textRange, textSegment.Start, pointer, xmlWriter, xamlTypeMapper, reduceElement: wpfPayload == null, out ignoreWriteHyperlinkEnd, ref ignoreList, preserveTextElements);
                 }
 
                 // Output the cell segment for one row
@@ -554,7 +554,7 @@ namespace System.Windows.Documents
                     // Note that this condition is consistent with the one in WriteEmbeddedObject -
                     // so that when we reduce the element type fromm UIContainer to Run/Paragraph
                     // we also output just a space instead of the embedded object conntained in it.
-                    elementTypeStandardized = TextSchema.GetStandardElementType(elementType, /*reduceElement:*/true);
+                    elementTypeStandardized = TextSchema.GetStandardElementType(elementType, reduceElement: true);
                 }
             }
             else if (preserveTextElements)
@@ -580,8 +580,8 @@ namespace System.Windows.Documents
 
             // Write properties
             DependencyObject complexProperties = new DependencyObject();
-            WriteInheritableProperties(elementTypeStandardized, textReader, xmlWriter, /*onlyAffected:*/true, complexProperties);
-            WriteNoninheritableProperties(elementTypeStandardized, textReader, xmlWriter, /*onlyAffected:*/true, complexProperties);
+            WriteInheritableProperties(elementTypeStandardized, textReader, xmlWriter, onlyAffected: true, complexProperties);
+            WriteNoninheritableProperties(elementTypeStandardized, textReader, xmlWriter, onlyAffected: true, complexProperties);
             if (customTextElement)
             {
                 WriteLocallySetProperties(elementTypeStandardized, textReader, xmlWriter, complexProperties);
@@ -621,7 +621,7 @@ namespace System.Windows.Documents
 
                 for (int i = startColumn; i <= endColumn && i < columns.Count; i++)
                 {
-                    WriteXamlAtomicElement(columns[i], xmlWriter, /*reduceElement:*/false);
+                    WriteXamlAtomicElement(columns[i], xmlWriter, reduceElement: false);
                 }
 
                 // Close the element for the complex property
@@ -698,14 +698,14 @@ namespace System.Windows.Documents
             }
             else
             {
-                WriteInheritableProperties(rootType, context, xmlWriter, /*onlyAffected:*/false, complexProperties);
+                WriteInheritableProperties(rootType, context, xmlWriter, onlyAffected: false, complexProperties);
             }
 
             if (rootType == typeof(Span))
             {
                 // Root element is not real element to paste. It is just a property bag for contextual properties.
                 // So we collect non-inheritable properties only for inline content; not needing it for block one.
-                WriteNoninheritableProperties(typeof(Span), context, xmlWriter, /*onlyAffected:*/false, complexProperties);
+                WriteNoninheritableProperties(typeof(Span), context, xmlWriter, onlyAffected: false, complexProperties);
             }
 
             // Write an indicator that last paragraph must be merged on paste
@@ -810,7 +810,7 @@ namespace System.Windows.Documents
                         else
                         {
                             // Regular case: serialize a property with its own name
-                            propertyName = GetPropertyNameForElement(property, elementTypeStandardized, /*forceComplexName:*/false);
+                            propertyName = GetPropertyNameForElement(property, elementTypeStandardized, forceComplexName: false);
                         }
                         xmlWriter.WriteAttributeString(propertyName, stringValue);
                     }
@@ -977,7 +977,7 @@ namespace System.Windows.Documents
                     {
                         stringValue = FilterNaNStringValueForDoublePropertyType(stringValue, locallySetProperty.PropertyType);
 
-                        string propertyName = GetPropertyNameForElement(locallySetProperty, elementTypeStandardized, /*forceComplexName:*/false);
+                        string propertyName = GetPropertyNameForElement(locallySetProperty, elementTypeStandardized, forceComplexName: false);
                         xmlWriter.WriteAttributeString(propertyName, stringValue);
                     }
                     else
@@ -1065,7 +1065,7 @@ namespace System.Windows.Documents
                 LocalValueEntry propertyEntry = properties.Current;
 
                 // Build an appropriate name for the complex property
-                string complexPropertyName = GetPropertyNameForElement(propertyEntry.Property, elementType, /*forceComplexName:*/true);
+                string complexPropertyName = GetPropertyNameForElement(propertyEntry.Property, elementType, forceComplexName: true);
 
                 // Write the start element for the complex property.
                 xmlWriter.WriteStartElement(complexPropertyName);
@@ -1177,7 +1177,7 @@ namespace System.Windows.Documents
                                 object value = image.GetValue(property);
 
                                 // Write the property as attribute string or add it to a list of complex properties.
-                                WriteNoninheritableProperty(xmlWriter, property, value, elementTypeStandardized, /*onlyAffected:*/true, complexProperties, image.ReadLocalValue(property));
+                                WriteNoninheritableProperty(xmlWriter, property, value, elementTypeStandardized, onlyAffected: true, complexProperties, image.ReadLocalValue(property));
                             }
                         }
 
@@ -1299,7 +1299,7 @@ namespace System.Windows.Documents
             if (fragment is Span)
             {
                 // Split structure at insertion point in target
-                insertionPosition = TextRangeEdit.SplitFormattingElements(insertionPosition, /*keepEmptyFormatting:*/false);
+                insertionPosition = TextRangeEdit.SplitFormattingElements(insertionPosition, keepEmptyFormatting: false);
                 Invariant.Assert(insertionPosition.Parent is Paragraph, "insertionPosition must be in a scope of a Paragraph after splitting formatting elements");
 
                 // Move the whole Span into the insertion point
@@ -1341,13 +1341,13 @@ namespace System.Windows.Documents
                 // Merge paragraphs on fragment boundaries
                 if (needFirstParagraphMerging)
                 {
-                    MergeParagraphsAtPosition(fragmentStart, /*mergingOnFragmentStart:*/true);
+                    MergeParagraphsAtPosition(fragmentStart, mergingOnFragmentStart: true);
                 }
 
                 // Get an indication that we need to merge last paragraph
                 if (!((Section)fragment).HasTrailingParagraphBreakOnPaste)
                 {
-                    MergeParagraphsAtPosition(fragmentEnd, /*mergingOnFragmentStart:*/false);
+                    MergeParagraphsAtPosition(fragmentEnd, mergingOnFragmentStart: false);
                 }
             }
 
@@ -1431,7 +1431,7 @@ namespace System.Windows.Documents
             else
             {
                 // split paragraph to create an insertion positionn at block level
-                insertionPosition = TextRangeEdit.InsertParagraphBreak(insertionPosition, /*moveIntoSecondParagraph:*/false);
+                insertionPosition = TextRangeEdit.InsertParagraphBreak(insertionPosition, moveIntoSecondParagraph: false);
             }
 
             // When insertionPosition is inside a ListItem, then InsertParagraphBreak will

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeSerialization.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeSerialization.cs
@@ -1126,7 +1126,7 @@ namespace System.Windows.Documents
                     System.ComponentModel.TypeConverter typeConverter = System.ComponentModel.TypeDescriptor.GetConverter(property.PropertyType);
                     Invariant.Assert(typeConverter != null, "typeConverter==null: is not expected for atomic elements");
                     Invariant.Assert(typeConverter.CanConvertTo(typeof(string)), "type is expected to be convertable into string type");
-                    string stringValue = (string)typeConverter.ConvertTo(/*ITypeDescriptorContext:*/null, CultureInfo.InvariantCulture, propertyValue, typeof(string));
+                    string stringValue = (string)typeConverter.ConvertTo(context: null, CultureInfo.InvariantCulture, propertyValue, typeof(string));
                     Invariant.Assert(stringValue != null, "expecting non-null stringValue");
                     xmlWriter.WriteAttributeString(property.Name, stringValue);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSchema.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSchema.cs
@@ -94,7 +94,7 @@ namespace System.Windows.Documents
 #if UNUSED
         internal static bool IsValidChild(TextElement parent, TextElement child)
         {
-            return ValidateChild(parent, child, false /* throwIfIllegalChild */, false /* throwIfIllegalHyperlinkDescendent */);
+            return ValidateChild(parent, child, throwIfIllegalChild: false, throwIfIllegalHyperlinkDescendent: false);
         }
 #endif
 
@@ -119,7 +119,7 @@ namespace System.Windows.Documents
 
         internal static bool IsValidChild(TextElement parent, Type childType)
         {
-            return ValidateChild(parent, childType, false /* throwIfIllegalChild */, false /* throwIfIllegalHyperlinkDescendent */);
+            return ValidateChild(parent, childType, throwIfIllegalChild: false, throwIfIllegalHyperlinkDescendent: false);
         }
 
         internal static bool ValidateChild(TextElement parent, Type childType, bool throwIfIllegalChild, bool throwIfIllegalHyperlinkDescendent)
@@ -150,7 +150,7 @@ namespace System.Windows.Documents
 
         internal static bool IsValidChild(TextPointer position, Type childType)
         {
-            return ValidateChild(position, childType, false /* throwIfIllegalChild */, false /* throwIfIllegalHyperlinkDescendent */);
+            return ValidateChild(position, childType, throwIfIllegalChild: false, throwIfIllegalHyperlinkDescendent: false);
         }
 
         internal static bool ValidateChild(TextPointer position, Type childType, bool throwIfIllegalChild, bool throwIfIllegalHyperlinkDescendent)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSelection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSelection.cs
@@ -47,7 +47,7 @@ namespace System.Windows.Documents
             _textEditor = textEditor;
 
             // Initialize active pointers of the selection - anchor and moving pointers
-            SetActivePositions(/*AnchorPosition:*/thisSelection.Start, thisSelection.End);
+            SetActivePositions(anchorPosition: thisSelection.Start, thisSelection.End);
 
             // Activate selection in case if this control has keyboard focus already
             thisSelection.UpdateCaretAndHighlight();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSelection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSelection.cs
@@ -107,7 +107,7 @@ namespace System.Windows.Documents
                 TextRangeBase.SelectWord(this, position);
 
                 ITextSelection thisSelection = this;
-                SetActivePositions(/*anchorPosition:*/thisSelection.Start, thisSelection.End);
+                SetActivePositions(anchorPosition: thisSelection.Start, thisSelection.End);
             }
             finally
             {
@@ -127,7 +127,7 @@ namespace System.Windows.Documents
 
                 // Check whether this behave correctly on double-click-drag; double-Click-extendwithkeyboard
                 ITextSelection thisSelection = this;
-                SetActivePositions(/*anchorPosition:*/position, thisSelection.End);
+                SetActivePositions(anchorPosition: position, thisSelection.End);
             }
             finally
             {
@@ -285,7 +285,7 @@ namespace System.Windows.Documents
                     if (this.IsEmpty)
                     {
                         // We need to ensure appropriate caret visual position.
-                        ((ITextSelection)this).SetCaretToPosition(((ITextRange)this).End, LogicalDirection.Forward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                        ((ITextSelection)this).SetCaretToPosition(((ITextRange)this).End, LogicalDirection.Forward, allowStopAtLineEnd: false, allowStopNearSpace: false);
                     }
 
                     Invariant.Assert(!this.IsTableCellRange);
@@ -662,7 +662,7 @@ namespace System.Windows.Documents
 
             bool contains = false;
 
-            ITextPointer position = this.TextView.GetTextPositionFromPoint(point, /*snapToText:*/false);
+            ITextPointer position = this.TextView.GetTextPositionFromPoint(point, snapToText: false);
 
             // Did we hit any text?
             if (position != null && thisSelection.Contains(position))
@@ -780,7 +780,7 @@ namespace System.Windows.Documents
             if ((Keyboard.Modifiers & ModifierKeys.Shift) != 0)
             {
                 // Shift modifier pressed - extending selection from existing one
-                thisSelection.ExtendSelectionByMouse(cursorPosition, /*forceWordSelection:*/false, /*forceParagraphSelection*/false);
+                thisSelection.ExtendSelectionByMouse(cursorPosition, forceWordSelection: false, forceParagraphSelection: false);
             }
             else
             {
@@ -833,7 +833,7 @@ namespace System.Windows.Documents
 
                 // Note that we use includeCellAtMovingPosition=true because we want that hit-tested table cell
                 // be included into selection no matter whether it's empty or not.
-                TextRangeBase.Select(this, startPosition, movingPosition, /*includeCellAtMovingPosition:*/true);
+                TextRangeBase.Select(this, startPosition, movingPosition, includeCellAtMovingPosition: true);
                 SetActivePositions(anchorPosition, movingPosition);
 
                 // Store previous cursor position - for the next extension event
@@ -957,7 +957,7 @@ namespace System.Windows.Documents
                         _anchorWordRangeHasBeenCrossedOnce = true;
 
                         if (!_allowWordExpansionOnAnchorEnd || //
-                            TextPointerBase.IsAtWordBoundary(anchorPosition, /*insideWordDirection:*/LogicalDirection.Forward))
+                            TextPointerBase.IsAtWordBoundary(anchorPosition, insideWordDirection: LogicalDirection.Forward))
                         {
                             // We collapse anchorPosition in two cases:
                             // If we have been re-entering the initial word before -
@@ -971,7 +971,7 @@ namespace System.Windows.Documents
                         }
 
                         if (TextPointerBase.IsAfterLastParagraph(cursorPosition) ||
-                            TextPointerBase.IsAtWordBoundary(cursorPosition, /*insideWordDirection:*/LogicalDirection.Forward))
+                            TextPointerBase.IsAtWordBoundary(cursorPosition, insideWordDirection: LogicalDirection.Forward))
                         {
                             cursorWordRange = new TextSegment(cursorPosition, cursorPosition);
                         }
@@ -1023,7 +1023,7 @@ namespace System.Windows.Documents
             Invariant.Assert(_anchorPosition != null);
             Invariant.Assert(_movingPositionEdge != MovingEdge.None);
 
-            if (!TextRangeEditTables.IsTableCellRange((TextPointer)_anchorPosition, (TextPointer)((ITextSelection)this).MovingPosition, /*includeCellAtMovingPosition:*/false, out anchorCell, out movingCell))
+            if (!TextRangeEditTables.IsTableCellRange((TextPointer)_anchorPosition, (TextPointer)((ITextSelection)this).MovingPosition, includeCellAtMovingPosition: false, out anchorCell, out movingCell))
             {
                 return false;
             }
@@ -1368,7 +1368,7 @@ namespace System.Windows.Documents
                 {
                     TextPointer cellStart = table.RowGroups[0].Rows[0].Cells[0].ContentStart;
 
-                    this.SetCaretToPosition(cellStart, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+                    this.SetCaretToPosition(cellStart, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: false);
                 }
 
                 return table;
@@ -1948,7 +1948,7 @@ namespace System.Windows.Documents
             // Move selection to this position
             if (movingPosition == null)
             {
-                thisSelection.SetCaretToPosition(cursorPosition, cursorPosition.LogicalDirection, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/false);
+                thisSelection.SetCaretToPosition(cursorPosition, cursorPosition.LogicalDirection, allowStopAtLineEnd: true, allowStopNearSpace: false);
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesDisplayAttributePropertyRanges.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesDisplayAttributePropertyRanges.cs
@@ -150,7 +150,7 @@ namespace System.Windows.Documents
 
 #if UNUSED_IME_HIGHLIGHT_LAYER
                         // Need to pass the foreground and background color of the composition
-                        _highlightLayer.Add(start, end, /*TextDecorationCollection:*/null);
+                        _highlightLayer.Add(start, end, TextDecorationCollection: null);
 #endif
 
                             // Add the attribute range into CompositionAdorner.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
@@ -959,7 +959,7 @@ namespace System.Windows.Documents
             }
 
             // Do the hittest.
-            position = view.GetTextPositionFromPoint(milPoint, (flags & UnsafeNativeMethods.GetPositionFromPointFlags.GXFPF_NEAREST) != 0 /* snapToText */);
+            position = view.GetTextPositionFromPoint(milPoint, snapToText: (flags & UnsafeNativeMethods.GetPositionFromPointFlags.GXFPF_NEAREST) != 0);
             if (position == null)
             {
                 // GXFPF_ROUND_NEAREST was clear and we didn't hit a char.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
@@ -364,7 +364,7 @@ namespace System.Windows.Documents
                 {
                     // Setting a caret.  Make sure we set Backward direction to
                     // keep the caret tight with the composition text.
-                    this.TextSelection.SetCaretToPosition(start, LogicalDirection.Backward, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                    this.TextSelection.SetCaretToPosition(start, LogicalDirection.Backward, allowStopAtLineEnd: true, allowStopNearSpace: true);
                 }
                 else if (selection[0].style.ase == UnsafeNativeMethods.TsActiveSelEnd.TS_AE_START)
                 {
@@ -513,7 +513,7 @@ namespace System.Windows.Documents
 
             try
             {
-                ITextRange range = new TextRange(start, end, true /* ignoreTextUnitBoundaries */);
+                ITextRange range = new TextRange(start, end, ignoreTextUnitBoundaries: true);
 
                 this.TextEditor.SetText(range, filteredText, InputLanguageManager.Current.CurrentInputLanguage);
 
@@ -672,7 +672,7 @@ namespace System.Windows.Documents
             //
 
             ITextRange range = new TextRange(this.TextSelection.AnchorPosition, this.TextSelection.MovingPosition);
-            range.ApplyTypingHeuristics(false /* overType */);
+            range.ApplyTypingHeuristics(overType: false);
 
             ITextPointer start;
             ITextPointer end;
@@ -711,7 +711,7 @@ namespace System.Windows.Documents
                     // We still need to call ApplyTypingHeuristics, even though
                     // we already did the work above, because it might need
                     // to spring load formatting.
-                    this.TextSelection.ApplyTypingHeuristics(false /* overType */);
+                    this.TextSelection.ApplyTypingHeuristics(overType: false);
 
                     //Invariant.Assert(this.TextSelection.Start.CompareTo(range.Start) == 0 && this.TextSelection.End.CompareTo(range.End) == 0);
                     // We cannot make this Assertion because TextRange will normalize
@@ -1950,7 +1950,7 @@ namespace System.Windows.Documents
                 //
                 // If we're here it means composition is being finalized
                 //
-                range = new TextRange(composition._ResultStart, composition._ResultEnd, true /* ignoreTextUnitBoundaries */);
+                range = new TextRange(composition._ResultStart, composition._ResultEnd, ignoreTextUnitBoundaries: true);
                 text = this.TextEditor._FilterText(composition.Text, range);
 
                 if (text.Length != composition.Text.Length)
@@ -1960,8 +1960,8 @@ namespace System.Windows.Documents
             }
             else
             {
-                range = new TextRange(composition._CompositionStart, composition._CompositionEnd, true /* ignoreTextUnitBoundaries */);
-                text = this.TextEditor._FilterText(composition.CompositionText, range, /*filterMaxLength:*/false);
+                range = new TextRange(composition._CompositionStart, composition._CompositionEnd, ignoreTextUnitBoundaries: true);
+                text = this.TextEditor._FilterText(composition.CompositionText, range, filterMaxLength: false);
 
                 // A change in length should not happen other than for MaxLength filtering during finalization since we cover those
                 // cases and reject input if necessary when the IME edits the document in the first place.
@@ -2002,7 +2002,7 @@ namespace System.Windows.Documents
                 }
                 else
                 {
-                    this.TextSelection.SetCaretToPosition(range.End, LogicalDirection.Backward, /*allowStopAtLineEnd:*/true, /*allowStopNearSpace:*/true);
+                    this.TextSelection.SetCaretToPosition(range.End, LogicalDirection.Backward, allowStopAtLineEnd: true, allowStopNearSpace: true);
                 }
 
                 compositionUndoUnit.RecordRedoSelectionState(range.End, range.End);
@@ -2242,7 +2242,7 @@ namespace System.Windows.Documents
                     try
                     {
                         _textChangeReentrencyCount++;
-                        _sink.OnTextChange(0 /* flags */, ref change);
+                        _sink.OnTextChange(flags: 0, ref change);
                     }
                     finally
                     {
@@ -2364,7 +2364,7 @@ namespace System.Windows.Documents
                             // Skip the public events for the changing of the composition
                             // by Cicero, but the below HandleCompositionEvents will raise
                             // the public events about the composition and text change.
-                            textEditor.Selection.EndChange(false /* disableScroll */, true /* skipEvents */);
+                            textEditor.Selection.EndChange(disableScroll: false, skipEvents: true);
                         }
                         finally
                         {
@@ -2672,7 +2672,7 @@ namespace System.Windows.Documents
 
             // Move the selection.
             container = this.TextContainer;
-            TextSelection.SetCaretToPosition(position, LogicalDirection.Backward, /*allowStopAtLineEnd:*/false, /*allowStopNearSpace:*/false);
+            TextSelection.SetCaretToPosition(position, LogicalDirection.Backward, allowStopAtLineEnd: false, allowStopNearSpace: false);
         }
 
         // Inserts an InkInteropObject at a specified position.
@@ -3268,7 +3268,7 @@ namespace System.Windows.Documents
         // filter MaxLength.
         private string FilterCompositionString(string text, int charsToReplaceCount)
         {
-            string newText = this.TextEditor._FilterText(text, charsToReplaceCount, /*filterMaxLength:*/false);
+            string newText = this.TextEditor._FilterText(text, charsToReplaceCount, filterMaxLength: false);
 
             // if the length has been changed, there is no way to recover and we finalize the composition string.
             if (newText.Length != text.Length)
@@ -3978,7 +3978,7 @@ namespace System.Windows.Documents
             finally
             {
                 _replayingIMEChangeReentrancyCount += deltaReplayingIMEChangeReentrancyCount;
-                this.TextSelection.EndChange(false /* disableScroll */, true /* skipEvents */);
+                this.TextSelection.EndChange(disableScroll: false, skipEvents: true);
             }
 
             if (IsTracing)
@@ -4006,7 +4006,7 @@ namespace System.Windows.Documents
                 }
                 finally
                 {
-                    this.TextSelection.EndChange(false /* disableScroll */, true /* skipEvents */);
+                    this.TextSelection.EndChange(disableScroll: false, skipEvents: true);
                 }
 
                 if (IsTracing)
@@ -4035,7 +4035,7 @@ namespace System.Windows.Documents
                 }
                 finally
                 {
-                    this.TextSelection.EndChange(false /* disableScroll */, true /* skipEvents */);
+                    this.TextSelection.EndChange(disableScroll: false, skipEvents: true);
                 }
 
                 if (IsTracing)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextTreeDeleteContentUndoUnit.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextTreeDeleteContentUndoUnit.cs
@@ -239,7 +239,7 @@ namespace System.Windows.Documents
             text = new char[count];
 
             // Copy the text.
-            TextTreeText.ReadText(this.TextContainer.RootTextBlock, symbolOffset, count, text, 0 /*startIndex*/);
+            TextTreeText.ReadText(this.TextContainer.RootTextBlock, symbolOffset, count, text, startIndex: 0);
 
             container = new TextContentContainer(text);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextTreeText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextTreeText.cs
@@ -312,7 +312,7 @@ namespace System.Windows.Documents
                 {
                     newBlock = new TextTreeTextBlock(TextTreeTextBlock.MaxBlockSize);
                     textOffset += newBlock.InsertText(0, text, textOffset, textEndOffset);
-                    newBlock.InsertAtNode(leftBlock, false /* insertBefore */);
+                    newBlock.InsertAtNode(leftBlock, insertBefore: false);
                     leftBlock = newBlock;
                 }
                 Invariant.Assert(newBlockCount == 1 || textOffset == textEndOffset, "Not all text copied!");
@@ -374,7 +374,7 @@ namespace System.Windows.Documents
                 {
                     newBlock = new TextTreeTextBlock(TextTreeTextBlock.MaxBlockSize);
                     textOffset += newBlock.InsertText(0, text, textOffset, textEndOffset);
-                    newBlock.InsertAtNode(leftBlock, false /* insertBefore */);
+                    newBlock.InsertAtNode(leftBlock, insertBefore: false);
                     leftBlock = newBlock;
                 }
                 Invariant.Assert(textOffset == textEndOffset, "Not all text copied!");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ValidationHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ValidationHelper.cs
@@ -103,7 +103,7 @@ namespace System.Windows.Documents
                 throw new ArgumentNullException(paramName);
             }
 
-            if (!TextSchema.IsValidChild(/*position:*/position, /*childType:*/child.GetType()))
+            if (!TextSchema.IsValidChild(position: position, childType: child.GetType()))
             {
                 throw new ArgumentException(SR.Format(SR.TextSchema_ChildTypeIsInvalid, position.Parent.GetType().Name, child.GetType().Name));
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/WpfPayload.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/WpfPayload.cs
@@ -159,7 +159,7 @@ namespace System.Windows.Documents
         /// </returns>
         internal static string SaveRange(ITextRange range, ref Stream stream, bool useFlowDocumentAsRoot)
         {
-            return SaveRange(range, ref stream, useFlowDocumentAsRoot, false /* preserveTextElements */);
+            return SaveRange(range, ref stream, useFlowDocumentAsRoot, preserveTextElements: false);
         }
 
         /// <summary>
@@ -189,7 +189,7 @@ namespace System.Windows.Documents
             ArgumentNullException.ThrowIfNull(range);
 
             // Create the wpf package in the stream
-            WpfPayload wpfPayload = new WpfPayload(/*package:*/null);
+            WpfPayload wpfPayload = new WpfPayload(package: null);
 
             // Create a string representing serialized xaml
             StringWriter stringWriter = new StringWriter(CultureInfo.InvariantCulture);
@@ -240,7 +240,7 @@ namespace System.Windows.Documents
             MemoryStream stream = new MemoryStream();
 
             // Create the wpf package in the stream
-            WpfPayload wpfPayload = new WpfPayload(/*package:*/null);
+            WpfPayload wpfPayload = new WpfPayload(package: null);
 
             // Create a package in the stream
             using (wpfPayload.CreatePackage(stream))
@@ -649,8 +649,8 @@ namespace System.Windows.Documents
             Byte[] buffer1 = new Byte[bufferSize];
             Byte[] buffer2 = new Byte[bufferSize];
 
-            imageSource1.CopyPixels(buffer1, stride, /*offset:*/0);
-            imageSource2.CopyPixels(buffer2, stride, /*offset:*/0);
+            imageSource1.CopyPixels(buffer1, stride, offset: 0);
+            imageSource2.CopyPixels(buffer2, stride, offset: 0);
             for (int i = 0; i < bufferSize; i++)
             {
                 if (buffer1[i] != buffer2[i])

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/EventTrigger.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/EventTrigger.cs
@@ -315,7 +315,7 @@ namespace System.Windows
                 // Store the RoutedEventHandler & target for use in DisconnectOneTrigger
                 eventTrigger._routedEventHandler = new RoutedEventHandler(listener.Handler);
                 eventTrigger._source.AddHandler( eventTrigger.RoutedEvent, eventTrigger._routedEventHandler,
-                                                 false /* HandledEventsToo */ );
+                                                 handledEventsToo: false);
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkContentElement.cs
@@ -339,7 +339,7 @@ namespace System.Windows
 
             ArgumentNullException.ThrowIfNull(resourceKey);
 
-            object resource = FrameworkElement.FindResourceInternal(null /* fe */, this, resourceKey);
+            object resource = FrameworkElement.FindResourceInternal(fe: null, this, resourceKey);
 
             if (resource == DependencyProperty.UnsetValue)
             {
@@ -366,7 +366,7 @@ namespace System.Windows
 
             ArgumentNullException.ThrowIfNull(resourceKey);
 
-            object resource = FrameworkElement.FindResourceInternal(null /* fe */, this, resourceKey);
+            object resource = FrameworkElement.FindResourceInternal(fe: null, this, resourceKey);
 
             if (resource == DependencyProperty.UnsetValue)
             {
@@ -714,15 +714,15 @@ namespace System.Windows
                         FrameworkElement feTemplatedParent = TemplatedParent as FrameworkElement;
 
                         FrameworkTemplate frameworkTemplate = feTemplatedParent.TemplateInternal;
-                        StyleHelper.OnTriggerSourcePropertyInvalidated(null, frameworkTemplate, TemplatedParent, dp, e, false /*invalidateOnlyContainer*/,
-                            ref frameworkTemplate.TriggerSourceRecordFromChildIndex, ref frameworkTemplate.PropertyTriggersWithActions, TemplateChildIndex /*sourceChildIndex*/);
+                        StyleHelper.OnTriggerSourcePropertyInvalidated(null, frameworkTemplate, TemplatedParent, dp, e, invalidateOnlyContainer: false,
+                            ref frameworkTemplate.TriggerSourceRecordFromChildIndex, ref frameworkTemplate.PropertyTriggersWithActions, sourceChildIndex: TemplateChildIndex);
                     }
 
                     // Do not validate Style during an invalidation if the Style was
                     // never used before (dependents do not need invalidation)
                     if (Style != null)
                     {
-                        StyleHelper.OnTriggerSourcePropertyInvalidated(Style, null, this, dp, e, true /*invalidateOnlyContainer*/,
+                        StyleHelper.OnTriggerSourcePropertyInvalidated(Style, null, this, dp, e, invalidateOnlyContainer: true,
                             ref Style.TriggerSourceRecordFromChildIndex, ref Style.PropertyTriggersWithActions, 0 /*sourceChildId*/); // Style can only have triggers that are driven by properties on the container
                     }
 
@@ -732,8 +732,8 @@ namespace System.Windows
                     // There may be container dependents in the ThemeStyle. Invalidate them.
                     if (ThemeStyle != null && Style != ThemeStyle)
                     {
-                        StyleHelper.OnTriggerSourcePropertyInvalidated(ThemeStyle, null, this, dp, e, true /*invalidateOnlyContainer*/,
-                            ref ThemeStyle.TriggerSourceRecordFromChildIndex, ref ThemeStyle.PropertyTriggersWithActions, 0 /*sourceChildIndex*/); // ThemeStyle can only have triggers that are driven by properties on the container
+                        StyleHelper.OnTriggerSourcePropertyInvalidated(ThemeStyle, null, this, dp, e, invalidateOnlyContainer: true,
+                            ref ThemeStyle.TriggerSourceRecordFromChildIndex, ref ThemeStyle.PropertyTriggersWithActions, sourceChildIndex: 0); // ThemeStyle can only have triggers that are driven by properties on the container
                     }
                 }
             }
@@ -1505,7 +1505,7 @@ namespace System.Windows
                         // inheritance behavior.
                         // This must have no performance effect as the subtree of this
                         // element is empty (no children yet added).
-                        TreeWalkHelper.InvalidateOnTreeChange(/*fe:*/null, /*fce:*/this, _parent, true);
+                        TreeWalkHelper.InvalidateOnTreeChange(fe: null, fce: this, _parent, true);
                     }
                 }
                 else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkContentElement.cs
@@ -723,7 +723,7 @@ namespace System.Windows
                     if (Style != null)
                     {
                         StyleHelper.OnTriggerSourcePropertyInvalidated(Style, null, this, dp, e, invalidateOnlyContainer: true,
-                            ref Style.TriggerSourceRecordFromChildIndex, ref Style.PropertyTriggersWithActions, 0 /*sourceChildId*/); // Style can only have triggers that are driven by properties on the container
+                            ref Style.TriggerSourceRecordFromChildIndex, ref Style.PropertyTriggersWithActions, sourceChildIndex: 0); // Style can only have triggers that are driven by properties on the container
                     }
 
                     // Do not validate Template during an invalidation if the Template was

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
@@ -819,7 +819,7 @@ namespace System.Windows
 
             ArgumentNullException.ThrowIfNull(resourceKey);
 
-            object resource = FrameworkElement.FindResourceInternal(this, null /* fce */, resourceKey);
+            object resource = FrameworkElement.FindResourceInternal(this, fce: null, resourceKey);
 
             if (resource == DependencyProperty.UnsetValue)
             {
@@ -847,7 +847,7 @@ namespace System.Windows
 
             ArgumentNullException.ThrowIfNull(resourceKey);
 
-            object resource = FrameworkElement.FindResourceInternal(this, null /* fce */, resourceKey);
+            object resource = FrameworkElement.FindResourceInternal(this, fce: null, resourceKey);
 
             if (resource == DependencyProperty.UnsetValue)
             {
@@ -2088,8 +2088,8 @@ namespace System.Windows
                         FrameworkTemplate frameworkTemplate = feTemplatedParent.TemplateInternal;
                         if (frameworkTemplate != null)
                         {
-                            StyleHelper.OnTriggerSourcePropertyInvalidated(null, frameworkTemplate, TemplatedParent, dp, e, false /*invalidateOnlyContainer*/,
-                                ref frameworkTemplate.TriggerSourceRecordFromChildIndex, ref frameworkTemplate.PropertyTriggersWithActions, TemplateChildIndex /*sourceChildIndex*/);
+                            StyleHelper.OnTriggerSourcePropertyInvalidated(null, frameworkTemplate, TemplatedParent, dp, e, invalidateOnlyContainer: false,
+                                ref frameworkTemplate.TriggerSourceRecordFromChildIndex, ref frameworkTemplate.PropertyTriggersWithActions, sourceChildIndex: TemplateChildIndex);
                         }
                     }
 
@@ -2097,23 +2097,23 @@ namespace System.Windows
                     // never used before (dependents do not need invalidation)
                     if (Style != null)
                     {
-                        StyleHelper.OnTriggerSourcePropertyInvalidated(Style, null, this, dp, e, true /*invalidateOnlyContainer*/,
-                            ref Style.TriggerSourceRecordFromChildIndex, ref Style.PropertyTriggersWithActions, 0 /*sourceChildIndex*/); // Style can only have triggers that are driven by properties on the container
+                        StyleHelper.OnTriggerSourcePropertyInvalidated(Style, null, this, dp, e, invalidateOnlyContainer: true,
+                            ref Style.TriggerSourceRecordFromChildIndex, ref Style.PropertyTriggersWithActions, sourceChildIndex: 0); // Style can only have triggers that are driven by properties on the container
                     }
 
                     // Do not validate Template during an invalidation if the Template was
                     // never used before (dependents do not need invalidation)
                     if (TemplateInternal != null)
                     {
-                        StyleHelper.OnTriggerSourcePropertyInvalidated(null, TemplateInternal, this, dp, e, !HasTemplateGeneratedSubTree /*invalidateOnlyContainer*/,
-                            ref TemplateInternal.TriggerSourceRecordFromChildIndex, ref TemplateInternal.PropertyTriggersWithActions, 0 /*sourceChildIndex*/); // These are driven by the container
+                        StyleHelper.OnTriggerSourcePropertyInvalidated(null, TemplateInternal, this, dp, e, invalidateOnlyContainer: !HasTemplateGeneratedSubTree,
+                            ref TemplateInternal.TriggerSourceRecordFromChildIndex, ref TemplateInternal.PropertyTriggersWithActions, sourceChildIndex: 0); // These are driven by the container
                     }
 
                     // There may be container dependents in the ThemeStyle. Invalidate them.
                     if (ThemeStyle != null && Style != ThemeStyle)
                     {
-                        StyleHelper.OnTriggerSourcePropertyInvalidated(ThemeStyle, null, this, dp, e, true /*invalidateOnlyContainer*/,
-                            ref ThemeStyle.TriggerSourceRecordFromChildIndex, ref ThemeStyle.PropertyTriggersWithActions, 0 /*sourceChildIndex*/); // ThemeStyle can only have triggers that are driven by properties on the container
+                        StyleHelper.OnTriggerSourcePropertyInvalidated(ThemeStyle, null, this, dp, e, invalidateOnlyContainer: true,
+                            ref ThemeStyle.TriggerSourceRecordFromChildIndex, ref ThemeStyle.PropertyTriggersWithActions, sourceChildIndex: 0); // ThemeStyle can only have triggers that are driven by properties on the container
                     }
                 }
             }
@@ -2643,7 +2643,7 @@ namespace System.Windows
                         // inheritance behavior.
                         // This must have no performance effect as the subtree of this
                         // element is empty (no children yet added).
-                        TreeWalkHelper.InvalidateOnTreeChange(/*fe:*/this, /*fce:*/null, _parent, true);
+                        TreeWalkHelper.InvalidateOnTreeChange(fe: this, fce: null, _parent, true);
                     }
                 }
                 else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElementFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElementFactory.cs
@@ -794,7 +794,7 @@ namespace System.Windows
                                 treeNodeFO,
                                 _childIndex,
                                 ref _frameworkTemplate.ChildRecordFromChildIndex,
-                                false /*isDetach*/,
+                                isDetach: false,
                                 this);
 
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkTemplate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkTemplate.cs
@@ -868,7 +868,7 @@ namespace System.Windows
                     dependencyObject.LookupEntry(dependencyProperty.GlobalIndex),
                     dependencyProperty,
                     dependencyProperty.GetMetadata(dependencyObject.DependencyObjectType),
-                    new EffectiveValueEntry() /* oldEntry */,
+                    oldEntry: new EffectiveValueEntry(),
                 ref entry,
                     coerceWithDeferredReference: false,
                     coerceWithCurrentValue: false,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkTemplate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkTemplate.cs
@@ -792,7 +792,7 @@ namespace System.Windows
                     // Allocate a slot for this unshared DP value in the per-instance store for MarkupExtensions
 
                     HybridDictionary instanceValues = StyleHelper.EnsureInstanceData(StyleHelper.TemplateDataField, templatedParent, InstanceStyleData.InstanceValues);
-                    StyleHelper.ProcessInstanceValue(dependencyObject, childIndex, instanceValues, dependencyProperty, StyleHelper.UnsharedTemplateContentPropertyIndex, true /*apply*/);
+                    StyleHelper.ProcessInstanceValue(dependencyObject, childIndex, instanceValues, dependencyProperty, StyleHelper.UnsharedTemplateContentPropertyIndex, apply: true);
 
                     value = bindingExpr.ParentBindingBase;
                 }
@@ -808,7 +808,7 @@ namespace System.Windows
                     // Allocate a slot for this unshared DP value in the per-instance store for MarkupExtensions
 
                     HybridDictionary instanceValues = StyleHelper.EnsureInstanceData(StyleHelper.TemplateDataField, templatedParent, InstanceStyleData.InstanceValues);
-                    StyleHelper.ProcessInstanceValue(dependencyObject, childIndex, instanceValues, dependencyProperty, StyleHelper.UnsharedTemplateContentPropertyIndex, true /*apply*/);
+                    StyleHelper.ProcessInstanceValue(dependencyObject, childIndex, instanceValues, dependencyProperty, StyleHelper.UnsharedTemplateContentPropertyIndex, apply: true);
 
                     // Create a Binding equivalent to the TemplateBindingExtension
 
@@ -870,8 +870,8 @@ namespace System.Windows
                     dependencyProperty.GetMetadata(dependencyObject.DependencyObjectType),
                     new EffectiveValueEntry() /* oldEntry */,
                 ref entry,
-                    false /* coerceWithDeferredReference */,
-                    false /* coerceWithCurrentValue */,
+                    coerceWithDeferredReference: false,
+                    coerceWithCurrentValue: false,
                     OperationType.Unknown);
 
             return true;
@@ -1418,7 +1418,7 @@ namespace System.Windows
         //
         internal void CopyParserContext(ParserContext parserContext)
         {
-            _parserContext = parserContext.ScopedCopy(false /*copyNameScopeStack*/ );
+            _parserContext = parserContext.ScopedCopy(copyNameScopeStack: false);
 
             // We need to clear the Journal bit, because we know we won't be able to honor it correctly.
             // Journaling journals the properties in the logical tree, so doesn't journal properties in the

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/KeyboardNavigation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/KeyboardNavigation.cs
@@ -983,7 +983,7 @@ namespace System.Windows.Input
             {
                 case FocusNavigationDirection.Next:
                     _navigationProperty = (modifierKeys & ModifierKeys.Control) == ModifierKeys.Control ? ControlTabNavigationProperty : TabNavigationProperty;
-                    nextTab = GetNextTab(currentElement, GetGroupParent(currentElement, true /*includeCurrent*/), false);
+                    nextTab = GetNextTab(currentElement, GetGroupParent(currentElement, includeCurrent: true), false);
                     break;
 
                 case FocusNavigationDirection.Previous:
@@ -1273,7 +1273,7 @@ namespace System.Windows.Input
 
         internal DependencyObject PredictFocusedElement(DependencyObject sourceElement, FocusNavigationDirection direction)
         {
-            return PredictFocusedElement(sourceElement, direction, /*treeViewNavigation*/ false);
+            return PredictFocusedElement(sourceElement, direction, treeViewNavigation: false);
         }
 
         internal DependencyObject PredictFocusedElement(DependencyObject sourceElement, FocusNavigationDirection direction, bool treeViewNavigation)
@@ -1858,7 +1858,7 @@ namespace System.Windows.Input
 
         private DependencyObject GetGroupParent(DependencyObject e)
         {
-            return GetGroupParent(e, false /*includeCurrent*/);
+            return GetGroupParent(e, includeCurrent: false);
         }
 
         // Go up thru the parent chain until we find TabNavigation != Continue
@@ -2702,7 +2702,7 @@ namespace System.Windows.Input
 
         private DependencyObject GetNextInDirection(DependencyObject sourceElement, FocusNavigationDirection direction)
         {
-            return GetNextInDirection(sourceElement, direction, /*treeViewNavigation*/ false);
+            return GetNextInDirection(sourceElement, direction, treeViewNavigation: false);
         }
 
         private DependencyObject GetNextInDirection(DependencyObject sourceElement, FocusNavigationDirection direction, bool treeViewNavigation)
@@ -2989,7 +2989,7 @@ namespace System.Windows.Input
                 ElementViewportPosition sourceElementPosition = ItemsControl.GetElementViewportPosition(viewportBoundsElement,
                     ItemsControl.TryGetTreeViewItemHeader(sourceElement) as UIElement,
                     direction,
-                    false /*fullyVisible*/,
+                    fullyVisible: false,
                     out sourceRect);
                 if (sourceElementPosition == ElementViewportPosition.None)
                 {
@@ -3021,7 +3021,7 @@ namespace System.Windows.Input
                         viewportBoundsElement,
                         currentRectElement as UIElement,
                         direction,
-                        false /*fullyVisible*/,
+                        fullyVisible: false,
                         out currentRect);
 
                     // Compute directionScore of the current element. Higher the

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/KeyboardNavigation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/KeyboardNavigation.cs
@@ -251,7 +251,7 @@ namespace System.Windows.Input
                         new FrameworkPropertyMetadata(
                                 BooleanBoxes.FalseBox,
                                 FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.OverridesInheritanceBehavior,
-                                null /* No PropertyChangedCallback */,
+                                propertyChangedCallback: null,
                                 new CoerceValueCallback(CoerceShowKeyboardCues)));
 
         // Coercion for ShowKeyboardCuesProperty

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
@@ -338,7 +338,7 @@ namespace System.Windows.Interop
             CompositionTarget vt = null;
             if (( Handle != IntPtr.Zero) && IsVisible)
             {
-                source = PresentationSource.CriticalFromVisual(this, false /* enable2DTo3DTransition */);
+                source = PresentationSource.CriticalFromVisual(this, enable2DTo3DTransition: false);
                 if(source != null)
                 {
                     vt = source.CompositionTarget;
@@ -559,7 +559,7 @@ namespace System.Windows.Interop
                 // We only allow the changes that are coming from Avalon layout. The hwnd is not allowed to change by itself.
                 // So the size of the hwnd should always be RenderSize and the position be where layout puts it.
                 case WindowMessage.WM_WINDOWPOSCHANGING:
-                    PresentationSource source = PresentationSource.CriticalFromVisual(this, false /* enable2DTo3DTransition */);
+                    PresentationSource source = PresentationSource.CriticalFromVisual(this, enable2DTo3DTransition: false);
 
                     if (source != null)
                     {
@@ -854,7 +854,7 @@ namespace System.Windows.Interop
             }
 
             // Add ourselves as an IKeyboardInputSinks child of our containing window.
-            IKeyboardInputSink source = PresentationSource.CriticalFromVisual(this, false /* enable2DTo3DTransition */) as IKeyboardInputSink;
+            IKeyboardInputSink source = PresentationSource.CriticalFromVisual(this, enable2DTo3DTransition: false) as IKeyboardInputSink;
             if(source != null)
             {
                 ((IKeyboardInputSink)this).KeyboardInputSite = source.RegisterKeyboardInputSink(this);
@@ -923,7 +923,7 @@ namespace System.Windows.Interop
             // Find the source window, this must be the parent window of
             // the child window.
             IntPtr hwndParent = IntPtr.Zero;
-            PresentationSource source = PresentationSource.CriticalFromVisual(this, false /* enable2DTo3DTransition */);
+            PresentationSource source = PresentationSource.CriticalFromVisual(this, enable2DTo3DTransition: false);
             if(source != null)
             {
                 HwndSource hwndSource = source as HwndSource ;
@@ -936,7 +936,7 @@ namespace System.Windows.Interop
             {
                 // attempt to also walk through 3D - if we get a non-null result then we know we are inside of
                 // a 3D scene which is not supported
-                PresentationSource goingThrough3DSource = PresentationSource.CriticalFromVisual(this, true /* enable2DTo3DTransition */);
+                PresentationSource goingThrough3DSource = PresentationSource.CriticalFromVisual(this, enable2DTo3DTransition: true);
                 if (goingThrough3DSource != null)
                 {
                     if (TraceHwndHost.IsEnabled)
@@ -1061,7 +1061,7 @@ namespace System.Windows.Interop
 
             // Convert from pixels to measure units.
             // PresentationSource can't be null if we get here.
-            PresentationSource source = PresentationSource.CriticalFromVisual(this, false /* enable2DTo3DTransition */);
+            PresentationSource source = PresentationSource.CriticalFromVisual(this, enable2DTo3DTransition: false);
             Point ptUpperLeft = new Point(rc.left, rc.top);
             Point ptLowerRight = new Point(rc.right, rc.bottom);
             ptUpperLeft = source.CompositionTarget.TransformFromDevice.Transform(ptUpperLeft);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/WindowInteropHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/WindowInteropHelper.cs
@@ -96,7 +96,7 @@ namespace System.Windows.Interop
 
             if (Handle == IntPtr.Zero)
             {
-                _window.CreateSourceWindow(false /*create hwnd during show*/);
+                _window.CreateSourceWindow(duringShow: false);
             }
 
             return Handle;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfSharedXamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfSharedXamlSchemaContext.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Baml2006
                     xType = CreateKnownBamlType(type.Name, false, _useV3Rules);
                     if (xType == null || xType.UnderlyingType != type)
                     {
-                        xType = new WpfXamlType(type, this, false /* isBamlType */, _useV3Rules);
+                        xType = new WpfXamlType(type, this, isBamlScenario: false, _useV3Rules);
                     }
                     _masterTypeTable.Add(type, xType);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfXamlMember.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfXamlMember.cs
@@ -140,7 +140,7 @@ namespace System.Windows.Baml2006
             }
             else
             {
-                result = new WpfXamlMember(DependencyProperty, false /*isAttachable*/);
+                result = new WpfXamlMember(DependencyProperty, isAttachable: false);
             }
             result.ApplyGetterFallback = true;
             return result;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfXamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfXamlType.cs
@@ -166,12 +166,12 @@ namespace System.Windows.Baml2006
 
         protected override XamlMember LookupMember(string name, bool skipReadOnlyCheck)
         {
-            return FindMember(name, false /* isAttached */, skipReadOnlyCheck);
+            return FindMember(name, isAttached: false, skipReadOnlyCheck);
         }
 
         protected override XamlMember LookupAttachableMember(string name)
         {
-            return FindMember(name, true /* isAttached */, false /* skipReadOnlyCheck doens't matter for Attached */);
+            return FindMember(name, isAttached: true, false /* skipReadOnlyCheck doens't matter for Attached */);
         }
 
         protected override IEnumerable<XamlMember> LookupAllMembers()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -536,7 +536,7 @@ namespace System.Windows.Markup
         private void ReadDocumentEndRecord()
         {
             Debug.Assert(0 == ReaderContextStack.Count); // if not zero we missed an EndElement
-            SetPropertyValueToParent(false /*fromStartTag*/);
+            SetPropertyValueToParent(fromStartTag: false);
             ParserContext.RootElement = null;
             MapTable.ClearConverterCache();
             EndOfDocument = true;
@@ -779,7 +779,7 @@ namespace System.Windows.Markup
                 XamlParseException.ThrowException( ParserContext,
                                                LineNumber,
                                                LinePosition,
-                                               String.Empty /*message*/,
+                                               message: String.Empty,
                                                e );
             }
 #endif
@@ -1196,7 +1196,7 @@ namespace System.Windows.Markup
             // Check if the element on the stack needs to be added to the tree as a child
             // If not, then continue and see if the element should be added to a list, dictionary,
             // array, set as a property value, etc.
-            SetPropertyValueToParent(false /*fromStartTag*/);
+            SetPropertyValueToParent(fromStartTag: false);
 
             Debug.Assert(!CurrentContext.CheckFlag(ReaderFlags.NeedToAddToTree), "Failed to add Element to tree before popping stack");
 
@@ -1254,7 +1254,7 @@ namespace System.Windows.Markup
         internal virtual void ReadKeyElementEndRecord()
         {
             object key = ProvideValueFromMarkupExtension((MarkupExtension)GetCurrentObjectData(),
-                                                         ParentObjectData, null /*member*/);
+                                                         ParentObjectData, member: null);
 
             SetKeyOnContext(key, XamlReaderHelper.DefinitionName, ParentContext, GrandParentContext);
             PopContext();
@@ -1669,7 +1669,7 @@ namespace System.Windows.Markup
         internal virtual void ReadDeferableContentStart(
             BamlDeferableContentStartRecord bamlRecord)
         {
-            ResourceDictionary dictionary = GetDictionaryFromContext(CurrentContext, true /*toInsert*/) as ResourceDictionary;
+            ResourceDictionary dictionary = GetDictionaryFromContext(CurrentContext, toInsert: true) as ResourceDictionary;
 
             if (dictionary != null)
             {
@@ -2965,7 +2965,7 @@ namespace System.Windows.Markup
         {
             short  attributeId = bamlPropertyArrayStartRecord.AttributeId;
             object parent = GetCurrentObjectData();
-            BamlCollectionHolder holder = new BamlCollectionHolder(this, parent, attributeId, false /*needDefault*/);
+            BamlCollectionHolder holder = new BamlCollectionHolder(this, parent, attributeId, needDefault: false);
 
             if (!holder.PropertyType.IsArray)
             {
@@ -3198,7 +3198,7 @@ namespace System.Windows.Markup
                 }
                 else if (context.ContextType == ReaderFlags.PropertyIList)
                 {
-                    BamlCollectionHolder holder = GetCollectionHolderFromContext(context, true /*toInsert*/);
+                    BamlCollectionHolder holder = GetCollectionHolderFromContext(context, toInsert: true);
 
                     result = holder.List;
                 }
@@ -3219,7 +3219,7 @@ namespace System.Windows.Markup
                 }
                 else if (context.ContextType == ReaderFlags.PropertyIAddChild)
                 {
-                    BamlCollectionHolder holder = GetCollectionHolderFromContext(context, false /*toInsert*/);
+                    BamlCollectionHolder holder = GetCollectionHolderFromContext(context, toInsert: false);
 
                     result = BamlRecordManager.AsIAddChild(holder.Collection);
                 }
@@ -3242,7 +3242,7 @@ namespace System.Windows.Markup
                 }
                 else if (context.ContextType == ReaderFlags.PropertyArray)
                 {
-                    BamlCollectionHolder holder = GetCollectionHolderFromContext(context, true /*toInsert*/);
+                    BamlCollectionHolder holder = GetCollectionHolderFromContext(context, toInsert: true);
 
                     result = holder.ArrayExt;
                 }
@@ -3366,7 +3366,7 @@ namespace System.Windows.Markup
             try
             {
                 // make sure parent is a dictionary
-                GetDictionaryFromContext(parentContext, true /*toInsert*/);
+                GetDictionaryFromContext(parentContext, toInsert: true);
             }
             catch (XamlParseException e)
             {
@@ -3991,7 +3991,7 @@ namespace System.Windows.Markup
             // directly instead of a StaticResource extension.  Check to see if the
             // attribute value is a resource key.
             string message = string.Empty;
-            if (FindResourceInParserStack(attribValue.Trim(), false /*allowDeferredResourceReference*/, false /*mustReturnDeferredResourceReference*/) == DependencyProperty.UnsetValue)
+            if (FindResourceInParserStack(attribValue.Trim(), allowDeferredResourceReference: false, mustReturnDeferredResourceReference: false) == DependencyProperty.UnsetValue)
             {
                 if (propertyType == typeof(Type))
                 {
@@ -4071,7 +4071,7 @@ namespace System.Windows.Markup
                 for (int i = contextStack.Count-1; i >= 0; i--)
                 {
                     ReaderContextStackData stackData = (ReaderContextStackData) contextStack[i];
-                    IDictionary dictionary = GetDictionaryFromContext(stackData, false /*toInsert*/);
+                    IDictionary dictionary = GetDictionaryFromContext(stackData, toInsert: false);
 
                     if (dictionary != null && dictionary.Contains(resourceNameObject))
                     {
@@ -4083,7 +4083,7 @@ namespace System.Windows.Markup
                         FrameworkElement feParent;
                         FrameworkContentElement fceParent;
 
-                        Helper.DowncastToFEorFCE(feOrfceParent, out feParent, out fceParent, false /*throwIfNeither*/);
+                        Helper.DowncastToFEorFCE(feOrfceParent, out feParent, out fceParent, throwIfNeither: false);
                         if (feParent != null)
                         {
                             value = feParent.FindResourceOnSelf(resourceNameObject, allowDeferredResourceReference, mustReturnDeferredResourceReference);
@@ -4215,7 +4215,7 @@ namespace System.Windows.Markup
                ThrowException(nameof(SR.ParserNoResource), resourceNameString);
             }
 
-            object value = FindResourceInParentChain(resourceNameObject, false /*allowDeferredResourceReference*/, false /*mustReturnDeferredResourceReference*/);
+            object value = FindResourceInParentChain(resourceNameObject, allowDeferredResourceReference: false, mustReturnDeferredResourceReference: false);
             if (value == DependencyProperty.UnsetValue)
             {
                 ThrowException(nameof(SR.ParserNoResource) , $"{{{resourceNameObject}}}");
@@ -4624,14 +4624,14 @@ namespace System.Windows.Markup
 
                 // Handle parent as a dictionary:
 
-                IDictionary dictionary = GetDictionaryFromContext(parentContext, true /*toInsert*/);
+                IDictionary dictionary = GetDictionaryFromContext(parentContext, toInsert: true);
                 if (dictionary != null)
                 {
                     // if this SetPropertyValueToParent call occurred during ReadElementStart, then we
                     // don't have a key for this element yet, and should wait until ReadElementEnd
                     if (!fromStartTag)
                     {
-                        currentObject = GetElementValue(currentObject, dictionary, null /*contentProperty*/, ref isMarkupExtension);
+                        currentObject = GetElementValue(currentObject, dictionary, contentProperty: null, ref isMarkupExtension);
 
                         if (currentContext.Key == null)
                         {
@@ -4652,7 +4652,7 @@ namespace System.Windows.Markup
                 IList list = GetListFromContext(parentContext);
                 if (list != null)
                 {
-                    currentObject = GetElementValue(currentObject, list, null /*contentProperty*/, ref isMarkupExtension);
+                    currentObject = GetElementValue(currentObject, list, contentProperty: null, ref isMarkupExtension);
 
                     list.Add(currentObject);
 
@@ -4665,7 +4665,7 @@ namespace System.Windows.Markup
                 ArrayExtension arrayExt = GetArrayExtensionFromContext(parentContext);
                 if (arrayExt != null)
                 {
-                    currentObject = GetElementValue(currentObject, arrayExt, null /*contentProperty*/, ref isMarkupExtension);
+                    currentObject = GetElementValue(currentObject, arrayExt, contentProperty: null, ref isMarkupExtension);
 
                     arrayExt.AddChild(currentObject);
 
@@ -4687,7 +4687,7 @@ namespace System.Windows.Markup
                 IAddChild iac = GetIAddChildFromContext(parentContext);
                 if (iac != null)
                 {
-                    currentObject = GetElementValue(currentObject, iac, null /*contentProperty*/, ref isMarkupExtension);
+                    currentObject = GetElementValue(currentObject, iac, contentProperty: null, ref isMarkupExtension);
 
                     // The object may have changed to a string if it was a MarkupExtension
                     // that returned a string from ProvideValue, so check for this and

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -2038,7 +2038,7 @@ namespace System.Windows.Markup
             WpfPropertyDefinition propertyDefinition = new WpfPropertyDefinition(
                                     this,
                                     attributeId,
-                                    ReaderFlags.DependencyObject == CurrentContext.ContextType /*targetIsDependencyObject*/ );
+                                    targetIsDependencyObject: ReaderFlags.DependencyObject == CurrentContext.ContextType);
 
             // Try DependencyProperty optimization.
             if (propertyDefinition.DependencyProperty != null)
@@ -4161,7 +4161,7 @@ namespace System.Windows.Markup
             if (!SystemResources.IsSystemResourcesParsing)
             {
                 object source;
-                result = FrameworkElement.FindResourceFromAppOrSystem(resourceNameObject, out source, false /*throwOnError*/, allowDeferredResourceReference, mustReturnDeferredResourceReference);
+                result = FrameworkElement.FindResourceFromAppOrSystem(resourceNameObject, out source, disableThrowOnResourceNotFound: false, allowDeferredResourceReference, mustReturnDeferredResourceReference);
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/ParserContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/ParserContext.cs
@@ -628,7 +628,7 @@ namespace System.Windows.Markup
 #if !PBTCOMPILER
         internal ParserContext ScopedCopy()
         {
-            return ScopedCopy( true /* copyNameScopeStack */ );
+            return ScopedCopy( copyNameScopeStack: true);
         }
 #endif
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/ElementMarkupObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/ElementMarkupObject.cs
@@ -1041,7 +1041,7 @@ namespace System.Windows.Markup.Primitives
 
         public override object Value
         {
-            get { return ElementProperty.CheckForMarkupExtension(PropertyType, _value, Context, true /*convertEnums*/); }
+            get { return ElementProperty.CheckForMarkupExtension(PropertyType, _value, Context, convertEnums: true); }
         }
 
         public override AttributeCollection Attributes

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/MarkupWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/MarkupWriter.cs
@@ -491,7 +491,7 @@ namespace System.Windows.Markup.Primitives
             PartiallyOrderedList<string, MarkupProperty> deferredProperties = null;
             Formatting previousFormatting = (_xmlTextWriter != null) ? _xmlTextWriter.Formatting : Formatting.None;
 
-            foreach (MarkupProperty property in item.GetProperties(false /*mapToConstructorArgs*/))
+            foreach (MarkupProperty property in item.GetProperties(mapToConstructorArgs: false))
             {
                 if (property.IsConstructorArgument)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/StyleXamlParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/StyleXamlParser.cs
@@ -1240,10 +1240,10 @@ namespace System.Windows.Markup
                                                                         assemblyName,
                                                                         KnownTypes.Types[(int)KnownElements.EventSetter].FullName,
                                                                         KnownTypes.Types[(int)KnownElements.EventSetter],
-                                                                        null /*serializerType*/,
-                                                                        false /*isEmptyElement*/,
-                                                                        false /*needsDictionaryKey*/,
-                                                                        false /*isInjected*/));
+                                                                        serializerType: null,
+                                                                        isEmptyElement: false,
+                                                                        needsDictionaryKey: false,
+                                                                        isInjected: false));
 
                         XamlPropertyNode xamlPropertyNode = new XamlPropertyNode(xamlClrEventNode.LineNumber,
                                                                                  xamlClrEventNode.LinePosition,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/WpfXamlLoader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/WpfXamlLoader.cs
@@ -154,7 +154,7 @@ namespace System.Windows.Markup
 
                 IStyleConnector styleConnector = rootObject as IStyleConnector;
                 TransformNodes(xamlReader, xamlWriter,
-                    false /*onlyLoadOneNode*/,
+                    onlyLoadOneNode: false,
                     skipJournaledProperties,
                     shouldPassLineNumberInfo, xamlLineInfo, xamlLineInfoConsumer,
                     stack, styleConnector);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlNodes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlNodes.cs
@@ -1096,9 +1096,9 @@ namespace System.Windows.Markup
                         typeFullName,
                         elementType,
                         serializerType,
-                        false /*isEmptyElement*/,
-                        false /*needsDictionaryKey*/,
-                        false /*isInjected*/)
+                        isEmptyElement: false,
+                        needsDictionaryKey: false,
+                        isInjected: false)
             {
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReader.cs
@@ -402,7 +402,7 @@ namespace System.Windows.Markup
 
                 while (!_textReader.IsEof)
                 {
-                    WpfXamlLoader.TransformNodes(xamlReader, _objectWriter, true /*onlyLoadOneNode*/, _skipJournaledProperties, shouldPassLineNumberInfo, xamlLineInfo, xamlLineInfoConsumer, _stack, _styleConnector);
+                    WpfXamlLoader.TransformNodes(xamlReader, _objectWriter, onlyLoadOneNode: true, _skipJournaledProperties, shouldPassLineNumberInfo, xamlLineInfo, xamlLineInfoConsumer, _stack, _styleConnector);
 
                     if (xamlReader.NodeType == System.Xaml.XamlNodeType.StartMember)
                     {
@@ -595,7 +595,7 @@ namespace System.Windows.Markup
 
                 while (!xamlReader.IsEof && !_parseCancelled)
                 {
-                    WpfXamlLoader.TransformNodes(xamlReader, _objectWriter, true /*onlyLoadOneNode*/, _skipJournaledProperties, shouldPassLineNumberInfo, xamlLineInfo, xamlLineInfoConsumer, _stack, _styleConnector);
+                    WpfXamlLoader.TransformNodes(xamlReader, _objectWriter, onlyLoadOneNode: true, _skipJournaledProperties, shouldPassLineNumberInfo, xamlLineInfo, xamlLineInfoConsumer, _stack, _styleConnector);
 
                     if (xamlReader.NodeType == System.Xaml.XamlNodeType.Value && _stack.CurrentFrame.Property == synchronousRecordProperty)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -1247,9 +1247,9 @@ namespace System.Windows.Markup
                         lastTextWasPreserved = (xmlSpacePreserveSet) ? true : false;
 
                         string collapsedText = CollapseText(XmlReader.Value,
-                            stripAllLeadingSpaces /* stripAllLeadingSpaces */,
-                            false /* stripAllRightWhitespace */ ,
-                            lastTextWasPreserved /* preserve */,
+                            stripAllLeadingSpaces: stripAllLeadingSpaces,
+                            stripAllRightWhitespace: false,
+                            preserve: lastTextWasPreserved,
                             out  stripAllLeadingSpaces); // set stripAllLeading spaces based on result.
 
                         textValueStringBuilder.Append(collapsedText);
@@ -4241,7 +4241,7 @@ namespace System.Windows.Markup
             // consistent downstream, always generate a Dictionary element tag now.
             string startElementAssemblyName = propertyType.Assembly.FullName;
             WriteElementStart(startElementAssemblyName, propertyType.FullName,
-                            depth, propertyType, serializerType, true /*isInjected*/);
+                            depth, propertyType, serializerType, isInjected: true);
 
             // Since a dictionary element is being explicitly injected and it cannot be created
             // via the TypeConverter syntax, we can reset the state now so that the token reader
@@ -4418,7 +4418,7 @@ namespace System.Windows.Markup
                 ParentContext.FirstChildRead = true;  // may already be true
 
             WriteElementStart(assemblyName, typeFullName, depth,
-                          currentObjectType, serializerType, false /*isInjected*/);
+                          currentObjectType, serializerType, isInjected: false);
 
             CurrentContext.ContextData = currentObjectType;
             CurrentContext.NamespaceUri = namespaceURI;
@@ -6442,7 +6442,7 @@ namespace System.Windows.Markup
                     {
                         // possible to have Text in the Buffer for the
                         // EndDocument if there is text at the root.
-                        textNodeAdded = CollapseAndAddTextNode(textFlowData, true /* stripAllRightWhitespace */);
+                        textNodeAdded = CollapseAndAddTextNode(textFlowData, stripAllRightWhitespace: true);
                         break;
                     }
 
@@ -6491,7 +6491,7 @@ namespace System.Windows.Markup
                         // !!! important set addNodeToBuffer to false so passed in text isn't added yet
                         // to the outputBuffer.
                         addNodeToBuffer = false;
-                        textNodeAdded = CollapseAndAddTextNode(textFlowData, false /* stripAllRightWhitespace */);
+                        textNodeAdded = CollapseAndAddTextNode(textFlowData, stripAllRightWhitespace: false);
 
                         // set the new text as the TextRun and update leading spaces
                         textFlowData.TextNode = (XamlTextNode)xamlNode;
@@ -6560,7 +6560,7 @@ namespace System.Windows.Markup
                             }
                             else
                             {
-                                textNodeAdded = CollapseAndAddTextNode(textFlowData, /*stripAllRightWhitespace:*/true);
+                                textNodeAdded = CollapseAndAddTextNode(textFlowData, stripAllRightWhitespace: true);
                             }
                         }
                         TextFlowStackData flowData = new TextFlowStackData();
@@ -6574,7 +6574,7 @@ namespace System.Windows.Markup
                 case XamlNodeType.PropertyIListEnd:
                 case XamlNodeType.PropertyIDictionaryEnd:
                     Debug.Assert(0 == textFlowData.InlineCount, "Text stack still has an inline count");
-                    textNodeAdded = CollapseAndAddTextNode(textFlowData, /*stripAllRightWhitespace:*/true);
+                    textNodeAdded = CollapseAndAddTextNode(textFlowData, stripAllRightWhitespace: true);
                     _textFlowStack.Pop();
                     break;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlStream.cs
@@ -83,7 +83,7 @@ namespace System.Windows.Markup
             }
 
             byte[] writeBuffer = GetBufferFromFilePosition(
-                                    WritePosition,false /*writer*/,
+                                    WritePosition, reader: false,
                                     out bufferOffset, out bufferIndex);
 
             Debug.Assert(null != writeBuffer,"Null writeBuffer returned");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlStream.cs
@@ -218,7 +218,7 @@ namespace System.Windows.Markup
             int bufferIndex;
 
             byte[] readBuffer = GetBufferFromFilePosition(
-                ReadPosition,true /*reader*/,
+                ReadPosition,reader: true,
                 out bufferOffset, out bufferIndex);
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/BeginStoryboard.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/BeginStoryboard.cs
@@ -207,11 +207,11 @@ public sealed class BeginStoryboard : TriggerAction
 
         if( Name != null )
         {
-            Storyboard.BeginCommon(targetObject, nameScope, _handoffBehavior, true /* == is controllable */, layer );
+            Storyboard.BeginCommon(targetObject, nameScope, _handoffBehavior, isControllable: true, layer );
         }
         else
         {
-            Storyboard.BeginCommon(targetObject, nameScope, _handoffBehavior, false /* == not controllable */, layer );
+            Storyboard.BeginCommon(targetObject, nameScope, _handoffBehavior, isControllable: false, layer );
         }
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
@@ -296,7 +296,7 @@ namespace System.Windows.Navigation
             // It also replays CustomContentState.
             Debug.Assert(_navStatus == NavigationStatus.Navigating);
             _navStatus = NavigationStatus.Navigated;
-            HandleNavigated(navState, false/*navigatedToNewContent*/);
+            HandleNavigated(navState, navigatedToNewContent: false);
         }
 
 
@@ -1105,7 +1105,7 @@ namespace System.Windows.Navigation
             Debug.Assert(bpu == null ||
                          navInfo == null ||
                          navInfo.Source == null ||
-                         IsSameUri(null, navInfo.Source, bpu, false /* withFragment */),
+                         IsSameUri(null, navInfo.Source, bpu, withFragment: false),
                          "Source in OnContentReady does not match source in NavigateInfo");
             if (bpu == null)
             {
@@ -1192,7 +1192,7 @@ namespace System.Windows.Navigation
             }
 
             // This will fire Navigated event and LoadCompleted event if all sub-loads are done
-            HandleNavigated(navState, !objectRefresh/*navigatedToNewContent*/);
+            HandleNavigated(navState, navigatedToNewContent: !objectRefresh);
         }
 
         // <summary>
@@ -1732,7 +1732,7 @@ namespace System.Windows.Navigation
             // Not checking for IsDisposed since that checks for app shutdown too and we need to
             // stop current loads during app shutdown
 
-            DoStopLoading(true/*clearRecursiveNavigations*/, true/*fireEvents*/);
+            DoStopLoading(clearRecursiveNavigations: true, fireEvents: true);
         }
 
         /// <summary>
@@ -1846,7 +1846,7 @@ namespace System.Windows.Navigation
                 fireStopped = true;
             }
 
-            _navigatorHostImpl?.OnSourceUpdatedFromNavService(true /* journalOrCancel */);
+            _navigatorHostImpl?.OnSourceUpdatedFromNavService(journalOrCancel: true);
 
             // Event handler exception continuality: if exception occurs in NavigationStopped event handler,
             // we want to finish stopping navigation.
@@ -1886,7 +1886,7 @@ namespace System.Windows.Navigation
                     {
                         for (; i < _childNavigationServices.Count; ++i)
                         {
-                            ((NavigationService)_childNavigationServices[i]).DoStopLoading(true, false/*fireEvents*/);
+                            ((NavigationService)_childNavigationServices[i]).DoStopLoading(true, fireEvents: false);
                         }
                     }
 
@@ -2007,7 +2007,7 @@ namespace System.Windows.Navigation
                 Debug.Assert(this.Application != null &&
                              this.Application.CheckAccess() == true &&
                              IsSameUri(null, Application.StartupUri,
-                                                     navigateInfo.Source, false /* withFragment */),
+                                                     navigateInfo.Source, withFragment: false),
                              "Encountered unexpected condition in FireNavigating, see comments in the file");
                 // Only allow this navigation to continue if the user has not
                 // reqeusted another navigation in the mean time.
@@ -2058,7 +2058,7 @@ namespace System.Windows.Navigation
                 Debug.Assert(navigateInfo.IsConsistent);
                 Debug.Assert(source == null ||
                              navigateInfo.Source == null ||
-                             IsSameUri(null, navigateInfo.Source, source, false /* withFragment */),
+                             IsSameUri(null, navigateInfo.Source, source, withFragment: false),
                              "Source argument does not match NavigateInfo.Source");
                 // Don't want to overwrite one passed in
                 if (source == null)
@@ -2105,7 +2105,7 @@ namespace System.Windows.Navigation
 
             if (allowNavigation == true)
             {
-                DoStopLoading(false /*clearRecursiveLoads*/, true /*fireEvents*/);
+                DoStopLoading(false /*clearRecursiveLoads*/, fireEvents: true);
                 Debug.Assert(PendingNavigationList.Count == 0,
                              "Pending child navigations were not stopped before starting a new navigation");
 
@@ -2142,7 +2142,7 @@ namespace System.Windows.Navigation
             // and the caller could now proceed with the navigation
             _recursiveNavigateList.Remove(localNavigateQueueItem);
 
-            _navigatorHostImpl?.OnSourceUpdatedFromNavService(true /* journalOrCancel */);
+            _navigatorHostImpl?.OnSourceUpdatedFromNavService(journalOrCancel: true);
 
             // Browser downloading state not reset; case 4.
             InformBrowserAboutStoppedNavigation();
@@ -2878,7 +2878,7 @@ namespace System.Windows.Navigation
                 // o will be null.
                 // We don't support browser hosting since .NET Core 3.0, so therefore canUseTopLevelBrowserForHTMLRendering = false
                 bool canUseTopLevelBrowserForHTMLRendering = false;
-                Object o = MimeObjectFactory.GetObjectAndCloseStreamCore(bindStream, contentType, destinationUri, canUseTopLevelBrowserForHTMLRendering, sandBoxContent, true /*allowAsync*/, IsJournalNavigation(navigateInfo), out _asyncObjectConverter, IsUnsafe);
+                Object o = MimeObjectFactory.GetObjectAndCloseStreamCore(bindStream, contentType, destinationUri, canUseTopLevelBrowserForHTMLRendering, sandBoxContent, allowAsync: true, IsJournalNavigation(navigateInfo), out _asyncObjectConverter, IsUnsafe);
 
                 if (o != null)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
@@ -271,7 +271,7 @@ namespace System.Windows.Navigation
             // Do not record a new [fragment] navigation if the address bar will not change.
             if (navMode == NavigationMode.Back || navMode == NavigationMode.Forward ||
                 (targetElementExists &&
-                 !IsSameUri(null, _currentSource, uri, true /* with Fragment */)))
+                 !IsSameUri(null, _currentSource, uri, withFragment: true)))
             {
                 Debug.Assert(navMode != NavigationMode.Refresh); // because of !IsSameUri() above
 
@@ -404,7 +404,7 @@ namespace System.Windows.Navigation
         {
             if (_journalScope == null && _navigatorHost != null)
             {
-                _journalScope = _navigatorHost.GetJournal(true/*do create*/);
+                _journalScope = _navigatorHost.GetJournal(create: true);
             }
             //Throw if no JNS?
             return _journalScope;
@@ -1526,7 +1526,7 @@ namespace System.Windows.Navigation
                     // between two different instances of the same page (URI).
                     isFragment = (navInfo == null || navInfo.JournalEntry == null
                                    || navInfo.JournalEntry.ContentId == _contentId)
-                        && IsSameUri(null, resolvedSource, _currentSource, false /* without Fragment */);
+                        && IsSameUri(null, resolvedSource, _currentSource, withFragment: false);
                 }
 
                 // If this is a refresh, we want to refresh the whole page so set isFragment to false
@@ -1875,7 +1875,7 @@ namespace System.Windows.Navigation
                     {
                         // if there is an exception (succeed == false), we want to stop children's loading without
                         // firing the events.
-                        ((NavigationService)_childNavigationServices[i]).DoStopLoading(true, succeed/*fireEvent: we only fire when succeed*/);
+                        ((NavigationService)_childNavigationServices[i]).DoStopLoading(true, fireEvents: succeed/*we only fire when succeed*/);
                     }
                 }
                 finally
@@ -2086,7 +2086,7 @@ namespace System.Windows.Navigation
             // that source changed.
             if ((_navigatorHostImpl != null) && (!navigateOnSourceChanged))
             {
-                _navigatorHostImpl.OnSourceUpdatedFromNavService(IsJournalNavigation(navigateInfo) /* journalOrCancel */);
+                _navigatorHostImpl.OnSourceUpdatedFromNavService(journalOrCancel: IsJournalNavigation(navigateInfo));
             }
 
             // Event handler exception continuality: if exception occurs in Navigating event handler, the cleanup action is
@@ -2105,7 +2105,7 @@ namespace System.Windows.Navigation
 
             if (allowNavigation == true)
             {
-                DoStopLoading(false /*clearRecursiveLoads*/, fireEvents: true);
+                DoStopLoading(clearRecursiveNavigations: false, fireEvents: true);
                 Debug.Assert(PendingNavigationList.Count == 0,
                              "Pending child navigations were not stopped before starting a new navigation");
 
@@ -3957,7 +3957,7 @@ namespace System.Windows.Navigation
             {
                 if (_journalScope == null && _navigatorHost != null)
                 {
-                    _journalScope = _navigatorHost.GetJournal(false/*don't create*/);
+                    _journalScope = _navigatorHost.GetJournal(create: false);
                 }
                 return _journalScope;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationWindow.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationWindow.cs
@@ -571,7 +571,7 @@ namespace System.Windows.Navigation
 
                 // Calling the internal Navigate from Frame and NavWin's Source DP's property changed callbacks
                 // We would not set value back in this case.
-                navWin._navigationService.Navigate(uriToNavigate, null, false, true/* navigateOnSourceChanged */);
+                navWin._navigationService.Navigate(uriToNavigate, null, false, navigateOnSourceChanged: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1375,7 +1375,7 @@ namespace System.Windows
 
             Uri baseUri = (_rootElement is IUriContext) ? ((IUriContext)_rootElement).BaseUri : _baseUri;
             return WpfXamlLoader.LoadDeferredContent(
-                    xamlReader, _objectWriterFactory, false /*skipJournaledProperites*/,
+                    xamlReader, _objectWriterFactory, skipJournaledProperties: false,
                     _rootElement, _objectWriterSettings, baseUri);
         }
 
@@ -1745,7 +1745,7 @@ namespace System.Windows
                                 _weakDeferredResourceReferences = new WeakReferenceList();
                             }
 
-                            _weakDeferredResourceReferences.Add(deferredResourceReference, true /*SkipFind*/);
+                            _weakDeferredResourceReferences.Add(deferredResourceReference, skipFind: true);
                         }
                         else
                         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -216,7 +216,7 @@ namespace System.Windows
                 // It can be a sync/async converter. It's the converter's responsiblity to close the stream.
                 // If it fails to find a convert, this call will return null.
                 System.Windows.Markup.XamlReader asyncObjectConverter;
-                ResourceDictionary loadedRD = MimeObjectFactory.GetObjectAndCloseStreamCore(s, contentType, uri, false, false, false /*allowAsync*/, false /*isJournalNavigation*/, out asyncObjectConverter, IsUnsafe)
+                ResourceDictionary loadedRD = MimeObjectFactory.GetObjectAndCloseStreamCore(s, contentType, uri, false, false, allowAsync: false, isJournalNavigation: false, out asyncObjectConverter, IsUnsafe)
                                             as ResourceDictionary;
 
                 if (loadedRD == null)
@@ -1301,7 +1301,7 @@ namespace System.Windows
                 // to a entry in a sub-dictionary inside the deferred entry.   There is other code, later
                 // when evaluating StaticResourceHolders, that does an search of the part that is missed here.
                 staticResourceWorker.ResourceKey = keyValue;
-                object obj = staticResourceWorker.TryProvideValueInternal(serviceProvider, true /*allowDeferredReference*/, true /* mustReturnDeferredResourceReference */);
+                object obj = staticResourceWorker.TryProvideValueInternal(serviceProvider, allowDeferredReference: true, mustReturnDeferredResourceReference: true);
 
                 Debug.Assert(obj is DeferredResourceReference);
                 staticResources[i] = new StaticResourceHolder(keyValue, obj as DeferredResourceReference);
@@ -1326,8 +1326,8 @@ namespace System.Windows
                     {
                         staticResourceValues[i] = context.BamlReader.FindResourceInParentChain(
                             ((StaticResourceExtension)staticResourceValues[i]).ResourceKey,
-                            true /*allowDeferredResourceReference*/,
-                            true /*mustReturnDeferredResourceReference*/);
+                            allowDeferredResourceReference: true,
+                            mustReturnDeferredResourceReference: true);
                     }
                     else
                     {
@@ -1340,8 +1340,8 @@ namespace System.Windows
 
                         object value = context.BamlReader.FindResourceInParserStack(
                             srHolder.ResourceKey,
-                            true /*allowDeferredResourceReference*/,
-                            true /*mustReturnDeferredResourceReference*/);
+                            allowDeferredResourceReference: true,
+                            mustReturnDeferredResourceReference: true);
 
                         if (value == DependencyProperty.UnsetValue)
                         {
@@ -1700,7 +1700,7 @@ namespace System.Windows
                 resourceKey,
                 allowDeferredResourceReference,
                 mustReturnDeferredResourceReference,
-                true /*canCacheAsThemeResource*/,
+                canCacheAsThemeResource: true,
                 out canCache);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceExpression.cs
@@ -123,7 +123,7 @@ namespace System.Windows
             {
                 FrameworkElement fe;
                 FrameworkContentElement fce;
-                Helper.DowncastToFEorFCE(_mentorCache, out fe, out fce, true /*throwIfNeither*/);
+                Helper.DowncastToFEorFCE(_mentorCache, out fe, out fce, throwIfNeither: true);
 
                 // If there is a mentor do a FindResource call starting at that node
                 resource = FrameworkElement.FindResourceInternal(fe,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceExpression.cs
@@ -144,7 +144,7 @@ namespace System.Windows
                                                                         out source,
                                                                         false, // disableThrowOnResourceFailure
                                                                         true,  // allowDeferredResourceReference
-                                                                        false  /* mustReturnDeferredResourceReference*/);
+                                                                        mustReturnDeferredResourceReference: false);
             }
 
             if (resource == null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Setter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Setter.cs
@@ -232,7 +232,7 @@ namespace System.Windows
             if (me is StaticResourceExtension)
             {
                 var sr = me as StaticResourceExtension;
-                setter.Value = sr.ProvideValueInternal(eventArgs.ServiceProvider, true /*allowDeferedReference*/);
+                setter.Value = sr.ProvideValueInternal(eventArgs.ServiceProvider, allowDeferredReference: true);
                 eventArgs.Handled = true;
             }
             else if (me is DynamicResourceExtension || me is BindingBase)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StaticResourceExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StaticResourceExtension.cs
@@ -83,7 +83,7 @@ namespace System.Windows
 
         internal object ProvideValueInternal(IServiceProvider serviceProvider, bool allowDeferredReference)
         {
-            object value = TryProvideValueInternal(serviceProvider, allowDeferredReference, false /* mustReturnDeferredResourceReference */);
+            object value = TryProvideValueInternal(serviceProvider, allowDeferredReference, mustReturnDeferredResourceReference: false);
 
             if (value == DependencyProperty.UnsetValue)
             {
@@ -267,7 +267,7 @@ namespace System.Windows
 
         internal object FindResourceInDeferredContent(IServiceProvider serviceProvider, bool allowDeferredReference, bool mustReturnDeferredResourceReference)
         {
-            ResourceDictionary dictionaryWithKey = FindTheResourceDictionary(serviceProvider, /* isDeferredContentSearch */ true);
+            ResourceDictionary dictionaryWithKey = FindTheResourceDictionary(serviceProvider, isDeferredContentSearch: true);
             object value = DependencyProperty.UnsetValue;
 
             if (dictionaryWithKey != null)
@@ -316,7 +316,7 @@ namespace System.Windows
                                                 bool allowDeferredReference,
                                                 bool mustReturnDeferredResourceReference)
         {
-            ResourceDictionary dictionaryWithKey = FindTheResourceDictionary(serviceProvider, /* isDeferredContentSearch */ false);
+            ResourceDictionary dictionaryWithKey = FindTheResourceDictionary(serviceProvider, isDeferredContentSearch: false);
 
             if (dictionaryWithKey != null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Style.cs
@@ -706,7 +706,7 @@ namespace System.Windows
 
                 // Track properties on the container that are being driven by
                 // the Style so that they can be invalidated during style changes
-                StyleHelper.AddContainerDependent(propertyValue.Property, false /*fromVisualTrigger*/, ref ContainerDependents);
+                StyleHelper.AddContainerDependent(propertyValue.Property, fromVisualTrigger: false, ref ContainerDependents);
             }
         }
 
@@ -752,7 +752,7 @@ namespace System.Windows
 
                         // Track properties on the container that are being driven by
                         // the Style so that they can be invalidated during style changes
-                        StyleHelper.AddContainerDependent(propertyValue.Property, true /*fromVisualTrigger*/, ref this.ContainerDependents);
+                        StyleHelper.AddContainerDependent(propertyValue.Property, fromVisualTrigger: true, ref this.ContainerDependents);
 
                         StyleHelper.UpdateTables(ref propertyValue, ref ChildRecordFromChildIndex,
                             ref TriggerSourceRecordFromChildIndex, ref ResourceDependents, ref _dataTriggerRecordFromBinding,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -1243,7 +1243,7 @@ namespace System.Windows
                     // that the childIndex is 0.
                     StyleHelper.AddEventDependent(0, eventHandlersStore, ref eventDependents);
                 }
-                eventHandlersStore.AddRoutedEventHandler(routedEvent, StyleHelper.EventTriggerHandlerOnContainer, false/* HandledEventsToo */);
+                eventHandlersStore.AddRoutedEventHandler(routedEvent, StyleHelper.EventTriggerHandlerOnContainer, handledEventsToo: false);
             }
             else
             {
@@ -1256,7 +1256,7 @@ namespace System.Windows
                     // the current FEF's EventHandlersStore.
                     StyleHelper.AddEventDependent(childIndex, childFef.EventHandlersStore, ref eventDependents);
                 }
-                childFef.EventHandlersStore.AddRoutedEventHandler(routedEvent, StyleHelper.EventTriggerHandlerOnChild, false/* HandledEventsToo */);
+                childFef.EventHandlersStore.AddRoutedEventHandler(routedEvent, StyleHelper.EventTriggerHandlerOnChild, handledEventsToo: false);
             }
         }
 
@@ -1287,7 +1287,7 @@ namespace System.Windows
             StyleHelper.AddEventDependent( childIndex,
                                            eventHandlersStore,
                                            ref eventDependents );
-            eventHandlersStore.AddRoutedEventHandler(routedEvent, StyleHelper.EventTriggerHandlerOnChild, false/* HandledEventsToo */);
+            eventHandlersStore.AddRoutedEventHandler(routedEvent, StyleHelper.EventTriggerHandlerOnChild, handledEventsToo: false);
 
         }
 
@@ -3698,7 +3698,7 @@ namespace System.Windows
                         target.LookupEntry(dp.GlobalIndex),
                         dp,
                         dp.GetMetadata(target.DependencyObjectType),
-                        new EffectiveValueEntry() /* oldEntry */,
+                        oldEntry: new EffectiveValueEntry(),
                     ref newEntry,
                         coerceWithDeferredReference: false,
                         coerceWithCurrentValue: false,
@@ -3838,7 +3838,7 @@ namespace System.Windows
                       target.LookupEntry(dp.GlobalIndex),
                       dp,
                       dp.GetMetadata(target.DependencyObjectType),
-                      new EffectiveValueEntry() /* oldEntry */,
+                      oldEntry: new EffectiveValueEntry(),
                       ref newEntry,
                       coerceWithDeferredReference: false,
                       coerceWithCurrentValue: false,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -943,7 +943,7 @@ namespace System.Windows
 
                                 // Track properties on the container that are being driven by
                                 // the Template so that they can be invalidated during Template changes
-                                StyleHelper.AddContainerDependent(propertyValue.Property, true /*fromVisualTrigger*/, ref containerDependents);
+                                StyleHelper.AddContainerDependent(propertyValue.Property, fromVisualTrigger: true, ref containerDependents);
                             }
 
                             StyleHelper.UpdateTables(ref propertyValue, ref childRecordFromChildIndex,
@@ -2282,7 +2282,7 @@ namespace System.Windows
                         foWalk,
                         childIndices[i],
                         ref oldFrameworkTemplate.ChildRecordFromChildIndex,
-                        true /*isDetach*/,
+                        isDetach: true,
                         oldFrameworkTemplate.VisualTree);
 
                 // Unapply unshared instance values on the current node
@@ -2302,7 +2302,7 @@ namespace System.Windows
                         {
                             // Clear the entry for this unshared value in the per-instance store for MarkupExtensions
 
-                            StyleHelper.ProcessInstanceValue(walk, childIndex, instanceValues, dp, -1, false /*apply*/);
+                            StyleHelper.ProcessInstanceValue(walk, childIndex, instanceValues, dp, -1, apply: false);
                         }
 
                         // Invalidate this property so that we no longer use the template applied value
@@ -3163,7 +3163,7 @@ namespace System.Windows
                     StyleHelper.StyleDataField,
                     fe, fce,
                     oldStyle, newStyle,
-                    null /* oldFrameworkTemplate */, null /* newFrameworkTemplate */,
+                    oldFrameworkTemplate: null, newFrameworkTemplate: null,
                     (InternalFlags)0);
 
                 // If this new style has resource references (either for the container
@@ -3245,7 +3245,7 @@ namespace System.Windows
                     StyleHelper.ThemeStyleDataField,
                     fe, fce,
                     oldThemeStyle, newThemeStyle,
-                    null /* oldFrameworkTemplate */, null /* newFrameworkTemplate */,
+                    oldFrameworkTemplate: null, newFrameworkTemplate: null,
                     (InternalFlags)0);
 
                 // If this new style has resource references (either for the container
@@ -3335,8 +3335,8 @@ namespace System.Windows
                 // this needs to happen for the *first* Template.
                 StyleHelper.UpdateInstanceData(
                     StyleHelper.TemplateDataField,
-                    feContainer /* fe */, null /* fce */,
-                    null /*oldStyle */, null /* newStyle */,
+                    fe: feContainer, fce: null,
+                    oldStyle: null, newStyle: null,
                     oldFrameworkTemplate, newFrameworkTemplate,
                     InternalFlags.HasTemplateGeneratedSubTree);
 
@@ -3394,7 +3394,7 @@ namespace System.Windows
 
                 // Propagate invalidation for resource references that may be
                 // picking stuff from the style's ResourceDictionary
-                DoTemplateResourcesInvalidations(container, feContainer, null /*fce*/, oldTemplate, newTemplate);
+                DoTemplateResourcesInvalidations(container, feContainer, fce: null, oldTemplate, newTemplate);
 
                 Debug.Assert(feContainer != null);
                 feContainer.OnTemplateChangedInternal(oldFrameworkTemplate, newFrameworkTemplate);
@@ -3462,7 +3462,7 @@ namespace System.Windows
                     // Set the ShouldLookupImplicitStyles flag if the given style's Resources has implicit styles.
                     SetShouldLookupImplicitStyles(new FrameworkObject(fe, fce), newStyleTables);
 
-                    TreeWalkHelper.InvalidateOnResourcesChange(fe, fce, new ResourcesChangeInfo(oldStyleTables, newStyleTables, true /*isStyleResourcesChange*/, false /*isTemplateResourcesChange*/, container));
+                    TreeWalkHelper.InvalidateOnResourcesChange(fe, fce, new ResourcesChangeInfo(oldStyleTables, newStyleTables, isStyleResourcesChange: true, isTemplateResourcesChange: false, container));
                 }
             }
         }
@@ -3509,7 +3509,7 @@ namespace System.Windows
                     // Set the ShouldLookupImplicitStyles flag if the given template's Resources has implicit styles.
                     SetShouldLookupImplicitStyles(new FrameworkObject(fe, fce), newResourceTable);
 
-                    TreeWalkHelper.InvalidateOnResourcesChange(fe, fce, new ResourcesChangeInfo(oldResourceTable, newResourceTable, false /*isStyleResourcesChange*/, true /*isTemplateResourcesChange*/, container));
+                    TreeWalkHelper.InvalidateOnResourcesChange(fe, fce, new ResourcesChangeInfo(oldResourceTable, newResourceTable, isStyleResourcesChange: false, isTemplateResourcesChange: true, container));
                 }
             }
         }
@@ -3642,7 +3642,7 @@ namespace System.Windows
                 DependencyProperty dp = oldContainerDependents[i].Property;
 
                 // Invalidate the property only if it is not locally set
-                if (!IsSetOnContainer(dp, ref exclusionContainerDependents, false /*alsoFromTriggers*/))
+                if (!IsSetOnContainer(dp, ref exclusionContainerDependents, alsoFromTriggers: false))
                 {
                     // call GetValueCore to get value from Style/Template
                     container.InvalidateProperty(dp);
@@ -3662,8 +3662,8 @@ namespace System.Windows
                     // Invalidate the property only if it
                     // - is not a part of oldContainerDependents and
                     // - is not locally set
-                    if (!IsSetOnContainer(dp, ref exclusionContainerDependents, false /*alsoFromTriggers*/) &&
-                        !IsSetOnContainer(dp, ref oldContainerDependents, false /*alsoFromTriggers*/))
+                    if (!IsSetOnContainer(dp, ref exclusionContainerDependents, alsoFromTriggers: false) &&
+                        !IsSetOnContainer(dp, ref oldContainerDependents, alsoFromTriggers: false))
                     {
                         ApplyStyleOrTemplateValue(fo, dp);
                     }
@@ -3700,8 +3700,8 @@ namespace System.Windows
                         dp.GetMetadata(target.DependencyObjectType),
                         new EffectiveValueEntry() /* oldEntry */,
                     ref newEntry,
-                        false /* coerceWithDeferredReference */,
-                        false /* coerceWithCurrentValue */,
+                        coerceWithDeferredReference: false,
+                        coerceWithCurrentValue: false,
                         OperationType.Unknown);
             }
         }
@@ -3840,8 +3840,8 @@ namespace System.Windows
                       dp.GetMetadata(target.DependencyObjectType),
                       new EffectiveValueEntry() /* oldEntry */,
                       ref newEntry,
-                      false /* coerceWithDeferredReference */,
-                      false /* coerceWithCurrentValue */,
+                      coerceWithDeferredReference: false,
+                      coerceWithCurrentValue: false,
                       OperationType.Unknown);
             }
         }
@@ -4066,7 +4066,7 @@ namespace System.Windows
                 //  2. If the data tells us the key in the dictionary that was modified and this property is refering to it or
                 //  3. If it tells us info about the changed dictionaries and this property was refering to one of their entries
                 //  4. If this a theme change
-                if (info.Contains(resourceDependents[i].Name, false /*isImplicitStyleKey*/))
+                if (info.Contains(resourceDependents[i].Name, isImplicitStyleKey: false))
                 {
                     DependencyObject child = null;
                     DependencyProperty invalidProperty = resourceDependents[i].Property;
@@ -4133,7 +4133,7 @@ namespace System.Windows
             for (int i = 0; i < count; i++)
             {
                 if (resourceDependents[i].ChildIndex == childIndex &&
-                    info.Contains(resourceDependents[i].Name, false /*isImplicitStyleKey*/))
+                    info.Contains(resourceDependents[i].Name, isImplicitStyleKey: false))
                 {
                     DependencyProperty dp = resourceDependents[i].Property;
                     // Update property on child
@@ -4777,7 +4777,7 @@ namespace System.Windows
                 if( !deferredActions.TryGetValue(triggerContainer, out actionList) )
                 {
                     actionList = new List<DeferredAction>();
-                    deferredActions.Add(/* key */triggerContainer,/* value */actionList);
+                    deferredActions.Add(key: triggerContainer,value: actionList);
                 }
 
                 actionList.Add(deferredAction);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -99,7 +99,7 @@ namespace System.Windows
         internal static object FindResourceInternal(object key)
         {
             // Call Forwarded
-            return FindResourceInternal(key, false /*allowDeferredResourceReference*/, false /*mustReturnDeferredResourceReference*/);
+            return FindResourceInternal(key, allowDeferredResourceReference: false, mustReturnDeferredResourceReference: false);
         }
 
         internal static object FindResourceInternal(object key, bool allowDeferredResourceReference, bool mustReturnDeferredResourceReference)
@@ -619,7 +619,7 @@ namespace System.Windows
                         bool external = (_themedLocation == ResourceDictionaryLocation.ExternalAssembly);
                         if (external)
                         {
-                            LoadExternalAssembly(false /* classic */, false /* generic */, out _themedDictionaryAssembly, out dictionaryAssemblyName);
+                            LoadExternalAssembly(classic: false, generic: false, out _themedDictionaryAssembly, out dictionaryAssemblyName);
                         }
                         else
                         {
@@ -634,7 +634,7 @@ namespace System.Windows
                             {
                                 // Themed resources should have been inside the source assembly, but failed to load.
                                 // Try falling back to external in case this is a theme that shipped later.
-                                LoadExternalAssembly(false /* classic */, false /* generic */, out _themedDictionaryAssembly, out dictionaryAssemblyName);
+                                LoadExternalAssembly(classic: false, generic: false, out _themedDictionaryAssembly, out dictionaryAssemblyName);
                                 if (_themedDictionaryAssembly != null)
                                 {
                                     dictionary = LoadDictionary(_themedDictionaryAssembly, dictionaryAssemblyName, ThemedResourceName, isTraceEnabled, out _themedDictionarySourceUri);
@@ -647,7 +647,7 @@ namespace System.Windows
                             // If a non-classic dictionary failed to load, then try to load classic.
                             if (external)
                             {
-                                LoadExternalAssembly(true /* classic */, false /* generic */, out _themedDictionaryAssembly, out dictionaryAssemblyName);
+                                LoadExternalAssembly(classic: true, generic: false, out _themedDictionaryAssembly, out dictionaryAssemblyName);
                             }
                             else
                             {
@@ -706,7 +706,7 @@ namespace System.Windows
                         string dictionaryAssemblyName;
                         if (_genericLocation == ResourceDictionaryLocation.ExternalAssembly)
                         {
-                            LoadExternalAssembly(false /* classic */, true /* generic */, out _genericDictionaryAssembly, out dictionaryAssemblyName);
+                            LoadExternalAssembly(classic: false, generic: true, out _genericDictionaryAssembly, out dictionaryAssemblyName);
                         }
                         else
                         {
@@ -1944,7 +1944,7 @@ namespace System.Windows
                     // Only cache keys that would be located by FindResourceInternal
                     if ((key is Type || key is ResourceKey) && _canCacheAsThemeResource && canCache)
                     {
-                        SystemResources.CacheResource(key, value, false /*isTraceEnabled*/);
+                        SystemResources.CacheResource(key, value, isTraceEnabled: false);
                     }
 
                     return value;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateContent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateContent.cs
@@ -693,13 +693,13 @@ namespace System.Windows
                         // Inline Template case:
                         if (staticResource.GetType() == typeof(StaticResourceExtension))
                         {
-                            obj = staticResource.TryProvideValueInternal(TemplateLoadData.ServiceProviderWrapper, true/*allowDeferredReference*/, true/*mustReturnDeferredResourceReference*/);
+                            obj = staticResource.TryProvideValueInternal(TemplateLoadData.ServiceProviderWrapper, allowDeferredReference: true, mustReturnDeferredResourceReference: true);
                         }
 
                         // Template in a Resource Dictionary entry case:
                         else if (staticResource.GetType() == typeof(StaticResourceHolder))
                         {
-                            obj = staticResource.FindResourceInDeferredContent(TemplateLoadData.ServiceProviderWrapper, true/*allowDeferredReference*/, false/*mustReturnDeferredResourceReference*/);
+                            obj = staticResource.FindResourceInDeferredContent(TemplateLoadData.ServiceProviderWrapper, allowDeferredReference: true, mustReturnDeferredResourceReference: false);
                             if (obj == DependencyProperty.UnsetValue)
                             {
                                 obj = null;  // value is only interesting if it improves the previous value.
@@ -776,7 +776,7 @@ namespace System.Windows
             // If the StaicResource was in NodeList form then it would not have been pre-resolved.
             // So do a full walk now, not a Live-Stack only.
             // Resolve the StaticResource value including lookup to the app and the theme
-            DeferredResourceReference value = (DeferredResourceReference)resource.TryProvideValueInternal(TemplateLoadData.ServiceProviderWrapper, true/*allowDeferredReference*/, true/*mustReturnDeferredResourceReference*/);
+            DeferredResourceReference value = (DeferredResourceReference)resource.TryProvideValueInternal(TemplateLoadData.ServiceProviderWrapper, allowDeferredReference: true, mustReturnDeferredResourceReference: true);
 
             // Return the value that will be written out the unshareable node list;
             return new StaticResourceHolder(resource.ResourceKey, value);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateNameScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateNameScope.cs
@@ -87,7 +87,7 @@ namespace System.Windows
 
             Helper.DowncastToFEorFCE( scopedElement as DependencyObject,
                                       out fe, out fce,
-                                      false /*throwIfNeither*/ );
+                                      throwIfNeither: false);
 
             int childIndex;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
@@ -851,8 +851,8 @@ namespace System.Windows
                     // invalidated these properties.
                     if (!fce.HasStyleChanged)
                     {
-                        StyleHelper.InvalidateResourceDependents(d, info, ref fce.Style.ResourceDependents, !
-                            false /*invalidateVisualTreeToo */);
+                        StyleHelper.InvalidateResourceDependents(d, info, ref fce.Style.ResourceDependents,
+                            invalidateVisualTreeToo: !false);
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
@@ -405,8 +405,8 @@ namespace System.Windows
                                 fMetadata,
                                 oldEntry,
                                 ref newEntry,
-                                false /* coerceWithDeferredReference */,
-                                false /* coerceWithCurrentValue */,
+                                coerceWithDeferredReference: false,
+                                coerceWithCurrentValue: false,
                                 operationType)
                             & (UpdateResult.ValueChanged | UpdateResult.InheritedValueOverridden))
                             == UpdateResult.ValueChanged;
@@ -425,8 +425,8 @@ namespace System.Windows
                                 fMetadata,
                                 oldEntry,
                                 ref newEntry,
-                                false /* coerceWithDeferredReference */,
-                                false /* coerceWithCurrentValue */,
+                                coerceWithDeferredReference: false,
+                                coerceWithCurrentValue: false,
                                 operationType)
                             & (UpdateResult.ValueChanged | UpdateResult.InheritedValueOverridden))
                             == UpdateResult.ValueChanged;
@@ -522,7 +522,7 @@ namespace System.Windows
         {
             Debug.Assert(d != null, "Must have non-null current node");
 
-            bool containsTypeOfKey = info.Contains(d.DependencyObjectType.SystemType, true /*isImplicitStyleKey*/);
+            bool containsTypeOfKey = info.Contains(d.DependencyObjectType.SystemType, isImplicitStyleKey: true);
             bool isSystemResourcesChange = info.IsThemeChange;
             bool isStyleResourcesChange = info.IsStyleResourcesChange;
             bool isTemplateResourcesChange = info.IsTemplateResourcesChange;
@@ -710,7 +710,7 @@ namespace System.Windows
                     {
                         // Record this property if it is referring
                         // to a resource that is being changed
-                        if (info.Contains(resource.ResourceKey, false /*isImplicitStyleKey*/))
+                        if (info.Contains(resource.ResourceKey, isImplicitStyleKey: false))
                         {
                             resources[invalidationCount]  = resource;
                             invalidationCount++;
@@ -777,7 +777,7 @@ namespace System.Windows
                     if (!fe.HasStyleChanged)
                     {
                         StyleHelper.InvalidateResourceDependents(d, info, ref fe.Style.ResourceDependents,
-                            false /* invalidateVisualTreeToo */);
+                            invalidateVisualTreeToo: false);
                     }
                 }
 
@@ -786,7 +786,7 @@ namespace System.Windows
                     // Check for resource references contained within associated Template.
                     // If found, invalidate all properties that are being driven by a resource
                     StyleHelper.InvalidateResourceDependents(d, info, ref fe.TemplateInternal.ResourceDependents,
-                        false /* invalidateVisualTreeToo */);
+                        invalidateVisualTreeToo: false);
                 }
 
                 if (fe.TemplateChildIndex > 0)
@@ -819,7 +819,7 @@ namespace System.Windows
                         if (themeStyle != fe.Style)
                         {
                             StyleHelper.InvalidateResourceDependents(d, info, ref themeStyle.ResourceDependents,
-                                false /* invalidateVisualTreeToo */);
+                                invalidateVisualTreeToo: false);
                         }
                     }
                 }
@@ -886,7 +886,7 @@ namespace System.Windows
                         if (themeStyle != fce.Style)
                         {
                             StyleHelper.InvalidateResourceDependents(d, info, ref themeStyle.ResourceDependents,
-                                false /*invalidateVisualTreeToo */);
+                                invalidateVisualTreeToo: false);
                         }
                     }
                 }
@@ -1056,8 +1056,8 @@ namespace System.Windows
                             metadata,
                             oldEntry,
                             ref newEntry,
-                            false /* coerceWithDeferredReference */,
-                            false /* coerceWithCurrentValue */,
+                            coerceWithDeferredReference: false,
+                            coerceWithCurrentValue: false,
                             OperationType.Inherit)
                         & (UpdateResult.ValueChanged | UpdateResult.InheritedValueOverridden))
                         == UpdateResult.ValueChanged;
@@ -1076,8 +1076,8 @@ namespace System.Windows
                             metadata,
                             oldEntry,
                             ref newEntry,
-                            false /* coerceWithDeferredReference */,
-                            false /* coerceWithCurrentValue */,
+                            coerceWithDeferredReference: false,
+                            coerceWithCurrentValue: false,
                             OperationType.Inherit)
                         & (UpdateResult.ValueChanged | UpdateResult.InheritedValueOverridden))
                         == UpdateResult.ValueChanged;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -4504,7 +4504,7 @@ namespace System.Windows
             while (ownedWindows.Count > 0)
             {
                 // if parent window is closing, child window Closing cannot be cancelled.
-                ownedWindows[0].InternalClose(false, true /* Ignore cancel */);
+                ownedWindows[0].InternalClose(false, ignoreCancel: true);
             }
 
             Debug.Assert(ownedWindows.Count == 0, "All owned windows should now be gone");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -81,11 +81,11 @@ namespace System.Windows
             EventManager.RegisterClassHandler(typeof(Window),
                 UIElement.ManipulationCompletedEvent,
                 new EventHandler<ManipulationCompletedEventArgs>(OnStaticManipulationCompleted),
-                /*handledEventsToo*/ true);
+                handledEventsToo: true);
             EventManager.RegisterClassHandler(typeof(Window),
                 UIElement.ManipulationInertiaStartingEvent,
                 new EventHandler<ManipulationInertiaStartingEventArgs>(OnStaticManipulationInertiaStarting),
-                /*handledEventsToo*/ true);
+                handledEventsToo: true);
 
             Window.DpiChangedEvent = EventManager.RegisterRoutedEvent("DpiChanged", RoutingStrategy.Bubble,
                 typeof (System.Windows.DpiChangedEventHandler), typeof (Window));


### PR DESCRIPTION
Contributes to dotnet/wpf#10018

## Description
I replaced comments specifying an argument name with named arguments, which were introduced in C# 7. This improves readability and maintainability.

My changes are in 2 commits. The first commit is automated changes using regexes and the second commit is manual changes where the comment is outdated or formatted differently than the parameter name.

**Note: The compiled IL is identical.**

## Customer Impact
None.

## Regression
No.

## Testing
Local build + validated IL.

## Risk
Low to none.