### PR TITLE
Avoid obsoletion warning suppression in ActiveXHost

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/ActiveXHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/ActiveXHost.cs
@@ -79,14 +79,11 @@ namespace System.Windows.Interop
         /// constructor for ActiveXHost
         internal ActiveXHost(Guid clsid, bool fTrusted ) : base( fTrusted )
         {
-            // Thread.ApartmentState is [Obsolete]
-            #pragma warning disable 0618
             // What if the control is marked as free-threaded?
-            if (Thread.CurrentThread.ApartmentState != ApartmentState.STA)
+            if (Thread.CurrentThread.GetApartmentState() is not ApartmentState.STA)
             {
                 throw new ThreadStateException(SR.Format(SR.AxRequiresApartmentThread, clsid.ToString()));
             }
-            #pragma warning restore 0618
 
             _clsid = clsid;
 


### PR DESCRIPTION
## Description

Avoids warning suppression for `ApartmentState` property by using the newer method instead. In the retrieval (get) context, checking for STA has no behavioral difference between those two, hence no reason to NOT use it.

Also, this is the only place in WPF where the swap to the method hasn't been done yet.

## Customer Impact

Cleaner codebase for developers, not using BCL obsoleted methods.

## Regression

No.

## Testing

Local build.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10689)