### PR TITLE
[StyleCleanUp] Fix misplaced using directives in CSP (IDE0065)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Generated/ToleranceTypeValidation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Generated/ToleranceTypeValidation.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 //
 //

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/helpers/ManagedStyle.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/helpers/ManagedStyle.cs
@@ -53,7 +53,6 @@ namespace MS.Internal.MilCodeGen.Helpers
                 [[inline]]
                     // Licensed to the .NET Foundation under one or more agreements.
                     // The .NET Foundation licenses this file to you under the MIT license.
-                    // See the LICENSE file in the project root for more information.
 
                     //
                     //

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/Generated/wgx_command_types.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/Generated/wgx_command_types.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 //
 //

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/Generated/wgx_commands.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/Generated/wgx_commands.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 //
 //

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/Generated/wgx_misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/Generated/wgx_misc.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 //
 //

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/Generated/wgx_resource_types.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/Generated/wgx_resource_types.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 //
 //

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/CsPrimeParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/CsPrimeParser.cs
@@ -11,14 +11,12 @@
 //
 //
 
+using System.Text.RegularExpressions;
+using System.Collections;
+using System.Text;
+
 namespace MS.Internal.Csp
 {
-    using System;
-    using System.IO;
-    using System.Text;
-    using System.Text.RegularExpressions;
-    using System.Collections;
-
     internal sealed class CsPrimeParser
     {
         private struct Position

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/CsPrimeRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/CsPrimeRuntime.cs
@@ -14,11 +14,10 @@
 //        provided to the project that Csp.exe will execute.
 //
 
+using System.Text;
+
 namespace MS.Internal.Csp
 {
-    using System;
-    using System.Text;
-
     public sealed class CsPrimeRuntime
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/GlobalUsings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/GlobalUsings.cs
@@ -1,0 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+global using System.IO;
+global using System;

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/MainClass.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/MainClass.cs
@@ -19,15 +19,13 @@
 //
 //------------------------------------------------------------------------------
 
+using System.CodeDom.Compiler;
+using System.Collections;
+using System.Diagnostics;
+using System.Text;
+
 namespace MS.Internal.Csp
 {
-    using System;
-    using System.Collections;
-    using System.Diagnostics;
-    using System.IO;
-    using System.Text;
-    using System.CodeDom.Compiler;
-
     internal sealed class MainClass
     {
         // Parameters affecting csp.exe as a whole.

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/Project.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/Project.cs
@@ -10,15 +10,13 @@
 //              a set of "C# prime" files, then executes the project.
 //
 
+using System.CodeDom.Compiler;
+using System.Collections;
+using System.Reflection;
+using System.Text;
+
 namespace MS.Internal.Csp
 {
-    using System;
-    using System.IO;
-    using System.Text;
-    using System.Collections;
-    using System.Reflection;
-    using System.CodeDom.Compiler;
-
     // This kind of exception is thrown when csp detects an
     // error in the project.
     public class CspProjectException : ApplicationException

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/TempDirectory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/TempDirectory.cs
@@ -13,9 +13,6 @@
 
 namespace MS.Internal.Csp
 {
-    using System;
-    using System.IO;
-
     internal class TempDirectory : IDisposable
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/csp.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/tools/csp/csp.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+  	<Compile Include="GlobalUsings.cs" />
     <Compile Include="MainClass.cs" />
     <Compile Include="Project.cs" />
     <Compile Include="TempDirectory.cs" />


### PR DESCRIPTION
Fixes #10682

## Description

This fixes `using` placements in CSP which I've overlooked when I've removed it in #10374 as we still don't run `MilCodeGen` during build, hence this fixes that + also corrects the header for IDE0073 for generated files from the last commit.

## Customer Impact

Cleaner codebase for developers, being able to run MilCodeGen.

## Regression

Kinda, MilCodeGen won't work without suppressing warnings now.

## Testing

Local build, codegen run.

## Risk

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10683)