### PR TITLE
Add tests for public API surface of BitmapSizeOptions, cleanup the class

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
@@ -28,13 +28,7 @@ namespace System.Windows.Media.Imaging
         /// specified width and the specified height are used, and
         /// the bitmap will be stretched to fit both those values.
         /// </summary>
-        public bool PreservesAspectRatio
-        {
-            get
-            {
-                return _preservesAspectRatio;
-            }
-        }
+        public bool PreservesAspectRatio { get; internal init; }
 
         /// <summary>
         /// PixelWidth of the resulting bitmap.  See description of
@@ -42,13 +36,7 @@ namespace System.Windows.Media.Imaging
         ///
         /// PixelWidth must be set to a value greater than zero to be valid.
         /// </summary>
-        public int PixelWidth
-        {
-            get
-            {
-                return _pixelWidth;
-            }
-        }
+        public int PixelWidth { get; internal init; }
 
         /// <summary>
         /// PixelHeight of the resulting bitmap.  See description of
@@ -56,25 +44,13 @@ namespace System.Windows.Media.Imaging
         ///
         /// PixelHeight must be set to a value greater than zero to be valid.
         /// </summary>
-        public int PixelHeight
-        {
-            get
-            {
-                return _pixelHeight;
-            }
-        }
+        public int PixelHeight { get; internal init; }
 
         /// <summary>
         /// Gets a value that represents the rotation angle that is applied to a bitmap.
         /// </summary>
         /// <remarks>Only increments of 90 degrees are supported.</remarks>
-        public Rotation Rotation
-        {
-            get
-            {
-                return _rotationAngle;
-            }
-        }
+        public Rotation Rotation { get; internal init; }
 
         /// <summary>
         /// Constructs an identity <see cref="BitmapSizeOptions"/>.
@@ -85,10 +61,10 @@ namespace System.Windows.Media.Imaging
         {
             BitmapSizeOptions sizeOptions = new BitmapSizeOptions
             {
-                _rotationAngle = Rotation.Rotate0,
-                _preservesAspectRatio = true,
-                _pixelHeight = 0,
-                _pixelWidth = 0
+                Rotation = Rotation.Rotate0,
+                PreservesAspectRatio = true,
+                PixelHeight = 0,
+                PixelWidth = 0
             };
 
             return sizeOptions;
@@ -106,10 +82,10 @@ namespace System.Windows.Media.Imaging
 
             BitmapSizeOptions sizeOptions = new BitmapSizeOptions
             {
-                _rotationAngle = Rotation.Rotate0,
-                _preservesAspectRatio = true,
-                _pixelHeight = pixelHeight,
-                _pixelWidth = 0
+                Rotation = Rotation.Rotate0,
+                PreservesAspectRatio = true,
+                PixelHeight = pixelHeight,
+                PixelWidth = 0
             };
 
             return sizeOptions;
@@ -126,10 +102,10 @@ namespace System.Windows.Media.Imaging
 
             BitmapSizeOptions sizeOptions = new BitmapSizeOptions
             {
-                _rotationAngle = Rotation.Rotate0,
-                _preservesAspectRatio = true,
-                _pixelWidth = pixelWidth,
-                _pixelHeight = 0
+                Rotation = Rotation.Rotate0,
+                PreservesAspectRatio = true,
+                PixelWidth = pixelWidth,
+                PixelHeight = 0
             };
 
             return sizeOptions;
@@ -149,10 +125,10 @@ namespace System.Windows.Media.Imaging
 
             BitmapSizeOptions sizeOptions = new BitmapSizeOptions
             {
-                _rotationAngle = Rotation.Rotate0,
-                _preservesAspectRatio = false,
-                _pixelWidth = pixelWidth,
-                _pixelHeight = pixelHeight
+                Rotation = Rotation.Rotate0,
+                PreservesAspectRatio = false,
+                PixelWidth = pixelWidth,
+                PixelHeight = pixelHeight
             };
 
             return sizeOptions;
@@ -179,10 +155,10 @@ namespace System.Windows.Media.Imaging
 
             BitmapSizeOptions sizeOptions = new BitmapSizeOptions
             {
-                _rotationAngle = rotation,
-                _preservesAspectRatio = true,
-                _pixelWidth = 0,
-                _pixelHeight = 0
+                Rotation = rotation,
+                PreservesAspectRatio = true,
+                PixelWidth = 0,
+                PixelHeight = 0
             };
 
             return sizeOptions;
@@ -193,26 +169,26 @@ namespace System.Windows.Media.Imaging
         /// </summary>
         internal void GetScaledWidthAndHeight(uint width, uint height, out uint newWidth, out uint newHeight)
         {
-            if (_pixelWidth == 0 && _pixelHeight != 0)
+            if (PixelWidth == 0 && PixelHeight != 0)
             {
-                Debug.Assert(_preservesAspectRatio);
+                Debug.Assert(PreservesAspectRatio);
 
-                newWidth = (uint)((_pixelHeight * width) / height);
-                newHeight = (uint)_pixelHeight;
+                newWidth = (uint)((PixelHeight * width) / height);
+                newHeight = (uint)PixelHeight;
             }
-            else if (_pixelWidth != 0 && _pixelHeight == 0)
+            else if (PixelWidth != 0 && PixelHeight == 0)
             {
-                Debug.Assert(_preservesAspectRatio);
+                Debug.Assert(PreservesAspectRatio);
 
-                newWidth = (uint)_pixelWidth;
-                newHeight = (uint)((_pixelWidth * height) / width);
+                newWidth = (uint)PixelWidth;
+                newHeight = (uint)((PixelWidth * height) / width);
             }
-            else if (_pixelWidth != 0 && _pixelHeight != 0)
+            else if (PixelWidth != 0 && PixelHeight != 0)
             {
-                Debug.Assert(!_preservesAspectRatio);
+                Debug.Assert(!PreservesAspectRatio);
 
-                newWidth = (uint)_pixelWidth;
-                newHeight = (uint)_pixelHeight;
+                newWidth = (uint)PixelWidth;
+                newHeight = (uint)PixelHeight;
             }
             else
             {
@@ -226,7 +202,7 @@ namespace System.Windows.Media.Imaging
         /// </summary>
         internal bool DoesScale
         {
-            get => _pixelWidth != 0 || _pixelHeight != 0;
+            get => PixelWidth != 0 || PixelHeight != 0;
         }
 
         /// <summary>
@@ -238,7 +214,7 @@ namespace System.Windows.Media.Imaging
             {
                 WICBitmapTransformOptions options = 0;
 
-                switch (_rotationAngle)
+                switch (Rotation)
                 {
                     case Rotation.Rotate0:
                         options = WICBitmapTransformOptions.WICBitmapTransformRotate0;
@@ -260,11 +236,6 @@ namespace System.Windows.Media.Imaging
                 return options;
             }
         }
-
-        private bool        _preservesAspectRatio;
-        private int         _pixelWidth;
-        private int         _pixelHeight;
-        private Rotation    _rotationAngle;
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
@@ -5,30 +5,24 @@ using MS.Internal;
 
 namespace System.Windows.Media.Imaging
 {
-    #region BitmapSizeOptions
-
     /// <summary>
-    /// Sizing options for an bitmap.  The resulting bitmap
-    /// will be scaled based on these options.
+    /// Sizing options for an bitmap. The resulting bitmap will be scaled based on these options.
     /// </summary>
     public class BitmapSizeOptions
     {
         /// <summary>
-        /// Construct an BitmapSizeOptions object.  Still need to set the Width and Height Properties.
+        /// Avoid construction of a plain object, use the factory methods instead.
         /// </summary>
-        private BitmapSizeOptions()
-        {
-        }
+        private BitmapSizeOptions() { }
 
         /// <summary>
-        /// Whether or not to preserve the aspect ratio of the original
-        /// bitmap.  If so, then the PixelWidth and PixelHeight are
-        /// maximum values for the bitmap size.  The resulting bitmap
-        /// is only guaranteed to have either its width or its height
-        /// match the specified values.  For example, if you want to
-        /// specify the height, while preserving the aspect ratio for
-        /// the width, then set the height to the desired value, and
-        /// set the width to Int32.MaxValue.
+        /// Whether or not to preserve the aspect ratio of the original bitmap.
+        /// If so, then the <see cref="PixelWidth"/> and <see cref="PixelHeight"/>
+        /// are both zero or at least one of them must be zero. The resulting bitmap
+        /// is only guaranteed to have either its width or its height match the
+        /// specified values. For example, if you want to specify the height,
+        /// while preserving the aspect ratio for the width, then set the height
+        /// to the desired value, and set the width to zero.
         ///
         /// If we are not to preserve aspect ratio, then both the
         /// specified width and the specified height are used, and
@@ -71,8 +65,9 @@ namespace System.Windows.Media.Imaging
         }
 
         /// <summary>
-        /// Rotation to rotate the bitmap.  Only multiples of 90 are supported.
+        /// Gets a value that represents the rotation angle that is applied to a bitmap.
         /// </summary>
+        /// <remarks>Only increments of 90 degrees are supported.</remarks>
         public Rotation Rotation
         {
             get
@@ -82,9 +77,10 @@ namespace System.Windows.Media.Imaging
         }
 
         /// <summary>
-        /// Constructs an identity BitmapSizeOptions (when passed to a TransformedBitmap, the
-        /// input is the same as the output).
+        /// Constructs an identity <see cref="BitmapSizeOptions"/>.
+        /// When passed to a TransformedBitmap, the input is the same as the output.
         /// </summary>
+        /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
         public static BitmapSizeOptions FromEmptyOptions()
         {
             BitmapSizeOptions sizeOptions = new BitmapSizeOptions
@@ -99,9 +95,11 @@ namespace System.Windows.Media.Imaging
         }
 
         /// <summary>
-        /// Constructs an BitmapSizeOptions that preserves the aspect ratio and enforces a height of pixelHeight.
+        /// Constructs an instance of <see cref="BitmapSizeOptions"/> that preserves the aspect ratio
+        /// of the source bitmap and enforces a height provided via <paramref name="pixelHeight"/>.
         /// </summary>
-        /// <param name="pixelHeight">Height of the resulting Bitmap</param>
+        /// <param name="pixelHeight">The height, in pixels, of the resulting bitmap.</param>
+        /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
         public static BitmapSizeOptions FromHeight(int pixelHeight)
         {
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelHeight);
@@ -118,9 +116,10 @@ namespace System.Windows.Media.Imaging
         }
 
         /// <summary>
-        /// Constructs an BitmapSizeOptions that preserves the aspect ratio and enforces a width of pixelWidth.
+        /// Constructs an instance of <see cref="BitmapSizeOptions"/> that preserves the aspect ratio
+        /// of the source bitmap and enforces a width provided via <paramref name="pixelWidth"/>.
         /// </summary>
-        /// <param name="pixelWidth">Width of the resulting Bitmap</param>
+        /// <param name="pixelWidth">The width, in pixels, of the resulting bitmap.</param>
         public static BitmapSizeOptions FromWidth(int pixelWidth)
         {
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelWidth);
@@ -137,11 +136,12 @@ namespace System.Windows.Media.Imaging
         }
 
         /// <summary>
-        /// Constructs an BitmapSizeOptions that does not preserve the aspect ratio and
-        /// instead uses dimensions pixelWidth x pixelHeight.
+        /// Constructs an instance of <see cref="BitmapSizeOptions"/> that does not preserve the aspect ratio and
+        /// instead uses the specified dimensions <paramref name="pixelWidth"/> x <paramref name="pixelHeight"/>.
         /// </summary>
         /// <param name="pixelWidth">Width of the resulting Bitmap</param>
         /// <param name="pixelHeight">Height of the resulting Bitmap</param>
+        /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
         public static BitmapSizeOptions FromWidthAndHeight(int pixelWidth, int pixelHeight)
         {
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelWidth);
@@ -159,10 +159,11 @@ namespace System.Windows.Media.Imaging
         }
 
         /// <summary>
-        /// Constructs an BitmapSizeOptions that does not preserve the aspect ratio and
-        /// instead uses dimensions pixelWidth x pixelHeight.
+        /// Initializes an instance of <see cref="BitmapSizeOptions"/> that preserves the aspect ratio of the
+        /// source bitmap and specifies an initial <see cref="Imaging.Rotation"/> to apply.
         /// </summary>
-        /// <param name="rotation">Angle to rotate</param>
+        /// <param name="rotation">The initial rotation value to apply. Only 90 degree increments are supported.</param>
+        /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
         public static BitmapSizeOptions FromRotation(Rotation rotation)
         {
             switch(rotation)
@@ -187,31 +188,28 @@ namespace System.Windows.Media.Imaging
             return sizeOptions;
         }
 
-        // Note: In this method, newWidth, newHeight are not affected by the
-        // rotation angle.
-        internal void GetScaledWidthAndHeight(
-            uint width,
-            uint height,
-            out uint newWidth,
-            out uint newHeight)
+        /// <summary>
+        /// Note: In this method, newWidth, newHeight are not affected by the rotation angle.
+        /// </summary>
+        internal void GetScaledWidthAndHeight(uint width, uint height, out uint newWidth, out uint newHeight)
         {
             if (_pixelWidth == 0 && _pixelHeight != 0)
             {
-                Debug.Assert(_preservesAspectRatio == true);
+                Debug.Assert(_preservesAspectRatio);
 
-                newWidth = (uint)((_pixelHeight * width)/height);
+                newWidth = (uint)((_pixelHeight * width) / height);
                 newHeight = (uint)_pixelHeight;
             }
             else if (_pixelWidth != 0 && _pixelHeight == 0)
             {
-                Debug.Assert(_preservesAspectRatio == true);
+                Debug.Assert(_preservesAspectRatio);
 
                 newWidth = (uint)_pixelWidth;
-                newHeight = (uint)((_pixelWidth * height)/width);
+                newHeight = (uint)((_pixelWidth * height) / width);
             }
             else if (_pixelWidth != 0 && _pixelHeight != 0)
             {
-                Debug.Assert(_preservesAspectRatio == false);
+                Debug.Assert(!_preservesAspectRatio);
 
                 newWidth = (uint)_pixelWidth;
                 newHeight = (uint)_pixelHeight;
@@ -223,14 +221,17 @@ namespace System.Windows.Media.Imaging
             }
         }
 
+        /// <summary>
+        /// Determines whether <see cref="PixelWidth"/> or <see cref="PixelHeight"/> are set to non-zero value.
+        /// </summary>
         internal bool DoesScale
         {
-            get
-            {
-                return (_pixelWidth != 0 || _pixelHeight != 0);
-            }
+            get => _pixelWidth != 0 || _pixelHeight != 0;
         }
 
+        /// <summary>
+        /// Converts the <see cref="Rotation"/> value to corresponding <see cref="WICBitmapTransformOptions"/>.
+        /// </summary>
         internal WICBitmapTransformOptions WICTransformOptions
         {
             get
@@ -265,7 +266,5 @@ namespace System.Windows.Media.Imaging
         private int         _pixelHeight;
         private Rotation    _rotationAngle;
     }
-
-    #endregion // BitmapSizeOptions
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
@@ -3,223 +3,222 @@
 
 using MS.Internal;
 
-namespace System.Windows.Media.Imaging
+namespace System.Windows.Media.Imaging;
+
+/// <summary>
+/// Sizing options for an bitmap. The resulting bitmap will be scaled based on these options.
+/// </summary>
+public class BitmapSizeOptions
 {
     /// <summary>
-    /// Sizing options for an bitmap. The resulting bitmap will be scaled based on these options.
+    /// Avoid construction of a plain object, use the factory methods instead.
     /// </summary>
-    public class BitmapSizeOptions
+    private BitmapSizeOptions() { }
+
+    /// <summary>
+    /// Whether or not to preserve the aspect ratio of the original bitmap.
+    /// If so, then the <see cref="PixelWidth"/> and <see cref="PixelHeight"/>
+    /// are both zero or at least one of them must be zero. The resulting bitmap
+    /// is only guaranteed to have either its width or its height match the
+    /// specified values. For example, if you want to specify the height,
+    /// while preserving the aspect ratio for the width, then set the height
+    /// to the desired value, and set the width to zero.
+    ///
+    /// If we are not to preserve aspect ratio, then both the
+    /// specified width and the specified height are used, and
+    /// the bitmap will be stretched to fit both those values.
+    /// </summary>
+    public bool PreservesAspectRatio { get; internal init; }
+
+    /// <summary>
+    /// PixelWidth of the resulting bitmap.  See description of
+    /// PreserveAspectRatio for how this value is used.
+    ///
+    /// PixelWidth must be set to a value greater than zero to be valid.
+    /// </summary>
+    public int PixelWidth { get; internal init; }
+
+    /// <summary>
+    /// PixelHeight of the resulting bitmap.  See description of
+    /// PreserveAspectRatio for how this value is used.
+    ///
+    /// PixelHeight must be set to a value greater than zero to be valid.
+    /// </summary>
+    public int PixelHeight { get; internal init; }
+
+    /// <summary>
+    /// Gets a value that represents the rotation angle that is applied to a bitmap.
+    /// </summary>
+    /// <remarks>Only increments of 90 degrees are supported.</remarks>
+    public Rotation Rotation { get; internal init; }
+
+    /// <summary>
+    /// Constructs an identity <see cref="BitmapSizeOptions"/>.
+    /// When passed to a TransformedBitmap, the input is the same as the output.
+    /// </summary>
+    /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
+    public static BitmapSizeOptions FromEmptyOptions()
     {
-        /// <summary>
-        /// Avoid construction of a plain object, use the factory methods instead.
-        /// </summary>
-        private BitmapSizeOptions() { }
-
-        /// <summary>
-        /// Whether or not to preserve the aspect ratio of the original bitmap.
-        /// If so, then the <see cref="PixelWidth"/> and <see cref="PixelHeight"/>
-        /// are both zero or at least one of them must be zero. The resulting bitmap
-        /// is only guaranteed to have either its width or its height match the
-        /// specified values. For example, if you want to specify the height,
-        /// while preserving the aspect ratio for the width, then set the height
-        /// to the desired value, and set the width to zero.
-        ///
-        /// If we are not to preserve aspect ratio, then both the
-        /// specified width and the specified height are used, and
-        /// the bitmap will be stretched to fit both those values.
-        /// </summary>
-        public bool PreservesAspectRatio { get; internal init; }
-
-        /// <summary>
-        /// PixelWidth of the resulting bitmap.  See description of
-        /// PreserveAspectRatio for how this value is used.
-        ///
-        /// PixelWidth must be set to a value greater than zero to be valid.
-        /// </summary>
-        public int PixelWidth { get; internal init; }
-
-        /// <summary>
-        /// PixelHeight of the resulting bitmap.  See description of
-        /// PreserveAspectRatio for how this value is used.
-        ///
-        /// PixelHeight must be set to a value greater than zero to be valid.
-        /// </summary>
-        public int PixelHeight { get; internal init; }
-
-        /// <summary>
-        /// Gets a value that represents the rotation angle that is applied to a bitmap.
-        /// </summary>
-        /// <remarks>Only increments of 90 degrees are supported.</remarks>
-        public Rotation Rotation { get; internal init; }
-
-        /// <summary>
-        /// Constructs an identity <see cref="BitmapSizeOptions"/>.
-        /// When passed to a TransformedBitmap, the input is the same as the output.
-        /// </summary>
-        /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
-        public static BitmapSizeOptions FromEmptyOptions()
+        BitmapSizeOptions sizeOptions = new BitmapSizeOptions
         {
-            BitmapSizeOptions sizeOptions = new BitmapSizeOptions
-            {
-                Rotation = Rotation.Rotate0,
-                PreservesAspectRatio = true,
-                PixelHeight = 0,
-                PixelWidth = 0
-            };
+            Rotation = Rotation.Rotate0,
+            PreservesAspectRatio = true,
+            PixelHeight = 0,
+            PixelWidth = 0
+        };
 
-            return sizeOptions;
+        return sizeOptions;
+    }
+
+    /// <summary>
+    /// Constructs an instance of <see cref="BitmapSizeOptions"/> that preserves the aspect ratio
+    /// of the source bitmap and enforces a height provided via <paramref name="pixelHeight"/>.
+    /// </summary>
+    /// <param name="pixelHeight">The height, in pixels, of the resulting bitmap.</param>
+    /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
+    public static BitmapSizeOptions FromHeight(int pixelHeight)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelHeight);
+
+        BitmapSizeOptions sizeOptions = new BitmapSizeOptions
+        {
+            Rotation = Rotation.Rotate0,
+            PreservesAspectRatio = true,
+            PixelHeight = pixelHeight,
+            PixelWidth = 0
+        };
+
+        return sizeOptions;
+    }
+
+    /// <summary>
+    /// Constructs an instance of <see cref="BitmapSizeOptions"/> that preserves the aspect ratio
+    /// of the source bitmap and enforces a width provided via <paramref name="pixelWidth"/>.
+    /// </summary>
+    /// <param name="pixelWidth">The width, in pixels, of the resulting bitmap.</param>
+    public static BitmapSizeOptions FromWidth(int pixelWidth)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelWidth);
+
+        BitmapSizeOptions sizeOptions = new BitmapSizeOptions
+        {
+            Rotation = Rotation.Rotate0,
+            PreservesAspectRatio = true,
+            PixelWidth = pixelWidth,
+            PixelHeight = 0
+        };
+
+        return sizeOptions;
+    }
+
+    /// <summary>
+    /// Constructs an instance of <see cref="BitmapSizeOptions"/> that does not preserve the aspect ratio and
+    /// instead uses the specified dimensions <paramref name="pixelWidth"/> x <paramref name="pixelHeight"/>.
+    /// </summary>
+    /// <param name="pixelWidth">Width of the resulting Bitmap</param>
+    /// <param name="pixelHeight">Height of the resulting Bitmap</param>
+    /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
+    public static BitmapSizeOptions FromWidthAndHeight(int pixelWidth, int pixelHeight)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelWidth);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelHeight);
+
+        BitmapSizeOptions sizeOptions = new BitmapSizeOptions
+        {
+            Rotation = Rotation.Rotate0,
+            PreservesAspectRatio = false,
+            PixelWidth = pixelWidth,
+            PixelHeight = pixelHeight
+        };
+
+        return sizeOptions;
+    }
+
+    /// <summary>
+    /// Initializes an instance of <see cref="BitmapSizeOptions"/> that preserves the aspect ratio of the
+    /// source bitmap and specifies an initial <see cref="Imaging.Rotation"/> to apply.
+    /// </summary>
+    /// <param name="rotation">The initial rotation value to apply. Only 90 degree increments are supported.</param>
+    /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
+    public static BitmapSizeOptions FromRotation(Rotation rotation)
+    {
+        if (rotation is not (Rotation.Rotate0 or Rotation.Rotate90 or Rotation.Rotate180 or Rotation.Rotate270))
+            throw new ArgumentException(SR.Image_SizeOptionsAngle, nameof(rotation));
+
+        BitmapSizeOptions sizeOptions = new BitmapSizeOptions
+        {
+            Rotation = rotation,
+            PreservesAspectRatio = true,
+            PixelWidth = 0,
+            PixelHeight = 0
+        };
+
+        return sizeOptions;
+    }
+
+    /// <summary>
+    /// Note: In this method, newWidth, newHeight are not affected by the rotation angle.
+    /// </summary>
+    internal void GetScaledWidthAndHeight(uint width, uint height, out uint newWidth, out uint newHeight)
+    {
+        if (PixelWidth == 0 && PixelHeight != 0)
+        {
+            Debug.Assert(PreservesAspectRatio);
+
+            newWidth = (uint)((PixelHeight * width) / height);
+            newHeight = (uint)PixelHeight;
         }
-
-        /// <summary>
-        /// Constructs an instance of <see cref="BitmapSizeOptions"/> that preserves the aspect ratio
-        /// of the source bitmap and enforces a height provided via <paramref name="pixelHeight"/>.
-        /// </summary>
-        /// <param name="pixelHeight">The height, in pixels, of the resulting bitmap.</param>
-        /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
-        public static BitmapSizeOptions FromHeight(int pixelHeight)
+        else if (PixelWidth != 0 && PixelHeight == 0)
         {
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelHeight);
+            Debug.Assert(PreservesAspectRatio);
 
-            BitmapSizeOptions sizeOptions = new BitmapSizeOptions
-            {
-                Rotation = Rotation.Rotate0,
-                PreservesAspectRatio = true,
-                PixelHeight = pixelHeight,
-                PixelWidth = 0
-            };
-
-            return sizeOptions;
+            newWidth = (uint)PixelWidth;
+            newHeight = (uint)((PixelWidth * height) / width);
         }
-
-        /// <summary>
-        /// Constructs an instance of <see cref="BitmapSizeOptions"/> that preserves the aspect ratio
-        /// of the source bitmap and enforces a width provided via <paramref name="pixelWidth"/>.
-        /// </summary>
-        /// <param name="pixelWidth">The width, in pixels, of the resulting bitmap.</param>
-        public static BitmapSizeOptions FromWidth(int pixelWidth)
+        else if (PixelWidth != 0 && PixelHeight != 0)
         {
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelWidth);
+            Debug.Assert(!PreservesAspectRatio);
 
-            BitmapSizeOptions sizeOptions = new BitmapSizeOptions
-            {
-                Rotation = Rotation.Rotate0,
-                PreservesAspectRatio = true,
-                PixelWidth = pixelWidth,
-                PixelHeight = 0
-            };
-
-            return sizeOptions;
+            newWidth = (uint)PixelWidth;
+            newHeight = (uint)PixelHeight;
         }
-
-        /// <summary>
-        /// Constructs an instance of <see cref="BitmapSizeOptions"/> that does not preserve the aspect ratio and
-        /// instead uses the specified dimensions <paramref name="pixelWidth"/> x <paramref name="pixelHeight"/>.
-        /// </summary>
-        /// <param name="pixelWidth">Width of the resulting Bitmap</param>
-        /// <param name="pixelHeight">Height of the resulting Bitmap</param>
-        /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
-        public static BitmapSizeOptions FromWidthAndHeight(int pixelWidth, int pixelHeight)
+        else
         {
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelWidth);
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelHeight);
-
-            BitmapSizeOptions sizeOptions = new BitmapSizeOptions
-            {
-                Rotation = Rotation.Rotate0,
-                PreservesAspectRatio = false,
-                PixelWidth = pixelWidth,
-                PixelHeight = pixelHeight
-            };
-
-            return sizeOptions;
+            newWidth = width;
+            newHeight = height;
         }
+    }
 
-        /// <summary>
-        /// Initializes an instance of <see cref="BitmapSizeOptions"/> that preserves the aspect ratio of the
-        /// source bitmap and specifies an initial <see cref="Imaging.Rotation"/> to apply.
-        /// </summary>
-        /// <param name="rotation">The initial rotation value to apply. Only 90 degree increments are supported.</param>
-        /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
-        public static BitmapSizeOptions FromRotation(Rotation rotation)
+    /// <summary>
+    /// Determines whether <see cref="PixelWidth"/> or <see cref="PixelHeight"/> are set to non-zero value.
+    /// </summary>
+    internal bool DoesScale
+    {
+        get => PixelWidth != 0 || PixelHeight != 0;
+    }
+
+    /// <summary>
+    /// Converts the <see cref="Rotation"/> value to corresponding <see cref="WICBitmapTransformOptions"/>.
+    /// </summary>
+    internal WICBitmapTransformOptions WICTransformOptions
+    {
+        get
         {
-            if (rotation is not (Rotation.Rotate0 or Rotation.Rotate90 or Rotation.Rotate180 or Rotation.Rotate270))
-                throw new ArgumentException(SR.Image_SizeOptionsAngle, nameof(rotation));
-
-            BitmapSizeOptions sizeOptions = new BitmapSizeOptions
+            switch (Rotation)
             {
-                Rotation = rotation,
-                PreservesAspectRatio = true,
-                PixelWidth = 0,
-                PixelHeight = 0
-            };
+                case Rotation.Rotate0:
+                    return WICBitmapTransformOptions.WICBitmapTransformRotate0;
+                case Rotation.Rotate90:
+                    return WICBitmapTransformOptions.WICBitmapTransformRotate90;
+                case Rotation.Rotate180:
+                    return WICBitmapTransformOptions.WICBitmapTransformRotate180;
+                case Rotation.Rotate270:
+                    return WICBitmapTransformOptions.WICBitmapTransformRotate270;
+                default:
+                    Debug.Assert(false);
 
-            return sizeOptions;
-        }
-
-        /// <summary>
-        /// Note: In this method, newWidth, newHeight are not affected by the rotation angle.
-        /// </summary>
-        internal void GetScaledWidthAndHeight(uint width, uint height, out uint newWidth, out uint newHeight)
-        {
-            if (PixelWidth == 0 && PixelHeight != 0)
-            {
-                Debug.Assert(PreservesAspectRatio);
-
-                newWidth = (uint)((PixelHeight * width) / height);
-                newHeight = (uint)PixelHeight;
-            }
-            else if (PixelWidth != 0 && PixelHeight == 0)
-            {
-                Debug.Assert(PreservesAspectRatio);
-
-                newWidth = (uint)PixelWidth;
-                newHeight = (uint)((PixelWidth * height) / width);
-            }
-            else if (PixelWidth != 0 && PixelHeight != 0)
-            {
-                Debug.Assert(!PreservesAspectRatio);
-
-                newWidth = (uint)PixelWidth;
-                newHeight = (uint)PixelHeight;
-            }
-            else
-            {
-                newWidth = width;
-                newHeight = height;
-            }
-        }
-
-        /// <summary>
-        /// Determines whether <see cref="PixelWidth"/> or <see cref="PixelHeight"/> are set to non-zero value.
-        /// </summary>
-        internal bool DoesScale
-        {
-            get => PixelWidth != 0 || PixelHeight != 0;
-        }
-
-        /// <summary>
-        /// Converts the <see cref="Rotation"/> value to corresponding <see cref="WICBitmapTransformOptions"/>.
-        /// </summary>
-        internal WICBitmapTransformOptions WICTransformOptions
-        {
-            get
-            {
-                switch (Rotation)
-                {
-                    case Rotation.Rotate0:
-                        return WICBitmapTransformOptions.WICBitmapTransformRotate0;
-                    case Rotation.Rotate90:
-                        return WICBitmapTransformOptions.WICBitmapTransformRotate90;
-                    case Rotation.Rotate180:
-                        return WICBitmapTransformOptions.WICBitmapTransformRotate180;
-                    case Rotation.Rotate270:
-                        return WICBitmapTransformOptions.WICBitmapTransformRotate270;
-                    default:
-                        Debug.Assert(false);
-
-                        // Fallback to default
-                        return WICBitmapTransformOptions.WICBitmapTransformRotate0;
-                }
+                    // Fallback to default
+                    return WICBitmapTransformOptions.WICBitmapTransformRotate0;
             }
         }
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
@@ -28,7 +28,7 @@ public class BitmapSizeOptions
     /// specified width and the specified height are used, and
     /// the bitmap will be stretched to fit both those values.
     /// </summary>
-    public bool PreservesAspectRatio { get; internal init; }
+    public bool PreservesAspectRatio { get; private init; }
 
     /// <summary>
     /// PixelWidth of the resulting bitmap.  See description of
@@ -36,7 +36,7 @@ public class BitmapSizeOptions
     ///
     /// PixelWidth must be set to a value greater than zero to be valid.
     /// </summary>
-    public int PixelWidth { get; internal init; }
+    public int PixelWidth { get; private init; }
 
     /// <summary>
     /// PixelHeight of the resulting bitmap.  See description of
@@ -44,13 +44,13 @@ public class BitmapSizeOptions
     ///
     /// PixelHeight must be set to a value greater than zero to be valid.
     /// </summary>
-    public int PixelHeight { get; internal init; }
+    public int PixelHeight { get; private init; }
 
     /// <summary>
     /// Gets a value that represents the rotation angle that is applied to a bitmap.
     /// </summary>
     /// <remarks>Only increments of 90 degrees are supported.</remarks>
-    public Rotation Rotation { get; internal init; }
+    public Rotation Rotation { get; private init; }
 
     /// <summary>
     /// Constructs an identity <see cref="BitmapSizeOptions"/>.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
@@ -142,16 +142,8 @@ namespace System.Windows.Media.Imaging
         /// <returns>An instance of <see cref="BitmapSizeOptions"/>.</returns>
         public static BitmapSizeOptions FromRotation(Rotation rotation)
         {
-            switch(rotation)
-            {
-                case Rotation.Rotate0:
-                case Rotation.Rotate90:
-                case Rotation.Rotate180:
-                case Rotation.Rotate270:
-                    break;
-                default:
-                    throw new ArgumentException(SR.Image_SizeOptionsAngle, nameof(rotation));
-            }
+            if (rotation is not (Rotation.Rotate0 or Rotation.Rotate90 or Rotation.Rotate180 or Rotation.Rotate270))
+                throw new ArgumentException(SR.Image_SizeOptionsAngle, nameof(rotation));
 
             BitmapSizeOptions sizeOptions = new BitmapSizeOptions
             {
@@ -212,28 +204,22 @@ namespace System.Windows.Media.Imaging
         {
             get
             {
-                WICBitmapTransformOptions options = 0;
-
                 switch (Rotation)
                 {
                     case Rotation.Rotate0:
-                        options = WICBitmapTransformOptions.WICBitmapTransformRotate0;
-                        break;
+                        return WICBitmapTransformOptions.WICBitmapTransformRotate0;
                     case Rotation.Rotate90:
-                        options = WICBitmapTransformOptions.WICBitmapTransformRotate90;
-                        break;
+                        return WICBitmapTransformOptions.WICBitmapTransformRotate90;
                     case Rotation.Rotate180:
-                        options = WICBitmapTransformOptions.WICBitmapTransformRotate180;
-                        break;
+                        return WICBitmapTransformOptions.WICBitmapTransformRotate180;
                     case Rotation.Rotate270:
-                        options = WICBitmapTransformOptions.WICBitmapTransformRotate270;
-                        break;
+                        return WICBitmapTransformOptions.WICBitmapTransformRotate270;
                     default:
                         Debug.Assert(false);
-                        break;
-                }
 
-                return options;
+                        // Fallback to default
+                        return WICBitmapTransformOptions.WICBitmapTransformRotate0;
+                }
             }
         }
     }

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/Imaging/BitmapSizeOptions.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/Imaging/BitmapSizeOptions.Tests.cs
@@ -1,0 +1,171 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Media.Imaging;
+
+public sealed class BitmapSizeOptionsTests
+{
+    [Fact]
+    public void Init_FromEmptyOptions_ShouldReturnZeroSizes()
+    {
+        BitmapSizeOptions options = BitmapSizeOptions.FromEmptyOptions();
+
+        Assert.Equal(0, options.PixelWidth);
+        Assert.Equal(0, options.PixelHeight);
+
+        // Rotation cannot be set on empty
+        Assert.Equal(Rotation.Rotate0, options.Rotation);
+        // AR is obviously preserved
+        Assert.True(options.PreservesAspectRatio);
+    }
+
+    [Fact]
+    public void Init_FromWidth_Zero_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => BitmapSizeOptions.FromWidth(0));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(50)]
+    [InlineData(100)]
+    [InlineData(200)]
+    [InlineData(300)]
+    [InlineData(400)]
+    [InlineData(500)]
+    [InlineData(600)]
+    [InlineData(1024)]
+    [InlineData(2048)]
+    [InlineData(4096)]
+    [InlineData(8192)]
+    [InlineData(3)]
+    [InlineData(7)]
+    [InlineData(11)]
+    [InlineData(17)]
+    [InlineData(23)]
+    [InlineData(37)]
+    [InlineData(int.MaxValue)]
+    public void Init_FromWidth_ShouldSetPixelWidth(int width)
+    {
+        BitmapSizeOptions options = BitmapSizeOptions.FromWidth(width);
+
+        Assert.Equal(width, options.PixelWidth);
+        Assert.Equal(0, options.PixelHeight);
+
+        // Rotation cannot be set when specifying width/height
+        Assert.Equal(Rotation.Rotate0, options.Rotation);
+        // When only width/height is set, AR is preserved
+        Assert.True(options.PreservesAspectRatio);
+    }
+
+    [Fact]
+    public void Init_FromHeight_Zero_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => BitmapSizeOptions.FromHeight(0));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(50)]
+    [InlineData(100)]
+    [InlineData(200)]
+    [InlineData(300)]
+    [InlineData(400)]
+    [InlineData(500)]
+    [InlineData(600)]
+    [InlineData(1024)]
+    [InlineData(2048)]
+    [InlineData(4096)]
+    [InlineData(8192)]
+    [InlineData(3)]
+    [InlineData(7)]
+    [InlineData(11)]
+    [InlineData(17)]
+    [InlineData(23)]
+    [InlineData(37)]
+    [InlineData(int.MaxValue)]
+    public void Init_FromHeight_ShouldSetPixelHeight(int height)
+    {
+        BitmapSizeOptions options = BitmapSizeOptions.FromHeight(height);
+
+        Assert.Equal(0, options.PixelWidth);
+        Assert.Equal(height, options.PixelHeight);
+
+        // Rotation cannot be set when specifying width/height
+        Assert.Equal(Rotation.Rotate0, options.Rotation);
+        // When only width/height is set, AR is preserved
+        Assert.True(options.PreservesAspectRatio);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(666, 0)]
+    [InlineData(0, 666)]
+    public void Init_FromWidthAndHeight_ThrowsArgumentOutOfRangeException(int width, int height)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => BitmapSizeOptions.FromWidthAndHeight(width, height));
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(10, 5)]
+    [InlineData(50, 25)]
+    [InlineData(100, 100)]
+    [InlineData(200, 150)]
+    [InlineData(300, 250)]
+    [InlineData(400, 300)]
+    [InlineData(500, 400)]
+    [InlineData(600, 450)]
+    [InlineData(1024, 768)]
+    [InlineData(2048, 1536)]
+    [InlineData(4096, 3072)]
+    [InlineData(8192, 4096)]
+    [InlineData(3, 2)]
+    [InlineData(7, 4)]
+    [InlineData(11, 6)]
+    [InlineData(17, 8)]
+    [InlineData(23, 10)]
+    [InlineData(37, 12)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    public void Init_FromWidthAndHeight_ShouldSetBoth(int width, int height)
+    {
+        BitmapSizeOptions options = BitmapSizeOptions.FromWidthAndHeight(width, height);
+
+        Assert.Equal(width, options.PixelWidth);
+        Assert.Equal(height, options.PixelHeight);
+
+        // Rotation cannot be set when specifying width/height
+        Assert.Equal(Rotation.Rotate0, options.Rotation);
+        // When width/height is both set, AR is not preserved
+        Assert.False(options.PreservesAspectRatio);
+    }
+
+    [Theory]
+    [InlineData(4)]
+    [InlineData(89)]
+    [InlineData(539)]
+    [InlineData(int.MaxValue)]
+    public void Init_FromRotation_Invalid_ThrowsArgumentException(int rotation)
+    {
+        Assert.Throws<ArgumentException>(() => BitmapSizeOptions.FromRotation((Rotation)rotation));
+    }
+
+    [Theory]
+    [InlineData(Rotation.Rotate0)]
+    [InlineData(Rotation.Rotate90)]
+    [InlineData(Rotation.Rotate180)]
+    [InlineData(Rotation.Rotate270)]
+    public void Init_FromRotation_Valid_ShouldSetOnlyRotation(Rotation rotation)
+    {
+        BitmapSizeOptions options = BitmapSizeOptions.FromRotation(rotation);
+
+        Assert.Equal(0, options.PixelWidth);
+        Assert.Equal(0, options.PixelHeight);
+
+        Assert.Equal(rotation, options.Rotation);
+
+        Assert.True(options.PreservesAspectRatio);
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/Imaging/BitmapSizeOptions.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/Imaging/BitmapSizeOptions.Tests.cs
@@ -19,10 +19,14 @@ public sealed class BitmapSizeOptionsTests
         Assert.True(options.PreservesAspectRatio);
     }
 
-    [Fact]
-    public void Init_FromWidth_Zero_ThrowsArgumentOutOfRangeException()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-666)]
+    [InlineData(int.MinValue)]
+    public void Init_FromWidth_NegativeOrZero_ThrowsArgumentOutOfRangeException(int width)
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => BitmapSizeOptions.FromWidth(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => BitmapSizeOptions.FromWidth(width));
     }
 
     [Theory]
@@ -59,10 +63,14 @@ public sealed class BitmapSizeOptionsTests
         Assert.True(options.PreservesAspectRatio);
     }
 
-    [Fact]
-    public void Init_FromHeight_Zero_ThrowsArgumentOutOfRangeException()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-666)]
+    [InlineData(int.MinValue)]
+    public void Init_FromHeight_NegativeOrZero_ThrowsArgumentOutOfRangeException(int height)
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => BitmapSizeOptions.FromHeight(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => BitmapSizeOptions.FromHeight(height));
     }
 
     [Theory]
@@ -100,10 +108,21 @@ public sealed class BitmapSizeOptionsTests
     }
 
     [Theory]
+    // Both are zero
     [InlineData(0, 0)]
+    // One parameter is zero, other is valid
     [InlineData(666, 0)]
     [InlineData(0, 666)]
-    public void Init_FromWidthAndHeight_ThrowsArgumentOutOfRangeException(int width, int height)
+    // Both are negative
+    [InlineData(-1, -1)]
+    [InlineData(-666, -666)]
+    [InlineData(int.MinValue, int.MinValue)]
+    // One parameter is negative, other is valid
+    [InlineData(-1, 666)]
+    [InlineData(666, -666)]
+    [InlineData(int.MinValue, 666)]
+    [InlineData(666, int.MinValue)]
+    public void Init_FromWidthAndHeight_NegativeOrZero_ThrowsArgumentOutOfRangeException(int width, int height)
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => BitmapSizeOptions.FromWidthAndHeight(width, height));
     }


### PR DESCRIPTION
## Description

Adds test for the entire public API surface of `BitmapSizeOptions`.

Beyond that, the following has been code:
- Updated xml doc to reflect the state of things (there were several incorrect claims that are correct in the official documentation / and also now proven via the unit tests, especially the rotation stuff)
- Uses auto-init properties now to allow for the field to be readonly after creation.
- The namespace has been flattened as in all new PRs. This is a separate commit to allow for easy review.

## Customer Impact

Better codegen and test coverage on public surface.

## Regression

No.

## Testing

Local build, unit tests.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10713)