### PR TITLE
[StyleCleanUp] Specify StringComparison for correctness (CA1310)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -38,9 +38,6 @@ dotnet_diagnostic.CA1067.severity = suggestion
 # CA1070: Do not declare event fields as virtual
 dotnet_diagnostic.CA1070.severity = suggestion
 
-# CA1310: Specify StringComparison for correctness
-dotnet_diagnostic.CA1310.severity = suggestion
-
 # CA1419: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
 dotnet_diagnostic.CA1419.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/ComWrappersSupport.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/ComWrappersSupport.cs
@@ -153,7 +153,7 @@ namespace WinRT
 
             Type type = obj.GetType();
 
-            if (type.FullName.StartsWith("ABI."))
+            if (type.FullName.StartsWith("ABI.", StringComparison.Ordinal))
             {
                 type = Projections.FindCustomPublicTypeForAbiType(type) ?? type.Assembly.GetType(type.FullName.Substring("ABI.".Length)) ?? type;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/TypeExtensions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/TypeExtensions.cs
@@ -5,9 +5,10 @@ using System.Reflection;
 
 namespace WinRT
 {
-
     internal static class TypeExtensions
     {
+        private const string NamespacePrefix = "MS.Internal.WindowsRuntime.";
+
         public static Type FindHelperType(this Type type)
         {
             if (typeof(Exception).IsAssignableFrom(type))
@@ -19,12 +20,14 @@ namespace WinRT
             {
                 return customMapping;
             }
-            var helper = $"ABI.{type.FullName}";
+
+            string helper = $"ABI.{type.FullName}";
             string helperTypeName2 = $"MS.Internal.WindowsRuntime.ABI.{type.FullName}";
-            if (type.FullName.StartsWith("MS.Internal.WindowsRuntime."))
+            if (type.FullName.StartsWith(NamespacePrefix, StringComparison.Ordinal))
             {
                 helper = $"MS.Internal.WindowsRuntime.ABI.{RemoveNamespacePrefix(type.FullName)}";
             }
+
             return Type.GetType(helper) ?? Type.GetType(helperTypeName2);
         }
 
@@ -72,12 +75,7 @@ namespace WinRT
 
         public static string RemoveNamespacePrefix(string ns)
         {
-            const string NamespacePrefix = "MS.Internal.WindowsRuntime.";
-            if (ns.StartsWith(NamespacePrefix))
-            {
-                return ns.Substring(NamespacePrefix.Length);
-            }
-            return ns;
+            return ns.StartsWith(NamespacePrefix, StringComparison.Ordinal) ? ns.Substring(NamespacePrefix.Length) : ns;
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemContainerGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemContainerGenerator.cs
@@ -1115,7 +1115,7 @@ namespace System.Windows.Controls
 
                 const string PublicKeyToken = "PublicKeyToken=";
                 string aqn = sourceType.AssemblyQualifiedName;
-                int index = aqn.LastIndexOf(PublicKeyToken);
+                int index = aqn.LastIndexOf(PublicKeyToken, StringComparison.Ordinal);
                 if (index >= 0)
                 {
                     ReadOnlySpan<char> token = aqn.AsSpan(index + PublicKeyToken.Length);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
@@ -4829,7 +4829,7 @@ namespace System.Windows.Documents
                     }
 
                     string name = t.ToString();
-                    isWPFControl = name.StartsWith("System.Windows.Controls.");
+                    isWPFControl = name.StartsWith("System.Windows.Controls.", StringComparison.Ordinal);
                     if (isWPFControl)
                     {
                         name = name.Substring(24);  // 24 == length of "s.w.c."

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/ElementMarkupObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/ElementMarkupObject.cs
@@ -495,15 +495,16 @@ namespace System.Windows.Markup.Primitives
                             Type keyType = GetDictionaryKeyType(dictionary);
 
                             // Attempt to emit the contents of the dictionary in a more deterministic
-                            // order. This is not guarenteed to be deterministic because it uses ToString
-                            // which is not guarenteed to be unique for each value. Keys with non-unique
+                            // order. This is not guaranteed to be deterministic because it uses ToString
+                            // which is not guaranteed to be unique for each value. Keys with non-unique
                             // ToString() values will not be emitted deterministically.
                             DictionaryEntry[] entries = new DictionaryEntry[dictionary.Count];
                             dictionary.CopyTo(entries, 0);
-                            Array.Sort(entries, delegate(DictionaryEntry one, DictionaryEntry two)
+                            Array.Sort(entries, static (DictionaryEntry one, DictionaryEntry two) =>
                             {
-                                return String.Compare(one.Key.ToString(), two.Key.ToString());
+                                return string.Compare(one.Key.ToString(), two.Key.ToString(), StringComparison.Ordinal);
                             });
+
                             foreach (DictionaryEntry entry in entries)
                             {
                                 ElementMarkupObject subItem 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
@@ -1892,12 +1892,14 @@ namespace MS.Internal.Automation
         {
             while (hwnd != NativeMethods.HWND.NULL)
             {
-                if (ProxyManager.GetClassName(hwnd).CompareTo("Progman") == 0)
+                if (ProxyManager.GetClassName(hwnd).Equals("Progman", StringComparison.Ordinal))
                 {
                     return true;
                 }
+
                 hwnd = SafeNativeMethods.GetAncestor(hwnd, SafeNativeMethods.GA_PARENT);
             }
+
             return false;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Misc.cs
@@ -864,12 +864,14 @@ namespace MS.Internal.AutomationProxies
         {
             while (hwnd != IntPtr.Zero)
             {
-                if (GetClassName(hwnd).CompareTo("Progman") == 0)
+                if (GetClassName(hwnd).Equals("Progman", StringComparison.Ordinal))
                 {
                     return true;
                 }
+
                 hwnd = NativeMethodsSetLastError.GetAncestor(hwnd, NativeMethods.GA_PARENT);
             }
+
             return false;
         }
 


### PR DESCRIPTION
Fixes #10703

## Description

Fixes culture-specific comparisons for compares that are not meant to be culture-specific (e.g. namespace names).

## Customer Impact

Cleaner codebase for developers, deterministic output of some functions.

## Regression

No.

## Testing

Local build.

## Risk

None but also medium (see self-review note).
