### PR TITLE
[StyleCleanUp] Use ArgumentOutOfRangeException throw helper (CA1512)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -53,9 +53,6 @@ dotnet_diagnostic.CA1510.severity = suggestion
 # CA2211: Non-constant fields should not be visible
 dotnet_diagnostic.CA2211.severity = suggestion
 
-# CA1512: Use ArgumentOutOfRangeException throw helper
-dotnet_diagnostic.CA1512.severity = suggestion
-
 # CA1513: Use ObjectDisposedException throw helper
 dotnet_diagnostic.CA1513.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/GlobalSuppressions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/GlobalSuppressions.cs
@@ -32,3 +32,6 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "Compat", Scope = "member", Target = "~M:System.Windows.Clipboard.IsCurrent(System.Windows.IDataObject)~System.Boolean")]
 [assembly: SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "Compat", Scope = "member", Target = "~M:System.Windows.DataObject.System#Runtime#InteropServices#ComTypes#IDataObject#EnumFormatEtc(System.Runtime.InteropServices.ComTypes.DATADIR)~System.Runtime.InteropServices.ComTypes.IEnumFORMATETC")]
 [assembly: SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "Compat", Scope = "member", Target = "~M:System.Windows.OleServicesContext.SetDispatcherThread")]
+
+// TODO: Remove these when analyzer issue is fixed (https://github.com/dotnet/roslyn-analyzers/issues/7617)
+[assembly: SuppressMessage("Maintainability", "CA1512:Use ArgumentOutOfRangeException throw helper", Justification = "Analyzer bug: https://github.com/dotnet/roslyn-analyzers/issues/7617", Scope = "member", Target = "~M:System.Windows.Interop.D3DImage.TryLock(System.Windows.Duration)~System.Boolean")]


### PR DESCRIPTION
Fixes #10674 

## Description

Fixes the leftover violations via suppressions as there's currently a bug I've described in https://github.com/dotnet/roslyn-analyzers/issues/7617. To be honest, `Duration` could simply implement `IEquatable<T>`/`IComparable<T>`.

## Customer Impact

Cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10675)