### PR TITLE
Avoid boxing booleans and allocations in UncommonField<bool>

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -44,22 +44,19 @@ namespace System.Windows
 
             EntryIndex entryIndex = instance.LookupEntry(_globalIndex);
 
-            // Set the value if it's not the default, otherwise remove the value.
-            if (!object.ReferenceEquals(value, _defaultValue))
+            // Special case boolean operations to avoid boxing with (mostly) UIA code paths
+            if (typeof(T) == typeof(bool))
             {
-                object valueObject;
-
-                if (typeof(T) == typeof(bool))
-                {
-                    // Use shared boxed instances rather than creating new objects for each SetValue call.
-                    valueObject = BooleanBoxes.Box(Unsafe.As<T, bool>(ref value));
-                }
-                else
-                {
-                    valueObject = value;
-                }
+                // Use shared boxed instances rather than creating new objects for each SetValue call.
+                object valueObject = BooleanBoxes.Box(Unsafe.BitCast<T, bool>(value));
 
                 instance.SetEffectiveValue(entryIndex, dp: null, _globalIndex, metadata: null, valueObject, BaseValueSourceInternal.Local);
+                _hasBeenSet = true;
+            }
+            // Set the value if it's not the default, otherwise remove the value.
+            else if (!ReferenceEquals(value, _defaultValue))
+            {
+                instance.SetEffectiveValue(entryIndex, dp: null, _globalIndex, metadata: null, value, BaseValueSourceInternal.Local);
                 _hasBeenSet = true;
             }
             else


### PR DESCRIPTION
Fixes #10677
Fixes #4114

## Description

Even though `UncommonField` itself is generic, the underlying value storage (EffectiveValues) is not, therefore values saved in uncommon field end up being boxed same way `DependencyProperty` values are.

A common case is storing a `boolean` (mostly `true`), which we can easily special-case using our `BooleanBoxes`.

While I could fix `Unset` values for value types, this wasn't originally done so that would be a behavioral change (though it would probably help in some cases to free up some memory).

## Customer Impact

See #10677 for impact of this change.

## Regression

Depends how you look at it, given the history. But it was boxing in the original, so I guess not.

## Testing

Local build, verifying functionality accross different scenarios (`GridView`, `HiearchicalVirtualization` via `TreeView`/`VirtualizingStackPanel`, etc.)

## Risk

Low, this just adds a generic path for `bool` that is otherwise eliminated.
