### PR TITLE
Replace ArrayList from FrameworkElement with List<TemplateKey>

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
@@ -65,10 +65,9 @@ namespace MS.Internal
 
 
         // Find a data template (or table template) resource
-        internal static object FindTemplateResourceFromAppOrSystem(DependencyObject target, ArrayList keys, int exactMatch, ref int bestMatch)
+        internal static object FindTemplateResourceFromAppOrSystem(DependencyObject target, List<TemplateKey> keys, int exactMatch, ref int bestMatch)
         {
             object resource = null;
-            int k;
 
             // Comment out below three lines code.
             // For now, we will always get the resource from Application level
@@ -86,7 +85,7 @@ namespace MS.Internal
             if (app != null)
             {
                 // If the element is rooted to a Window and App exists, defer to App.
-                for (k = 0;  k < bestMatch;  ++k)
+                for (int k = 0; k < bestMatch; k++)
                 {
                     object appResource = Application.Current.FindResourceInternal(keys[k]);
                     if (appResource != null)
@@ -105,7 +104,7 @@ namespace MS.Internal
             if (bestMatch >= exactMatch)
             {
                 // Try the system resource collection.
-                for (k = 0;  k < bestMatch;  ++k)
+                for (int k = 0; k < bestMatch; k++)
                 {
                     object sysResource = SystemResources.FindResourceInternal(keys[k]);
                     if (sysResource != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
@@ -1409,18 +1409,18 @@ namespace System.Windows
                 return null;
             }
 
-            Type type;
-            object dataType = ContentPresenter.DataTypeForItem(item, target, out type);
-
-            ArrayList keys = new ArrayList();
+            object dataType = ContentPresenter.DataTypeForItem(item, target, out Type type);
 
             // construct the list of acceptable keys, in priority order
-            int exactMatch = -1;    // number of entries that count as an exact match
-
             // add compound keys for the dataType and all its base types
+            List<TemplateKey> keys = new();
+
+            // number of entries that count as an exact match
+            int exactMatch = -1;
+
             while (dataType != null)
             {
-                object key = null;
+                TemplateKey key = null;
                 if (templateType == typeof(ItemContainerTemplate))
                     key = new ItemContainerTemplateKey(dataType);
                 else if (templateType == typeof(DataTemplate))
@@ -1436,7 +1436,7 @@ namespace System.Windows
                 if (type != null)
                 {
                     type = type.BaseType;
-                    if (type == typeof(Object))     // don't search for Object - perf
+                    if (type == typeof(object))     // don't search for Object - perf
                         type = null;
                 }
 
@@ -1461,14 +1461,14 @@ namespace System.Windows
         }
 
         // Search the parent chain for a [Data|Table]Template in a ResourceDictionary.
-        private static object FindTemplateResourceInTree(DependencyObject target, ArrayList keys, int exactMatch, ref int bestMatch)
+        private static object FindTemplateResourceInTree(DependencyObject target, List<TemplateKey> keys, int exactMatch, ref int bestMatch)
         {
             Debug.Assert(target != null, "Don't call FindTemplateResource with a null target object");
 
             ResourceDictionary table;
             object resource = null;
 
-            FrameworkObject fo = new FrameworkObject(target);
+            FrameworkObject fo = new(target);
             Debug.Assert(fo.IsValid, "Don't call FindTemplateResource with a target object that is neither a FrameworkElement nor a FrameworkContentElement");
 
             while (fo.IsValid)
@@ -1482,9 +1482,9 @@ namespace System.Windows
                 // Fetch the ResourceDictionary
                 // for the given target element
                 table = GetInstanceResourceDictionary(fo.FE, fo.FCE);
-                if( table != null )
+                if (table != null)
                 {
-                    candidate = FindBestMatchInResourceDictionary( table, keys, exactMatch, ref bestMatch );
+                    candidate = FindBestMatchInResourceDictionary(table, keys, exactMatch, ref bestMatch);
                     if (candidate != null)
                     {
                         resource = candidate;
@@ -1501,9 +1501,9 @@ namespace System.Windows
                 // -------------------------------------------
 
                 table = GetStyleResourceDictionary(fo.FE, fo.FCE);
-                if( table != null )
+                if (table != null)
                 {
-                    candidate = FindBestMatchInResourceDictionary( table, keys, exactMatch, ref bestMatch );
+                    candidate = FindBestMatchInResourceDictionary(table, keys, exactMatch, ref bestMatch);
                     if (candidate != null)
                     {
                         resource = candidate;
@@ -1520,9 +1520,9 @@ namespace System.Windows
                 // -------------------------------------------
 
                 table = GetThemeStyleResourceDictionary(fo.FE, fo.FCE);
-                if( table != null )
+                if (table != null)
                 {
-                    candidate = FindBestMatchInResourceDictionary( table, keys, exactMatch, ref bestMatch );
+                    candidate = FindBestMatchInResourceDictionary(table, keys, exactMatch, ref bestMatch);
                     if (candidate != null)
                     {
                         resource = candidate;
@@ -1539,9 +1539,9 @@ namespace System.Windows
                 // -------------------------------------------
 
                 table = GetTemplateResourceDictionary(fo.FE, fo.FCE);
-                if( table != null )
+                if (table != null)
                 {
-                    candidate = FindBestMatchInResourceDictionary( table, keys, exactMatch, ref bestMatch );
+                    candidate = FindBestMatchInResourceDictionary(table, keys, exactMatch, ref bestMatch);
                     if (candidate != null)
                     {
                         resource = candidate;
@@ -1580,16 +1580,14 @@ namespace System.Windows
 
         // Given a ResourceDictionary and a set of keys, try to find the best
         //  match in the resource dictionary.
-        private static object FindBestMatchInResourceDictionary(
-            ResourceDictionary table, ArrayList keys, int exactMatch, ref int bestMatch)
+        private static object FindBestMatchInResourceDictionary(ResourceDictionary table, List<TemplateKey> keys, int exactMatch, ref int bestMatch)
         {
             object resource = null;
-            int k;
 
             // Search target element's ResourceDictionary for the resource
             if (table != null)
             {
-                for (k = 0;  k < bestMatch;  ++k)
+                for (int k = 0; k < bestMatch; k++)
                 {
                     object candidate = table[keys[k]];
                     if (candidate != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
@@ -3133,17 +3133,11 @@ namespace System.Windows
             return continueInvalidation;
         }
 
-        internal static bool InvalidateAutomationIntermediateElements(
-            DependencyObject mergePoint,
-            DependencyObject modelTreeNode)
+        internal static bool InvalidateAutomationIntermediateElements(DependencyObject mergePoint, DependencyObject modelTreeNode)
         {
-            UIElement e = null;
-            ContentElement ce = null;
-            UIElement3D e3d = null;
-
             while (modelTreeNode != null && modelTreeNode != mergePoint)
             {
-                if (!UIElementHelper.InvalidateAutomationPeer(modelTreeNode, out e, out ce, out e3d))
+                if (!UIElementHelper.InvalidateAutomationPeer(modelTreeNode, out _, out _, out _))
                 {
                     return false;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
@@ -1404,7 +1404,7 @@ namespace System.Windows
         internal static object FindTemplateResourceInternal(DependencyObject target, object item, Type templateType)
         {
             // Data styling doesn't apply to UIElement (bug 1007133).
-            if (item == null || (item is UIElement))
+            if (item is null or UIElement)
             {
                 return null;
             }
@@ -1420,14 +1420,10 @@ namespace System.Windows
 
             while (dataType != null)
             {
-                TemplateKey key = null;
                 if (templateType == typeof(ItemContainerTemplate))
-                    key = new ItemContainerTemplateKey(dataType);
+                    keys.Add(new ItemContainerTemplateKey(dataType));
                 else if (templateType == typeof(DataTemplate))
-                    key = new DataTemplateKey(dataType);
-
-                if (key != null)
-                    keys.Add(key);
+                    keys.Add(new DataTemplateKey(dataType));
 
                 // all keys added for the given item type itself count as an exact match
                 if (exactMatch == -1)


### PR DESCRIPTION
## Description

Replaces `ArrayList` with `List<TemplateKey>` to increase type safety and promote strongly-typed code. Most of the perf benefits beyond t0 were now erased in post .NET 9 as the `ArrayList` methods are usually successfully de-abstracted but that doesn't really matter as its still a benefit to use a generic collection type instead e.g. to bypass cast checks.

## Customer Impact

Cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low, just a type swap on private collection.