### PR TITLE
Replace ArrayList from CompositionAdorner with List<AttributeRange>

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CompositionAdorner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/CompositionAdorner.cs
@@ -37,7 +37,7 @@ namespace System.Windows.Documents
         /// <param name="textView">
         /// TextView to which this CompositionAdorner is attached as adorner.
         /// </param>
-        internal CompositionAdorner(ITextView textView) : this(textView, new ArrayList())
+        internal CompositionAdorner(ITextView textView) : this(textView, new List<AttributeRange>())
         {
         }
 
@@ -50,8 +50,7 @@ namespace System.Windows.Documents
         /// <param name="attributeRanges">
         /// Attribute ranges
         /// </param>
-        internal CompositionAdorner(ITextView textView, ArrayList attributeRanges)
-            : base(textView.RenderScope)
+        private CompositionAdorner(ITextView textView, List<AttributeRange> attributeRanges) : base(textView.RenderScope)
         {
             Debug.Assert(textView != null && textView.RenderScope != null);
 
@@ -83,23 +82,17 @@ namespace System.Windows.Documents
         /// Transform to apply to the adorner
         /// </returns>
         public override GeneralTransform GetDesiredTransform(GeneralTransform transform)
-        {            
-            TranslateTransform translation;
-            GeneralTransformGroup group = new GeneralTransformGroup();
-
+        {
             // Get the matrix transform out, skip all non affine transforms
-            Transform t = transform.AffineTransform;
-            if (t == null)
-            {                
-                t = Transform.Identity;                
-            }
+            Transform t = transform.AffineTransform ?? Transform.Identity;
 
             // Translate the adorner to (0, 0) point
-            translation = new TranslateTransform(-(t.Value.OffsetX), -(t.Value.OffsetY));
+            TranslateTransform translation = new(-t.Value.OffsetX, -t.Value.OffsetY);
 
+            GeneralTransformGroup group = new GeneralTransformGroup();
             group.Children.Add(translation);
 
-            if (transform != null)
+            if (transform is not null)
             {
                 group.Children.Add(transform);
             }
@@ -124,8 +117,7 @@ namespace System.Windows.Documents
         {
             // Get the matrix from AdornedElement to the visual parent to get the transformed
             // start/end point
-            Visual parent2d = VisualTreeHelper.GetParent(this.AdornedElement) as Visual;
-            if (parent2d == null)
+            if (VisualTreeHelper.GetParent(AdornedElement) is not Visual parent2d)
             {
                 return;
             }
@@ -149,7 +141,7 @@ namespace System.Windows.Documents
                 DoubleCollection dashArray;
 
                 // Get the composition attribute range from the attribute range lists
-                AttributeRange attributeRange = (AttributeRange)_attributeRanges[i];
+                AttributeRange attributeRange = _attributeRanges[i];
 
                 // Skip the rendering composition lines if the composition line doesn't exist.
                 if (attributeRange.CompositionLines.Count == 0)
@@ -158,7 +150,7 @@ namespace System.Windows.Documents
                 }
 
                 // Set the line bold and squiggle
-                bool lineBold = attributeRange.TextServicesDisplayAttribute.IsBoldLine ? true : false;
+                bool lineBold = attributeRange.TextServicesDisplayAttribute.IsBoldLine;
                 bool squiggle = false;
                 bool hasVirtualSelection = (attributeRange.TextServicesDisplayAttribute.AttrInfo & UnsafeNativeMethods.TF_DA_ATTR_INFO.TF_ATTR_TARGET_CONVERTED) != 0;
 
@@ -340,15 +332,14 @@ namespace System.Windows.Documents
             for (int i = 0; i < _attributeRanges.Count; i++)
             {
                 // Get the composition attribute range from the attribute range lists
-                AttributeRange attributeRange = (AttributeRange)_attributeRanges[i];
+                AttributeRange attributeRange = _attributeRanges[i];
 
                 // Add the composition lines for rendering the composition lines
                 attributeRange.AddCompositionLines();
             }
 
             // Invalidate the CompositionAdorner to update the rendering.
-            AdornerLayer adornerLayer = VisualTreeHelper.GetParent(this) as AdornerLayer;
-            if (adornerLayer != null)
+            if (VisualTreeHelper.GetParent(this) is AdornerLayer adornerLayer)
             {
                 adornerLayer.Update(AdornedElement);
                 adornerLayer.InvalidateArrange();
@@ -375,7 +366,7 @@ namespace System.Windows.Documents
         {
             if (_adornerLayer != null)
             {
-                // Remove CompositionAdorner form the socping of AdornerLayer
+                // Remove CompositionAdorner from the scoping of AdornerLayer
                 _adornerLayer.Remove(this);
                 _adornerLayer = null;
             }
@@ -398,7 +389,7 @@ namespace System.Windows.Documents
         private ITextView _textView;
 
         // ArrayList for the composition attribute ranges
-        private readonly ArrayList _attributeRanges;
+        private readonly List<AttributeRange> _attributeRanges;
 
         // Composition line's dot length
         private const double DotLength = 1.2;


### PR DESCRIPTION
## Description

Replaces `ArrayList` with `List<AttributeRange>` to increase type safety and promote strongly-typed code. Most of the perf benefits beyond t0 were now erased in post .NET 9 as the `ArrayList` methods are usually successfully de-abstracted but that doesn't really matter as its still a benefit to use a generic collection type instead e.g. to bypass cast checks.

## Customer Impact

Cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low, just a type swap on private collection.
