### PR TITLE
Avoid caching `typeof` result to decrease code size and improve perf

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/DrawingAttributeSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/DrawingAttributeSerializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //#define OLD_ISF
@@ -608,7 +608,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                 using (MemoryStream localStream = new MemoryStream(6)) //reasonable default
                 {
                     Int32 stylusTip = Convert.ToInt32(da.StylusTip, System.Globalization.CultureInfo.InvariantCulture);
-                    System.Runtime.InteropServices.VarEnum type = SerializationHelper.ConvertToVarEnum(PersistenceTypes.StylusTip, true);
+                    System.Runtime.InteropServices.VarEnum type = SerializationHelper.ConvertToVarEnum(typeof(Int32), true);
                     ExtendedPropertySerializer.EncodeAttribute(KnownIds.StylusTip, stylusTip, type, localStream);
 
                     cbData += ExtendedPropertySerializer.EncodeAsISF(KnownIds.StylusTip, localStream.ToArray(), stream, guidList, 0, true);
@@ -680,12 +680,5 @@ namespace MS.Internal.Ink.InkSerializedFormat
 
 
         #endregion // Encoding
-
-        internal static class PersistenceTypes
-        {
-            public static readonly Type StylusTip = typeof(Int32);
-            public static readonly Type IsHollow = typeof(bool);
-            public static readonly Type StylusTipTransform = typeof(string);
-        }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/ContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/ContentElement.cs
@@ -19,8 +19,6 @@ namespace System.Windows
 {
     public partial class ContentElement : IAnimatable
     {
-        static private readonly Type _typeofThis = typeof(ContentElement);
-
         #region IAnimatable
 
         /// <summary>
@@ -721,77 +719,77 @@ namespace System.Windows
         private static void RegisterProperties()
         {
             UIElement.IsMouseDirectlyOverPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox, // default value
                                             new PropertyChangedCallback(IsMouseDirectlyOver_Changed)));
 
             UIElement.IsMouseOverPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
             UIElement.IsStylusOverPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
             UIElement.IsKeyboardFocusWithinPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
             UIElement.IsMouseCapturedPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox, // default value
                                             new PropertyChangedCallback(IsMouseCaptured_Changed)));
 
             UIElement.IsMouseCaptureWithinPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
             UIElement.IsStylusDirectlyOverPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox, // default value
                                             new PropertyChangedCallback(IsStylusDirectlyOver_Changed)));
 
             UIElement.IsStylusCapturedPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox, // default value
                                             new PropertyChangedCallback(IsStylusCaptured_Changed)));
 
             UIElement.IsStylusCaptureWithinPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
             UIElement.IsKeyboardFocusedPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox, // default value
                                             new PropertyChangedCallback(IsKeyboardFocused_Changed)));
 
             UIElement.AreAnyTouchesDirectlyOverPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
             UIElement.AreAnyTouchesOverPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
             UIElement.AreAnyTouchesCapturedPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
             UIElement.AreAnyTouchesCapturedWithinPropertyKey.OverrideMetadata(
-                                _typeofThis,
+                                typeof(ContentElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
         }
@@ -801,7 +799,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.PreviewMouseDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseDownEvent = Mouse.PreviewMouseDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseDownEvent = Mouse.PreviewMouseDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the mouse button was pressed
@@ -820,7 +818,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseDownEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseDownEvent = Mouse.MouseDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseDownEvent = Mouse.MouseDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the mouse button was pressed
@@ -839,7 +837,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.PreviewMouseUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseUpEvent = Mouse.PreviewMouseUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseUpEvent = Mouse.PreviewMouseUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the mouse button was released
@@ -858,7 +856,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseUpEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseUpEvent = Mouse.MouseUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseUpEvent = Mouse.MouseUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the mouse button was released
@@ -877,7 +875,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.PreviewMouseLeftButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseLeftButtonDownEvent = UIElement.PreviewMouseLeftButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseLeftButtonDownEvent = UIElement.PreviewMouseLeftButtonDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the left mouse button was pressed
@@ -896,7 +894,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.MouseLeftButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseLeftButtonDownEvent = UIElement.MouseLeftButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseLeftButtonDownEvent = UIElement.MouseLeftButtonDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the left mouse button was pressed
@@ -915,7 +913,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.PreviewMouseLeftButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseLeftButtonUpEvent = UIElement.PreviewMouseLeftButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseLeftButtonUpEvent = UIElement.PreviewMouseLeftButtonUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the left mouse button was released
@@ -934,7 +932,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.MouseLeftButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseLeftButtonUpEvent = UIElement.MouseLeftButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseLeftButtonUpEvent = UIElement.MouseLeftButtonUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the left mouse button was released
@@ -953,7 +951,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.PreviewMouseRightButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseRightButtonDownEvent = UIElement.PreviewMouseRightButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseRightButtonDownEvent = UIElement.PreviewMouseRightButtonDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the right mouse button was pressed
@@ -972,7 +970,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.MouseRightButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseRightButtonDownEvent = UIElement.MouseRightButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseRightButtonDownEvent = UIElement.MouseRightButtonDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the right mouse button was pressed
@@ -991,7 +989,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.PreviewMouseRightButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseRightButtonUpEvent = UIElement.PreviewMouseRightButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseRightButtonUpEvent = UIElement.PreviewMouseRightButtonUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the right mouse button was released
@@ -1010,7 +1008,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.MouseRightButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseRightButtonUpEvent = UIElement.MouseRightButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseRightButtonUpEvent = UIElement.MouseRightButtonUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the right mouse button was released
@@ -1029,7 +1027,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.PreviewMouseMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseMoveEvent = Mouse.PreviewMouseMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseMoveEvent = Mouse.PreviewMouseMoveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a mouse move
@@ -1048,7 +1046,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseMoveEvent = Mouse.MouseMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseMoveEvent = Mouse.MouseMoveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a mouse move
@@ -1067,7 +1065,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.PreviewMouseWheelEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseWheelEvent = Mouse.PreviewMouseWheelEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseWheelEvent = Mouse.PreviewMouseWheelEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a mouse wheel rotation
@@ -1086,7 +1084,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseWheelEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseWheelEvent = Mouse.MouseWheelEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseWheelEvent = Mouse.MouseWheelEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a mouse wheel rotation
@@ -1105,7 +1103,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseEnterEvent = Mouse.MouseEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseEnterEvent = Mouse.MouseEnterEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the mouse entered this element
@@ -1124,7 +1122,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseLeaveEvent = Mouse.MouseLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseLeaveEvent = Mouse.MouseLeaveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the mouse left this element
@@ -1143,7 +1141,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.GotMouseCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent GotMouseCaptureEvent = Mouse.GotMouseCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GotMouseCaptureEvent = Mouse.GotMouseCaptureEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting that this element got the mouse capture
@@ -1162,7 +1160,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.LostMouseCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent LostMouseCaptureEvent = Mouse.LostMouseCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent LostMouseCaptureEvent = Mouse.LostMouseCaptureEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting that this element lost the mouse capture
@@ -1181,7 +1179,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.QueryCursorEvent.
         /// </summary>
-        public static readonly RoutedEvent QueryCursorEvent = Mouse.QueryCursorEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent QueryCursorEvent = Mouse.QueryCursorEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the cursor to display was requested
@@ -1200,7 +1198,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusDownEvent = Stylus.PreviewStylusDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusDownEvent = Stylus.PreviewStylusDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a stylus-down
@@ -1219,7 +1217,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusDownEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusDownEvent = Stylus.StylusDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusDownEvent = Stylus.StylusDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a stylus-down
@@ -1238,7 +1236,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusUpEvent = Stylus.PreviewStylusUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusUpEvent = Stylus.PreviewStylusUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a stylus-up
@@ -1257,7 +1255,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusUpEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusUpEvent = Stylus.StylusUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusUpEvent = Stylus.StylusUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a stylus-up
@@ -1276,7 +1274,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusMoveEvent = Stylus.PreviewStylusMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusMoveEvent = Stylus.PreviewStylusMoveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a stylus move
@@ -1295,7 +1293,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusMoveEvent = Stylus.StylusMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusMoveEvent = Stylus.StylusMoveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a stylus move
@@ -1314,7 +1312,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusInAirMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusInAirMoveEvent = Stylus.PreviewStylusInAirMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusInAirMoveEvent = Stylus.PreviewStylusInAirMoveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a stylus-in-air-move
@@ -1333,7 +1331,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusInAirMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusInAirMoveEvent = Stylus.StylusInAirMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusInAirMoveEvent = Stylus.StylusInAirMoveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a stylus-in-air-move
@@ -1352,7 +1350,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusEnterEvent = Stylus.StylusEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusEnterEvent = Stylus.StylusEnterEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the stylus entered this element
@@ -1371,7 +1369,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusLeaveEvent = Stylus.StylusLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusLeaveEvent = Stylus.StylusLeaveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the stylus left this element
@@ -1390,7 +1388,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusInRangeEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusInRangeEvent = Stylus.PreviewStylusInRangeEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusInRangeEvent = Stylus.PreviewStylusInRangeEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the stylus is now in range of the digitizer
@@ -1409,7 +1407,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusInRangeEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusInRangeEvent = Stylus.StylusInRangeEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusInRangeEvent = Stylus.StylusInRangeEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the stylus is now in range of the digitizer
@@ -1428,7 +1426,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusOutOfRangeEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusOutOfRangeEvent = Stylus.PreviewStylusOutOfRangeEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusOutOfRangeEvent = Stylus.PreviewStylusOutOfRangeEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the stylus is now out of range of the digitizer
@@ -1447,7 +1445,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusOutOfRangeEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusOutOfRangeEvent = Stylus.StylusOutOfRangeEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusOutOfRangeEvent = Stylus.StylusOutOfRangeEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the stylus is now out of range of the digitizer
@@ -1466,7 +1464,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusSystemGestureEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusSystemGestureEvent = Stylus.PreviewStylusSystemGestureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusSystemGestureEvent = Stylus.PreviewStylusSystemGestureEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a stylus system gesture
@@ -1485,7 +1483,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusSystemGestureEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusSystemGestureEvent = Stylus.StylusSystemGestureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusSystemGestureEvent = Stylus.StylusSystemGestureEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a stylus system gesture
@@ -1504,7 +1502,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.GotStylusCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent GotStylusCaptureEvent = Stylus.GotStylusCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GotStylusCaptureEvent = Stylus.GotStylusCaptureEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting that this element got the stylus capture
@@ -1523,7 +1521,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.LostStylusCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent LostStylusCaptureEvent = Stylus.LostStylusCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent LostStylusCaptureEvent = Stylus.LostStylusCaptureEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting that this element lost the stylus capture
@@ -1542,7 +1540,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusButtonDownEvent = Stylus.StylusButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusButtonDownEvent = Stylus.StylusButtonDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the stylus button is down
@@ -1561,7 +1559,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusButtonUpEvent = Stylus.StylusButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusButtonUpEvent = Stylus.StylusButtonUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the stylus button is up
@@ -1580,7 +1578,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusButtonDownEvent = Stylus.PreviewStylusButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusButtonDownEvent = Stylus.PreviewStylusButtonDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the stylus button is down
@@ -1599,7 +1597,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusButtonUpEvent = Stylus.PreviewStylusButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusButtonUpEvent = Stylus.PreviewStylusButtonUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the stylus button is up
@@ -1618,7 +1616,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.PreviewKeyDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewKeyDownEvent = Keyboard.PreviewKeyDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewKeyDownEvent = Keyboard.PreviewKeyDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a key was pressed
@@ -1637,7 +1635,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.KeyDownEvent.
         /// </summary>
-        public static readonly RoutedEvent KeyDownEvent = Keyboard.KeyDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent KeyDownEvent = Keyboard.KeyDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a key was pressed
@@ -1656,7 +1654,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.PreviewKeyUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewKeyUpEvent = Keyboard.PreviewKeyUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewKeyUpEvent = Keyboard.PreviewKeyUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a key was released
@@ -1675,7 +1673,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.KeyUpEvent.
         /// </summary>
-        public static readonly RoutedEvent KeyUpEvent = Keyboard.KeyUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent KeyUpEvent = Keyboard.KeyUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a key was released
@@ -1694,7 +1692,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.PreviewGotKeyboardFocusEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewGotKeyboardFocusEvent = Keyboard.PreviewGotKeyboardFocusEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewGotKeyboardFocusEvent = Keyboard.PreviewGotKeyboardFocusEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting that the keyboard is focused on this element
@@ -1713,7 +1711,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.GotKeyboardFocusEvent.
         /// </summary>
-        public static readonly RoutedEvent GotKeyboardFocusEvent = Keyboard.GotKeyboardFocusEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GotKeyboardFocusEvent = Keyboard.GotKeyboardFocusEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting that the keyboard is focused on this element
@@ -1732,7 +1730,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.PreviewLostKeyboardFocusEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewLostKeyboardFocusEvent = Keyboard.PreviewLostKeyboardFocusEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewLostKeyboardFocusEvent = Keyboard.PreviewLostKeyboardFocusEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting that the keyboard is no longer focusekeyboard is no longer focuseed
@@ -1751,7 +1749,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.LostKeyboardFocusEvent.
         /// </summary>
-        public static readonly RoutedEvent LostKeyboardFocusEvent = Keyboard.LostKeyboardFocusEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent LostKeyboardFocusEvent = Keyboard.LostKeyboardFocusEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting that the keyboard is no longer focusekeyboard is no longer focuseed
@@ -1770,7 +1768,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the TextCompositionManager.PreviewTextInputEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewTextInputEvent = TextCompositionManager.PreviewTextInputEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewTextInputEvent = TextCompositionManager.PreviewTextInputEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting text composition
@@ -1789,7 +1787,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the TextCompositionManager.TextInputEvent.
         /// </summary>
-        public static readonly RoutedEvent TextInputEvent = TextCompositionManager.TextInputEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TextInputEvent = TextCompositionManager.TextInputEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting text composition
@@ -1808,7 +1806,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewQueryContinueDragEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewQueryContinueDragEvent = DragDrop.PreviewQueryContinueDragEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewQueryContinueDragEvent = DragDrop.PreviewQueryContinueDragEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the preview query continue drag is going to happen
@@ -1827,7 +1825,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.QueryContinueDragEvent.
         /// </summary>
-        public static readonly RoutedEvent QueryContinueDragEvent = DragDrop.QueryContinueDragEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent QueryContinueDragEvent = DragDrop.QueryContinueDragEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the query continue drag is going to happen
@@ -1846,7 +1844,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewGiveFeedbackEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewGiveFeedbackEvent = DragDrop.PreviewGiveFeedbackEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewGiveFeedbackEvent = DragDrop.PreviewGiveFeedbackEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the preview give feedback is going to happen
@@ -1865,7 +1863,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.GiveFeedbackEvent.
         /// </summary>
-        public static readonly RoutedEvent GiveFeedbackEvent = DragDrop.GiveFeedbackEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GiveFeedbackEvent = DragDrop.GiveFeedbackEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the give feedback is going to happen
@@ -1884,7 +1882,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewDragEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewDragEnterEvent = DragDrop.PreviewDragEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewDragEnterEvent = DragDrop.PreviewDragEnterEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the preview drag enter is going to happen
@@ -1903,7 +1901,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.DragEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent DragEnterEvent = DragDrop.DragEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent DragEnterEvent = DragDrop.DragEnterEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the drag enter is going to happen
@@ -1922,7 +1920,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewDragOverEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewDragOverEvent = DragDrop.PreviewDragOverEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewDragOverEvent = DragDrop.PreviewDragOverEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the preview drag over is going to happen
@@ -1941,7 +1939,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.DragOverEvent.
         /// </summary>
-        public static readonly RoutedEvent DragOverEvent = DragDrop.DragOverEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent DragOverEvent = DragDrop.DragOverEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the drag over is going to happen
@@ -1960,7 +1958,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewDragLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewDragLeaveEvent = DragDrop.PreviewDragLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewDragLeaveEvent = DragDrop.PreviewDragLeaveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the preview drag leave is going to happen
@@ -1979,7 +1977,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.DragLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent DragLeaveEvent = DragDrop.DragLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent DragLeaveEvent = DragDrop.DragLeaveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the drag leave is going to happen
@@ -1998,7 +1996,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewDropEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewDropEvent = DragDrop.PreviewDropEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewDropEvent = DragDrop.PreviewDropEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the preview drop is going to happen
@@ -2017,7 +2015,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.DropEvent.
         /// </summary>
-        public static readonly RoutedEvent DropEvent = DragDrop.DropEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent DropEvent = DragDrop.DropEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the drag enter is going to happen
@@ -2036,7 +2034,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.PreviewTouchDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewTouchDownEvent = Touch.PreviewTouchDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewTouchDownEvent = Touch.PreviewTouchDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a finger touched the screen
@@ -2056,7 +2054,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchDownEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchDownEvent = Touch.TouchDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchDownEvent = Touch.TouchDownEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a finger touched the screen
@@ -2076,7 +2074,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.PreviewTouchMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewTouchMoveEvent = Touch.PreviewTouchMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewTouchMoveEvent = Touch.PreviewTouchMoveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a finger moved across the screen
@@ -2096,7 +2094,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchMoveEvent = Touch.TouchMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchMoveEvent = Touch.TouchMoveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a finger moved across the screen
@@ -2116,7 +2114,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.PreviewTouchUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewTouchUpEvent = Touch.PreviewTouchUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewTouchUpEvent = Touch.PreviewTouchUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a finger lifted off the screen
@@ -2136,7 +2134,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchUpEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchUpEvent = Touch.TouchUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchUpEvent = Touch.TouchUpEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a finger lifted off the screen
@@ -2156,7 +2154,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.GotTouchCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent GotTouchCaptureEvent = Touch.GotTouchCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GotTouchCaptureEvent = Touch.GotTouchCaptureEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a finger was captured to an element
@@ -2176,7 +2174,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.LostTouchCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent LostTouchCaptureEvent = Touch.LostTouchCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent LostTouchCaptureEvent = Touch.LostTouchCaptureEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting a finger is no longer captured to an element
@@ -2196,7 +2194,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchEnterEvent = Touch.TouchEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchEnterEvent = Touch.TouchEnterEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the mouse entered this element
@@ -2216,7 +2214,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchLeaveEvent = Touch.TouchLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchLeaveEvent = Touch.TouchLeaveEvent.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     Event reporting the mouse left this element
@@ -2236,7 +2234,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsMouseDirectlyOver property.
         /// </summary>
-        public static readonly DependencyProperty IsMouseDirectlyOverProperty = UIElement.IsMouseDirectlyOverProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsMouseDirectlyOverProperty = UIElement.IsMouseDirectlyOverProperty.AddOwner(typeof(ContentElement));
 
         private static void IsMouseDirectlyOver_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -2271,17 +2269,17 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsMouseOver property.
         /// </summary>
-        public static readonly DependencyProperty IsMouseOverProperty = UIElement.IsMouseOverProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsMouseOverProperty = UIElement.IsMouseOverProperty.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     The dependency property for the IsStylusOver property.
         /// </summary>
-        public static readonly DependencyProperty IsStylusOverProperty = UIElement.IsStylusOverProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsStylusOverProperty = UIElement.IsStylusOverProperty.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     The dependency property for the IsKeyboardFocusWithin property.
         /// </summary>
-        public static readonly DependencyProperty IsKeyboardFocusWithinProperty = UIElement.IsKeyboardFocusWithinProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsKeyboardFocusWithinProperty = UIElement.IsKeyboardFocusWithinProperty.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     An event reporting that the IsKeyboardFocusWithin property changed.
@@ -2311,7 +2309,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsMouseCaptured property.
         /// </summary>
-        public static readonly DependencyProperty IsMouseCapturedProperty = UIElement.IsMouseCapturedProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsMouseCapturedProperty = UIElement.IsMouseCapturedProperty.AddOwner(typeof(ContentElement));
 
         private static void IsMouseCaptured_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -2346,7 +2344,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsMouseCaptureWithin property.
         /// </summary>
-        public static readonly DependencyProperty IsMouseCaptureWithinProperty = UIElement.IsMouseCaptureWithinProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsMouseCaptureWithinProperty = UIElement.IsMouseCaptureWithinProperty.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     An event reporting that the IsMouseCaptureWithin property changed.
@@ -2376,7 +2374,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsStylusDirectlyOver property.
         /// </summary>
-        public static readonly DependencyProperty IsStylusDirectlyOverProperty = UIElement.IsStylusDirectlyOverProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsStylusDirectlyOverProperty = UIElement.IsStylusDirectlyOverProperty.AddOwner(typeof(ContentElement));
 
         private static void IsStylusDirectlyOver_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -2411,7 +2409,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsStylusCaptured property.
         /// </summary>
-        public static readonly DependencyProperty IsStylusCapturedProperty = UIElement.IsStylusCapturedProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsStylusCapturedProperty = UIElement.IsStylusCapturedProperty.AddOwner(typeof(ContentElement));
 
         private static void IsStylusCaptured_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -2446,7 +2444,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsStylusCaptureWithin property.
         /// </summary>
-        public static readonly DependencyProperty IsStylusCaptureWithinProperty = UIElement.IsStylusCaptureWithinProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsStylusCaptureWithinProperty = UIElement.IsStylusCaptureWithinProperty.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     An event reporting that the IsStylusCaptureWithin property changed.
@@ -2476,7 +2474,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsKeyboardFocused property.
         /// </summary>
-        public static readonly DependencyProperty IsKeyboardFocusedProperty = UIElement.IsKeyboardFocusedProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsKeyboardFocusedProperty = UIElement.IsKeyboardFocusedProperty.AddOwner(typeof(ContentElement));
 
         private static void IsKeyboardFocused_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -2511,22 +2509,22 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the AreAnyTouchesDirectlyOver property.
         /// </summary>
-        public static readonly DependencyProperty AreAnyTouchesDirectlyOverProperty = UIElement.AreAnyTouchesDirectlyOverProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty AreAnyTouchesDirectlyOverProperty = UIElement.AreAnyTouchesDirectlyOverProperty.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     The dependency property for the AreAnyTouchesOver property.
         /// </summary>
-        public static readonly DependencyProperty AreAnyTouchesOverProperty = UIElement.AreAnyTouchesOverProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty AreAnyTouchesOverProperty = UIElement.AreAnyTouchesOverProperty.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     The dependency property for the AreAnyTouchesCaptured property.
         /// </summary>
-        public static readonly DependencyProperty AreAnyTouchesCapturedProperty = UIElement.AreAnyTouchesCapturedProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty AreAnyTouchesCapturedProperty = UIElement.AreAnyTouchesCapturedProperty.AddOwner(typeof(ContentElement));
 
         /// <summary>
         ///     The dependency property for the AreAnyTouchesCapturedWithin property.
         /// </summary>
-        public static readonly DependencyProperty AreAnyTouchesCapturedWithinProperty = UIElement.AreAnyTouchesCapturedWithinProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty AreAnyTouchesCapturedWithinProperty = UIElement.AreAnyTouchesCapturedWithinProperty.AddOwner(typeof(ContentElement));
 
         internal bool ReadFlag(CoreFlags field)
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/TextDecoration.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/TextDecoration.cs
@@ -263,11 +263,10 @@ namespace System.Windows
 
 
             // Initializations
-            Type typeofThis = typeof(TextDecoration);
             PenProperty =
                   RegisterProperty("Pen",
                                    typeof(Pen),
-                                   typeofThis,
+                                   typeof(TextDecoration),
                                    null,
                                    null,
                                    null,
@@ -276,7 +275,7 @@ namespace System.Windows
             PenOffsetProperty =
                   RegisterProperty("PenOffset",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(TextDecoration),
                                    0.0,
                                    null,
                                    null,
@@ -285,7 +284,7 @@ namespace System.Windows
             PenOffsetUnitProperty =
                   RegisterProperty("PenOffsetUnit",
                                    typeof(TextDecorationUnit),
-                                   typeofThis,
+                                   typeof(TextDecoration),
                                    TextDecorationUnit.FontRecommended,
                                    null,
                                    new ValidateValueCallback(System.Windows.ValidateEnums.IsTextDecorationUnitValid),
@@ -294,7 +293,7 @@ namespace System.Windows
             PenThicknessUnitProperty =
                   RegisterProperty("PenThicknessUnit",
                                    typeof(TextDecorationUnit),
-                                   typeofThis,
+                                   typeof(TextDecoration),
                                    TextDecorationUnit.FontRecommended,
                                    null,
                                    new ValidateValueCallback(System.Windows.ValidateEnums.IsTextDecorationUnitValid),
@@ -303,7 +302,7 @@ namespace System.Windows
             LocationProperty =
                   RegisterProperty("Location",
                                    typeof(TextDecorationLocation),
-                                   typeofThis,
+                                   typeof(TextDecoration),
                                    TextDecorationLocation.Underline,
                                    null,
                                    new ValidateValueCallback(System.Windows.ValidateEnums.IsTextDecorationLocationValid),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement.cs
@@ -19,8 +19,6 @@ namespace System.Windows
 {
     public partial class UIElement : IAnimatable
     {
-        static private readonly Type _typeofThis = typeof(UIElement);
-
         #region IAnimatable
 
         /// <summary>
@@ -2754,7 +2752,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.PreviewMouseDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseDownEvent = Mouse.PreviewMouseDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseDownEvent = Mouse.PreviewMouseDownEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the mouse button was pressed
@@ -2773,7 +2771,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseDownEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseDownEvent = Mouse.MouseDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseDownEvent = Mouse.MouseDownEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the mouse button was pressed
@@ -2792,7 +2790,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.PreviewMouseUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseUpEvent = Mouse.PreviewMouseUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseUpEvent = Mouse.PreviewMouseUpEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the mouse button was released
@@ -2811,7 +2809,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseUpEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseUpEvent = Mouse.MouseUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseUpEvent = Mouse.MouseUpEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the mouse button was released
@@ -2830,7 +2828,7 @@ namespace System.Windows
         /// <summary>
         ///     Declaration of the routed event reporting the left mouse button was pressed
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseLeftButtonDownEvent = EventManager.RegisterRoutedEvent("PreviewMouseLeftButtonDown", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), _typeofThis);
+        public static readonly RoutedEvent PreviewMouseLeftButtonDownEvent = EventManager.RegisterRoutedEvent("PreviewMouseLeftButtonDown", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the left mouse button was pressed
@@ -2849,7 +2847,7 @@ namespace System.Windows
         /// <summary>
         ///     Declaration of the routed event reporting the left mouse button was pressed
         /// </summary>
-        public static readonly RoutedEvent MouseLeftButtonDownEvent = EventManager.RegisterRoutedEvent("MouseLeftButtonDown", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), _typeofThis);
+        public static readonly RoutedEvent MouseLeftButtonDownEvent = EventManager.RegisterRoutedEvent("MouseLeftButtonDown", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the left mouse button was pressed
@@ -2868,7 +2866,7 @@ namespace System.Windows
         /// <summary>
         ///     Declaration of the routed event reporting the left mouse button was released
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseLeftButtonUpEvent = EventManager.RegisterRoutedEvent("PreviewMouseLeftButtonUp", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), _typeofThis);
+        public static readonly RoutedEvent PreviewMouseLeftButtonUpEvent = EventManager.RegisterRoutedEvent("PreviewMouseLeftButtonUp", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the left mouse button was released
@@ -2887,7 +2885,7 @@ namespace System.Windows
         /// <summary>
         ///     Declaration of the routed event reporting the left mouse button was released
         /// </summary>
-        public static readonly RoutedEvent MouseLeftButtonUpEvent = EventManager.RegisterRoutedEvent("MouseLeftButtonUp", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), _typeofThis);
+        public static readonly RoutedEvent MouseLeftButtonUpEvent = EventManager.RegisterRoutedEvent("MouseLeftButtonUp", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the left mouse button was released
@@ -2906,7 +2904,7 @@ namespace System.Windows
         /// <summary>
         ///     Declaration of the routed event reporting the right mouse button was pressed
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseRightButtonDownEvent = EventManager.RegisterRoutedEvent("PreviewMouseRightButtonDown", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), _typeofThis);
+        public static readonly RoutedEvent PreviewMouseRightButtonDownEvent = EventManager.RegisterRoutedEvent("PreviewMouseRightButtonDown", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the right mouse button was pressed
@@ -2925,7 +2923,7 @@ namespace System.Windows
         /// <summary>
         ///     Declaration of the routed event reporting the right mouse button was pressed
         /// </summary>
-        public static readonly RoutedEvent MouseRightButtonDownEvent = EventManager.RegisterRoutedEvent("MouseRightButtonDown", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), _typeofThis);
+        public static readonly RoutedEvent MouseRightButtonDownEvent = EventManager.RegisterRoutedEvent("MouseRightButtonDown", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the right mouse button was pressed
@@ -2944,7 +2942,7 @@ namespace System.Windows
         /// <summary>
         ///     Declaration of the routed event reporting the right mouse button was released
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseRightButtonUpEvent = EventManager.RegisterRoutedEvent("PreviewMouseRightButtonUp", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), _typeofThis);
+        public static readonly RoutedEvent PreviewMouseRightButtonUpEvent = EventManager.RegisterRoutedEvent("PreviewMouseRightButtonUp", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the right mouse button was released
@@ -2963,7 +2961,7 @@ namespace System.Windows
         /// <summary>
         ///     Declaration of the routed event reporting the right mouse button was released
         /// </summary>
-        public static readonly RoutedEvent MouseRightButtonUpEvent = EventManager.RegisterRoutedEvent("MouseRightButtonUp", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), _typeofThis);
+        public static readonly RoutedEvent MouseRightButtonUpEvent = EventManager.RegisterRoutedEvent("MouseRightButtonUp", RoutingStrategy.Direct, typeof(MouseButtonEventHandler), typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the right mouse button was released
@@ -2982,7 +2980,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.PreviewMouseMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseMoveEvent = Mouse.PreviewMouseMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseMoveEvent = Mouse.PreviewMouseMoveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a mouse move
@@ -3001,7 +2999,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseMoveEvent = Mouse.MouseMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseMoveEvent = Mouse.MouseMoveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a mouse move
@@ -3020,7 +3018,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.PreviewMouseWheelEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseWheelEvent = Mouse.PreviewMouseWheelEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseWheelEvent = Mouse.PreviewMouseWheelEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a mouse wheel rotation
@@ -3039,7 +3037,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseWheelEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseWheelEvent = Mouse.MouseWheelEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseWheelEvent = Mouse.MouseWheelEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a mouse wheel rotation
@@ -3058,7 +3056,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseEnterEvent = Mouse.MouseEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseEnterEvent = Mouse.MouseEnterEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the mouse entered this element
@@ -3077,7 +3075,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseLeaveEvent = Mouse.MouseLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseLeaveEvent = Mouse.MouseLeaveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the mouse left this element
@@ -3096,7 +3094,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.GotMouseCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent GotMouseCaptureEvent = Mouse.GotMouseCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GotMouseCaptureEvent = Mouse.GotMouseCaptureEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting that this element got the mouse capture
@@ -3115,7 +3113,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.LostMouseCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent LostMouseCaptureEvent = Mouse.LostMouseCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent LostMouseCaptureEvent = Mouse.LostMouseCaptureEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting that this element lost the mouse capture
@@ -3134,7 +3132,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.QueryCursorEvent.
         /// </summary>
-        public static readonly RoutedEvent QueryCursorEvent = Mouse.QueryCursorEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent QueryCursorEvent = Mouse.QueryCursorEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the cursor to display was requested
@@ -3153,7 +3151,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusDownEvent = Stylus.PreviewStylusDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusDownEvent = Stylus.PreviewStylusDownEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a stylus-down
@@ -3172,7 +3170,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusDownEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusDownEvent = Stylus.StylusDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusDownEvent = Stylus.StylusDownEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a stylus-down
@@ -3191,7 +3189,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusUpEvent = Stylus.PreviewStylusUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusUpEvent = Stylus.PreviewStylusUpEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a stylus-up
@@ -3210,7 +3208,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusUpEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusUpEvent = Stylus.StylusUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusUpEvent = Stylus.StylusUpEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a stylus-up
@@ -3229,7 +3227,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusMoveEvent = Stylus.PreviewStylusMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusMoveEvent = Stylus.PreviewStylusMoveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a stylus move
@@ -3248,7 +3246,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusMoveEvent = Stylus.StylusMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusMoveEvent = Stylus.StylusMoveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a stylus move
@@ -3267,7 +3265,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusInAirMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusInAirMoveEvent = Stylus.PreviewStylusInAirMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusInAirMoveEvent = Stylus.PreviewStylusInAirMoveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a stylus-in-air-move
@@ -3286,7 +3284,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusInAirMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusInAirMoveEvent = Stylus.StylusInAirMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusInAirMoveEvent = Stylus.StylusInAirMoveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a stylus-in-air-move
@@ -3305,7 +3303,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusEnterEvent = Stylus.StylusEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusEnterEvent = Stylus.StylusEnterEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the stylus entered this element
@@ -3324,7 +3322,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusLeaveEvent = Stylus.StylusLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusLeaveEvent = Stylus.StylusLeaveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the stylus left this element
@@ -3343,7 +3341,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusInRangeEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusInRangeEvent = Stylus.PreviewStylusInRangeEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusInRangeEvent = Stylus.PreviewStylusInRangeEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the stylus is now in range of the digitizer
@@ -3362,7 +3360,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusInRangeEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusInRangeEvent = Stylus.StylusInRangeEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusInRangeEvent = Stylus.StylusInRangeEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the stylus is now in range of the digitizer
@@ -3381,7 +3379,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusOutOfRangeEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusOutOfRangeEvent = Stylus.PreviewStylusOutOfRangeEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusOutOfRangeEvent = Stylus.PreviewStylusOutOfRangeEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the stylus is now out of range of the digitizer
@@ -3400,7 +3398,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusOutOfRangeEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusOutOfRangeEvent = Stylus.StylusOutOfRangeEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusOutOfRangeEvent = Stylus.StylusOutOfRangeEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the stylus is now out of range of the digitizer
@@ -3419,7 +3417,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusSystemGestureEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusSystemGestureEvent = Stylus.PreviewStylusSystemGestureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusSystemGestureEvent = Stylus.PreviewStylusSystemGestureEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a stylus system gesture
@@ -3438,7 +3436,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusSystemGestureEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusSystemGestureEvent = Stylus.StylusSystemGestureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusSystemGestureEvent = Stylus.StylusSystemGestureEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a stylus system gesture
@@ -3457,7 +3455,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.GotStylusCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent GotStylusCaptureEvent = Stylus.GotStylusCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GotStylusCaptureEvent = Stylus.GotStylusCaptureEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting that this element got the stylus capture
@@ -3476,7 +3474,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.LostStylusCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent LostStylusCaptureEvent = Stylus.LostStylusCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent LostStylusCaptureEvent = Stylus.LostStylusCaptureEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting that this element lost the stylus capture
@@ -3495,7 +3493,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusButtonDownEvent = Stylus.StylusButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusButtonDownEvent = Stylus.StylusButtonDownEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the stylus button is down
@@ -3514,7 +3512,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusButtonUpEvent = Stylus.StylusButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusButtonUpEvent = Stylus.StylusButtonUpEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the stylus button is up
@@ -3533,7 +3531,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusButtonDownEvent = Stylus.PreviewStylusButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusButtonDownEvent = Stylus.PreviewStylusButtonDownEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the stylus button is down
@@ -3552,7 +3550,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusButtonUpEvent = Stylus.PreviewStylusButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusButtonUpEvent = Stylus.PreviewStylusButtonUpEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the stylus button is up
@@ -3571,7 +3569,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.PreviewKeyDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewKeyDownEvent = Keyboard.PreviewKeyDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewKeyDownEvent = Keyboard.PreviewKeyDownEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a key was pressed
@@ -3590,7 +3588,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.KeyDownEvent.
         /// </summary>
-        public static readonly RoutedEvent KeyDownEvent = Keyboard.KeyDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent KeyDownEvent = Keyboard.KeyDownEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a key was pressed
@@ -3609,7 +3607,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.PreviewKeyUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewKeyUpEvent = Keyboard.PreviewKeyUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewKeyUpEvent = Keyboard.PreviewKeyUpEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a key was released
@@ -3628,7 +3626,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.KeyUpEvent.
         /// </summary>
-        public static readonly RoutedEvent KeyUpEvent = Keyboard.KeyUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent KeyUpEvent = Keyboard.KeyUpEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a key was released
@@ -3647,7 +3645,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.PreviewGotKeyboardFocusEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewGotKeyboardFocusEvent = Keyboard.PreviewGotKeyboardFocusEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewGotKeyboardFocusEvent = Keyboard.PreviewGotKeyboardFocusEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting that the keyboard is focused on this element
@@ -3666,7 +3664,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.GotKeyboardFocusEvent.
         /// </summary>
-        public static readonly RoutedEvent GotKeyboardFocusEvent = Keyboard.GotKeyboardFocusEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GotKeyboardFocusEvent = Keyboard.GotKeyboardFocusEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting that the keyboard is focused on this element
@@ -3685,7 +3683,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.PreviewLostKeyboardFocusEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewLostKeyboardFocusEvent = Keyboard.PreviewLostKeyboardFocusEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewLostKeyboardFocusEvent = Keyboard.PreviewLostKeyboardFocusEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting that the keyboard is no longer focusekeyboard is no longer focuseed
@@ -3704,7 +3702,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.LostKeyboardFocusEvent.
         /// </summary>
-        public static readonly RoutedEvent LostKeyboardFocusEvent = Keyboard.LostKeyboardFocusEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent LostKeyboardFocusEvent = Keyboard.LostKeyboardFocusEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting that the keyboard is no longer focusekeyboard is no longer focuseed
@@ -3723,7 +3721,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the TextCompositionManager.PreviewTextInputEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewTextInputEvent = TextCompositionManager.PreviewTextInputEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewTextInputEvent = TextCompositionManager.PreviewTextInputEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting text composition
@@ -3742,7 +3740,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the TextCompositionManager.TextInputEvent.
         /// </summary>
-        public static readonly RoutedEvent TextInputEvent = TextCompositionManager.TextInputEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TextInputEvent = TextCompositionManager.TextInputEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting text composition
@@ -3761,7 +3759,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewQueryContinueDragEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewQueryContinueDragEvent = DragDrop.PreviewQueryContinueDragEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewQueryContinueDragEvent = DragDrop.PreviewQueryContinueDragEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the preview query continue drag is going to happen
@@ -3780,7 +3778,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.QueryContinueDragEvent.
         /// </summary>
-        public static readonly RoutedEvent QueryContinueDragEvent = DragDrop.QueryContinueDragEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent QueryContinueDragEvent = DragDrop.QueryContinueDragEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the query continue drag is going to happen
@@ -3799,7 +3797,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewGiveFeedbackEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewGiveFeedbackEvent = DragDrop.PreviewGiveFeedbackEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewGiveFeedbackEvent = DragDrop.PreviewGiveFeedbackEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the preview give feedback is going to happen
@@ -3818,7 +3816,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.GiveFeedbackEvent.
         /// </summary>
-        public static readonly RoutedEvent GiveFeedbackEvent = DragDrop.GiveFeedbackEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GiveFeedbackEvent = DragDrop.GiveFeedbackEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the give feedback is going to happen
@@ -3837,7 +3835,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewDragEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewDragEnterEvent = DragDrop.PreviewDragEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewDragEnterEvent = DragDrop.PreviewDragEnterEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the preview drag enter is going to happen
@@ -3856,7 +3854,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.DragEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent DragEnterEvent = DragDrop.DragEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent DragEnterEvent = DragDrop.DragEnterEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the drag enter is going to happen
@@ -3875,7 +3873,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewDragOverEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewDragOverEvent = DragDrop.PreviewDragOverEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewDragOverEvent = DragDrop.PreviewDragOverEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the preview drag over is going to happen
@@ -3894,7 +3892,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.DragOverEvent.
         /// </summary>
-        public static readonly RoutedEvent DragOverEvent = DragDrop.DragOverEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent DragOverEvent = DragDrop.DragOverEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the drag over is going to happen
@@ -3913,7 +3911,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewDragLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewDragLeaveEvent = DragDrop.PreviewDragLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewDragLeaveEvent = DragDrop.PreviewDragLeaveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the preview drag leave is going to happen
@@ -3932,7 +3930,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.DragLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent DragLeaveEvent = DragDrop.DragLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent DragLeaveEvent = DragDrop.DragLeaveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the drag leave is going to happen
@@ -3951,7 +3949,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewDropEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewDropEvent = DragDrop.PreviewDropEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewDropEvent = DragDrop.PreviewDropEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the preview drop is going to happen
@@ -3970,7 +3968,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.DropEvent.
         /// </summary>
-        public static readonly RoutedEvent DropEvent = DragDrop.DropEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent DropEvent = DragDrop.DropEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the drag enter is going to happen
@@ -3989,7 +3987,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.PreviewTouchDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewTouchDownEvent = Touch.PreviewTouchDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewTouchDownEvent = Touch.PreviewTouchDownEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a finger touched the screen
@@ -4009,7 +4007,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchDownEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchDownEvent = Touch.TouchDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchDownEvent = Touch.TouchDownEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a finger touched the screen
@@ -4029,7 +4027,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.PreviewTouchMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewTouchMoveEvent = Touch.PreviewTouchMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewTouchMoveEvent = Touch.PreviewTouchMoveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a finger moved across the screen
@@ -4049,7 +4047,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchMoveEvent = Touch.TouchMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchMoveEvent = Touch.TouchMoveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a finger moved across the screen
@@ -4069,7 +4067,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.PreviewTouchUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewTouchUpEvent = Touch.PreviewTouchUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewTouchUpEvent = Touch.PreviewTouchUpEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a finger lifted off the screen
@@ -4089,7 +4087,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchUpEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchUpEvent = Touch.TouchUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchUpEvent = Touch.TouchUpEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a finger lifted off the screen
@@ -4109,7 +4107,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.GotTouchCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent GotTouchCaptureEvent = Touch.GotTouchCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GotTouchCaptureEvent = Touch.GotTouchCaptureEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a finger was captured to an element
@@ -4129,7 +4127,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.LostTouchCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent LostTouchCaptureEvent = Touch.LostTouchCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent LostTouchCaptureEvent = Touch.LostTouchCaptureEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting a finger is no longer captured to an element
@@ -4149,7 +4147,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchEnterEvent = Touch.TouchEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchEnterEvent = Touch.TouchEnterEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the mouse entered this element
@@ -4169,7 +4167,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchLeaveEvent = Touch.TouchLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchLeaveEvent = Touch.TouchLeaveEvent.AddOwner(typeof(UIElement));
 
         /// <summary>
         ///     Event reporting the mouse left this element
@@ -4193,7 +4191,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "IsMouseDirectlyOver",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox, // default value
                                             new PropertyChangedCallback(IsMouseDirectlyOver_Changed)));
@@ -4247,7 +4245,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "IsMouseOver",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
@@ -4264,7 +4262,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "IsStylusOver",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
@@ -4281,7 +4279,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "IsKeyboardFocusWithin",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
@@ -4329,7 +4327,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "IsMouseCaptured",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox, // default value
                                             new PropertyChangedCallback(IsMouseCaptured_Changed)));
@@ -4383,7 +4381,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "IsMouseCaptureWithin",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
@@ -4431,7 +4429,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "IsStylusDirectlyOver",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox, // default value
                                             new PropertyChangedCallback(IsStylusDirectlyOver_Changed)));
@@ -4485,7 +4483,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "IsStylusCaptured",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox, // default value
                                             new PropertyChangedCallback(IsStylusCaptured_Changed)));
@@ -4539,7 +4537,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "IsStylusCaptureWithin",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
@@ -4587,7 +4585,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "IsKeyboardFocused",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox, // default value
                                             new PropertyChangedCallback(IsKeyboardFocused_Changed)));
@@ -4641,7 +4639,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "AreAnyTouchesDirectlyOver",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
@@ -4658,7 +4656,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "AreAnyTouchesOver",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
@@ -4675,7 +4673,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "AreAnyTouchesCaptured",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 
@@ -4692,7 +4690,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "AreAnyTouchesCapturedWithin",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(UIElement),
                                 new PropertyMetadata(
                                             BooleanBoxes.FalseBox));
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement3D.cs
@@ -19,8 +19,6 @@ namespace System.Windows
 {
     public partial class UIElement3D 
     {
-        static private readonly Type _typeofThis = typeof(UIElement3D);
-
 
 
         #region Commands
@@ -531,7 +529,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.PreviewMouseDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseDownEvent = Mouse.PreviewMouseDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseDownEvent = Mouse.PreviewMouseDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the mouse button was pressed
@@ -550,7 +548,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseDownEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseDownEvent = Mouse.MouseDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseDownEvent = Mouse.MouseDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the mouse button was pressed
@@ -569,7 +567,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.PreviewMouseUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseUpEvent = Mouse.PreviewMouseUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseUpEvent = Mouse.PreviewMouseUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the mouse button was released
@@ -588,7 +586,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseUpEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseUpEvent = Mouse.MouseUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseUpEvent = Mouse.MouseUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the mouse button was released
@@ -607,7 +605,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.PreviewMouseLeftButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseLeftButtonDownEvent = UIElement.PreviewMouseLeftButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseLeftButtonDownEvent = UIElement.PreviewMouseLeftButtonDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the left mouse button was pressed
@@ -626,7 +624,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.MouseLeftButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseLeftButtonDownEvent = UIElement.MouseLeftButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseLeftButtonDownEvent = UIElement.MouseLeftButtonDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the left mouse button was pressed
@@ -645,7 +643,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.PreviewMouseLeftButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseLeftButtonUpEvent = UIElement.PreviewMouseLeftButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseLeftButtonUpEvent = UIElement.PreviewMouseLeftButtonUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the left mouse button was released
@@ -664,7 +662,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.MouseLeftButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseLeftButtonUpEvent = UIElement.MouseLeftButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseLeftButtonUpEvent = UIElement.MouseLeftButtonUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the left mouse button was released
@@ -683,7 +681,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.PreviewMouseRightButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseRightButtonDownEvent = UIElement.PreviewMouseRightButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseRightButtonDownEvent = UIElement.PreviewMouseRightButtonDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the right mouse button was pressed
@@ -702,7 +700,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.MouseRightButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseRightButtonDownEvent = UIElement.MouseRightButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseRightButtonDownEvent = UIElement.MouseRightButtonDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the right mouse button was pressed
@@ -721,7 +719,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.PreviewMouseRightButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseRightButtonUpEvent = UIElement.PreviewMouseRightButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseRightButtonUpEvent = UIElement.PreviewMouseRightButtonUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the right mouse button was released
@@ -740,7 +738,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the UIElement.MouseRightButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseRightButtonUpEvent = UIElement.MouseRightButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseRightButtonUpEvent = UIElement.MouseRightButtonUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the right mouse button was released
@@ -759,7 +757,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.PreviewMouseMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseMoveEvent = Mouse.PreviewMouseMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseMoveEvent = Mouse.PreviewMouseMoveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a mouse move
@@ -778,7 +776,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseMoveEvent = Mouse.MouseMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseMoveEvent = Mouse.MouseMoveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a mouse move
@@ -797,7 +795,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.PreviewMouseWheelEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewMouseWheelEvent = Mouse.PreviewMouseWheelEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewMouseWheelEvent = Mouse.PreviewMouseWheelEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a mouse wheel rotation
@@ -816,7 +814,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseWheelEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseWheelEvent = Mouse.MouseWheelEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseWheelEvent = Mouse.MouseWheelEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a mouse wheel rotation
@@ -835,7 +833,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseEnterEvent = Mouse.MouseEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseEnterEvent = Mouse.MouseEnterEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the mouse entered this element
@@ -854,7 +852,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.MouseLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent MouseLeaveEvent = Mouse.MouseLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent MouseLeaveEvent = Mouse.MouseLeaveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the mouse left this element
@@ -873,7 +871,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.GotMouseCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent GotMouseCaptureEvent = Mouse.GotMouseCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GotMouseCaptureEvent = Mouse.GotMouseCaptureEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting that this element got the mouse capture
@@ -892,7 +890,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.LostMouseCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent LostMouseCaptureEvent = Mouse.LostMouseCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent LostMouseCaptureEvent = Mouse.LostMouseCaptureEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting that this element lost the mouse capture
@@ -911,7 +909,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Mouse.QueryCursorEvent.
         /// </summary>
-        public static readonly RoutedEvent QueryCursorEvent = Mouse.QueryCursorEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent QueryCursorEvent = Mouse.QueryCursorEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the cursor to display was requested
@@ -930,7 +928,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusDownEvent = Stylus.PreviewStylusDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusDownEvent = Stylus.PreviewStylusDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a stylus-down
@@ -949,7 +947,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusDownEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusDownEvent = Stylus.StylusDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusDownEvent = Stylus.StylusDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a stylus-down
@@ -968,7 +966,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusUpEvent = Stylus.PreviewStylusUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusUpEvent = Stylus.PreviewStylusUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a stylus-up
@@ -987,7 +985,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusUpEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusUpEvent = Stylus.StylusUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusUpEvent = Stylus.StylusUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a stylus-up
@@ -1006,7 +1004,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusMoveEvent = Stylus.PreviewStylusMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusMoveEvent = Stylus.PreviewStylusMoveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a stylus move
@@ -1025,7 +1023,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusMoveEvent = Stylus.StylusMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusMoveEvent = Stylus.StylusMoveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a stylus move
@@ -1044,7 +1042,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusInAirMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusInAirMoveEvent = Stylus.PreviewStylusInAirMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusInAirMoveEvent = Stylus.PreviewStylusInAirMoveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a stylus-in-air-move
@@ -1063,7 +1061,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusInAirMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusInAirMoveEvent = Stylus.StylusInAirMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusInAirMoveEvent = Stylus.StylusInAirMoveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a stylus-in-air-move
@@ -1082,7 +1080,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusEnterEvent = Stylus.StylusEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusEnterEvent = Stylus.StylusEnterEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the stylus entered this element
@@ -1101,7 +1099,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusLeaveEvent = Stylus.StylusLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusLeaveEvent = Stylus.StylusLeaveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the stylus left this element
@@ -1120,7 +1118,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusInRangeEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusInRangeEvent = Stylus.PreviewStylusInRangeEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusInRangeEvent = Stylus.PreviewStylusInRangeEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the stylus is now in range of the digitizer
@@ -1139,7 +1137,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusInRangeEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusInRangeEvent = Stylus.StylusInRangeEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusInRangeEvent = Stylus.StylusInRangeEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the stylus is now in range of the digitizer
@@ -1158,7 +1156,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusOutOfRangeEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusOutOfRangeEvent = Stylus.PreviewStylusOutOfRangeEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusOutOfRangeEvent = Stylus.PreviewStylusOutOfRangeEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the stylus is now out of range of the digitizer
@@ -1177,7 +1175,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusOutOfRangeEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusOutOfRangeEvent = Stylus.StylusOutOfRangeEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusOutOfRangeEvent = Stylus.StylusOutOfRangeEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the stylus is now out of range of the digitizer
@@ -1196,7 +1194,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusSystemGestureEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusSystemGestureEvent = Stylus.PreviewStylusSystemGestureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusSystemGestureEvent = Stylus.PreviewStylusSystemGestureEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a stylus system gesture
@@ -1215,7 +1213,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusSystemGestureEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusSystemGestureEvent = Stylus.StylusSystemGestureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusSystemGestureEvent = Stylus.StylusSystemGestureEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a stylus system gesture
@@ -1234,7 +1232,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.GotStylusCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent GotStylusCaptureEvent = Stylus.GotStylusCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GotStylusCaptureEvent = Stylus.GotStylusCaptureEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting that this element got the stylus capture
@@ -1253,7 +1251,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.LostStylusCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent LostStylusCaptureEvent = Stylus.LostStylusCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent LostStylusCaptureEvent = Stylus.LostStylusCaptureEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting that this element lost the stylus capture
@@ -1272,7 +1270,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusButtonDownEvent = Stylus.StylusButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusButtonDownEvent = Stylus.StylusButtonDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the stylus button is down
@@ -1291,7 +1289,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.StylusButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent StylusButtonUpEvent = Stylus.StylusButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent StylusButtonUpEvent = Stylus.StylusButtonUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the stylus button is up
@@ -1310,7 +1308,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusButtonDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusButtonDownEvent = Stylus.PreviewStylusButtonDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusButtonDownEvent = Stylus.PreviewStylusButtonDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the stylus button is down
@@ -1329,7 +1327,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Stylus.PreviewStylusButtonUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewStylusButtonUpEvent = Stylus.PreviewStylusButtonUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewStylusButtonUpEvent = Stylus.PreviewStylusButtonUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the stylus button is up
@@ -1348,7 +1346,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.PreviewKeyDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewKeyDownEvent = Keyboard.PreviewKeyDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewKeyDownEvent = Keyboard.PreviewKeyDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a key was pressed
@@ -1367,7 +1365,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.KeyDownEvent.
         /// </summary>
-        public static readonly RoutedEvent KeyDownEvent = Keyboard.KeyDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent KeyDownEvent = Keyboard.KeyDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a key was pressed
@@ -1386,7 +1384,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.PreviewKeyUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewKeyUpEvent = Keyboard.PreviewKeyUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewKeyUpEvent = Keyboard.PreviewKeyUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a key was released
@@ -1405,7 +1403,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.KeyUpEvent.
         /// </summary>
-        public static readonly RoutedEvent KeyUpEvent = Keyboard.KeyUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent KeyUpEvent = Keyboard.KeyUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a key was released
@@ -1424,7 +1422,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.PreviewGotKeyboardFocusEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewGotKeyboardFocusEvent = Keyboard.PreviewGotKeyboardFocusEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewGotKeyboardFocusEvent = Keyboard.PreviewGotKeyboardFocusEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting that the keyboard is focused on this element
@@ -1443,7 +1441,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.GotKeyboardFocusEvent.
         /// </summary>
-        public static readonly RoutedEvent GotKeyboardFocusEvent = Keyboard.GotKeyboardFocusEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GotKeyboardFocusEvent = Keyboard.GotKeyboardFocusEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting that the keyboard is focused on this element
@@ -1462,7 +1460,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.PreviewLostKeyboardFocusEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewLostKeyboardFocusEvent = Keyboard.PreviewLostKeyboardFocusEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewLostKeyboardFocusEvent = Keyboard.PreviewLostKeyboardFocusEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting that the keyboard is no longer focusekeyboard is no longer focuseed
@@ -1481,7 +1479,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Keyboard.LostKeyboardFocusEvent.
         /// </summary>
-        public static readonly RoutedEvent LostKeyboardFocusEvent = Keyboard.LostKeyboardFocusEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent LostKeyboardFocusEvent = Keyboard.LostKeyboardFocusEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting that the keyboard is no longer focusekeyboard is no longer focuseed
@@ -1500,7 +1498,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the TextCompositionManager.PreviewTextInputEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewTextInputEvent = TextCompositionManager.PreviewTextInputEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewTextInputEvent = TextCompositionManager.PreviewTextInputEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting text composition
@@ -1519,7 +1517,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the TextCompositionManager.TextInputEvent.
         /// </summary>
-        public static readonly RoutedEvent TextInputEvent = TextCompositionManager.TextInputEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TextInputEvent = TextCompositionManager.TextInputEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting text composition
@@ -1538,7 +1536,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewQueryContinueDragEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewQueryContinueDragEvent = DragDrop.PreviewQueryContinueDragEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewQueryContinueDragEvent = DragDrop.PreviewQueryContinueDragEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the preview query continue drag is going to happen
@@ -1557,7 +1555,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.QueryContinueDragEvent.
         /// </summary>
-        public static readonly RoutedEvent QueryContinueDragEvent = DragDrop.QueryContinueDragEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent QueryContinueDragEvent = DragDrop.QueryContinueDragEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the query continue drag is going to happen
@@ -1576,7 +1574,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewGiveFeedbackEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewGiveFeedbackEvent = DragDrop.PreviewGiveFeedbackEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewGiveFeedbackEvent = DragDrop.PreviewGiveFeedbackEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the preview give feedback is going to happen
@@ -1595,7 +1593,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.GiveFeedbackEvent.
         /// </summary>
-        public static readonly RoutedEvent GiveFeedbackEvent = DragDrop.GiveFeedbackEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GiveFeedbackEvent = DragDrop.GiveFeedbackEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the give feedback is going to happen
@@ -1614,7 +1612,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewDragEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewDragEnterEvent = DragDrop.PreviewDragEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewDragEnterEvent = DragDrop.PreviewDragEnterEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the preview drag enter is going to happen
@@ -1633,7 +1631,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.DragEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent DragEnterEvent = DragDrop.DragEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent DragEnterEvent = DragDrop.DragEnterEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the drag enter is going to happen
@@ -1652,7 +1650,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewDragOverEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewDragOverEvent = DragDrop.PreviewDragOverEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewDragOverEvent = DragDrop.PreviewDragOverEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the preview drag over is going to happen
@@ -1671,7 +1669,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.DragOverEvent.
         /// </summary>
-        public static readonly RoutedEvent DragOverEvent = DragDrop.DragOverEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent DragOverEvent = DragDrop.DragOverEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the drag over is going to happen
@@ -1690,7 +1688,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewDragLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewDragLeaveEvent = DragDrop.PreviewDragLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewDragLeaveEvent = DragDrop.PreviewDragLeaveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the preview drag leave is going to happen
@@ -1709,7 +1707,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.DragLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent DragLeaveEvent = DragDrop.DragLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent DragLeaveEvent = DragDrop.DragLeaveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the drag leave is going to happen
@@ -1728,7 +1726,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.PreviewDropEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewDropEvent = DragDrop.PreviewDropEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewDropEvent = DragDrop.PreviewDropEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the preview drop is going to happen
@@ -1747,7 +1745,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the DragDrop.DropEvent.
         /// </summary>
-        public static readonly RoutedEvent DropEvent = DragDrop.DropEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent DropEvent = DragDrop.DropEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the drag enter is going to happen
@@ -1766,7 +1764,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.PreviewTouchDownEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewTouchDownEvent = Touch.PreviewTouchDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewTouchDownEvent = Touch.PreviewTouchDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a finger touched the screen
@@ -1786,7 +1784,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchDownEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchDownEvent = Touch.TouchDownEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchDownEvent = Touch.TouchDownEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a finger touched the screen
@@ -1806,7 +1804,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.PreviewTouchMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewTouchMoveEvent = Touch.PreviewTouchMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewTouchMoveEvent = Touch.PreviewTouchMoveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a finger moved across the screen
@@ -1826,7 +1824,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchMoveEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchMoveEvent = Touch.TouchMoveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchMoveEvent = Touch.TouchMoveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a finger moved across the screen
@@ -1846,7 +1844,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.PreviewTouchUpEvent.
         /// </summary>
-        public static readonly RoutedEvent PreviewTouchUpEvent = Touch.PreviewTouchUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent PreviewTouchUpEvent = Touch.PreviewTouchUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a finger lifted off the screen
@@ -1866,7 +1864,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchUpEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchUpEvent = Touch.TouchUpEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchUpEvent = Touch.TouchUpEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a finger lifted off the screen
@@ -1886,7 +1884,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.GotTouchCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent GotTouchCaptureEvent = Touch.GotTouchCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent GotTouchCaptureEvent = Touch.GotTouchCaptureEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a finger was captured to an element
@@ -1906,7 +1904,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.LostTouchCaptureEvent.
         /// </summary>
-        public static readonly RoutedEvent LostTouchCaptureEvent = Touch.LostTouchCaptureEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent LostTouchCaptureEvent = Touch.LostTouchCaptureEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting a finger is no longer captured to an element
@@ -1926,7 +1924,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchEnterEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchEnterEvent = Touch.TouchEnterEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchEnterEvent = Touch.TouchEnterEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the mouse entered this element
@@ -1946,7 +1944,7 @@ namespace System.Windows
         /// <summary>
         ///     Alias to the Touch.TouchLeaveEvent.
         /// </summary>
-        public static readonly RoutedEvent TouchLeaveEvent = Touch.TouchLeaveEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent TouchLeaveEvent = Touch.TouchLeaveEvent.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     Event reporting the mouse left this element
@@ -1966,7 +1964,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsMouseDirectlyOver property.
         /// </summary>
-        public static readonly DependencyProperty IsMouseDirectlyOverProperty = UIElement.IsMouseDirectlyOverProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsMouseDirectlyOverProperty = UIElement.IsMouseDirectlyOverProperty.AddOwner(typeof(UIElement3D));
 
         private static void IsMouseDirectlyOver_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -2001,17 +1999,17 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsMouseOver property.
         /// </summary>
-        public static readonly DependencyProperty IsMouseOverProperty = UIElement.IsMouseOverProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsMouseOverProperty = UIElement.IsMouseOverProperty.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     The dependency property for the IsStylusOver property.
         /// </summary>
-        public static readonly DependencyProperty IsStylusOverProperty = UIElement.IsStylusOverProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsStylusOverProperty = UIElement.IsStylusOverProperty.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     The dependency property for the IsKeyboardFocusWithin property.
         /// </summary>
-        public static readonly DependencyProperty IsKeyboardFocusWithinProperty = UIElement.IsKeyboardFocusWithinProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsKeyboardFocusWithinProperty = UIElement.IsKeyboardFocusWithinProperty.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     An event reporting that the IsKeyboardFocusWithin property changed.
@@ -2041,7 +2039,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsMouseCaptured property.
         /// </summary>
-        public static readonly DependencyProperty IsMouseCapturedProperty = UIElement.IsMouseCapturedProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsMouseCapturedProperty = UIElement.IsMouseCapturedProperty.AddOwner(typeof(UIElement3D));
 
         private static void IsMouseCaptured_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -2076,7 +2074,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsMouseCaptureWithin property.
         /// </summary>
-        public static readonly DependencyProperty IsMouseCaptureWithinProperty = UIElement.IsMouseCaptureWithinProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsMouseCaptureWithinProperty = UIElement.IsMouseCaptureWithinProperty.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     An event reporting that the IsMouseCaptureWithin property changed.
@@ -2106,7 +2104,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsStylusDirectlyOver property.
         /// </summary>
-        public static readonly DependencyProperty IsStylusDirectlyOverProperty = UIElement.IsStylusDirectlyOverProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsStylusDirectlyOverProperty = UIElement.IsStylusDirectlyOverProperty.AddOwner(typeof(UIElement3D));
 
         private static void IsStylusDirectlyOver_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -2141,7 +2139,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsStylusCaptured property.
         /// </summary>
-        public static readonly DependencyProperty IsStylusCapturedProperty = UIElement.IsStylusCapturedProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsStylusCapturedProperty = UIElement.IsStylusCapturedProperty.AddOwner(typeof(UIElement3D));
 
         private static void IsStylusCaptured_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -2176,7 +2174,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsStylusCaptureWithin property.
         /// </summary>
-        public static readonly DependencyProperty IsStylusCaptureWithinProperty = UIElement.IsStylusCaptureWithinProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsStylusCaptureWithinProperty = UIElement.IsStylusCaptureWithinProperty.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     An event reporting that the IsStylusCaptureWithin property changed.
@@ -2206,7 +2204,7 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the IsKeyboardFocused property.
         /// </summary>
-        public static readonly DependencyProperty IsKeyboardFocusedProperty = UIElement.IsKeyboardFocusedProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsKeyboardFocusedProperty = UIElement.IsKeyboardFocusedProperty.AddOwner(typeof(UIElement3D));
 
         private static void IsKeyboardFocused_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -2241,22 +2239,22 @@ namespace System.Windows
         /// <summary>
         ///     The dependency property for the AreAnyTouchesDirectlyOver property.
         /// </summary>
-        public static readonly DependencyProperty AreAnyTouchesDirectlyOverProperty = UIElement.AreAnyTouchesDirectlyOverProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty AreAnyTouchesDirectlyOverProperty = UIElement.AreAnyTouchesDirectlyOverProperty.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     The dependency property for the AreAnyTouchesOver property.
         /// </summary>
-        public static readonly DependencyProperty AreAnyTouchesOverProperty = UIElement.AreAnyTouchesOverProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty AreAnyTouchesOverProperty = UIElement.AreAnyTouchesOverProperty.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     The dependency property for the AreAnyTouchesCaptured property.
         /// </summary>
-        public static readonly DependencyProperty AreAnyTouchesCapturedProperty = UIElement.AreAnyTouchesCapturedProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty AreAnyTouchesCapturedProperty = UIElement.AreAnyTouchesCapturedProperty.AddOwner(typeof(UIElement3D));
 
         /// <summary>
         ///     The dependency property for the AreAnyTouchesCapturedWithin property.
         /// </summary>
-        public static readonly DependencyProperty AreAnyTouchesCapturedWithinProperty = UIElement.AreAnyTouchesCapturedWithinProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty AreAnyTouchesCapturedWithinProperty = UIElement.AreAnyTouchesCapturedWithinProperty.AddOwner(typeof(UIElement3D));
 
         internal bool ReadFlag(CoreFlags field)
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CanExecuteChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CanExecuteChangedEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -160,14 +160,13 @@ namespace System.Windows.Input
         {
             get
             {
-                Type managerType = typeof(CanExecuteChangedEventManager);
-                CanExecuteChangedEventManager manager = (CanExecuteChangedEventManager)GetCurrentManager(managerType);
+                CanExecuteChangedEventManager manager = (CanExecuteChangedEventManager)GetCurrentManager(typeof(CanExecuteChangedEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new CanExecuteChangedEventManager();
-                    SetCurrentManager(managerType, manager);
+                    SetCurrentManager(typeof(CanExecuteChangedEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CommandManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CommandManager.cs
@@ -901,14 +901,13 @@ namespace System.Windows.Input
             {
                 get
                 {
-                    Type managerType = typeof(RequerySuggestedEventManager);
-                    RequerySuggestedEventManager manager = (RequerySuggestedEventManager)GetCurrentManager(managerType);
+                    RequerySuggestedEventManager manager = (RequerySuggestedEventManager)GetCurrentManager(typeof(CanExecuteChangedEventManager));
 
                     // at first use, create and register a new manager
                     if (manager == null)
                     {
                         manager = new RequerySuggestedEventManager();
-                        SetCurrentManager(managerType, manager);
+                        SetCurrentManager(typeof(CanExecuteChangedEventManager), manager);
                     }
 
                     return manager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/DynamicRendererThreadManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/DynamicRendererThreadManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -93,14 +93,13 @@ namespace System.Windows.Input.StylusPlugIns
         {
             get
             {
-                Type managerType = typeof(DispatcherShutdownStartedEventManager);
-                DispatcherShutdownStartedEventManager manager = (DispatcherShutdownStartedEventManager)GetCurrentManager(managerType);
+                DispatcherShutdownStartedEventManager manager = (DispatcherShutdownStartedEventManager)GetCurrentManager(typeof(DispatcherShutdownStartedEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new DispatcherShutdownStartedEventManager();
-                    SetCurrentManager(managerType, manager);
+                    SetCurrentManager(typeof(DispatcherShutdownStartedEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ByteAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ByteAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static ByteAnimation()
         {
-            Type typeofProp = typeof(Byte?);
-            Type typeofThis = typeof(ByteAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Byte?),
+                typeof(ByteAnimation),
                 new PropertyMetadata((Byte?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Byte?),
+                typeof(ByteAnimation),
                 new PropertyMetadata((Byte?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Byte?),
+                typeof(ByteAnimation),
                 new PropertyMetadata((Byte?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(ByteAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ColorAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ColorAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static ColorAnimation()
         {
-            Type typeofProp = typeof(Color?);
-            Type typeofThis = typeof(ColorAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Color?),
+                typeof(ColorAnimation),
                 new PropertyMetadata((Color?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Color?),
+                typeof(ColorAnimation),
                 new PropertyMetadata((Color?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Color?),
+                typeof(ColorAnimation),
                 new PropertyMetadata((Color?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(ColorAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/DecimalAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/DecimalAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static DecimalAnimation()
         {
-            Type typeofProp = typeof(Decimal?);
-            Type typeofThis = typeof(DecimalAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Decimal?),
+                typeof(DecimalAnimation),
                 new PropertyMetadata((Decimal?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Decimal?),
+                typeof(DecimalAnimation),
                 new PropertyMetadata((Decimal?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Decimal?),
+                typeof(DecimalAnimation),
                 new PropertyMetadata((Decimal?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(DecimalAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/DoubleAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/DoubleAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static DoubleAnimation()
         {
-            Type typeofProp = typeof(Double?);
-            Type typeofThis = typeof(DoubleAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Double?),
+                typeof(DoubleAnimation),
                 new PropertyMetadata((Double?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Double?),
+                typeof(DoubleAnimation),
                 new PropertyMetadata((Double?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Double?),
+                typeof(DoubleAnimation),
                 new PropertyMetadata((Double?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(DoubleAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Int16Animation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Int16Animation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static Int16Animation()
         {
-            Type typeofProp = typeof(Int16?);
-            Type typeofThis = typeof(Int16Animation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Int16?),
+                typeof(Int16Animation),
                 new PropertyMetadata((Int16?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Int16?),
+                typeof(Int16Animation),
                 new PropertyMetadata((Int16?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Int16?),
+                typeof(Int16Animation),
                 new PropertyMetadata((Int16?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(Int16Animation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Int32Animation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Int32Animation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static Int32Animation()
         {
-            Type typeofProp = typeof(Int32?);
-            Type typeofThis = typeof(Int32Animation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Int32?),
+                typeof(Int32Animation),
                 new PropertyMetadata((Int32?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Int32?),
+                typeof(Int32Animation),
                 new PropertyMetadata((Int32?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Int32?),
+                typeof(Int32Animation),
                 new PropertyMetadata((Int32?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(Int32Animation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Int64Animation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Int64Animation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static Int64Animation()
         {
-            Type typeofProp = typeof(Int64?);
-            Type typeofThis = typeof(Int64Animation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Int64?),
+                typeof(Int64Animation),
                 new PropertyMetadata((Int64?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Int64?),
+                typeof(Int64Animation),
                 new PropertyMetadata((Int64?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Int64?),
+                typeof(Int64Animation),
                 new PropertyMetadata((Int64?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(Int64Animation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Point3DAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Point3DAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static Point3DAnimation()
         {
-            Type typeofProp = typeof(Point3D?);
-            Type typeofThis = typeof(Point3DAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Point3D?),
+                typeof(Point3DAnimation),
                 new PropertyMetadata((Point3D?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Point3D?),
+                typeof(Point3DAnimation),
                 new PropertyMetadata((Point3D?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Point3D?),
+                typeof(Point3DAnimation),
                 new PropertyMetadata((Point3D?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(Point3DAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/PointAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/PointAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static PointAnimation()
         {
-            Type typeofProp = typeof(Point?);
-            Type typeofThis = typeof(PointAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Point?),
+                typeof(PointAnimation),
                 new PropertyMetadata((Point?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Point?),
+                typeof(PointAnimation),
                 new PropertyMetadata((Point?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Point?),
+                typeof(PointAnimation),
                 new PropertyMetadata((Point?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(PointAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/QuaternionAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/QuaternionAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static QuaternionAnimation()
         {
-            Type typeofProp = typeof(Quaternion?);
-            Type typeofThis = typeof(QuaternionAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Quaternion?),
+                typeof(QuaternionAnimation),
                 new PropertyMetadata((Quaternion?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Quaternion?),
+                typeof(QuaternionAnimation),
                 new PropertyMetadata((Quaternion?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Quaternion?),
+                typeof(QuaternionAnimation),
                 new PropertyMetadata((Quaternion?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(QuaternionAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/RectAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/RectAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static RectAnimation()
         {
-            Type typeofProp = typeof(Rect?);
-            Type typeofThis = typeof(RectAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Rect?),
+                typeof(RectAnimation),
                 new PropertyMetadata((Rect?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Rect?),
+                typeof(RectAnimation),
                 new PropertyMetadata((Rect?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Rect?),
+                typeof(RectAnimation),
                 new PropertyMetadata((Rect?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(RectAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Rotation3DAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Rotation3DAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static Rotation3DAnimation()
         {
-            Type typeofProp = typeof(Rotation3D);
-            Type typeofThis = typeof(Rotation3DAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Rotation3D),
+                typeof(Rotation3DAnimation),
                 new PropertyMetadata((Rotation3D)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Rotation3D),
+                typeof(Rotation3DAnimation),
                 new PropertyMetadata((Rotation3D)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Rotation3D),
+                typeof(Rotation3DAnimation),
                 new PropertyMetadata((Rotation3D)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(Rotation3DAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/SingleAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/SingleAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static SingleAnimation()
         {
-            Type typeofProp = typeof(Single?);
-            Type typeofThis = typeof(SingleAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Single?),
+                typeof(SingleAnimation),
                 new PropertyMetadata((Single?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Single?),
+                typeof(SingleAnimation),
                 new PropertyMetadata((Single?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Single?),
+                typeof(SingleAnimation),
                 new PropertyMetadata((Single?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(SingleAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/SizeAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/SizeAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static SizeAnimation()
         {
-            Type typeofProp = typeof(Size?);
-            Type typeofThis = typeof(SizeAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Size?),
+                typeof(SizeAnimation),
                 new PropertyMetadata((Size?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Size?),
+                typeof(SizeAnimation),
                 new PropertyMetadata((Size?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Size?),
+                typeof(SizeAnimation),
                 new PropertyMetadata((Size?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(SizeAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/TimelineGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/TimelineGroup.cs
@@ -173,11 +173,10 @@ namespace System.Windows.Media.Animation
 
 
             // Initializations
-            Type typeofThis = typeof(TimelineGroup);
             ChildrenProperty =
                   RegisterProperty("Children",
                                    typeof(TimelineCollection),
-                                   typeofThis,
+                                   typeof(TimelineGroup),
                                    new FreezableDefaultValueFactory(TimelineCollection.Empty),
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Vector3DAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Vector3DAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static Vector3DAnimation()
         {
-            Type typeofProp = typeof(Vector3D?);
-            Type typeofThis = typeof(Vector3DAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Vector3D?),
+                typeof(Vector3DAnimation),
                 new PropertyMetadata((Vector3D?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Vector3D?),
+                typeof(Vector3DAnimation),
                 new PropertyMetadata((Vector3D?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Vector3D?),
+                typeof(Vector3DAnimation),
                 new PropertyMetadata((Vector3D?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(Vector3DAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/VectorAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/VectorAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static VectorAnimation()
         {
-            Type typeofProp = typeof(Vector?);
-            Type typeofThis = typeof(VectorAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Vector?),
+                typeof(VectorAnimation),
                 new PropertyMetadata((Vector?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Vector?),
+                typeof(VectorAnimation),
                 new PropertyMetadata((Vector?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Vector?),
+                typeof(VectorAnimation),
                 new PropertyMetadata((Vector?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(VectorAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/BitmapCacheBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/BitmapCacheBrush.cs
@@ -373,11 +373,11 @@ namespace System.Windows.Media
             return null;
         }
 
-        private static void StaticInitialize(Type typeofThis)
-        {             
-            OpacityProperty.OverrideMetadata(typeofThis, new IndependentlyAnimatedPropertyMetadata(1.0, propertyChangedCallback: null, CoerceOpacity));
-            TransformProperty.OverrideMetadata(typeofThis, new UIPropertyMetadata(null, propertyChangedCallback: null, CoerceTransform));
-            RelativeTransformProperty.OverrideMetadata(typeofThis, new UIPropertyMetadata(null, propertyChangedCallback: null, CoerceRelativeTransform));
+        private static void StaticInitialize()
+        {
+            OpacityProperty.OverrideMetadata(typeof(BitmapCacheBrush), new IndependentlyAnimatedPropertyMetadata(1.0, propertyChangedCallback: null, CoerceOpacity));
+            TransformProperty.OverrideMetadata(typeof(BitmapCacheBrush), new UIPropertyMetadata(null, propertyChangedCallback: null, CoerceTransform));
+            RelativeTransformProperty.OverrideMetadata(typeof(BitmapCacheBrush), new UIPropertyMetadata(null, propertyChangedCallback: null, CoerceRelativeTransform));
         }
 
         private ContainerVisual _dummyVisual;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BevelBitmapEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BevelBitmapEffect.cs
@@ -288,11 +288,10 @@ namespace System.Windows.Media.Effects
 
 
             // Initializations
-            Type typeofThis = typeof(BevelBitmapEffect);
             BevelWidthProperty =
                   RegisterProperty("BevelWidth",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(BevelBitmapEffect),
                                    5.0,
                                    new PropertyChangedCallback(BevelWidthPropertyChanged),
                                    null,
@@ -301,7 +300,7 @@ namespace System.Windows.Media.Effects
             ReliefProperty =
                   RegisterProperty("Relief",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(BevelBitmapEffect),
                                    0.3,
                                    new PropertyChangedCallback(ReliefPropertyChanged),
                                    null,
@@ -310,7 +309,7 @@ namespace System.Windows.Media.Effects
             LightAngleProperty =
                   RegisterProperty("LightAngle",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(BevelBitmapEffect),
                                    135.0,
                                    new PropertyChangedCallback(LightAnglePropertyChanged),
                                    null,
@@ -319,7 +318,7 @@ namespace System.Windows.Media.Effects
             SmoothnessProperty =
                   RegisterProperty("Smoothness",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(BevelBitmapEffect),
                                    0.2,
                                    new PropertyChangedCallback(SmoothnessPropertyChanged),
                                    null,
@@ -328,7 +327,7 @@ namespace System.Windows.Media.Effects
             EdgeProfileProperty =
                   RegisterProperty("EdgeProfile",
                                    typeof(EdgeProfile),
-                                   typeofThis,
+                                   typeof(BevelBitmapEffect),
                                    EdgeProfile.Linear,
                                    null,
                                    new ValidateValueCallback(System.Windows.Media.Effects.ValidateEnums.IsEdgeProfileValid),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectGroup.cs
@@ -196,11 +196,10 @@ namespace System.Windows.Media.Effects
 
 
             // Initializations
-            Type typeofThis = typeof(BitmapEffectGroup);
             ChildrenProperty =
                   RegisterProperty("Children",
                                    typeof(BitmapEffectCollection),
-                                   typeofThis,
+                                   typeof(BitmapEffectGroup),
                                    new FreezableDefaultValueFactory(BitmapEffectCollection.Empty),
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectInput.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectInput.cs
@@ -229,11 +229,10 @@ namespace System.Windows.Media.Effects
 
 
             // Initializations
-            Type typeofThis = typeof(BitmapEffectInput);
             InputProperty =
                   RegisterProperty("Input",
                                    typeof(BitmapSource),
-                                   typeofThis,
+                                   typeof(BitmapEffectInput),
                                    BitmapEffectInput.ContextInputSource,
                                    null,
                                    null,
@@ -242,7 +241,7 @@ namespace System.Windows.Media.Effects
             AreaToApplyEffectUnitsProperty =
                   RegisterProperty("AreaToApplyEffectUnits",
                                    typeof(BrushMappingMode),
-                                   typeofThis,
+                                   typeof(BitmapEffectInput),
                                    BrushMappingMode.RelativeToBoundingBox,
                                    null,
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsBrushMappingModeValid),
@@ -251,7 +250,7 @@ namespace System.Windows.Media.Effects
             AreaToApplyEffectProperty =
                   RegisterProperty("AreaToApplyEffect",
                                    typeof(Rect),
-                                   typeofThis,
+                                   typeof(BitmapEffectInput),
                                    Rect.Empty,
                                    new PropertyChangedCallback(AreaToApplyEffectPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BlurBitmapEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BlurBitmapEffect.cs
@@ -207,11 +207,10 @@ namespace System.Windows.Media.Effects
 
 
             // Initializations
-            Type typeofThis = typeof(BlurBitmapEffect);
             RadiusProperty =
                   RegisterProperty("Radius",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(BlurBitmapEffect),
                                    5.0,
                                    new PropertyChangedCallback(RadiusPropertyChanged),
                                    null,
@@ -220,7 +219,7 @@ namespace System.Windows.Media.Effects
             KernelTypeProperty =
                   RegisterProperty("KernelType",
                                    typeof(KernelType),
-                                   typeofThis,
+                                   typeof(BlurBitmapEffect),
                                    KernelType.Gaussian,
                                    null,
                                    new ValidateValueCallback(System.Windows.Media.Effects.ValidateEnums.IsKernelTypeValid),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BlurEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BlurEffect.cs
@@ -313,11 +313,10 @@ namespace System.Windows.Media.Effects
 
 
             // Initializations
-            Type typeofThis = typeof(BlurEffect);
             RadiusProperty =
                   RegisterProperty("Radius",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(BlurEffect),
                                    5.0,
                                    new PropertyChangedCallback(RadiusPropertyChanged),
                                    null,
@@ -326,7 +325,7 @@ namespace System.Windows.Media.Effects
             KernelTypeProperty =
                   RegisterProperty("KernelType",
                                    typeof(KernelType),
-                                   typeofThis,
+                                   typeof(BlurEffect),
                                    KernelType.Gaussian,
                                    new PropertyChangedCallback(KernelTypePropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.Effects.ValidateEnums.IsKernelTypeValid),
@@ -335,7 +334,7 @@ namespace System.Windows.Media.Effects
             RenderingBiasProperty =
                   RegisterProperty("RenderingBias",
                                    typeof(RenderingBias),
-                                   typeofThis,
+                                   typeof(BlurEffect),
                                    RenderingBias.Performance,
                                    new PropertyChangedCallback(RenderingBiasPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.Effects.ValidateEnums.IsRenderingBiasValid),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/DropShadowBitmapEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/DropShadowBitmapEffect.cs
@@ -322,11 +322,10 @@ namespace System.Windows.Media.Effects
 
 
             // Initializations
-            Type typeofThis = typeof(DropShadowBitmapEffect);
             ShadowDepthProperty =
                   RegisterProperty("ShadowDepth",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(DropShadowBitmapEffect),
                                    5.0,
                                    new PropertyChangedCallback(ShadowDepthPropertyChanged),
                                    null,
@@ -335,7 +334,7 @@ namespace System.Windows.Media.Effects
             ColorProperty =
                   RegisterProperty("Color",
                                    typeof(Color),
-                                   typeofThis,
+                                   typeof(DropShadowBitmapEffect),
                                    Colors.Black,
                                    new PropertyChangedCallback(ColorPropertyChanged),
                                    null,
@@ -344,7 +343,7 @@ namespace System.Windows.Media.Effects
             DirectionProperty =
                   RegisterProperty("Direction",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(DropShadowBitmapEffect),
                                    315.0,
                                    new PropertyChangedCallback(DirectionPropertyChanged),
                                    null,
@@ -353,7 +352,7 @@ namespace System.Windows.Media.Effects
             NoiseProperty =
                   RegisterProperty("Noise",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(DropShadowBitmapEffect),
                                    0.0,
                                    new PropertyChangedCallback(NoisePropertyChanged),
                                    null,
@@ -362,7 +361,7 @@ namespace System.Windows.Media.Effects
             OpacityProperty =
                   RegisterProperty("Opacity",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(DropShadowBitmapEffect),
                                    1.0,
                                    new PropertyChangedCallback(OpacityPropertyChanged),
                                    null,
@@ -371,7 +370,7 @@ namespace System.Windows.Media.Effects
             SoftnessProperty =
                   RegisterProperty("Softness",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(DropShadowBitmapEffect),
                                    0.5,
                                    new PropertyChangedCallback(SoftnessPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/DropShadowEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/DropShadowEffect.cs
@@ -417,11 +417,10 @@ namespace System.Windows.Media.Effects
 
 
             // Initializations
-            Type typeofThis = typeof(DropShadowEffect);
             ShadowDepthProperty =
                   RegisterProperty("ShadowDepth",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(DropShadowEffect),
                                    5.0,
                                    new PropertyChangedCallback(ShadowDepthPropertyChanged),
                                    null,
@@ -430,7 +429,7 @@ namespace System.Windows.Media.Effects
             ColorProperty =
                   RegisterProperty("Color",
                                    typeof(Color),
-                                   typeofThis,
+                                   typeof(DropShadowEffect),
                                    Colors.Black,
                                    new PropertyChangedCallback(ColorPropertyChanged),
                                    null,
@@ -439,7 +438,7 @@ namespace System.Windows.Media.Effects
             DirectionProperty =
                   RegisterProperty("Direction",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(DropShadowEffect),
                                    315.0,
                                    new PropertyChangedCallback(DirectionPropertyChanged),
                                    null,
@@ -448,7 +447,7 @@ namespace System.Windows.Media.Effects
             OpacityProperty =
                   RegisterProperty("Opacity",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(DropShadowEffect),
                                    1.0,
                                    new PropertyChangedCallback(OpacityPropertyChanged),
                                    null,
@@ -457,7 +456,7 @@ namespace System.Windows.Media.Effects
             BlurRadiusProperty =
                   RegisterProperty("BlurRadius",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(DropShadowEffect),
                                    5.0,
                                    new PropertyChangedCallback(BlurRadiusPropertyChanged),
                                    null,
@@ -466,7 +465,7 @@ namespace System.Windows.Media.Effects
             RenderingBiasProperty =
                   RegisterProperty("RenderingBias",
                                    typeof(RenderingBias),
-                                   typeofThis,
+                                   typeof(DropShadowEffect),
                                    RenderingBias.Performance,
                                    new PropertyChangedCallback(RenderingBiasPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.Effects.ValidateEnums.IsRenderingBiasValid),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/EmbossBitmapEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/EmbossBitmapEffect.cs
@@ -214,11 +214,10 @@ namespace System.Windows.Media.Effects
 
 
             // Initializations
-            Type typeofThis = typeof(EmbossBitmapEffect);
             LightAngleProperty =
                   RegisterProperty("LightAngle",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(EmbossBitmapEffect),
                                    45.0,
                                    new PropertyChangedCallback(LightAnglePropertyChanged),
                                    null,
@@ -227,7 +226,7 @@ namespace System.Windows.Media.Effects
             ReliefProperty =
                   RegisterProperty("Relief",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(EmbossBitmapEffect),
                                    0.44,
                                    new PropertyChangedCallback(ReliefPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/OuterGlowBitmapEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/OuterGlowBitmapEffect.cs
@@ -268,11 +268,10 @@ namespace System.Windows.Media.Effects
 
 
             // Initializations
-            Type typeofThis = typeof(OuterGlowBitmapEffect);
             GlowColorProperty =
                   RegisterProperty("GlowColor",
                                    typeof(Color),
-                                   typeofThis,
+                                   typeof(OuterGlowBitmapEffect),
                                    Colors.Gold,
                                    new PropertyChangedCallback(GlowColorPropertyChanged),
                                    null,
@@ -281,7 +280,7 @@ namespace System.Windows.Media.Effects
             GlowSizeProperty =
                   RegisterProperty("GlowSize",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(OuterGlowBitmapEffect),
                                    5.0,
                                    new PropertyChangedCallback(GlowSizePropertyChanged),
                                    null,
@@ -290,7 +289,7 @@ namespace System.Windows.Media.Effects
             NoiseProperty =
                   RegisterProperty("Noise",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(OuterGlowBitmapEffect),
                                    0.0,
                                    new PropertyChangedCallback(NoisePropertyChanged),
                                    null,
@@ -299,7 +298,7 @@ namespace System.Windows.Media.Effects
             OpacityProperty =
                   RegisterProperty("Opacity",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(OuterGlowBitmapEffect),
                                    1.0,
                                    new PropertyChangedCallback(OpacityPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/PixelShader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/PixelShader.cs
@@ -280,11 +280,10 @@ namespace System.Windows.Media.Effects
 
 
             // Initializations
-            Type typeofThis = typeof(PixelShader);
             UriSourceProperty =
                   RegisterProperty("UriSource",
                                    typeof(Uri),
-                                   typeofThis,
+                                   typeof(PixelShader),
                                    null,
                                    new PropertyChangedCallback(UriSourcePropertyChanged),
                                    null,
@@ -293,7 +292,7 @@ namespace System.Windows.Media.Effects
             ShaderRenderModeProperty =
                   RegisterProperty("ShaderRenderMode",
                                    typeof(ShaderRenderMode),
-                                   typeofThis,
+                                   typeof(PixelShader),
                                    ShaderRenderMode.Auto,
                                    new PropertyChangedCallback(ShaderRenderModePropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.Effects.ValidateEnums.IsShaderRenderModeValid),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/ShaderEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/ShaderEffect.cs
@@ -279,11 +279,10 @@ namespace System.Windows.Media.Effects
 
 
             // Initializations
-            Type typeofThis = typeof(ShaderEffect);
             PixelShaderProperty =
                   RegisterProperty("PixelShader",
                                    typeof(PixelShader),
-                                   typeofThis,
+                                   typeof(ShaderEffect),
                                    null,
                                    new PropertyChangedCallback(PixelShaderPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ArcSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ArcSegment.cs
@@ -268,11 +268,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(ArcSegment);
             PointProperty =
                   RegisterProperty("Point",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(ArcSegment),
                                    new Point(),
                                    null,
                                    null,
@@ -281,7 +280,7 @@ namespace System.Windows.Media
             SizeProperty =
                   RegisterProperty("Size",
                                    typeof(Size),
-                                   typeofThis,
+                                   typeof(ArcSegment),
                                    new Size(),
                                    null,
                                    null,
@@ -290,7 +289,7 @@ namespace System.Windows.Media
             RotationAngleProperty =
                   RegisterProperty("RotationAngle",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ArcSegment),
                                    0.0,
                                    null,
                                    null,
@@ -299,7 +298,7 @@ namespace System.Windows.Media
             IsLargeArcProperty =
                   RegisterProperty("IsLargeArc",
                                    typeof(bool),
-                                   typeofThis,
+                                   typeof(ArcSegment),
                                    false,
                                    null,
                                    null,
@@ -308,7 +307,7 @@ namespace System.Windows.Media
             SweepDirectionProperty =
                   RegisterProperty("SweepDirection",
                                    typeof(SweepDirection),
-                                   typeofThis,
+                                   typeof(ArcSegment),
                                    SweepDirection.Counterclockwise,
                                    null,
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsSweepDirectionValid),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BezierSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BezierSegment.cs
@@ -243,11 +243,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(BezierSegment);
             Point1Property =
                   RegisterProperty("Point1",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(BezierSegment),
                                    new Point(),
                                    null,
                                    null,
@@ -256,7 +255,7 @@ namespace System.Windows.Media
             Point2Property =
                   RegisterProperty("Point2",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(BezierSegment),
                                    new Point(),
                                    null,
                                    null,
@@ -265,7 +264,7 @@ namespace System.Windows.Media
             Point3Property =
                   RegisterProperty("Point3",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(BezierSegment),
                                    new Point(),
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BitmapCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BitmapCache.cs
@@ -320,11 +320,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(BitmapCache);
             RenderAtScaleProperty =
                   RegisterProperty("RenderAtScale",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(BitmapCache),
                                    1.0,
                                    new PropertyChangedCallback(RenderAtScalePropertyChanged),
                                    null,
@@ -333,7 +332,7 @@ namespace System.Windows.Media
             SnapsToDevicePixelsProperty =
                   RegisterProperty("SnapsToDevicePixels",
                                    typeof(bool),
-                                   typeofThis,
+                                   typeof(BitmapCache),
                                    false,
                                    new PropertyChangedCallback(SnapsToDevicePixelsPropertyChanged),
                                    null,
@@ -342,7 +341,7 @@ namespace System.Windows.Media
             EnableClearTypeProperty =
                   RegisterProperty("EnableClearType",
                                    typeof(bool),
-                                   typeofThis,
+                                   typeof(BitmapCache),
                                    false,
                                    new PropertyChangedCallback(EnableClearTypePropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BitmapCacheBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BitmapCacheBrush.cs
@@ -525,12 +525,12 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(BitmapCacheBrush);
-            StaticInitialize(typeofThis);
+            StaticInitialize();
+
             TargetProperty =
                   RegisterProperty("Target",
                                    typeof(Visual),
-                                   typeofThis,
+                                   typeof(BitmapCacheBrush),
                                    null,
                                    new PropertyChangedCallback(TargetPropertyChanged),
                                    null,
@@ -539,7 +539,7 @@ namespace System.Windows.Media
             BitmapCacheProperty =
                   RegisterProperty("BitmapCache",
                                    typeof(BitmapCache),
-                                   typeofThis,
+                                   typeof(BitmapCacheBrush),
                                    null,
                                    new PropertyChangedCallback(BitmapCachePropertyChanged),
                                    null,
@@ -548,7 +548,7 @@ namespace System.Windows.Media
             AutoLayoutContentProperty =
                   RegisterProperty("AutoLayoutContent",
                                    typeof(bool),
-                                   typeofThis,
+                                   typeof(BitmapCacheBrush),
                                    true,
                                    new PropertyChangedCallback(AutoLayoutContentPropertyChanged),
                                    null,
@@ -557,7 +557,7 @@ namespace System.Windows.Media
             InternalTargetProperty =
                   RegisterProperty("InternalTarget",
                                    typeof(Visual),
-                                   typeofThis,
+                                   typeof(BitmapCacheBrush),
                                    null,
                                    new PropertyChangedCallback(InternalTargetPropertyChanged),
                                    null,
@@ -566,7 +566,7 @@ namespace System.Windows.Media
             AutoWrapTargetProperty =
                   RegisterProperty("AutoWrapTarget",
                                    typeof(bool),
-                                   typeofThis,
+                                   typeof(BitmapCacheBrush),
                                    false,
                                    new PropertyChangedCallback(AutoWrapTargetPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Brush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Brush.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -444,11 +444,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(Brush);
             OpacityProperty =
                   RegisterProperty("Opacity",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(Brush),
                                    1.0,
                                    new PropertyChangedCallback(OpacityPropertyChanged),
                                    null,
@@ -457,7 +456,7 @@ namespace System.Windows.Media
             TransformProperty =
                   RegisterProperty("Transform",
                                    typeof(Transform),
-                                   typeofThis,
+                                   typeof(Brush),
                                    Transform.Identity,
                                    new PropertyChangedCallback(TransformPropertyChanged),
                                    null,
@@ -466,7 +465,7 @@ namespace System.Windows.Media
             RelativeTransformProperty =
                   RegisterProperty("RelativeTransform",
                                    typeof(Transform),
-                                   typeofThis,
+                                   typeof(Brush),
                                    Transform.Identity,
                                    new PropertyChangedCallback(RelativeTransformPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/CombinedGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/CombinedGeometry.cs
@@ -447,11 +447,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(CombinedGeometry);
             GeometryCombineModeProperty =
                   RegisterProperty("GeometryCombineMode",
                                    typeof(GeometryCombineMode),
-                                   typeofThis,
+                                   typeof(CombinedGeometry),
                                    GeometryCombineMode.Union,
                                    new PropertyChangedCallback(GeometryCombineModePropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsGeometryCombineModeValid),
@@ -460,7 +459,7 @@ namespace System.Windows.Media
             Geometry1Property =
                   RegisterProperty("Geometry1",
                                    typeof(Geometry),
-                                   typeofThis,
+                                   typeof(CombinedGeometry),
                                    Geometry.Empty,
                                    new PropertyChangedCallback(Geometry1PropertyChanged),
                                    null,
@@ -469,7 +468,7 @@ namespace System.Windows.Media
             Geometry2Property =
                   RegisterProperty("Geometry2",
                                    typeof(Geometry),
-                                   typeofThis,
+                                   typeof(CombinedGeometry),
                                    Geometry.Empty,
                                    new PropertyChangedCallback(Geometry2PropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DashStyle.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DashStyle.cs
@@ -338,11 +338,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(DashStyle);
             OffsetProperty =
                   RegisterProperty("Offset",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(DashStyle),
                                    0.0,
                                    new PropertyChangedCallback(OffsetPropertyChanged),
                                    null,
@@ -351,7 +350,7 @@ namespace System.Windows.Media
             DashesProperty =
                   RegisterProperty("Dashes",
                                    typeof(DoubleCollection),
-                                   typeofThis,
+                                   typeof(DashStyle),
                                    new FreezableDefaultValueFactory(DoubleCollection.Empty),
                                    new PropertyChangedCallback(DashesPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingBrush.cs
@@ -382,11 +382,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(DrawingBrush);
             DrawingProperty =
                   RegisterProperty("Drawing",
                                    typeof(Drawing),
-                                   typeofThis,
+                                   typeof(DrawingBrush),
                                    null,
                                    new PropertyChangedCallback(DrawingPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingGroup.cs
@@ -875,11 +875,10 @@ namespace System.Windows.Media
                                        new PropertyChangedCallback(ClearTypeHintPropertyChanged)));
 
             // Initializations
-            Type typeofThis = typeof(DrawingGroup);
             ChildrenProperty =
                   RegisterProperty("Children",
                                    typeof(DrawingCollection),
-                                   typeofThis,
+                                   typeof(DrawingGroup),
                                    new FreezableDefaultValueFactory(DrawingCollection.Empty),
                                    new PropertyChangedCallback(ChildrenPropertyChanged),
                                    null,
@@ -888,7 +887,7 @@ namespace System.Windows.Media
             ClipGeometryProperty =
                   RegisterProperty("ClipGeometry",
                                    typeof(Geometry),
-                                   typeofThis,
+                                   typeof(DrawingGroup),
                                    null,
                                    new PropertyChangedCallback(ClipGeometryPropertyChanged),
                                    null,
@@ -897,7 +896,7 @@ namespace System.Windows.Media
             OpacityProperty =
                   RegisterProperty("Opacity",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(DrawingGroup),
                                    1.0,
                                    new PropertyChangedCallback(OpacityPropertyChanged),
                                    null,
@@ -906,7 +905,7 @@ namespace System.Windows.Media
             OpacityMaskProperty =
                   RegisterProperty("OpacityMask",
                                    typeof(Brush),
-                                   typeofThis,
+                                   typeof(DrawingGroup),
                                    null,
                                    new PropertyChangedCallback(OpacityMaskPropertyChanged),
                                    null,
@@ -915,7 +914,7 @@ namespace System.Windows.Media
             TransformProperty =
                   RegisterProperty("Transform",
                                    typeof(Transform),
-                                   typeofThis,
+                                   typeof(DrawingGroup),
                                    null,
                                    new PropertyChangedCallback(TransformPropertyChanged),
                                    null,
@@ -924,7 +923,7 @@ namespace System.Windows.Media
             GuidelineSetProperty =
                   RegisterProperty("GuidelineSet",
                                    typeof(GuidelineSet),
-                                   typeofThis,
+                                   typeof(DrawingGroup),
                                    null,
                                    new PropertyChangedCallback(GuidelineSetPropertyChanged),
                                    null,
@@ -933,7 +932,7 @@ namespace System.Windows.Media
             BitmapEffectProperty =
                   RegisterProperty("BitmapEffect",
                                    typeof(BitmapEffect),
-                                   typeofThis,
+                                   typeof(DrawingGroup),
                                    null,
                                    new PropertyChangedCallback(BitmapEffectPropertyChanged),
                                    null,
@@ -942,7 +941,7 @@ namespace System.Windows.Media
             BitmapEffectInputProperty =
                   RegisterProperty("BitmapEffectInput",
                                    typeof(BitmapEffectInput),
-                                   typeofThis,
+                                   typeof(DrawingGroup),
                                    null,
                                    new PropertyChangedCallback(BitmapEffectInputPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingImage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingImage.cs
@@ -319,11 +319,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(DrawingImage);
             DrawingProperty =
                   RegisterProperty("Drawing",
                                    typeof(Drawing),
-                                   typeofThis,
+                                   typeof(DrawingImage),
                                    null,
                                    new PropertyChangedCallback(DrawingPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/EllipseGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/EllipseGeometry.cs
@@ -364,11 +364,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(EllipseGeometry);
             RadiusXProperty =
                   RegisterProperty("RadiusX",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(EllipseGeometry),
                                    0.0,
                                    new PropertyChangedCallback(RadiusXPropertyChanged),
                                    null,
@@ -377,7 +376,7 @@ namespace System.Windows.Media
             RadiusYProperty =
                   RegisterProperty("RadiusY",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(EllipseGeometry),
                                    0.0,
                                    new PropertyChangedCallback(RadiusYPropertyChanged),
                                    null,
@@ -386,7 +385,7 @@ namespace System.Windows.Media
             CenterProperty =
                   RegisterProperty("Center",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(EllipseGeometry),
                                    new Point(),
                                    new PropertyChangedCallback(CenterPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeneralTransformGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeneralTransformGroup.cs
@@ -190,11 +190,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(GeneralTransformGroup);
             ChildrenProperty =
                   RegisterProperty("Children",
                                    typeof(GeneralTransformCollection),
-                                   typeofThis,
+                                   typeof(GeneralTransformGroup),
                                    new FreezableDefaultValueFactory(GeneralTransformCollection.Empty),
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Geometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Geometry.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -357,11 +357,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(Geometry);
             TransformProperty =
                   RegisterProperty("Transform",
                                    typeof(Transform),
-                                   typeofThis,
+                                   typeof(Geometry),
                                    Transform.Identity,
                                    new PropertyChangedCallback(TransformPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryDrawing.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryDrawing.cs
@@ -454,11 +454,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(GeometryDrawing);
             BrushProperty =
                   RegisterProperty("Brush",
                                    typeof(Brush),
-                                   typeofThis,
+                                   typeof(GeometryDrawing),
                                    null,
                                    new PropertyChangedCallback(BrushPropertyChanged),
                                    null,
@@ -467,7 +466,7 @@ namespace System.Windows.Media
             PenProperty =
                   RegisterProperty("Pen",
                                    typeof(Pen),
-                                   typeofThis,
+                                   typeof(GeometryDrawing),
                                    null,
                                    new PropertyChangedCallback(PenPropertyChanged),
                                    null,
@@ -476,7 +475,7 @@ namespace System.Windows.Media
             GeometryProperty =
                   RegisterProperty("Geometry",
                                    typeof(Geometry),
-                                   typeofThis,
+                                   typeof(GeometryDrawing),
                                    null,
                                    new PropertyChangedCallback(GeometryPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryGroup.cs
@@ -490,11 +490,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(GeometryGroup);
             FillRuleProperty =
                   RegisterProperty("FillRule",
                                    typeof(FillRule),
-                                   typeofThis,
+                                   typeof(GeometryGroup),
                                    FillRule.EvenOdd,
                                    new PropertyChangedCallback(FillRulePropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsFillRuleValid),
@@ -503,7 +502,7 @@ namespace System.Windows.Media
             ChildrenProperty =
                   RegisterProperty("Children",
                                    typeof(GeometryCollection),
-                                   typeofThis,
+                                   typeof(GeometryGroup),
                                    new FreezableDefaultValueFactory(GeometryCollection.Empty),
                                    new PropertyChangedCallback(ChildrenPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GlyphRunDrawing.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GlyphRunDrawing.cs
@@ -361,11 +361,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(GlyphRunDrawing);
             GlyphRunProperty =
                   RegisterProperty("GlyphRun",
                                    typeof(GlyphRun),
-                                   typeofThis,
+                                   typeof(GlyphRunDrawing),
                                    null,
                                    new PropertyChangedCallback(GlyphRunPropertyChanged),
                                    null,
@@ -374,7 +373,7 @@ namespace System.Windows.Media
             ForegroundBrushProperty =
                   RegisterProperty("ForegroundBrush",
                                    typeof(Brush),
-                                   typeofThis,
+                                   typeof(GlyphRunDrawing),
                                    null,
                                    new PropertyChangedCallback(ForegroundBrushPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GradientBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GradientBrush.cs
@@ -287,11 +287,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(GradientBrush);
             ColorInterpolationModeProperty =
                   RegisterProperty("ColorInterpolationMode",
                                    typeof(ColorInterpolationMode),
-                                   typeofThis,
+                                   typeof(GradientBrush),
                                    ColorInterpolationMode.SRgbLinearInterpolation,
                                    new PropertyChangedCallback(ColorInterpolationModePropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsColorInterpolationModeValid),
@@ -300,7 +299,7 @@ namespace System.Windows.Media
             MappingModeProperty =
                   RegisterProperty("MappingMode",
                                    typeof(BrushMappingMode),
-                                   typeofThis,
+                                   typeof(GradientBrush),
                                    BrushMappingMode.RelativeToBoundingBox,
                                    new PropertyChangedCallback(MappingModePropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsBrushMappingModeValid),
@@ -309,7 +308,7 @@ namespace System.Windows.Media
             SpreadMethodProperty =
                   RegisterProperty("SpreadMethod",
                                    typeof(GradientSpreadMethod),
-                                   typeofThis,
+                                   typeof(GradientBrush),
                                    GradientSpreadMethod.Pad,
                                    new PropertyChangedCallback(SpreadMethodPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsGradientSpreadMethodValid),
@@ -318,7 +317,7 @@ namespace System.Windows.Media
             GradientStopsProperty =
                   RegisterProperty("GradientStops",
                                    typeof(GradientStopCollection),
-                                   typeofThis,
+                                   typeof(GradientBrush),
                                    new FreezableDefaultValueFactory(GradientStopCollection.Empty),
                                    new PropertyChangedCallback(GradientStopsPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GuidelineSet.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GuidelineSet.cs
@@ -367,11 +367,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(GuidelineSet);
             GuidelinesXProperty =
                   RegisterProperty("GuidelinesX",
                                    typeof(DoubleCollection),
-                                   typeofThis,
+                                   typeof(GuidelineSet),
                                    new FreezableDefaultValueFactory(DoubleCollection.Empty),
                                    new PropertyChangedCallback(GuidelinesXPropertyChanged),
                                    null,
@@ -380,7 +379,7 @@ namespace System.Windows.Media
             GuidelinesYProperty =
                   RegisterProperty("GuidelinesY",
                                    typeof(DoubleCollection),
-                                   typeofThis,
+                                   typeof(GuidelineSet),
                                    new FreezableDefaultValueFactory(DoubleCollection.Empty),
                                    new PropertyChangedCallback(GuidelinesYPropertyChanged),
                                    null,
@@ -389,7 +388,7 @@ namespace System.Windows.Media
             IsDynamicProperty =
                   RegisterProperty("IsDynamic",
                                    typeof(bool),
-                                   typeofThis,
+                                   typeof(GuidelineSet),
                                    false,
                                    new PropertyChangedCallback(IsDynamicPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageBrush.cs
@@ -382,11 +382,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(ImageBrush);
             ImageSourceProperty =
                   RegisterProperty("ImageSource",
                                    typeof(ImageSource),
-                                   typeofThis,
+                                   typeof(ImageBrush),
                                    null,
                                    new PropertyChangedCallback(ImageSourcePropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageDrawing.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageDrawing.cs
@@ -340,11 +340,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(ImageDrawing);
             ImageSourceProperty =
                   RegisterProperty("ImageSource",
                                    typeof(ImageSource),
-                                   typeofThis,
+                                   typeof(ImageDrawing),
                                    null,
                                    new PropertyChangedCallback(ImageSourcePropertyChanged),
                                    null,
@@ -353,7 +352,7 @@ namespace System.Windows.Media
             RectProperty =
                   RegisterProperty("Rect",
                                    typeof(Rect),
-                                   typeofThis,
+                                   typeof(ImageDrawing),
                                    Rect.Empty,
                                    new PropertyChangedCallback(RectPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LineGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LineGeometry.cs
@@ -316,11 +316,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(LineGeometry);
             StartPointProperty =
                   RegisterProperty("StartPoint",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(LineGeometry),
                                    new Point(),
                                    new PropertyChangedCallback(StartPointPropertyChanged),
                                    null,
@@ -329,7 +328,7 @@ namespace System.Windows.Media
             EndPointProperty =
                   RegisterProperty("EndPoint",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(LineGeometry),
                                    new Point(),
                                    new PropertyChangedCallback(EndPointPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LineSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LineSegment.cs
@@ -201,11 +201,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(LineSegment);
             PointProperty =
                   RegisterProperty("Point",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(LineSegment),
                                    new Point(),
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LinearGradientBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LinearGradientBrush.cs
@@ -286,11 +286,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(LinearGradientBrush);
             StartPointProperty =
                   RegisterProperty("StartPoint",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(LinearGradientBrush),
                                    new Point(0,0),
                                    new PropertyChangedCallback(StartPointPropertyChanged),
                                    null,
@@ -299,7 +298,7 @@ namespace System.Windows.Media
             EndPointProperty =
                   RegisterProperty("EndPoint",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(LinearGradientBrush),
                                    new Point(1,1),
                                    new PropertyChangedCallback(EndPointPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/MatrixTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/MatrixTransform.cs
@@ -277,11 +277,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(MatrixTransform);
             MatrixProperty =
                   RegisterProperty("Matrix",
                                    typeof(Matrix),
-                                   typeofThis,
+                                   typeof(MatrixTransform),
                                    new Matrix(),
                                    new PropertyChangedCallback(MatrixPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/MediaTimeline.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/MediaTimeline.cs
@@ -201,11 +201,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(MediaTimeline);
             SourceProperty =
                   RegisterProperty("Source",
                                    typeof(Uri),
-                                   typeofThis,
+                                   typeof(MediaTimeline),
                                    null,
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigure.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigure.cs
@@ -265,11 +265,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(PathFigure);
             StartPointProperty =
                   RegisterProperty("StartPoint",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(PathFigure),
                                    new Point(),
                                    null,
                                    null,
@@ -278,7 +277,7 @@ namespace System.Windows.Media
             IsFilledProperty =
                   RegisterProperty("IsFilled",
                                    typeof(bool),
-                                   typeofThis,
+                                   typeof(PathFigure),
                                    true,
                                    null,
                                    null,
@@ -287,7 +286,7 @@ namespace System.Windows.Media
             SegmentsProperty =
                   RegisterProperty("Segments",
                                    typeof(PathSegmentCollection),
-                                   typeofThis,
+                                   typeof(PathFigure),
                                    new FreezableDefaultValueFactory(PathSegmentCollection.Empty),
                                    null,
                                    null,
@@ -296,7 +295,7 @@ namespace System.Windows.Media
             IsClosedProperty =
                   RegisterProperty("IsClosed",
                                    typeof(bool),
-                                   typeofThis,
+                                   typeof(PathFigure),
                                    false,
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathGeometry.cs
@@ -288,11 +288,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(PathGeometry);
             FillRuleProperty =
                   RegisterProperty("FillRule",
                                    typeof(FillRule),
-                                   typeofThis,
+                                   typeof(PathGeometry),
                                    FillRule.EvenOdd,
                                    new PropertyChangedCallback(FillRulePropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsFillRuleValid),
@@ -301,7 +300,7 @@ namespace System.Windows.Media
             FiguresProperty =
                   RegisterProperty("Figures",
                                    typeof(PathFigureCollection),
-                                   typeofThis,
+                                   typeof(PathGeometry),
                                    new FreezableDefaultValueFactory(PathFigureCollection.Empty),
                                    new PropertyChangedCallback(FiguresPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathSegment.cs
@@ -201,11 +201,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(PathSegment);
             IsStrokedProperty =
                   RegisterProperty("IsStroked",
                                    typeof(bool),
-                                   typeofThis,
+                                   typeof(PathSegment),
                                    true,
                                    null,
                                    null,
@@ -214,7 +213,7 @@ namespace System.Windows.Media
             IsSmoothJoinProperty =
                   RegisterProperty("IsSmoothJoin",
                                    typeof(bool),
-                                   typeofThis,
+                                   typeof(PathSegment),
                                    false,
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Pen.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Pen.cs
@@ -564,11 +564,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(Pen);
             BrushProperty =
                   RegisterProperty("Brush",
                                    typeof(Brush),
-                                   typeofThis,
+                                   typeof(Pen),
                                    null,
                                    new PropertyChangedCallback(BrushPropertyChanged),
                                    null,
@@ -577,7 +576,7 @@ namespace System.Windows.Media
             ThicknessProperty =
                   RegisterProperty("Thickness",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(Pen),
                                    1.0,
                                    new PropertyChangedCallback(ThicknessPropertyChanged),
                                    null,
@@ -586,7 +585,7 @@ namespace System.Windows.Media
             StartLineCapProperty =
                   RegisterProperty("StartLineCap",
                                    typeof(PenLineCap),
-                                   typeofThis,
+                                   typeof(Pen),
                                    PenLineCap.Flat,
                                    new PropertyChangedCallback(StartLineCapPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsPenLineCapValid),
@@ -595,7 +594,7 @@ namespace System.Windows.Media
             EndLineCapProperty =
                   RegisterProperty("EndLineCap",
                                    typeof(PenLineCap),
-                                   typeofThis,
+                                   typeof(Pen),
                                    PenLineCap.Flat,
                                    new PropertyChangedCallback(EndLineCapPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsPenLineCapValid),
@@ -604,7 +603,7 @@ namespace System.Windows.Media
             DashCapProperty =
                   RegisterProperty("DashCap",
                                    typeof(PenLineCap),
-                                   typeofThis,
+                                   typeof(Pen),
                                    PenLineCap.Square,
                                    new PropertyChangedCallback(DashCapPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsPenLineCapValid),
@@ -613,7 +612,7 @@ namespace System.Windows.Media
             LineJoinProperty =
                   RegisterProperty("LineJoin",
                                    typeof(PenLineJoin),
-                                   typeofThis,
+                                   typeof(Pen),
                                    PenLineJoin.Miter,
                                    new PropertyChangedCallback(LineJoinPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsPenLineJoinValid),
@@ -622,7 +621,7 @@ namespace System.Windows.Media
             MiterLimitProperty =
                   RegisterProperty("MiterLimit",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(Pen),
                                    10.0,
                                    new PropertyChangedCallback(MiterLimitPropertyChanged),
                                    null,
@@ -631,7 +630,7 @@ namespace System.Windows.Media
             DashStyleProperty =
                   RegisterProperty("DashStyle",
                                    typeof(DashStyle),
-                                   typeofThis,
+                                   typeof(Pen),
                                    DashStyles.Solid,
                                    new PropertyChangedCallback(DashStylePropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyBezierSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyBezierSegment.cs
@@ -203,11 +203,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(PolyBezierSegment);
             PointsProperty =
                   RegisterProperty("Points",
                                    typeof(PointCollection),
-                                   typeofThis,
+                                   typeof(PolyBezierSegment),
                                    new FreezableDefaultValueFactory(PointCollection.Empty),
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyLineSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyLineSegment.cs
@@ -203,11 +203,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(PolyLineSegment);
             PointsProperty =
                   RegisterProperty("Points",
                                    typeof(PointCollection),
-                                   typeofThis,
+                                   typeof(PolyLineSegment),
                                    new FreezableDefaultValueFactory(PointCollection.Empty),
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyQuadraticBezierSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyQuadraticBezierSegment.cs
@@ -203,11 +203,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(PolyQuadraticBezierSegment);
             PointsProperty =
                   RegisterProperty("Points",
                                    typeof(PointCollection),
-                                   typeofThis,
+                                   typeof(PolyQuadraticBezierSegment),
                                    new FreezableDefaultValueFactory(PointCollection.Empty),
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/QuadraticBezierSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/QuadraticBezierSegment.cs
@@ -208,11 +208,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(QuadraticBezierSegment);
             Point1Property =
                   RegisterProperty("Point1",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(QuadraticBezierSegment),
                                    new Point(),
                                    null,
                                    null,
@@ -221,7 +220,7 @@ namespace System.Windows.Media
             Point2Property =
                   RegisterProperty("Point2",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(QuadraticBezierSegment),
                                    new Point(),
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RadialGradientBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RadialGradientBrush.cs
@@ -338,11 +338,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(RadialGradientBrush);
             CenterProperty =
                   RegisterProperty("Center",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(RadialGradientBrush),
                                    new Point(0.5,0.5),
                                    new PropertyChangedCallback(CenterPropertyChanged),
                                    null,
@@ -351,7 +350,7 @@ namespace System.Windows.Media
             RadiusXProperty =
                   RegisterProperty("RadiusX",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(RadialGradientBrush),
                                    0.5,
                                    new PropertyChangedCallback(RadiusXPropertyChanged),
                                    null,
@@ -360,7 +359,7 @@ namespace System.Windows.Media
             RadiusYProperty =
                   RegisterProperty("RadiusY",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(RadialGradientBrush),
                                    0.5,
                                    new PropertyChangedCallback(RadiusYPropertyChanged),
                                    null,
@@ -369,7 +368,7 @@ namespace System.Windows.Media
             GradientOriginProperty =
                   RegisterProperty("GradientOrigin",
                                    typeof(Point),
-                                   typeofThis,
+                                   typeof(RadialGradientBrush),
                                    new Point(0.5,0.5),
                                    new PropertyChangedCallback(GradientOriginPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RectangleGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RectangleGeometry.cs
@@ -362,11 +362,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(RectangleGeometry);
             RadiusXProperty =
                   RegisterProperty("RadiusX",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(RectangleGeometry),
                                    0.0,
                                    new PropertyChangedCallback(RadiusXPropertyChanged),
                                    null,
@@ -375,7 +374,7 @@ namespace System.Windows.Media
             RadiusYProperty =
                   RegisterProperty("RadiusY",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(RectangleGeometry),
                                    0.0,
                                    new PropertyChangedCallback(RadiusYPropertyChanged),
                                    null,
@@ -384,7 +383,7 @@ namespace System.Windows.Media
             RectProperty =
                   RegisterProperty("Rect",
                                    typeof(Rect),
-                                   typeofThis,
+                                   typeof(RectangleGeometry),
                                    Rect.Empty,
                                    new PropertyChangedCallback(RectPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RotateTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RotateTransform.cs
@@ -330,11 +330,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(RotateTransform);
             AngleProperty =
                   RegisterProperty("Angle",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(RotateTransform),
                                    0.0,
                                    new PropertyChangedCallback(AnglePropertyChanged),
                                    null,
@@ -343,7 +342,7 @@ namespace System.Windows.Media
             CenterXProperty =
                   RegisterProperty("CenterX",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(RotateTransform),
                                    0.0,
                                    new PropertyChangedCallback(CenterXPropertyChanged),
                                    null,
@@ -352,7 +351,7 @@ namespace System.Windows.Media
             CenterYProperty =
                   RegisterProperty("CenterY",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(RotateTransform),
                                    0.0,
                                    new PropertyChangedCallback(CenterYPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ScaleTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ScaleTransform.cs
@@ -363,11 +363,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(ScaleTransform);
             ScaleXProperty =
                   RegisterProperty("ScaleX",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ScaleTransform),
                                    1.0,
                                    new PropertyChangedCallback(ScaleXPropertyChanged),
                                    null,
@@ -376,7 +375,7 @@ namespace System.Windows.Media
             ScaleYProperty =
                   RegisterProperty("ScaleY",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ScaleTransform),
                                    1.0,
                                    new PropertyChangedCallback(ScaleYPropertyChanged),
                                    null,
@@ -385,7 +384,7 @@ namespace System.Windows.Media
             CenterXProperty =
                   RegisterProperty("CenterX",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ScaleTransform),
                                    0.0,
                                    new PropertyChangedCallback(CenterXPropertyChanged),
                                    null,
@@ -394,7 +393,7 @@ namespace System.Windows.Media
             CenterYProperty =
                   RegisterProperty("CenterY",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ScaleTransform),
                                    0.0,
                                    new PropertyChangedCallback(CenterYPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/SkewTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/SkewTransform.cs
@@ -363,11 +363,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(SkewTransform);
             AngleXProperty =
                   RegisterProperty("AngleX",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(SkewTransform),
                                    0.0,
                                    new PropertyChangedCallback(AngleXPropertyChanged),
                                    null,
@@ -376,7 +375,7 @@ namespace System.Windows.Media
             AngleYProperty =
                   RegisterProperty("AngleY",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(SkewTransform),
                                    0.0 ,
                                    new PropertyChangedCallback(AngleYPropertyChanged),
                                    null,
@@ -385,7 +384,7 @@ namespace System.Windows.Media
             CenterXProperty =
                   RegisterProperty("CenterX",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(SkewTransform),
                                    0.0,
                                    new PropertyChangedCallback(CenterXPropertyChanged),
                                    null,
@@ -394,7 +393,7 @@ namespace System.Windows.Media
             CenterYProperty =
                   RegisterProperty("CenterY",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(SkewTransform),
                                    0.0,
                                    new PropertyChangedCallback(CenterYPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/SolidColorBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/SolidColorBrush.cs
@@ -319,11 +319,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(SolidColorBrush);
             ColorProperty =
                   RegisterProperty("Color",
                                    typeof(Color),
-                                   typeofThis,
+                                   typeof(SolidColorBrush),
                                    Colors.Transparent,
                                    new PropertyChangedCallback(ColorPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/StreamGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/StreamGeometry.cs
@@ -194,11 +194,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(StreamGeometry);
             FillRuleProperty =
                   RegisterProperty("FillRule",
                                    typeof(FillRule),
-                                   typeofThis,
+                                   typeof(StreamGeometry),
                                    FillRule.EvenOdd,
                                    new PropertyChangedCallback(FillRulePropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsFillRuleValid),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TextEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TextEffect.cs
@@ -289,11 +289,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(TextEffect);
             TransformProperty =
                   RegisterProperty("Transform",
                                    typeof(Transform),
-                                   typeofThis,
+                                   typeof(TextEffect),
                                    null,
                                    null,
                                    null,
@@ -302,7 +301,7 @@ namespace System.Windows.Media
             ClipProperty =
                   RegisterProperty("Clip",
                                    typeof(Geometry),
-                                   typeofThis,
+                                   typeof(TextEffect),
                                    null,
                                    null,
                                    null,
@@ -311,7 +310,7 @@ namespace System.Windows.Media
             ForegroundProperty =
                   RegisterProperty("Foreground",
                                    typeof(Brush),
-                                   typeofThis,
+                                   typeof(TextEffect),
                                    null,
                                    null,
                                    null,
@@ -320,7 +319,7 @@ namespace System.Windows.Media
             PositionStartProperty =
                   RegisterProperty("PositionStart",
                                    typeof(int),
-                                   typeofThis,
+                                   typeof(TextEffect),
                                    0,
                                    null,
                                    new ValidateValueCallback(ValidatePositionStartValue),
@@ -329,7 +328,7 @@ namespace System.Windows.Media
             PositionCountProperty =
                   RegisterProperty("PositionCount",
                                    typeof(int),
-                                   typeofThis,
+                                   typeof(TextEffect),
                                    0,
                                    null,
                                    new ValidateValueCallback(ValidatePositionCountValue),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TileBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TileBrush.cs
@@ -413,11 +413,10 @@ namespace System.Windows.Media
                                        new PropertyChangedCallback(CacheInvalidationThresholdMaximumPropertyChanged)));
 
             // Initializations
-            Type typeofThis = typeof(TileBrush);
             ViewportUnitsProperty =
                   RegisterProperty("ViewportUnits",
                                    typeof(BrushMappingMode),
-                                   typeofThis,
+                                   typeof(TileBrush),
                                    BrushMappingMode.RelativeToBoundingBox,
                                    new PropertyChangedCallback(ViewportUnitsPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsBrushMappingModeValid),
@@ -426,7 +425,7 @@ namespace System.Windows.Media
             ViewboxUnitsProperty =
                   RegisterProperty("ViewboxUnits",
                                    typeof(BrushMappingMode),
-                                   typeofThis,
+                                   typeof(TileBrush),
                                    BrushMappingMode.RelativeToBoundingBox,
                                    new PropertyChangedCallback(ViewboxUnitsPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsBrushMappingModeValid),
@@ -435,7 +434,7 @@ namespace System.Windows.Media
             ViewportProperty =
                   RegisterProperty("Viewport",
                                    typeof(Rect),
-                                   typeofThis,
+                                   typeof(TileBrush),
                                    new Rect(0,0,1,1),
                                    new PropertyChangedCallback(ViewportPropertyChanged),
                                    null,
@@ -444,7 +443,7 @@ namespace System.Windows.Media
             ViewboxProperty =
                   RegisterProperty("Viewbox",
                                    typeof(Rect),
-                                   typeofThis,
+                                   typeof(TileBrush),
                                    new Rect(0,0,1,1),
                                    new PropertyChangedCallback(ViewboxPropertyChanged),
                                    null,
@@ -453,7 +452,7 @@ namespace System.Windows.Media
             StretchProperty =
                   RegisterProperty("Stretch",
                                    typeof(Stretch),
-                                   typeofThis,
+                                   typeof(TileBrush),
                                    Stretch.Fill,
                                    new PropertyChangedCallback(StretchPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsStretchValid),
@@ -462,7 +461,7 @@ namespace System.Windows.Media
             TileModeProperty =
                   RegisterProperty("TileMode",
                                    typeof(TileMode),
-                                   typeofThis,
+                                   typeof(TileBrush),
                                    TileMode.None,
                                    new PropertyChangedCallback(TileModePropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsTileModeValid),
@@ -471,7 +470,7 @@ namespace System.Windows.Media
             AlignmentXProperty =
                   RegisterProperty("AlignmentX",
                                    typeof(AlignmentX),
-                                   typeofThis,
+                                   typeof(TileBrush),
                                    AlignmentX.Center,
                                    new PropertyChangedCallback(AlignmentXPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsAlignmentXValid),
@@ -480,7 +479,7 @@ namespace System.Windows.Media
             AlignmentYProperty =
                   RegisterProperty("AlignmentY",
                                    typeof(AlignmentY),
-                                   typeofThis,
+                                   typeof(TileBrush),
                                    AlignmentY.Center,
                                    new PropertyChangedCallback(AlignmentYPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.ValidateEnums.IsAlignmentYValid),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Transform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Transform.cs
@@ -24,7 +24,6 @@ using System.Windows.Media.Converters;
 
 namespace System.Windows.Media
 {
-
     [TypeConverter(typeof(TransformConverter))]
     [ValueSerializer(typeof(TransformValueSerializer))] // Used by MarkupWriter
     public abstract partial class Transform : GeneralTransform, DUCE.IResource

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformGroup.cs
@@ -445,11 +445,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(TransformGroup);
             ChildrenProperty =
                   RegisterProperty("Children",
                                    typeof(TransformCollection),
-                                   typeofThis,
+                                   typeof(TransformGroup),
                                    new FreezableDefaultValueFactory(TransformCollection.Empty),
                                    new PropertyChangedCallback(ChildrenPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TranslateTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TranslateTransform.cs
@@ -297,11 +297,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(TranslateTransform);
             XProperty =
                   RegisterProperty("X",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(TranslateTransform),
                                    0.0,
                                    new PropertyChangedCallback(XPropertyChanged),
                                    null,
@@ -310,7 +309,7 @@ namespace System.Windows.Media
             YProperty =
                   RegisterProperty("Y",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(TranslateTransform),
                                    0.0,
                                    new PropertyChangedCallback(YPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VideoDrawing.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VideoDrawing.cs
@@ -321,11 +321,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(VideoDrawing);
             PlayerProperty =
                   RegisterProperty("Player",
                                    typeof(MediaPlayer),
-                                   typeofThis,
+                                   typeof(VideoDrawing),
                                    null,
                                    new PropertyChangedCallback(PlayerPropertyChanged),
                                    null,
@@ -334,7 +333,7 @@ namespace System.Windows.Media
             RectProperty =
                   RegisterProperty("Rect",
                                    typeof(Rect),
-                                   typeofThis,
+                                   typeof(VideoDrawing),
                                    Rect.Empty,
                                    new PropertyChangedCallback(RectPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VisualBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VisualBrush.cs
@@ -416,11 +416,10 @@ namespace System.Windows.Media
 
 
             // Initializations
-            Type typeofThis = typeof(VisualBrush);
             VisualProperty =
                   RegisterProperty("Visual",
                                    typeof(Visual),
-                                   typeofThis,
+                                   typeof(VisualBrush),
                                    null,
                                    new PropertyChangedCallback(VisualPropertyChanged),
                                    null,
@@ -429,7 +428,7 @@ namespace System.Windows.Media
             AutoLayoutContentProperty =
                   RegisterProperty("AutoLayoutContent",
                                    typeof(bool),
-                                   typeofThis,
+                                   typeof(VisualBrush),
                                    true,
                                    new PropertyChangedCallback(AutoLayoutContentPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/Generated/BitmapImage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/Generated/BitmapImage.cs
@@ -487,11 +487,10 @@ namespace System.Windows.Media.Imaging
 
 
             // Initializations
-            Type typeofThis = typeof(BitmapImage);
             UriCachePolicyProperty =
                   RegisterProperty("UriCachePolicy",
                                    typeof(RequestCachePolicy),
-                                   typeofThis,
+                                   typeof(BitmapImage),
                                    null,
                                    new PropertyChangedCallback(UriCachePolicyPropertyChanged),
                                    null,
@@ -500,7 +499,7 @@ namespace System.Windows.Media.Imaging
             UriSourceProperty =
                   RegisterProperty("UriSource",
                                    typeof(Uri),
-                                   typeofThis,
+                                   typeof(BitmapImage),
                                    null,
                                    new PropertyChangedCallback(UriSourcePropertyChanged),
                                    null,
@@ -509,7 +508,7 @@ namespace System.Windows.Media.Imaging
             StreamSourceProperty =
                   RegisterProperty("StreamSource",
                                    typeof(Stream),
-                                   typeofThis,
+                                   typeof(BitmapImage),
                                    null,
                                    new PropertyChangedCallback(StreamSourcePropertyChanged),
                                    null,
@@ -518,7 +517,7 @@ namespace System.Windows.Media.Imaging
             DecodePixelWidthProperty =
                   RegisterProperty("DecodePixelWidth",
                                    typeof(int),
-                                   typeofThis,
+                                   typeof(BitmapImage),
                                    0,
                                    new PropertyChangedCallback(DecodePixelWidthPropertyChanged),
                                    null,
@@ -527,7 +526,7 @@ namespace System.Windows.Media.Imaging
             DecodePixelHeightProperty =
                   RegisterProperty("DecodePixelHeight",
                                    typeof(int),
-                                   typeofThis,
+                                   typeof(BitmapImage),
                                    0,
                                    new PropertyChangedCallback(DecodePixelHeightPropertyChanged),
                                    null,
@@ -536,7 +535,7 @@ namespace System.Windows.Media.Imaging
             RotationProperty =
                   RegisterProperty("Rotation",
                                    typeof(Rotation),
-                                   typeofThis,
+                                   typeof(BitmapImage),
                                    Rotation.Rotate0,
                                    new PropertyChangedCallback(RotationPropertyChanged),
                                    new ValidateValueCallback(System.Windows.Media.Imaging.ValidateEnums.IsRotationValid),
@@ -545,7 +544,7 @@ namespace System.Windows.Media.Imaging
             SourceRectProperty =
                   RegisterProperty("SourceRect",
                                    typeof(Int32Rect),
-                                   typeofThis,
+                                   typeof(BitmapImage),
                                    Int32Rect.Empty,
                                    new PropertyChangedCallback(SourceRectPropertyChanged),
                                    null,
@@ -554,7 +553,7 @@ namespace System.Windows.Media.Imaging
             CreateOptionsProperty =
                   RegisterProperty("CreateOptions",
                                    typeof(BitmapCreateOptions),
-                                   typeofThis,
+                                   typeof(BitmapImage),
                                    BitmapCreateOptions.None,
                                    new PropertyChangedCallback(CreateOptionsPropertyChanged),
                                    null,
@@ -563,7 +562,7 @@ namespace System.Windows.Media.Imaging
             CacheOptionProperty =
                   RegisterProperty("CacheOption",
                                    typeof(BitmapCacheOption),
-                                   typeofThis,
+                                   typeof(BitmapImage),
                                    BitmapCacheOption.Default,
                                    new PropertyChangedCallback(CacheOptionPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/Generated/ColorConvertedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/Generated/ColorConvertedBitmap.cs
@@ -361,11 +361,10 @@ namespace System.Windows.Media.Imaging
 
 
             // Initializations
-            Type typeofThis = typeof(ColorConvertedBitmap);
             SourceProperty =
                   RegisterProperty("Source",
                                    typeof(BitmapSource),
-                                   typeofThis,
+                                   typeof(ColorConvertedBitmap),
                                    null,
                                    new PropertyChangedCallback(SourcePropertyChanged),
                                    null,
@@ -374,7 +373,7 @@ namespace System.Windows.Media.Imaging
             SourceColorContextProperty =
                   RegisterProperty("SourceColorContext",
                                    typeof(ColorContext),
-                                   typeofThis,
+                                   typeof(ColorConvertedBitmap),
                                    null,
                                    new PropertyChangedCallback(SourceColorContextPropertyChanged),
                                    null,
@@ -383,7 +382,7 @@ namespace System.Windows.Media.Imaging
             DestinationColorContextProperty =
                   RegisterProperty("DestinationColorContext",
                                    typeof(ColorContext),
-                                   typeofThis,
+                                   typeof(ColorConvertedBitmap),
                                    null,
                                    new PropertyChangedCallback(DestinationColorContextPropertyChanged),
                                    null,
@@ -392,7 +391,7 @@ namespace System.Windows.Media.Imaging
             DestinationFormatProperty =
                   RegisterProperty("DestinationFormat",
                                    typeof(PixelFormat),
-                                   typeofThis,
+                                   typeof(ColorConvertedBitmap),
                                    PixelFormats.Pbgra32,
                                    new PropertyChangedCallback(DestinationFormatPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/Generated/CroppedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/Generated/CroppedBitmap.cs
@@ -303,11 +303,10 @@ namespace System.Windows.Media.Imaging
 
 
             // Initializations
-            Type typeofThis = typeof(CroppedBitmap);
             SourceProperty =
                   RegisterProperty("Source",
                                    typeof(BitmapSource),
-                                   typeofThis,
+                                   typeof(CroppedBitmap),
                                    null,
                                    new PropertyChangedCallback(SourcePropertyChanged),
                                    null,
@@ -316,7 +315,7 @@ namespace System.Windows.Media.Imaging
             SourceRectProperty =
                   RegisterProperty("SourceRect",
                                    typeof(Int32Rect),
-                                   typeofThis,
+                                   typeof(CroppedBitmap),
                                    Int32Rect.Empty,
                                    new PropertyChangedCallback(SourceRectPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/Generated/FormatConvertedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/Generated/FormatConvertedBitmap.cs
@@ -361,11 +361,10 @@ namespace System.Windows.Media.Imaging
 
 
             // Initializations
-            Type typeofThis = typeof(FormatConvertedBitmap);
             SourceProperty =
                   RegisterProperty("Source",
                                    typeof(BitmapSource),
-                                   typeofThis,
+                                   typeof(FormatConvertedBitmap),
                                    null,
                                    new PropertyChangedCallback(SourcePropertyChanged),
                                    null,
@@ -374,7 +373,7 @@ namespace System.Windows.Media.Imaging
             DestinationFormatProperty =
                   RegisterProperty("DestinationFormat",
                                    typeof(PixelFormat),
-                                   typeofThis,
+                                   typeof(FormatConvertedBitmap),
                                    PixelFormats.Pbgra32,
                                    new PropertyChangedCallback(DestinationFormatPropertyChanged),
                                    null,
@@ -383,7 +382,7 @@ namespace System.Windows.Media.Imaging
             DestinationPaletteProperty =
                   RegisterProperty("DestinationPalette",
                                    typeof(BitmapPalette),
-                                   typeofThis,
+                                   typeof(FormatConvertedBitmap),
                                    null,
                                    new PropertyChangedCallback(DestinationPalettePropertyChanged),
                                    null,
@@ -392,7 +391,7 @@ namespace System.Windows.Media.Imaging
             AlphaThresholdProperty =
                   RegisterProperty("AlphaThreshold",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(FormatConvertedBitmap),
                                    0.0,
                                    new PropertyChangedCallback(AlphaThresholdPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/Generated/TransformedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/Generated/TransformedBitmap.cs
@@ -326,11 +326,10 @@ namespace System.Windows.Media.Imaging
 
 
             // Initializations
-            Type typeofThis = typeof(TransformedBitmap);
             SourceProperty =
                   RegisterProperty("Source",
                                    typeof(BitmapSource),
-                                   typeofThis,
+                                   typeof(TransformedBitmap),
                                    null,
                                    new PropertyChangedCallback(SourcePropertyChanged),
                                    null,
@@ -339,7 +338,7 @@ namespace System.Windows.Media.Imaging
             TransformProperty =
                   RegisterProperty("Transform",
                                    typeof(Transform),
-                                   typeofThis,
+                                   typeof(TransformedBitmap),
                                    Transform.Identity,
                                    new PropertyChangedCallback(TransformPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/AxisAngleRotation3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/AxisAngleRotation3D.cs
@@ -299,11 +299,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(AxisAngleRotation3D);
             AxisProperty =
                   RegisterProperty("Axis",
                                    typeof(Vector3D),
-                                   typeofThis,
+                                   typeof(AxisAngleRotation3D),
                                    new Vector3D(0,1,0),
                                    new PropertyChangedCallback(AxisPropertyChanged),
                                    null,
@@ -312,7 +311,7 @@ namespace System.Windows.Media.Media3D
             AngleProperty =
                   RegisterProperty("Angle",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(AxisAngleRotation3D),
                                    (double)0.0,
                                    new PropertyChangedCallback(AnglePropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Camera.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Camera.cs
@@ -340,11 +340,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(Camera);
             TransformProperty =
                   RegisterProperty("Transform",
                                    typeof(Transform3D),
-                                   typeofThis,
+                                   typeof(Camera),
                                    Transform3D.Identity,
                                    new PropertyChangedCallback(TransformPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/DiffuseMaterial.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/DiffuseMaterial.cs
@@ -375,11 +375,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(DiffuseMaterial);
             ColorProperty =
                   RegisterProperty("Color",
                                    typeof(Color),
-                                   typeofThis,
+                                   typeof(DiffuseMaterial),
                                    Colors.White,
                                    new PropertyChangedCallback(ColorPropertyChanged),
                                    null,
@@ -388,7 +387,7 @@ namespace System.Windows.Media.Media3D
             AmbientColorProperty =
                   RegisterProperty("AmbientColor",
                                    typeof(Color),
-                                   typeofThis,
+                                   typeof(DiffuseMaterial),
                                    Colors.White,
                                    new PropertyChangedCallback(AmbientColorPropertyChanged),
                                    null,
@@ -397,7 +396,7 @@ namespace System.Windows.Media.Media3D
             BrushProperty =
                   RegisterProperty("Brush",
                                    typeof(Brush),
-                                   typeofThis,
+                                   typeof(DiffuseMaterial),
                                    null,
                                    new PropertyChangedCallback(BrushPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/DirectionalLight.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/DirectionalLight.cs
@@ -287,11 +287,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(DirectionalLight);
             DirectionProperty =
                   RegisterProperty("Direction",
                                    typeof(Vector3D),
-                                   typeofThis,
+                                   typeof(DirectionalLight),
                                    new Vector3D(0,0,-1),
                                    new PropertyChangedCallback(DirectionPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/EmissiveMaterial.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/EmissiveMaterial.cs
@@ -347,11 +347,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(EmissiveMaterial);
             ColorProperty =
                   RegisterProperty("Color",
                                    typeof(Color),
-                                   typeofThis,
+                                   typeof(EmissiveMaterial),
                                    Colors.White,
                                    new PropertyChangedCallback(ColorPropertyChanged),
                                    null,
@@ -360,7 +359,7 @@ namespace System.Windows.Media.Media3D
             BrushProperty =
                   RegisterProperty("Brush",
                                    typeof(Brush),
-                                   typeofThis,
+                                   typeof(EmissiveMaterial),
                                    null,
                                    new PropertyChangedCallback(BrushPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeneralTransform3DGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeneralTransform3DGroup.cs
@@ -188,11 +188,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(GeneralTransform3DGroup);
             ChildrenProperty =
                   RegisterProperty("Children",
                                    typeof(GeneralTransform3DCollection),
-                                   typeofThis,
+                                   typeof(GeneralTransform3DGroup),
                                    new FreezableDefaultValueFactory(GeneralTransform3DCollection.Empty),
                                    null,
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeometryModel3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeometryModel3D.cs
@@ -473,11 +473,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(GeometryModel3D);
             GeometryProperty =
                   RegisterProperty("Geometry",
                                    typeof(Geometry3D),
-                                   typeofThis,
+                                   typeof(GeometryModel3D),
                                    null,
                                    new PropertyChangedCallback(GeometryPropertyChanged),
                                    null,
@@ -486,7 +485,7 @@ namespace System.Windows.Media.Media3D
             MaterialProperty =
                   RegisterProperty("Material",
                                    typeof(Material),
-                                   typeofThis,
+                                   typeof(GeometryModel3D),
                                    null,
                                    new PropertyChangedCallback(MaterialPropertyChanged),
                                    null,
@@ -495,7 +494,7 @@ namespace System.Windows.Media.Media3D
             BackMaterialProperty =
                   RegisterProperty("BackMaterial",
                                    typeof(Material),
-                                   typeofThis,
+                                   typeof(GeometryModel3D),
                                    null,
                                    new PropertyChangedCallback(BackMaterialPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Light.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Light.cs
@@ -198,11 +198,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(Light);
             ColorProperty =
                   RegisterProperty("Color",
                                    typeof(Color),
-                                   typeofThis,
+                                   typeof(Light),
                                    Colors.White,
                                    new PropertyChangedCallback(ColorPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MaterialGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MaterialGroup.cs
@@ -443,11 +443,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(MaterialGroup);
             ChildrenProperty =
                   RegisterProperty("Children",
                                    typeof(MaterialCollection),
-                                   typeofThis,
+                                   typeof(MaterialGroup),
                                    new FreezableDefaultValueFactory(MaterialCollection.Empty),
                                    new PropertyChangedCallback(ChildrenPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MatrixCamera.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MatrixCamera.cs
@@ -302,11 +302,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(MatrixCamera);
             ViewMatrixProperty =
                   RegisterProperty("ViewMatrix",
                                    typeof(Matrix3D),
-                                   typeofThis,
+                                   typeof(MatrixCamera),
                                    Matrix3D.Identity,
                                    new PropertyChangedCallback(ViewMatrixPropertyChanged),
                                    null,
@@ -315,7 +314,7 @@ namespace System.Windows.Media.Media3D
             ProjectionMatrixProperty =
                   RegisterProperty("ProjectionMatrix",
                                    typeof(Matrix3D),
-                                   typeofThis,
+                                   typeof(MatrixCamera),
                                    Matrix3D.Identity,
                                    new PropertyChangedCallback(ProjectionMatrixPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MatrixTransform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MatrixTransform3D.cs
@@ -268,11 +268,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(MatrixTransform3D);
             MatrixProperty =
                   RegisterProperty("Matrix",
                                    typeof(Matrix3D),
-                                   typeofThis,
+                                   typeof(MatrixTransform3D),
                                    Matrix3D.Identity,
                                    new PropertyChangedCallback(MatrixPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MeshGeometry3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MeshGeometry3D.cs
@@ -444,11 +444,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(MeshGeometry3D);
             PositionsProperty =
                   RegisterProperty("Positions",
                                    typeof(Point3DCollection),
-                                   typeofThis,
+                                   typeof(MeshGeometry3D),
                                    new FreezableDefaultValueFactory(Point3DCollection.Empty),
                                    new PropertyChangedCallback(PositionsPropertyChanged),
                                    null,
@@ -457,7 +456,7 @@ namespace System.Windows.Media.Media3D
             NormalsProperty =
                   RegisterProperty("Normals",
                                    typeof(Vector3DCollection),
-                                   typeofThis,
+                                   typeof(MeshGeometry3D),
                                    new FreezableDefaultValueFactory(Vector3DCollection.Empty),
                                    new PropertyChangedCallback(NormalsPropertyChanged),
                                    null,
@@ -466,7 +465,7 @@ namespace System.Windows.Media.Media3D
             TextureCoordinatesProperty =
                   RegisterProperty("TextureCoordinates",
                                    typeof(PointCollection),
-                                   typeofThis,
+                                   typeof(MeshGeometry3D),
                                    new FreezableDefaultValueFactory(PointCollection.Empty),
                                    new PropertyChangedCallback(TextureCoordinatesPropertyChanged),
                                    null,
@@ -475,7 +474,7 @@ namespace System.Windows.Media.Media3D
             TriangleIndicesProperty =
                   RegisterProperty("TriangleIndices",
                                    typeof(Int32Collection),
-                                   typeofThis,
+                                   typeof(MeshGeometry3D),
                                    new FreezableDefaultValueFactory(Int32Collection.Empty),
                                    new PropertyChangedCallback(TriangleIndicesPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3D.cs
@@ -340,11 +340,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(Model3D);
             TransformProperty =
                   RegisterProperty("Transform",
                                    typeof(Transform3D),
-                                   typeofThis,
+                                   typeof(Model3D),
                                    Transform3D.Identity,
                                    new PropertyChangedCallback(TransformPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3DGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3DGroup.cs
@@ -460,11 +460,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(Model3DGroup);
             ChildrenProperty =
                   RegisterProperty("Children",
                                    typeof(Model3DCollection),
-                                   typeofThis,
+                                   typeof(Model3DGroup),
                                    new FreezableDefaultValueFactory(Model3DCollection.Empty),
                                    new PropertyChangedCallback(ChildrenPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/OrthographicCamera.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/OrthographicCamera.cs
@@ -311,11 +311,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(OrthographicCamera);
             WidthProperty =
                   RegisterProperty("Width",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(OrthographicCamera),
                                    (double)2.0,
                                    new PropertyChangedCallback(WidthPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/PerspectiveCamera.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/PerspectiveCamera.cs
@@ -311,11 +311,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(PerspectiveCamera);
             FieldOfViewProperty =
                   RegisterProperty("FieldOfView",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(PerspectiveCamera),
                                    (double)45.0,
                                    new PropertyChangedCallback(FieldOfViewPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/PointLightBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/PointLightBase.cs
@@ -293,11 +293,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(PointLightBase);
             PositionProperty =
                   RegisterProperty("Position",
                                    typeof(Point3D),
-                                   typeofThis,
+                                   typeof(PointLightBase),
                                    new Point3D(),
                                    new PropertyChangedCallback(PositionPropertyChanged),
                                    null,
@@ -306,7 +305,7 @@ namespace System.Windows.Media.Media3D
             RangeProperty =
                   RegisterProperty("Range",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(PointLightBase),
                                    Double.PositiveInfinity,
                                    new PropertyChangedCallback(RangePropertyChanged),
                                    null,
@@ -315,7 +314,7 @@ namespace System.Windows.Media.Media3D
             ConstantAttenuationProperty =
                   RegisterProperty("ConstantAttenuation",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(PointLightBase),
                                    1.0,
                                    new PropertyChangedCallback(ConstantAttenuationPropertyChanged),
                                    null,
@@ -324,7 +323,7 @@ namespace System.Windows.Media.Media3D
             LinearAttenuationProperty =
                   RegisterProperty("LinearAttenuation",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(PointLightBase),
                                    0.0,
                                    new PropertyChangedCallback(LinearAttenuationPropertyChanged),
                                    null,
@@ -333,7 +332,7 @@ namespace System.Windows.Media.Media3D
             QuadraticAttenuationProperty =
                   RegisterProperty("QuadraticAttenuation",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(PointLightBase),
                                    0.0,
                                    new PropertyChangedCallback(QuadraticAttenuationPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/ProjectionCamera.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/ProjectionCamera.cs
@@ -293,11 +293,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(ProjectionCamera);
             NearPlaneDistanceProperty =
                   RegisterProperty("NearPlaneDistance",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ProjectionCamera),
                                    (double)0.125,
                                    new PropertyChangedCallback(NearPlaneDistancePropertyChanged),
                                    null,
@@ -306,7 +305,7 @@ namespace System.Windows.Media.Media3D
             FarPlaneDistanceProperty =
                   RegisterProperty("FarPlaneDistance",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ProjectionCamera),
                                    (double)Double.PositiveInfinity,
                                    new PropertyChangedCallback(FarPlaneDistancePropertyChanged),
                                    null,
@@ -315,7 +314,7 @@ namespace System.Windows.Media.Media3D
             PositionProperty =
                   RegisterProperty("Position",
                                    typeof(Point3D),
-                                   typeofThis,
+                                   typeof(ProjectionCamera),
                                    new Point3D(),
                                    new PropertyChangedCallback(PositionPropertyChanged),
                                    null,
@@ -324,7 +323,7 @@ namespace System.Windows.Media.Media3D
             LookDirectionProperty =
                   RegisterProperty("LookDirection",
                                    typeof(Vector3D),
-                                   typeofThis,
+                                   typeof(ProjectionCamera),
                                    new Vector3D(0,0,-1),
                                    new PropertyChangedCallback(LookDirectionPropertyChanged),
                                    null,
@@ -333,7 +332,7 @@ namespace System.Windows.Media.Media3D
             UpDirectionProperty =
                   RegisterProperty("UpDirection",
                                    typeof(Vector3D),
-                                   typeofThis,
+                                   typeof(ProjectionCamera),
                                    new Vector3D(0,1,0),
                                    new PropertyChangedCallback(UpDirectionPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/QuaternionRotation3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/QuaternionRotation3D.cs
@@ -278,11 +278,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(QuaternionRotation3D);
             QuaternionProperty =
                   RegisterProperty("Quaternion",
                                    typeof(Quaternion),
-                                   typeofThis,
+                                   typeof(QuaternionRotation3D),
                                    Quaternion.Identity,
                                    new PropertyChangedCallback(QuaternionPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/RotateTransform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/RotateTransform3D.cs
@@ -422,11 +422,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(RotateTransform3D);
             CenterXProperty =
                   RegisterProperty("CenterX",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(RotateTransform3D),
                                    0.0,
                                    new PropertyChangedCallback(CenterXPropertyChanged),
                                    null,
@@ -435,7 +434,7 @@ namespace System.Windows.Media.Media3D
             CenterYProperty =
                   RegisterProperty("CenterY",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(RotateTransform3D),
                                    0.0,
                                    new PropertyChangedCallback(CenterYPropertyChanged),
                                    null,
@@ -444,7 +443,7 @@ namespace System.Windows.Media.Media3D
             CenterZProperty =
                   RegisterProperty("CenterZ",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(RotateTransform3D),
                                    0.0,
                                    new PropertyChangedCallback(CenterZPropertyChanged),
                                    null,
@@ -453,7 +452,7 @@ namespace System.Windows.Media.Media3D
             RotationProperty =
                   RegisterProperty("Rotation",
                                    typeof(Rotation3D),
-                                   typeofThis,
+                                   typeof(RotateTransform3D),
                                    Rotation3D.Identity,
                                    new PropertyChangedCallback(RotationPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/ScaleTransform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/ScaleTransform3D.cs
@@ -450,11 +450,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(ScaleTransform3D);
             ScaleXProperty =
                   RegisterProperty("ScaleX",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ScaleTransform3D),
                                    1.0,
                                    new PropertyChangedCallback(ScaleXPropertyChanged),
                                    null,
@@ -463,7 +462,7 @@ namespace System.Windows.Media.Media3D
             ScaleYProperty =
                   RegisterProperty("ScaleY",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ScaleTransform3D),
                                    1.0,
                                    new PropertyChangedCallback(ScaleYPropertyChanged),
                                    null,
@@ -472,7 +471,7 @@ namespace System.Windows.Media.Media3D
             ScaleZProperty =
                   RegisterProperty("ScaleZ",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ScaleTransform3D),
                                    1.0,
                                    new PropertyChangedCallback(ScaleZPropertyChanged),
                                    null,
@@ -481,7 +480,7 @@ namespace System.Windows.Media.Media3D
             CenterXProperty =
                   RegisterProperty("CenterX",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ScaleTransform3D),
                                    0.0,
                                    new PropertyChangedCallback(CenterXPropertyChanged),
                                    null,
@@ -490,7 +489,7 @@ namespace System.Windows.Media.Media3D
             CenterYProperty =
                   RegisterProperty("CenterY",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ScaleTransform3D),
                                    0.0,
                                    new PropertyChangedCallback(CenterYPropertyChanged),
                                    null,
@@ -499,7 +498,7 @@ namespace System.Windows.Media.Media3D
             CenterZProperty =
                   RegisterProperty("CenterZ",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(ScaleTransform3D),
                                    0.0,
                                    new PropertyChangedCallback(CenterZPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/SpecularMaterial.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/SpecularMaterial.cs
@@ -375,11 +375,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(SpecularMaterial);
             ColorProperty =
                   RegisterProperty("Color",
                                    typeof(Color),
-                                   typeofThis,
+                                   typeof(SpecularMaterial),
                                    Colors.White,
                                    new PropertyChangedCallback(ColorPropertyChanged),
                                    null,
@@ -388,7 +387,7 @@ namespace System.Windows.Media.Media3D
             BrushProperty =
                   RegisterProperty("Brush",
                                    typeof(Brush),
-                                   typeofThis,
+                                   typeof(SpecularMaterial),
                                    null,
                                    new PropertyChangedCallback(BrushPropertyChanged),
                                    null,
@@ -397,7 +396,7 @@ namespace System.Windows.Media.Media3D
             SpecularPowerProperty =
                   RegisterProperty("SpecularPower",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(SpecularMaterial),
                                    40.0,
                                    new PropertyChangedCallback(SpecularPowerPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/SpotLight.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/SpotLight.cs
@@ -383,11 +383,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(SpotLight);
             DirectionProperty =
                   RegisterProperty("Direction",
                                    typeof(Vector3D),
-                                   typeofThis,
+                                   typeof(SpotLight),
                                    new Vector3D(0,0,-1),
                                    new PropertyChangedCallback(DirectionPropertyChanged),
                                    null,
@@ -396,7 +395,7 @@ namespace System.Windows.Media.Media3D
             OuterConeAngleProperty =
                   RegisterProperty("OuterConeAngle",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(SpotLight),
                                    90.0,
                                    new PropertyChangedCallback(OuterConeAnglePropertyChanged),
                                    null,
@@ -405,7 +404,7 @@ namespace System.Windows.Media.Media3D
             InnerConeAngleProperty =
                   RegisterProperty("InnerConeAngle",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(SpotLight),
                                    180.0,
                                    new PropertyChangedCallback(InnerConeAnglePropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Transform3DGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Transform3DGroup.cs
@@ -443,11 +443,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(Transform3DGroup);
             ChildrenProperty =
                   RegisterProperty("Children",
                                    typeof(Transform3DCollection),
-                                   typeofThis,
+                                   typeof(Transform3DGroup),
                                    new FreezableDefaultValueFactory(Transform3DCollection.Empty),
                                    new PropertyChangedCallback(ChildrenPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/TranslateTransform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/TranslateTransform3D.cs
@@ -339,11 +339,10 @@ namespace System.Windows.Media.Media3D
 
 
             // Initializations
-            Type typeofThis = typeof(TranslateTransform3D);
             OffsetXProperty =
                   RegisterProperty("OffsetX",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(TranslateTransform3D),
                                    0.0,
                                    new PropertyChangedCallback(OffsetXPropertyChanged),
                                    null,
@@ -352,7 +351,7 @@ namespace System.Windows.Media.Media3D
             OffsetYProperty =
                   RegisterProperty("OffsetY",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(TranslateTransform3D),
                                    0.0,
                                    new PropertyChangedCallback(OffsetYPropertyChanged),
                                    null,
@@ -361,7 +360,7 @@ namespace System.Windows.Media.Media3D
             OffsetZProperty =
                   RegisterProperty("OffsetZ",
                                    typeof(double),
-                                   typeofThis,
+                                   typeof(TranslateTransform3D),
                                    0.0,
                                    new PropertyChangedCallback(OffsetZPropertyChanged),
                                    null,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DefaultValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DefaultValueConverter.cs
@@ -205,7 +205,7 @@ namespace MS.Internal.Data
                     if (culture != null && (mi = targetType.GetMethod("Parse",
                                             BindingFlags.Public | BindingFlags.Static,
                                             null,
-                                            new Type[] { StringType, typeof(System.Globalization.NumberStyles), typeof(System.IFormatProvider) },
+                                            new Type[] { typeof(string), typeof(System.Globalization.NumberStyles), typeof(System.IFormatProvider) },
                                             null))
                                 != null)
                     {
@@ -214,7 +214,7 @@ namespace MS.Internal.Data
                     else if (culture != null && (mi = targetType.GetMethod("Parse",
                                             BindingFlags.Public | BindingFlags.Static,
                                             null,
-                                            new Type[] { StringType, typeof(System.IFormatProvider) },
+                                            new Type[] { typeof(string), typeof(System.IFormatProvider) },
                                             null))
                                 != null)
                     {
@@ -223,7 +223,7 @@ namespace MS.Internal.Data
                     else if ((mi = targetType.GetMethod("Parse",
                                             BindingFlags.Public | BindingFlags.Static,
                                             null,
-                                            new Type[] { StringType },
+                                            new Type[] { typeof(string) },
                                             null))
                                 != null)
                     {
@@ -364,7 +364,6 @@ namespace MS.Internal.Data
         private bool _shouldConvertFrom;
         private bool _shouldConvertTo;
         private DataBindEngine _engine;
-        private static Type StringType = typeof(String);
     }
 
     #endregion DefaultValueConverter

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PropertyPathWorker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PropertyPathWorker.cs
@@ -1212,7 +1212,7 @@ namespace MS.Internal.Data
                         if (MatchIndexerParameters(null, aryInfo, args, false))
                         {
                             info = SystemCoreHelper.GetIndexerAccessor(args.Length);
-                            sourceType = typeof(Object);
+                            sourceType = typeof(object);
                         }
                     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/StaticPropertyChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/StaticPropertyChangedEventManager.cs
@@ -121,14 +121,13 @@ namespace MS.Internal.Data
         {
             get
             {
-                Type managerType = typeof(StaticPropertyChangedEventManager);
-                StaticPropertyChangedEventManager manager = (StaticPropertyChangedEventManager)GetCurrentManager(managerType);
+                StaticPropertyChangedEventManager manager = (StaticPropertyChangedEventManager)GetCurrentManager(typeof(StaticPropertyChangedEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new StaticPropertyChangedEventManager();
-                    SetCurrentManager(managerType, manager);
+                    SetCurrentManager(typeof(StaticPropertyChangedEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ValueChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ValueChangedEventManager.cs
@@ -267,13 +267,13 @@ namespace MS.Internal.Data
         {
             get
             {
-                ValueChangedEventManager manager = (ValueChangedEventManager)GetCurrentManager(typeof(StaticPropertyChangedEventManager));
+                ValueChangedEventManager manager = (ValueChangedEventManager)GetCurrentManager(typeof(ValueChangedEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new ValueChangedEventManager();
-                    SetCurrentManager(typeof(StaticPropertyChangedEventManager), manager);
+                    SetCurrentManager(typeof(ValueChangedEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ValueChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ValueChangedEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -267,14 +267,13 @@ namespace MS.Internal.Data
         {
             get
             {
-                Type managerType = typeof(ValueChangedEventManager);
-                ValueChangedEventManager manager = (ValueChangedEventManager)GetCurrentManager(managerType);
+                ValueChangedEventManager manager = (ValueChangedEventManager)GetCurrentManager(typeof(StaticPropertyChangedEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new ValueChangedEventManager();
-                    SetCurrentManager(managerType, manager);
+                    SetCurrentManager(typeof(StaticPropertyChangedEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/XmlNodeChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/XmlNodeChangedEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -129,14 +129,13 @@ namespace MS.Internal.Data
         {
             get
             {
-                Type managerType = typeof(XmlNodeChangedEventManager);
-                XmlNodeChangedEventManager manager = (XmlNodeChangedEventManager)GetCurrentManager(managerType);
+                XmlNodeChangedEventManager manager = (XmlNodeChangedEventManager)GetCurrentManager(typeof(XmlNodeChangedEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new XmlNodeChangedEventManager();
-                    SetCurrentManager(managerType, manager);
+                    SetCurrentManager(typeof(XmlNodeChangedEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ControlTemplate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ControlTemplate.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -149,14 +149,10 @@ namespace System.Windows.Controls
         //
         internal override Type TargetTypeInternal
         {
-            get 
-            {  
-                if (TargetType != null)
-                {
-                    return TargetType; 
-                }
-
-                return DefaultTargetType;
+            get
+            {
+                // Target type is FrameworkElement by default
+                return TargetType is not null ? TargetType : typeof(Control);
             }
         }
 
@@ -182,9 +178,6 @@ namespace System.Windows.Controls
 
         private Type                    _targetType;
         private TriggerCollection       _triggers;
-        
-        // Target type is FrameworkElement by default
-        internal static readonly Type DefaultTargetType = typeof(Control);
 
         #endregion Data
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -34,36 +34,34 @@ namespace System.Windows.Controls
         /// </summary>
         static DataGrid()
         {
-            Type ownerType = typeof(DataGrid);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(typeof(DataGrid)));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(typeof(DataGrid)));
             FrameworkElementFactory dataGridRowPresenterFactory = new FrameworkElementFactory(typeof(DataGridRowsPresenter));
             dataGridRowPresenterFactory.SetValue(FrameworkElement.NameProperty, ItemsPanelPartName);
-            ItemsPanelProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new ItemsPanelTemplate(dataGridRowPresenterFactory)));
-            VirtualizingPanel.IsVirtualizingProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true, null, new CoerceValueCallback(OnCoerceIsVirtualizingProperty)));
-            VirtualizingPanel.VirtualizationModeProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(VirtualizationMode.Recycling));
-            ItemContainerStyleProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceItemContainerStyle)));
-            ItemContainerStyleSelectorProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceItemContainerStyleSelector)));
-            ItemsSourceProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata((PropertyChangedCallback)null, OnCoerceItemsSourceProperty));
-            AlternationCountProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(0, null, new CoerceValueCallback(OnCoerceAlternationCount)));
-            IsEnabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsEnabledChanged)));
-            IsKeyboardFocusWithinPropertyKey.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsKeyboardFocusWithinChanged)));
-            IsSynchronizedWithCurrentItemProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceIsSynchronizedWithCurrentItem)));
-            IsTabStopProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
-            KeyboardNavigation.DirectionalNavigationProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(KeyboardNavigationMode.Contained));
-            KeyboardNavigation.ControlTabNavigationProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(KeyboardNavigationMode.Once));
+            ItemsPanelProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(new ItemsPanelTemplate(dataGridRowPresenterFactory)));
+            VirtualizingPanel.IsVirtualizingProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(true, null, new CoerceValueCallback(OnCoerceIsVirtualizingProperty)));
+            VirtualizingPanel.VirtualizationModeProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(VirtualizationMode.Recycling));
+            ItemContainerStyleProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceItemContainerStyle)));
+            ItemContainerStyleSelectorProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceItemContainerStyleSelector)));
+            ItemsSourceProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata((PropertyChangedCallback)null, OnCoerceItemsSourceProperty));
+            AlternationCountProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(0, null, new CoerceValueCallback(OnCoerceAlternationCount)));
+            IsEnabledProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsEnabledChanged)));
+            IsKeyboardFocusWithinPropertyKey.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsKeyboardFocusWithinChanged)));
+            IsSynchronizedWithCurrentItemProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceIsSynchronizedWithCurrentItem)));
+            IsTabStopProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(false));
+            KeyboardNavigation.DirectionalNavigationProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(KeyboardNavigationMode.Contained));
+            KeyboardNavigation.ControlTabNavigationProperty.OverrideMetadata(typeof(DataGrid), new FrameworkPropertyMetadata(KeyboardNavigationMode.Once));
 
-            CommandManager.RegisterClassInputBinding(ownerType, new InputBinding(BeginEditCommand, new KeyGesture(Key.F2)));
-            CommandManager.RegisterClassCommandBinding(ownerType, new CommandBinding(BeginEditCommand, new ExecutedRoutedEventHandler(OnExecutedBeginEdit), new CanExecuteRoutedEventHandler(OnCanExecuteBeginEdit)));
+            CommandManager.RegisterClassInputBinding(typeof(DataGrid), new InputBinding(BeginEditCommand, new KeyGesture(Key.F2)));
+            CommandManager.RegisterClassCommandBinding(typeof(DataGrid), new CommandBinding(BeginEditCommand, new ExecutedRoutedEventHandler(OnExecutedBeginEdit), new CanExecuteRoutedEventHandler(OnCanExecuteBeginEdit)));
 
-            CommandManager.RegisterClassCommandBinding(ownerType, new CommandBinding(CommitEditCommand, new ExecutedRoutedEventHandler(OnExecutedCommitEdit), new CanExecuteRoutedEventHandler(OnCanExecuteCommitEdit)));
+            CommandManager.RegisterClassCommandBinding(typeof(DataGrid), new CommandBinding(CommitEditCommand, new ExecutedRoutedEventHandler(OnExecutedCommitEdit), new CanExecuteRoutedEventHandler(OnCanExecuteCommitEdit)));
 
-            CommandManager.RegisterClassInputBinding(ownerType, new InputBinding(CancelEditCommand, new KeyGesture(Key.Escape)));
-            CommandManager.RegisterClassCommandBinding(ownerType, new CommandBinding(CancelEditCommand, new ExecutedRoutedEventHandler(OnExecutedCancelEdit), new CanExecuteRoutedEventHandler(OnCanExecuteCancelEdit)));
+            CommandManager.RegisterClassInputBinding(typeof(DataGrid), new InputBinding(CancelEditCommand, new KeyGesture(Key.Escape)));
+            CommandManager.RegisterClassCommandBinding(typeof(DataGrid), new CommandBinding(CancelEditCommand, new ExecutedRoutedEventHandler(OnExecutedCancelEdit), new CanExecuteRoutedEventHandler(OnCanExecuteCancelEdit)));
 
-            CommandManager.RegisterClassCommandBinding(ownerType, new CommandBinding(SelectAllCommand, new ExecutedRoutedEventHandler(OnExecutedSelectAll), new CanExecuteRoutedEventHandler(OnCanExecuteSelectAll)));
+            CommandManager.RegisterClassCommandBinding(typeof(DataGrid), new CommandBinding(SelectAllCommand, new ExecutedRoutedEventHandler(OnExecutedSelectAll), new CanExecuteRoutedEventHandler(OnCanExecuteSelectAll)));
 
-            CommandManager.RegisterClassCommandBinding(ownerType, new CommandBinding(DeleteCommand, new ExecutedRoutedEventHandler(OnExecutedDelete), new CanExecuteRoutedEventHandler(OnCanExecuteDelete)));
+            CommandManager.RegisterClassCommandBinding(typeof(DataGrid), new CommandBinding(DeleteCommand, new ExecutedRoutedEventHandler(OnExecutedDelete), new CanExecuteRoutedEventHandler(OnCanExecuteDelete)));
 
             // Default Clipboard handling
             CommandManager.RegisterClassCommandBinding(typeof(DataGrid), new CommandBinding(ApplicationCommands.Copy, new ExecutedRoutedEventHandler(OnExecutedCopy), new CanExecuteRoutedEventHandler(OnCanExecuteCopy)));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Image.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Image.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -601,14 +601,13 @@ namespace System.Windows.Controls
             {
                 get
                 {
-                    Type managerType = typeof(DownloadCompletedEventManager);
-                    DownloadCompletedEventManager manager = (DownloadCompletedEventManager)GetCurrentManager(managerType);
+                    DownloadCompletedEventManager manager = (DownloadCompletedEventManager)GetCurrentManager(typeof(DownloadCompletedEventManager));
 
                     // at first use, create and register a new manager
                     if (manager == null)
                     {
                         manager = new DownloadCompletedEventManager();
-                        SetCurrentManager(managerType, manager);
+                        SetCurrentManager(typeof(DownloadCompletedEventManager), manager);
                     }
 
                     return manager;
@@ -725,14 +724,13 @@ namespace System.Windows.Controls
             {
                 get
                 {
-                    Type managerType = typeof(DownloadFailedEventManager);
-                    DownloadFailedEventManager manager = (DownloadFailedEventManager)GetCurrentManager(managerType);
+                    DownloadFailedEventManager manager = (DownloadFailedEventManager)GetCurrentManager(typeof(DownloadFailedEventManager));
 
                     // at first use, create and register a new manager
                     if (manager == null)
                     {
                         manager = new DownloadFailedEventManager();
-                        SetCurrentManager(managerType, manager);
+                        SetCurrentManager(typeof(DownloadFailedEventManager), manager);
                     }
 
                     return manager;
@@ -849,14 +847,13 @@ namespace System.Windows.Controls
             {
                 get
                 {
-                    Type managerType = typeof(DecodeFailedEventManager);
-                    DecodeFailedEventManager manager = (DecodeFailedEventManager)GetCurrentManager(managerType);
+                    DecodeFailedEventManager manager = (DecodeFailedEventManager)GetCurrentManager(typeof(DecodeFailedEventManager));
 
                     // at first use, create and register a new manager
                     if (manager == null)
                     {
                         manager = new DecodeFailedEventManager();
-                        SetCurrentManager(managerType, manager);
+                        SetCurrentManager(typeof(DecodeFailedEventManager), manager);
                     }
 
                     return manager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/InkCanvas.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/InkCanvas.cs
@@ -43,8 +43,6 @@ namespace System.Windows.Controls
         /// </summary>
         static InkCanvas()
         {
-            Type ownerType = typeof(InkCanvas);
-
             //
             // We should add the following listener as the class handler which will be guarantied to receive the
             // notification before the handler on the instances. So we won't be trapped in the bad state due to the
@@ -52,46 +50,46 @@ namespace System.Windows.Controls
             // Listen to stylus events which will be redirected to the current StylusEditingBehavior
 
             //Down
-            EventManager.RegisterClassHandler(ownerType, Stylus.StylusDownEvent,
+            EventManager.RegisterClassHandler(typeof(InkCanvas), Stylus.StylusDownEvent,
                 new StylusDownEventHandler(_OnDeviceDown<StylusDownEventArgs>));
-            EventManager.RegisterClassHandler(ownerType, Mouse.MouseDownEvent,
+            EventManager.RegisterClassHandler(typeof(InkCanvas), Mouse.MouseDownEvent,
                 new MouseButtonEventHandler(_OnDeviceDown<MouseButtonEventArgs>));
 
             //Up
-            EventManager.RegisterClassHandler(ownerType, Stylus.StylusUpEvent,
+            EventManager.RegisterClassHandler(typeof(InkCanvas), Stylus.StylusUpEvent,
                 new StylusEventHandler(_OnDeviceUp<StylusEventArgs>));
-            EventManager.RegisterClassHandler(ownerType, Mouse.MouseUpEvent,
+            EventManager.RegisterClassHandler(typeof(InkCanvas), Mouse.MouseUpEvent,
                 new MouseButtonEventHandler(_OnDeviceUp<MouseButtonEventArgs>));
 
 
 
-            EventManager.RegisterClassHandler(ownerType, Mouse.QueryCursorEvent,
+            EventManager.RegisterClassHandler(typeof(InkCanvas), Mouse.QueryCursorEvent,
                 new QueryCursorEventHandler(_OnQueryCursor), true);
 
             // Set up the commanding handlers
             _RegisterClipboardHandlers();
-            CommandHelpers.RegisterCommandHandler(ownerType, ApplicationCommands.Delete,
+            CommandHelpers.RegisterCommandHandler(typeof(InkCanvas), ApplicationCommands.Delete,
                 new ExecutedRoutedEventHandler(_OnCommandExecuted), new CanExecuteRoutedEventHandler(_OnQueryCommandEnabled));
 
-            CommandHelpers.RegisterCommandHandler(ownerType, ApplicationCommands.SelectAll,
+            CommandHelpers.RegisterCommandHandler(typeof(InkCanvas), ApplicationCommands.SelectAll,
                 Key.A, ModifierKeys.Control, new ExecutedRoutedEventHandler(_OnCommandExecuted), new CanExecuteRoutedEventHandler(_OnQueryCommandEnabled));
 
-            CommandHelpers.RegisterCommandHandler(ownerType, InkCanvas.DeselectCommand,
+            CommandHelpers.RegisterCommandHandler(typeof(InkCanvas), InkCanvas.DeselectCommand,
                 new ExecutedRoutedEventHandler(_OnCommandExecuted), new CanExecuteRoutedEventHandler(_OnQueryCommandEnabled),
                 KeyGesture.CreateFromResourceStrings(InkCanvasDeselectKey, nameof(SR.InkCanvasDeselectKeyDisplayString)));
 
             //
             //set our clipping
             //
-            ClipToBoundsProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(BooleanBoxes.TrueBox));
+            ClipToBoundsProperty.OverrideMetadata(typeof(InkCanvas), new FrameworkPropertyMetadata(BooleanBoxes.TrueBox));
 
             //
             //enable input focus
             //
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(BooleanBoxes.TrueBox));
+            FocusableProperty.OverrideMetadata(typeof(InkCanvas), new FrameworkPropertyMetadata(BooleanBoxes.TrueBox));
 
             // The default InkCanvas style
-            Style defaultStyle = new Style(ownerType);
+            Style defaultStyle = new Style(typeof(InkCanvas));
             // The background - Window Color
             defaultStyle.Setters.Add(new Setter(InkCanvas.BackgroundProperty,
                             new DynamicResourceExtension(SystemColors.WindowBrushKey)));
@@ -133,10 +131,10 @@ namespace System.Windows.Controls
             // Seal the default style
             defaultStyle.Seal();
 
-            StyleProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(defaultStyle));
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(typeof(InkCanvas)));
+            StyleProperty.OverrideMetadata(typeof(InkCanvas), new FrameworkPropertyMetadata(defaultStyle));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(InkCanvas), new FrameworkPropertyMetadata(typeof(InkCanvas)));
 
-            FocusVisualStyleProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata((object)null /* default value */));
+            FocusVisualStyleProperty.OverrideMetadata(typeof(InkCanvas), new FrameworkPropertyMetadata(defaultValue: null));
         }
 
         /// <summary>
@@ -2464,12 +2462,10 @@ namespace System.Windows.Controls
         /// </summary>
         private static void _RegisterClipboardHandlers()
         {
-            Type ownerType = typeof(InkCanvas);
-
-            CommandHelpers.RegisterCommandHandler(ownerType, ApplicationCommands.Cut,
+            CommandHelpers.RegisterCommandHandler(typeof(InkCanvas), ApplicationCommands.Cut,
                 new ExecutedRoutedEventHandler(_OnCommandExecuted), new CanExecuteRoutedEventHandler(_OnQueryCommandEnabled),
                 KeyGesture.CreateFromResourceStrings(KeyShiftDelete, nameof(SR.KeyShiftDeleteDisplayString)));
-            CommandHelpers.RegisterCommandHandler(ownerType, ApplicationCommands.Copy,
+            CommandHelpers.RegisterCommandHandler(typeof(InkCanvas), ApplicationCommands.Copy,
                 new ExecutedRoutedEventHandler(_OnCommandExecuted), new CanExecuteRoutedEventHandler(_OnQueryCommandEnabled),
                 KeyGesture.CreateFromResourceStrings(KeyCtrlInsert, nameof(SR.KeyCtrlInsertDisplayString)));
 
@@ -2478,7 +2474,7 @@ namespace System.Windows.Controls
             CanExecuteRoutedEventHandler pasteQueryEnabledEventHandler = new CanExecuteRoutedEventHandler(_OnQueryCommandEnabled);
             InputGesture pasteInputGesture = KeyGesture.CreateFromResourceStrings(KeyShiftInsert, SR.KeyShiftInsertDisplayString);
 
-            CommandHelpers.RegisterCommandHandler(ownerType, ApplicationCommands.Paste,
+            CommandHelpers.RegisterCommandHandler(typeof(InkCanvas), ApplicationCommands.Paste,
                 pasteExecuteEventHandler, pasteQueryEnabledEventHandler, pasteInputGesture);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridColumnHeadersPresenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridColumnHeadersPresenter.cs
@@ -29,20 +29,18 @@ namespace System.Windows.Controls.Primitives
 
         static DataGridColumnHeadersPresenter()
         {
-            Type ownerType = typeof(DataGridColumnHeadersPresenter);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(DataGridColumnHeadersPresenter), new FrameworkPropertyMetadata(typeof(DataGridColumnHeadersPresenter)));
+            FocusableProperty.OverrideMetadata(typeof(DataGridColumnHeadersPresenter), new FrameworkPropertyMetadata(false));
 
             FrameworkElementFactory factory = new FrameworkElementFactory(typeof(DataGridCellsPanel));
-            ItemsPanelProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new ItemsPanelTemplate(factory)));
+            ItemsPanelProperty.OverrideMetadata(typeof(DataGridColumnHeadersPresenter), new FrameworkPropertyMetadata(new ItemsPanelTemplate(factory)));
 
             VirtualizingPanel.IsVirtualizingProperty.OverrideMetadata(
-                ownerType,
+                typeof(DataGridColumnHeadersPresenter),
                 new FrameworkPropertyMetadata(false, new PropertyChangedCallback(OnIsVirtualizingPropertyChanged), new CoerceValueCallback(OnCoerceIsVirtualizingProperty)));
 
             VirtualizingPanel.VirtualizationModeProperty.OverrideMetadata(
-                ownerType,
+                typeof(DataGridColumnHeadersPresenter),
                 new FrameworkPropertyMetadata(VirtualizationMode.Recycling));
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/GridViewRowPresenterBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/GridViewRowPresenterBase.cs
@@ -463,14 +463,13 @@ namespace System.Windows.Controls.Primitives
         {
             get
             {
-                Type managerType = typeof(InternalCollectionChangedEventManager);
-                InternalCollectionChangedEventManager manager = (InternalCollectionChangedEventManager)GetCurrentManager(managerType);
+                InternalCollectionChangedEventManager manager = (InternalCollectionChangedEventManager)GetCurrentManager(typeof(InternalCollectionChangedEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new InternalCollectionChangedEventManager();
-                    SetCurrentManager(managerType, manager);
+                    SetCurrentManager(typeof(InternalCollectionChangedEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/StickyNote.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/StickyNote.cs
@@ -65,8 +65,6 @@ namespace System.Windows.Controls
         /// </summary>
         static StickyNoteControl()
         {
-            Type owner = typeof(StickyNoteControl);
-
             // Register event handlers
             // 
             // We want to bring a note to front when the input device is pressed down on it at the first time.
@@ -81,10 +79,10 @@ namespace System.Windows.Controls
             // FUTURE-2005/05/27-WAYNEZEN,
             // Regardsing to Flick, We should remove the listener for PreviewStylusDownEvent if we turn InkCanvas EditingMode to None
             // when StickyNote losts the focus. The line needs to be revisited.
-            EventManager.RegisterClassHandler(owner, Stylus.PreviewStylusDownEvent, new StylusDownEventHandler(_OnPreviewDeviceDown<StylusDownEventArgs>));
-            EventManager.RegisterClassHandler(owner, Mouse.PreviewMouseDownEvent, new MouseButtonEventHandler(_OnPreviewDeviceDown<MouseButtonEventArgs>));
-            EventManager.RegisterClassHandler(owner, Mouse.MouseDownEvent, new MouseButtonEventHandler(_OnDeviceDown<MouseButtonEventArgs>));
-            EventManager.RegisterClassHandler(owner, ContextMenuService.ContextMenuOpeningEvent, new ContextMenuEventHandler(_OnContextMenuOpening));
+            EventManager.RegisterClassHandler(typeof(StickyNoteControl), Stylus.PreviewStylusDownEvent, new StylusDownEventHandler(_OnPreviewDeviceDown<StylusDownEventArgs>));
+            EventManager.RegisterClassHandler(typeof(StickyNoteControl), Mouse.PreviewMouseDownEvent, new MouseButtonEventHandler(_OnPreviewDeviceDown<MouseButtonEventArgs>));
+            EventManager.RegisterClassHandler(typeof(StickyNoteControl), Mouse.MouseDownEvent, new MouseButtonEventHandler(_OnDeviceDown<MouseButtonEventArgs>));
+            EventManager.RegisterClassHandler(typeof(StickyNoteControl), ContextMenuService.ContextMenuOpeningEvent, new ContextMenuEventHandler(_OnContextMenuOpening));
 
             CommandHelpers.RegisterCommandHandler(typeof(StickyNoteControl), StickyNoteControl.DeleteNoteCommand,
                 new ExecutedRoutedEventHandler(_OnCommandExecuted), new CanExecuteRoutedEventHandler(_OnQueryCommandEnabled));
@@ -94,22 +92,22 @@ namespace System.Windows.Controls
             //
             // set the main style CRK to the default theme style key
             //
-            DefaultStyleKeyProperty.OverrideMetadata(owner, new FrameworkPropertyMetadata(
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(StickyNoteControl), new FrameworkPropertyMetadata(
                 new ComponentResourceKey(typeof(PresentationUIStyleResources), "StickyNoteControlStyleKey")));
 
-            KeyboardNavigation.TabNavigationProperty.OverrideMetadata(owner, new FrameworkPropertyMetadata(KeyboardNavigationMode.Local));
-            Control.IsTabStopProperty.OverrideMetadata(owner, new FrameworkPropertyMetadata(false));
+            KeyboardNavigation.TabNavigationProperty.OverrideMetadata(typeof(StickyNoteControl), new FrameworkPropertyMetadata(KeyboardNavigationMode.Local));
+            Control.IsTabStopProperty.OverrideMetadata(typeof(StickyNoteControl), new FrameworkPropertyMetadata(false));
 
             // Override the changed callback of the Foreground Property.
             ForegroundProperty.OverrideMetadata(
-                    owner,
+                    typeof(StickyNoteControl),
                     new FrameworkPropertyMetadata(new PropertyChangedCallback(_UpdateInkDrawingAttributes)));
 
-            FontFamilyProperty.OverrideMetadata(owner, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnFontPropertyChanged)));
-            FontSizeProperty.OverrideMetadata(owner, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnFontPropertyChanged)));
-            FontStretchProperty.OverrideMetadata(owner, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnFontPropertyChanged)));
-            FontStyleProperty.OverrideMetadata(owner, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnFontPropertyChanged)));
-            FontWeightProperty.OverrideMetadata(owner, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnFontPropertyChanged)));
+            FontFamilyProperty.OverrideMetadata(typeof(StickyNoteControl), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnFontPropertyChanged)));
+            FontSizeProperty.OverrideMetadata(typeof(StickyNoteControl), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnFontPropertyChanged)));
+            FontStretchProperty.OverrideMetadata(typeof(StickyNoteControl), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnFontPropertyChanged)));
+            FontStyleProperty.OverrideMetadata(typeof(StickyNoteControl), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnFontPropertyChanged)));
+            FontWeightProperty.OverrideMetadata(typeof(StickyNoteControl), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnFontPropertyChanged)));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/DataChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/DataChangedEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -123,14 +123,13 @@ namespace System.Windows.Data
         {
             get
             {
-                Type managerType = typeof(DataChangedEventManager);
-                DataChangedEventManager manager = (DataChangedEventManager)GetCurrentManager(managerType);
+                DataChangedEventManager manager = (DataChangedEventManager)GetCurrentManager(typeof(DataChangedEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new DataChangedEventManager();
-                    SetCurrentManager(managerType, manager);
+                    SetCurrentManager(typeof(DataChangedEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FlowDocument.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FlowDocument.cs
@@ -1609,7 +1609,7 @@ namespace System.Windows.Documents
         {
             ArgumentNullException.ThrowIfNull(value);
 
-            if (!TextSchema.IsValidChildOfContainer(typeof(FlowDocument), childType: value.GetType()))
+            if (!TextSchema.IsValidChildOfContainer(parentType: typeof(FlowDocument), childType: value.GetType()))
             {
                 throw new ArgumentException(SR.Format(SR.TextSchema_ChildTypeIsInvalid, nameof(FlowDocument), value.GetType().Name));
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FlowDocument.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FlowDocument.cs
@@ -62,8 +62,6 @@ namespace System.Windows.Documents
     [ContentProperty("Blocks")]
     public class FlowDocument : FrameworkContentElement, IDocumentPaginatorSource, IServiceProvider, IAddChild
     {
-        private static readonly Type _typeofThis = typeof(FlowDocument);
-
         //-------------------------------------------------------------------
         //
         //  Constructors
@@ -83,11 +81,11 @@ namespace System.Windows.Documents
             DependencyProperty[] typographyProperties = Typography.TypographyPropertiesList;
             for (int i = 0; i < typographyProperties.Length; i++)
             {
-                typographyProperties[i].OverrideMetadata(_typeofThis, new FrameworkPropertyMetadata(typographyChanged));
+                typographyProperties[i].OverrideMetadata(typeof(FlowDocument), new FrameworkPropertyMetadata(typographyChanged));
             }
 
-            DefaultStyleKeyProperty.OverrideMetadata(_typeofThis, new FrameworkPropertyMetadata(_typeofThis));
-            FocusableProperty.OverrideMetadata(_typeofThis, new FrameworkPropertyMetadata(true));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(FlowDocument), new FrameworkPropertyMetadata(typeof(FlowDocument)));
+            FocusableProperty.OverrideMetadata(typeof(FlowDocument), new FrameworkPropertyMetadata(true));
 
             ControlsTraceLogger.AddControl(TelemetryControls.FlowDocument);
         }
@@ -195,8 +193,7 @@ namespace System.Windows.Documents
         /// <summary>
         /// DependencyProperty for <see cref="FontFamily" /> property.
         /// </summary>
-        public static readonly DependencyProperty FontFamilyProperty =
-                TextElement.FontFamilyProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty FontFamilyProperty = TextElement.FontFamilyProperty.AddOwner(typeof(FlowDocument));
 
         /// <summary>
         /// The FontFamily property specifies the font family.
@@ -214,8 +211,7 @@ namespace System.Windows.Documents
         /// <summary>
         /// DependencyProperty for <see cref="FontStyle" /> property.
         /// </summary>
-        public static readonly DependencyProperty FontStyleProperty =
-                TextElement.FontStyleProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty FontStyleProperty = TextElement.FontStyleProperty.AddOwner(typeof(FlowDocument));
 
         /// <summary>
         /// The FontStyle property requests normal, italic, and oblique faces within a font family.
@@ -229,8 +225,7 @@ namespace System.Windows.Documents
         /// <summary>
         /// DependencyProperty for <see cref="FontWeight" /> property.
         /// </summary>
-        public static readonly DependencyProperty FontWeightProperty =
-                TextElement.FontWeightProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty FontWeightProperty = TextElement.FontWeightProperty.AddOwner(typeof(FlowDocument));
 
         /// <summary>
         /// The FontWeight property specifies the weight of the font.
@@ -244,8 +239,7 @@ namespace System.Windows.Documents
         /// <summary>
         /// DependencyProperty for <see cref="FontStretch" /> property.
         /// </summary>
-        public static readonly DependencyProperty FontStretchProperty =
-                TextElement.FontStretchProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty FontStretchProperty = TextElement.FontStretchProperty.AddOwner(typeof(FlowDocument));
 
         /// <summary>
         /// The FontStretch property selects a normal, condensed, or extended face from a font family.
@@ -259,9 +253,7 @@ namespace System.Windows.Documents
         /// <summary>
         /// DependencyProperty for <see cref="FontSize" /> property.
         /// </summary>
-        public static readonly DependencyProperty FontSizeProperty =
-                TextElement.FontSizeProperty.AddOwner(
-                        _typeofThis);
+        public static readonly DependencyProperty FontSizeProperty = TextElement.FontSizeProperty.AddOwner(typeof(FlowDocument));
 
         /// <summary>
         /// The FontSize property specifies the size of the font.
@@ -277,9 +269,7 @@ namespace System.Windows.Documents
         /// <summary>
         /// DependencyProperty for <see cref="Foreground" /> property.
         /// </summary>
-        public static readonly DependencyProperty ForegroundProperty =
-                TextElement.ForegroundProperty.AddOwner(
-                        _typeofThis);
+        public static readonly DependencyProperty ForegroundProperty = TextElement.ForegroundProperty.AddOwner(typeof(FlowDocument));
 
         /// <summary>
         /// The Foreground property specifies the foreground brush of an element's text content.
@@ -295,7 +285,7 @@ namespace System.Windows.Documents
         /// </summary>
         public static readonly DependencyProperty BackgroundProperty =
                 TextElement.BackgroundProperty.AddOwner(
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 null,
                                 FrameworkPropertyMetadataOptions.AffectsRender));
@@ -314,7 +304,7 @@ namespace System.Windows.Documents
         /// </summary>
         public static readonly DependencyProperty TextEffectsProperty =
                 TextElement.TextEffectsProperty.AddOwner(
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 new FreezableDefaultValueFactory(TextEffectCollection.Empty),
                                 FrameworkPropertyMetadataOptions.AffectsRender));
@@ -331,8 +321,7 @@ namespace System.Windows.Documents
         /// <summary>
         /// DependencyProperty for <see cref="TextAlignment" /> property.
         /// </summary>
-        public static readonly DependencyProperty TextAlignmentProperty =
-                Block.TextAlignmentProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty TextAlignmentProperty = Block.TextAlignmentProperty.AddOwner(typeof(FlowDocument));
 
         /// <summary>
         /// The TextAlignment property specifies the alignmnet of the element.
@@ -346,8 +335,7 @@ namespace System.Windows.Documents
         /// <summary>
         /// DependencyProperty for <see cref="FlowDirection" /> property.
         /// </summary>
-        public static readonly DependencyProperty FlowDirectionProperty =
-                Block.FlowDirectionProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty FlowDirectionProperty = Block.FlowDirectionProperty.AddOwner(typeof(FlowDocument));
 
         /// <summary>
         /// The FlowDirection property specifies the flow direction of the element.
@@ -361,8 +349,7 @@ namespace System.Windows.Documents
         /// <summary>
         /// DependencyProperty for <see cref="LineHeight" /> property.
         /// </summary>
-        public static readonly DependencyProperty LineHeightProperty =
-                Block.LineHeightProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty LineHeightProperty = Block.LineHeightProperty.AddOwner(typeof(FlowDocument));
 
         /// <summary>
         /// The LineHeight property specifies the height of each generated line box.
@@ -377,8 +364,7 @@ namespace System.Windows.Documents
         /// <summary>
         /// DependencyProperty for <see cref="LineStackingStrategy" /> property.
         /// </summary>
-        public static readonly DependencyProperty LineStackingStrategyProperty =
-                Block.LineStackingStrategyProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty LineStackingStrategyProperty = Block.LineStackingStrategyProperty.AddOwner(typeof(FlowDocument));
 
         /// <summary>
         /// The LineStackingStrategy property specifies how lines are placed
@@ -396,7 +382,7 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "ColumnWidth",
                         typeof(double),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 double.NaN,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure));
@@ -421,7 +407,7 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "ColumnGap",
                         typeof(double),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 double.NaN,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure),
@@ -446,7 +432,7 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "IsColumnWidthFlexible",
                         typeof(bool),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 true,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure));
@@ -469,7 +455,7 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "ColumnRuleWidth",
                         typeof(double),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 0.0,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure),
@@ -494,7 +480,7 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "ColumnRuleBrush",
                         typeof(Brush),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 null,
                                 FrameworkPropertyMetadataOptions.AffectsRender));
@@ -515,7 +501,7 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "IsOptimalParagraphEnabled",
                         typeof(bool),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure));
@@ -536,7 +522,7 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "PageWidth",
                         typeof(double),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 double.NaN,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -562,7 +548,7 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "MinPageWidth",
                         typeof(double),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 0.0,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -587,7 +573,7 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "MaxPageWidth",
                         typeof(double),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 double.PositiveInfinity,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -613,7 +599,7 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "PageHeight",
                         typeof(double),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 double.NaN,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -639,7 +625,7 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "MinPageHeight",
                         typeof(double),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 0.0,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -664,7 +650,7 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "MaxPageHeight",
                         typeof(double),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
                                 double.PositiveInfinity,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -690,9 +676,9 @@ namespace System.Windows.Documents
                 DependencyProperty.Register(
                         "PagePadding",
                         typeof(Thickness),
-                        _typeofThis,
+                        typeof(FlowDocument),
                         new FrameworkPropertyMetadata(
-                                new Thickness(Double.NaN),
+                                new Thickness(double.NaN),
                                 FrameworkPropertyMetadataOptions.AffectsMeasure,
                                 new PropertyChangedCallback(OnPageMetricsChanged)),
                         new ValidateValueCallback(IsValidPagePadding));
@@ -726,8 +712,7 @@ namespace System.Windows.Documents
         /// <summary>
         /// DependencyProperty for hyphenation property.
         /// </summary>
-        public static readonly DependencyProperty IsHyphenationEnabledProperty =
-                Block.IsHyphenationEnabledProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty IsHyphenationEnabledProperty = Block.IsHyphenationEnabledProperty.AddOwner(typeof(FlowDocument));
 
         /// <summary>
         /// CLR property for hyphenation
@@ -1624,9 +1609,9 @@ namespace System.Windows.Documents
         {
             ArgumentNullException.ThrowIfNull(value);
 
-            if (!TextSchema.IsValidChildOfContainer(/*parentType:*/_typeofThis, /*childType:*/value.GetType()))
+            if (!TextSchema.IsValidChildOfContainer(typeof(FlowDocument), childType: value.GetType()))
             {
-                throw new ArgumentException(SR.Format(SR.TextSchema_ChildTypeIsInvalid, _typeofThis.Name, value.GetType().Name));
+                throw new ArgumentException(SR.Format(SR.TextSchema_ChildTypeIsInvalid, nameof(FlowDocument), value.GetType().Name));
             }
 
             // Checking that the element inserted does not have a parent

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Typography.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Typography.cs
@@ -11,14 +11,11 @@ using MS.Internal.Text;
 namespace System.Windows.Documents
 {
     /// <summary>
-    /// Provide access to typography porperties of element in syntax of Typography.xxx = yyy;
+    /// Provide access to typography properties of element in syntax of Typography.xxx = yyy;
     /// Actual data is stored in the owner.
     /// </summary>
     public sealed class Typography
     {
-        private static readonly Type _typeofThis = typeof(Typography);
-        private static readonly Type _typeofBool = typeof(bool);
-        
         #region Constructors
 
         /// <summary>
@@ -1478,9 +1475,9 @@ namespace System.Windows.Documents
         /// <summary> StandardLigatures Property </summary>
         public static readonly DependencyProperty StandardLigaturesProperty =
                 DependencyProperty.RegisterAttached(
-                        "StandardLigatures", 
-                        _typeofBool, 
-                        _typeofThis,
+                        "StandardLigatures",
+                        typeof(bool),
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 true,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1488,9 +1485,9 @@ namespace System.Windows.Documents
         /// <summary> ContextualLigatures Property </summary>
         public static readonly DependencyProperty ContextualLigaturesProperty =
                 DependencyProperty.RegisterAttached(
-                        "ContextualLigatures", 
-                        _typeofBool, 
-                        _typeofThis,
+                        "ContextualLigatures",
+                        typeof(bool),
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 true,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1499,8 +1496,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty DiscretionaryLigaturesProperty =
                 DependencyProperty.RegisterAttached(
                         "DiscretionaryLigatures", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool),
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1509,8 +1506,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty HistoricalLigaturesProperty =
                 DependencyProperty.RegisterAttached(
                         "HistoricalLigatures", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool),
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1519,8 +1516,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty AnnotationAlternatesProperty =
                 DependencyProperty.RegisterAttached(
                         "AnnotationAlternates", 
-                        typeof(int), 
-                        _typeofThis,
+                        typeof(int),
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 0,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1529,8 +1526,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty ContextualAlternatesProperty =
                 DependencyProperty.RegisterAttached(
                         "ContextualAlternates", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool),
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 true,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1539,8 +1536,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty HistoricalFormsProperty =
                 DependencyProperty.RegisterAttached(
                         "HistoricalForms", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1549,8 +1546,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty KerningProperty =
                 DependencyProperty.RegisterAttached(
                         "Kerning", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 true,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1559,8 +1556,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty CapitalSpacingProperty =
                 DependencyProperty.RegisterAttached(
                         "CapitalSpacing", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1569,8 +1566,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty CaseSensitiveFormsProperty =
                 DependencyProperty.RegisterAttached(
                         "CaseSensitiveForms", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1579,8 +1576,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet1Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet1", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1589,8 +1586,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet2Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet2", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1599,8 +1596,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet3Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet3", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1609,8 +1606,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet4Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet4", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1619,8 +1616,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet5Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet5", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1629,8 +1626,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet6Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet6", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1639,8 +1636,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet7Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet7", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1649,8 +1646,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet8Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet8", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1659,8 +1656,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet9Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet9", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1669,8 +1666,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet10Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet10", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1679,8 +1676,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet11Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet11", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1689,8 +1686,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet12Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet12", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1699,8 +1696,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet13Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet13", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1709,8 +1706,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet14Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet14", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1719,8 +1716,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet15Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet15", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1729,8 +1726,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet16Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet16", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1739,8 +1736,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet17Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet17", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1749,8 +1746,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet18Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet18", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1759,8 +1756,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet19Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet19", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1769,8 +1766,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty StylisticSet20Property =
                 DependencyProperty.RegisterAttached(
                         "StylisticSet20", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1780,7 +1777,7 @@ namespace System.Windows.Documents
                 DependencyProperty.RegisterAttached(
                         "Fraction", 
                         typeof(FontFraction), 
-                        _typeofThis,
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 FontFraction.Normal,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1789,8 +1786,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty SlashedZeroProperty =
                 DependencyProperty.RegisterAttached(
                         "SlashedZero", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1799,8 +1796,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty MathematicalGreekProperty =
                 DependencyProperty.RegisterAttached(
                         "MathematicalGreek", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1809,8 +1806,8 @@ namespace System.Windows.Documents
         public static readonly DependencyProperty EastAsianExpertFormsProperty =
                 DependencyProperty.RegisterAttached(
                         "EastAsianExpertForms", 
-                        _typeofBool, 
-                        _typeofThis,
+                        typeof(bool), 
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 false,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1820,7 +1817,7 @@ namespace System.Windows.Documents
                 DependencyProperty.RegisterAttached(
                         "Variants", 
                         typeof(FontVariants), 
-                        _typeofThis,
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 FontVariants.Normal,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1830,7 +1827,7 @@ namespace System.Windows.Documents
                 DependencyProperty.RegisterAttached(
                         "Capitals", 
                         typeof(FontCapitals), 
-                        _typeofThis,
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 FontCapitals.Normal,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1840,7 +1837,7 @@ namespace System.Windows.Documents
                 DependencyProperty.RegisterAttached(
                         "NumeralStyle", 
                         typeof(FontNumeralStyle), 
-                        _typeofThis,
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 FontNumeralStyle.Normal,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1850,7 +1847,7 @@ namespace System.Windows.Documents
                 DependencyProperty.RegisterAttached(
                         "NumeralAlignment", 
                         typeof(FontNumeralAlignment), 
-                        _typeofThis,
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 FontNumeralAlignment.Normal,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1860,7 +1857,7 @@ namespace System.Windows.Documents
                 DependencyProperty.RegisterAttached(
                         "EastAsianWidths", 
                         typeof(FontEastAsianWidths), 
-                        _typeofThis,
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 FontEastAsianWidths.Normal,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1870,7 +1867,7 @@ namespace System.Windows.Documents
                 DependencyProperty.RegisterAttached(
                         "EastAsianLanguage", 
                         typeof(FontEastAsianLanguage), 
-                        _typeofThis,
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 FontEastAsianLanguage.Normal,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1880,7 +1877,7 @@ namespace System.Windows.Documents
                 DependencyProperty.RegisterAttached(
                         "StandardSwashes", 
                         typeof(int), 
-                        _typeofThis,
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 0,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1890,7 +1887,7 @@ namespace System.Windows.Documents
                 DependencyProperty.RegisterAttached(
                         "ContextualSwashes", 
                         typeof(int), 
-                        _typeofThis,
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 0,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
@@ -1900,7 +1897,7 @@ namespace System.Windows.Documents
                 DependencyProperty.RegisterAttached(
                         "StylisticAlternates", 
                         typeof(int), 
-                        _typeofThis,
+                        typeof(Typography),
                         new FrameworkPropertyMetadata(
                                 0,
                                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
@@ -92,8 +92,6 @@ namespace System.Windows
     [UsableDuringInitialization(true)]
     public partial class FrameworkElement : UIElement, IFrameworkInputElement, ISupportInitialize, IHaveResources, IQueryAmbient
     {
-        private static readonly Type _typeofThis = typeof(FrameworkElement);
-
         /// <summary>
         ///     Default FrameworkElement constructor
         /// </summary>
@@ -133,7 +131,7 @@ namespace System.Windows
                 DependencyProperty.Register(
                         "Style",
                         typeof(Style),
-                        _typeofThis,
+                        typeof(FrameworkElement),
                         new FrameworkPropertyMetadata(
                                 (Style) null,   // default value
                                 FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -171,7 +169,7 @@ namespace System.Windows
         /// OverridesDefaultStyleProperty
         /// </summary>
         public static readonly DependencyProperty OverridesDefaultStyleProperty
-            = DependencyProperty.Register("OverridesDefaultStyle", typeof(bool), _typeofThis,
+            = DependencyProperty.Register("OverridesDefaultStyle", typeof(bool), typeof(FrameworkElement),
                                             new FrameworkPropertyMetadata(
                                                         BooleanBoxes.FalseBox,   // default value
                                                         FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -222,7 +220,7 @@ namespace System.Windows
         /// DefaultStyleKeyProperty
         /// </summary>
         protected internal static readonly DependencyProperty DefaultStyleKeyProperty
-            = DependencyProperty.Register("DefaultStyleKey", typeof(object), _typeofThis,
+            = DependencyProperty.Register("DefaultStyleKey", typeof(object), typeof(FrameworkElement),
                                             new FrameworkPropertyMetadata(
                                                         null,   // default value
                                                         FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -2363,37 +2361,37 @@ namespace System.Windows
 
         static FrameworkElement()
         {
-            SnapsToDevicePixelsProperty.OverrideMetadata(_typeofThis, new FrameworkPropertyMetadata(BooleanBoxes.FalseBox, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsArrange));
+            SnapsToDevicePixelsProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(BooleanBoxes.FalseBox, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsArrange));
 
-            EventManager.RegisterClassHandler(_typeofThis, Mouse.QueryCursorEvent, new QueryCursorEventHandler(FrameworkElement.OnQueryCursorOverride), true);
+            EventManager.RegisterClassHandler(typeof(FrameworkElement), Mouse.QueryCursorEvent, new QueryCursorEventHandler(FrameworkElement.OnQueryCursorOverride), true);
 
-            EventManager.RegisterClassHandler(_typeofThis, Keyboard.PreviewGotKeyboardFocusEvent, new KeyboardFocusChangedEventHandler(OnPreviewGotKeyboardFocus));
-            EventManager.RegisterClassHandler(_typeofThis, Keyboard.GotKeyboardFocusEvent, new KeyboardFocusChangedEventHandler(OnGotKeyboardFocus));
-            EventManager.RegisterClassHandler(_typeofThis, Keyboard.LostKeyboardFocusEvent, new KeyboardFocusChangedEventHandler(OnLostKeyboardFocus));
+            EventManager.RegisterClassHandler(typeof(FrameworkElement), Keyboard.PreviewGotKeyboardFocusEvent, new KeyboardFocusChangedEventHandler(OnPreviewGotKeyboardFocus));
+            EventManager.RegisterClassHandler(typeof(FrameworkElement), Keyboard.GotKeyboardFocusEvent, new KeyboardFocusChangedEventHandler(OnGotKeyboardFocus));
+            EventManager.RegisterClassHandler(typeof(FrameworkElement), Keyboard.LostKeyboardFocusEvent, new KeyboardFocusChangedEventHandler(OnLostKeyboardFocus));
 
-            AllowDropProperty.OverrideMetadata(_typeofThis, new FrameworkPropertyMetadata(BooleanBoxes.FalseBox, FrameworkPropertyMetadataOptions.Inherits));
+            AllowDropProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(BooleanBoxes.FalseBox, FrameworkPropertyMetadataOptions.Inherits));
 
-            Stylus.IsPressAndHoldEnabledProperty.AddOwner(_typeofThis, new FrameworkPropertyMetadata(BooleanBoxes.TrueBox, FrameworkPropertyMetadataOptions.Inherits));
-            Stylus.IsFlicksEnabledProperty.AddOwner(_typeofThis, new FrameworkPropertyMetadata(BooleanBoxes.TrueBox, FrameworkPropertyMetadataOptions.Inherits));
-            Stylus.IsTapFeedbackEnabledProperty.AddOwner(_typeofThis, new FrameworkPropertyMetadata(BooleanBoxes.TrueBox, FrameworkPropertyMetadataOptions.Inherits));
-            Stylus.IsTouchFeedbackEnabledProperty.AddOwner(_typeofThis, new FrameworkPropertyMetadata(BooleanBoxes.TrueBox, FrameworkPropertyMetadataOptions.Inherits));
+            Stylus.IsPressAndHoldEnabledProperty.AddOwner(typeof(FrameworkElement), new FrameworkPropertyMetadata(BooleanBoxes.TrueBox, FrameworkPropertyMetadataOptions.Inherits));
+            Stylus.IsFlicksEnabledProperty.AddOwner(typeof(FrameworkElement), new FrameworkPropertyMetadata(BooleanBoxes.TrueBox, FrameworkPropertyMetadataOptions.Inherits));
+            Stylus.IsTapFeedbackEnabledProperty.AddOwner(typeof(FrameworkElement), new FrameworkPropertyMetadata(BooleanBoxes.TrueBox, FrameworkPropertyMetadataOptions.Inherits));
+            Stylus.IsTouchFeedbackEnabledProperty.AddOwner(typeof(FrameworkElement), new FrameworkPropertyMetadata(BooleanBoxes.TrueBox, FrameworkPropertyMetadataOptions.Inherits));
 
             PropertyChangedCallback numberSubstitutionChanged = new PropertyChangedCallback(NumberSubstitutionChanged);
-            NumberSubstitution.CultureSourceProperty.OverrideMetadata(_typeofThis, new FrameworkPropertyMetadata(NumberCultureSource.User, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, numberSubstitutionChanged));
-            NumberSubstitution.CultureOverrideProperty.OverrideMetadata(_typeofThis, new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, numberSubstitutionChanged));
-            NumberSubstitution.SubstitutionProperty.OverrideMetadata(_typeofThis, new FrameworkPropertyMetadata(NumberSubstitutionMethod.AsCulture, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, numberSubstitutionChanged));
+            NumberSubstitution.CultureSourceProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(NumberCultureSource.User, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, numberSubstitutionChanged));
+            NumberSubstitution.CultureOverrideProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, numberSubstitutionChanged));
+            NumberSubstitution.SubstitutionProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(NumberSubstitutionMethod.AsCulture, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, numberSubstitutionChanged));
 
             // Exposing these events in protected virtual methods
-            EventManager.RegisterClassHandler(_typeofThis, ToolTipOpeningEvent, new ToolTipEventHandler(OnToolTipOpeningThunk));
-            EventManager.RegisterClassHandler(_typeofThis, ToolTipClosingEvent, new ToolTipEventHandler(OnToolTipClosingThunk));
-            EventManager.RegisterClassHandler(_typeofThis, ContextMenuOpeningEvent, new ContextMenuEventHandler(OnContextMenuOpeningThunk));
-            EventManager.RegisterClassHandler(_typeofThis, ContextMenuClosingEvent, new ContextMenuEventHandler(OnContextMenuClosingThunk));
+            EventManager.RegisterClassHandler(typeof(FrameworkElement), ToolTipOpeningEvent, new ToolTipEventHandler(OnToolTipOpeningThunk));
+            EventManager.RegisterClassHandler(typeof(FrameworkElement), ToolTipClosingEvent, new ToolTipEventHandler(OnToolTipClosingThunk));
+            EventManager.RegisterClassHandler(typeof(FrameworkElement), ContextMenuOpeningEvent, new ContextMenuEventHandler(OnContextMenuOpeningThunk));
+            EventManager.RegisterClassHandler(typeof(FrameworkElement), ContextMenuClosingEvent, new ContextMenuEventHandler(OnContextMenuClosingThunk));
 
             // Coerce Callback for font properties for responding to system themes
-            TextElement.FontFamilyProperty.OverrideMetadata(_typeofThis, new FrameworkPropertyMetadata(SystemFonts.MessageFontFamily, FrameworkPropertyMetadataOptions.Inherits, null, new CoerceValueCallback(CoerceFontFamily)));
-            TextElement.FontSizeProperty.OverrideMetadata(_typeofThis, new FrameworkPropertyMetadata(SystemFonts.ThemeMessageFontSize, FrameworkPropertyMetadataOptions.Inherits, null, new CoerceValueCallback(CoerceFontSize)));
-            TextElement.FontStyleProperty.OverrideMetadata(_typeofThis, new FrameworkPropertyMetadata(SystemFonts.MessageFontStyle, FrameworkPropertyMetadataOptions.Inherits, null, new CoerceValueCallback(CoerceFontStyle)));
-            TextElement.FontWeightProperty.OverrideMetadata(_typeofThis, new FrameworkPropertyMetadata(SystemFonts.MessageFontWeight, FrameworkPropertyMetadataOptions.Inherits, null, new CoerceValueCallback(CoerceFontWeight)));
+            TextElement.FontFamilyProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(SystemFonts.MessageFontFamily, FrameworkPropertyMetadataOptions.Inherits, null, new CoerceValueCallback(CoerceFontFamily)));
+            TextElement.FontSizeProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(SystemFonts.ThemeMessageFontSize, FrameworkPropertyMetadataOptions.Inherits, null, new CoerceValueCallback(CoerceFontSize)));
+            TextElement.FontStyleProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(SystemFonts.MessageFontStyle, FrameworkPropertyMetadataOptions.Inherits, null, new CoerceValueCallback(CoerceFontStyle)));
+            TextElement.FontWeightProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(SystemFonts.MessageFontWeight, FrameworkPropertyMetadataOptions.Inherits, null, new CoerceValueCallback(CoerceFontWeight)));
 
             TextOptions.TextRenderingModeProperty.OverrideMetadata(
                 typeof(FrameworkElement),
@@ -2681,7 +2679,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "DataContext",
                                 typeof(object),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(null,
                                         FrameworkPropertyMetadataOptions.Inherits,
                                         new PropertyChangedCallback(OnDataContextChanged)));
@@ -2768,7 +2766,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "BindingGroup",
                                 typeof(BindingGroup),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(null,
                                         FrameworkPropertyMetadataOptions.Inherits));
 
@@ -3167,7 +3165,7 @@ namespace System.Windows
                     DependencyProperty.RegisterAttached(
                                 "Language",
                                 typeof(XmlLanguage),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                         XmlLanguage.GetLanguage("en-US"),
                                         FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
@@ -3191,7 +3189,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "Name",
                                 typeof(string),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                     string.Empty,                           // defaultValue
                                     FrameworkPropertyMetadataOptions.None,  // flags
@@ -3219,7 +3217,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "Tag",
                                 typeof(object),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata((object) null));
 
         /// <summary>
@@ -3239,7 +3237,7 @@ namespace System.Windows
         ///     this is originally registered on InputMethod class
         /// </summary>
         public static readonly DependencyProperty InputScopeProperty =
-                    InputMethod.InputScopeProperty.AddOwner(_typeofThis,
+                    InputMethod.InputScopeProperty.AddOwner(typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata((InputScope)null, // default value
                                             FrameworkPropertyMetadataOptions.Inherits));
 
@@ -3257,7 +3255,7 @@ namespace System.Windows
         /// <summary>
         /// RequestBringIntoView Event
         /// </summary>
-        public static readonly RoutedEvent RequestBringIntoViewEvent = EventManager.RegisterRoutedEvent("RequestBringIntoView", RoutingStrategy.Bubble, typeof(RequestBringIntoViewEventHandler), _typeofThis);
+        public static readonly RoutedEvent RequestBringIntoViewEvent = EventManager.RegisterRoutedEvent("RequestBringIntoView", RoutingStrategy.Bubble, typeof(RequestBringIntoViewEventHandler), typeof(FrameworkElement));
 
         /// <summary>
         /// Handler registration for RequestBringIntoView event.
@@ -3296,7 +3294,7 @@ namespace System.Windows
         /// <summary>
         /// SizeChanged event
         /// </summary>
-        public static readonly RoutedEvent SizeChangedEvent = EventManager.RegisterRoutedEvent("SizeChanged", RoutingStrategy.Direct, typeof(SizeChangedEventHandler), _typeofThis);
+        public static readonly RoutedEvent SizeChangedEvent = EventManager.RegisterRoutedEvent("SizeChanged", RoutingStrategy.Direct, typeof(SizeChangedEventHandler), typeof(FrameworkElement));
 
         /// <summary>
         /// SizeChanged event. It is fired when ActualWidth or ActualHeight (or both) changed.
@@ -3322,7 +3320,7 @@ namespace System.Windows
                 DependencyProperty.RegisterReadOnly(
                         "ActualWidth",
                         typeof(double),
-                        _typeofThis,
+                        typeof(FrameworkElement),
                         _actualWidthMetadata);
 
         private static object GetActualWidth(DependencyObject d, out BaseValueSourceInternal source)
@@ -3367,7 +3365,7 @@ namespace System.Windows
                 DependencyProperty.RegisterReadOnly(
                         "ActualHeight",
                         typeof(double),
-                        _typeofThis,
+                        typeof(FrameworkElement),
                         _actualHeightMetadata);
 
         private static object GetActualHeight(DependencyObject d, out BaseValueSourceInternal source)
@@ -3409,7 +3407,7 @@ namespace System.Windows
         public static readonly DependencyProperty LayoutTransformProperty = DependencyProperty.Register(
                     "LayoutTransform",
                     typeof(Transform),
-                    _typeofThis,
+                    typeof(FrameworkElement),
                     new FrameworkPropertyMetadata(
                             Transform.Identity,
                             FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -3467,7 +3465,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "Width",
                                 typeof(double),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                         Double.NaN,
                                         FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -3493,7 +3491,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "MinWidth",
                                 typeof(double),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                         0d,
                                         FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -3519,7 +3517,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "MaxWidth",
                                 typeof(double),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                         Double.PositiveInfinity,
                                         FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -3546,7 +3544,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "Height",
                                 typeof(double),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                     Double.NaN,
                                     FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -3572,7 +3570,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "MinHeight",
                                 typeof(double),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                         0d,
                                         FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -3598,7 +3596,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "MaxHeight",
                                 typeof(double),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                         Double.PositiveInfinity,
                                         FrameworkPropertyMetadataOptions.AffectsMeasure,
@@ -3624,7 +3622,7 @@ namespace System.Windows
                     DependencyProperty.RegisterAttached(
                                 "FlowDirection",
                                 typeof(FlowDirection),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                             System.Windows.FlowDirection.LeftToRight, // default value
                                             FrameworkPropertyMetadataOptions.Inherits
@@ -3708,7 +3706,7 @@ namespace System.Windows
         /// </summary>
         [CommonDependencyProperty]
         public static readonly DependencyProperty MarginProperty
-            = DependencyProperty.Register("Margin", typeof(Thickness), _typeofThis,
+            = DependencyProperty.Register("Margin", typeof(Thickness), typeof(FrameworkElement),
                                           new FrameworkPropertyMetadata(
                                                 new Thickness(),
                                                 FrameworkPropertyMetadataOptions.AffectsMeasure),
@@ -3742,7 +3740,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "HorizontalAlignment",
                                 typeof(HorizontalAlignment),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                             HorizontalAlignment.Stretch,
                                             FrameworkPropertyMetadataOptions.AffectsArrange),
@@ -3774,7 +3772,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "VerticalAlignment",
                                 typeof(VerticalAlignment),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                             VerticalAlignment.Stretch,
                                             FrameworkPropertyMetadataOptions.AffectsArrange),
@@ -3825,7 +3823,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "FocusVisualStyle",
                                 typeof(Style),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(DefaultFocusVisualStyle));
 
 
@@ -3845,7 +3843,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "Cursor",
                                 typeof(Cursor),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                             (object) null, // default value
                                             0,
@@ -3879,7 +3877,7 @@ namespace System.Windows
                     DependencyProperty.Register(
                                 "ForceCursor",
                                 typeof(bool),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new FrameworkPropertyMetadata(
                                             BooleanBoxes.FalseBox, // default value
                                             0,
@@ -5627,7 +5625,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "LoadedPending",
                                 typeof(object[]),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new PropertyMetadata(null)); // default value
 
         /// <summary>
@@ -5644,7 +5642,7 @@ namespace System.Windows
                     DependencyProperty.RegisterReadOnly(
                                 "UnloadedPending",
                                 typeof(object[]),
-                                _typeofThis,
+                                typeof(FrameworkElement),
                                 new PropertyMetadata(null)); // default value
 
         /// <summary>
@@ -5699,7 +5697,7 @@ namespace System.Windows
         /// <summary>
         ///     Loaded RoutedEvent
         /// </summary>
-        public static readonly RoutedEvent LoadedEvent = EventManager.RegisterRoutedEvent("Loaded", RoutingStrategy.Direct, typeof(RoutedEventHandler), _typeofThis);
+        public static readonly RoutedEvent LoadedEvent = EventManager.RegisterRoutedEvent("Loaded", RoutingStrategy.Direct, typeof(RoutedEventHandler), typeof(FrameworkElement));
 
         /// <summary>
         ///     This event is fired when the element is laid out, rendered and ready for interaction
@@ -5765,7 +5763,7 @@ namespace System.Windows
         /// <summary>
         ///     Unloaded private key
         /// </summary>
-        public static readonly RoutedEvent UnloadedEvent = EventManager.RegisterRoutedEvent("Unloaded", RoutingStrategy.Direct, typeof(RoutedEventHandler), _typeofThis);
+        public static readonly RoutedEvent UnloadedEvent = EventManager.RegisterRoutedEvent("Unloaded", RoutingStrategy.Direct, typeof(RoutedEventHandler), typeof(FrameworkElement));
 
         /// <summary>
         ///     This clr event is fired when this element is detached form a loaded tree
@@ -5864,8 +5862,7 @@ namespace System.Windows
         /// <summary>
         ///     The DependencyProperty for the ToolTip property
         /// </summary>
-        public static readonly DependencyProperty ToolTipProperty =
-            ToolTipService.ToolTipProperty.AddOwner(_typeofThis);
+        public static readonly DependencyProperty ToolTipProperty = ToolTipService.ToolTipProperty.AddOwner(typeof(FrameworkElement));
 
         /// <summary>
         ///     The ToolTip for the element.
@@ -5895,7 +5892,7 @@ namespace System.Windows
         /// </summary>
         public static readonly DependencyProperty ContextMenuProperty =
             ContextMenuService.ContextMenuProperty.AddOwner(
-                        _typeofThis,
+                        typeof(FrameworkElement),
                         new FrameworkPropertyMetadata((ContextMenu) null));
 
         /// <summary>
@@ -5917,7 +5914,7 @@ namespace System.Windows
         /// <summary>
         ///     The RoutedEvent for the ToolTipOpening event.
         /// </summary>
-        public static readonly RoutedEvent ToolTipOpeningEvent = ToolTipService.ToolTipOpeningEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent ToolTipOpeningEvent = ToolTipService.ToolTipOpeningEvent.AddOwner(typeof(FrameworkElement));
 
         /// <summary>
         ///     An event that fires just before a ToolTip should be opened.
@@ -5955,7 +5952,7 @@ namespace System.Windows
         /// <summary>
         ///     The RoutedEvent for the ToolTipClosing event.
         /// </summary>
-        public static readonly RoutedEvent ToolTipClosingEvent = ToolTipService.ToolTipClosingEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent ToolTipClosingEvent = ToolTipService.ToolTipClosingEvent.AddOwner(typeof(FrameworkElement));
 
         /// <summary>
         ///     An event that fires just before a ToolTip should be closed.
@@ -5987,7 +5984,7 @@ namespace System.Windows
         /// <summary>
         ///     RoutedEvent for the ContextMenuOpening event.
         /// </summary>
-        public static readonly RoutedEvent ContextMenuOpeningEvent = ContextMenuService.ContextMenuOpeningEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent ContextMenuOpeningEvent = ContextMenuService.ContextMenuOpeningEvent.AddOwner(typeof(FrameworkElement));
 
         /// <summary>
         ///     An event that fires just before a ContextMenu should be opened.
@@ -6018,7 +6015,7 @@ namespace System.Windows
         /// <summary>
         ///     RoutedEvent for the ContextMenuClosing event.
         /// </summary>
-        public static readonly RoutedEvent ContextMenuClosingEvent = ContextMenuService.ContextMenuClosingEvent.AddOwner(_typeofThis);
+        public static readonly RoutedEvent ContextMenuClosingEvent = ContextMenuService.ContextMenuClosingEvent.AddOwner(typeof(FrameworkElement));
 
         /// <summary>
         ///     An event that fires just as a ContextMenu closes.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/LostFocusEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/LostFocusEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -137,14 +137,13 @@ namespace System.Windows
         {
             get
             {
-                Type managerType = typeof(LostFocusEventManager);
-                LostFocusEventManager manager = (LostFocusEventManager)GetCurrentManager(managerType);
+                LostFocusEventManager manager = (LostFocusEventManager)GetCurrentManager(typeof(LostFocusEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new LostFocusEventManager();
-                    SetCurrentManager(managerType, manager);
+                    SetCurrentManager(typeof(LostFocusEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/RestrictiveXamlXmlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/RestrictiveXamlXmlReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -19,7 +19,6 @@ namespace System.Windows.Markup
     {
         private const string AllowedTypesForRestrictiveXamlContexts = @"SOFTWARE\Microsoft\.NETFramework\Windows Presentation Foundation\XPSAllowedTypes";
         private static readonly HashSet<string> AllXamlNamespaces = new HashSet<string>(XamlLanguage.XamlNamespaces);
-        private static readonly Type DependencyObjectType = typeof(System.Windows.DependencyObject);
         private static readonly HashSet<string> SafeTypesFromRegistry = ReadAllowedTypesForRestrictedXamlContexts();
 
         private static HashSet<string> ReadAllowedTypesForRestrictedXamlContexts()
@@ -193,7 +192,7 @@ namespace System.Windows.Markup
             // - any DependencyObject-derived type which exists in the System.Windows.* namespace.
 
             bool isValidNamespace = type.Namespace != null && (type.Namespace.Equals("System.Windows", StringComparison.Ordinal) || type.Namespace.StartsWith("System.Windows.", StringComparison.Ordinal));
-            bool isValidSubClass = type.IsSubclassOf(DependencyObjectType);
+            bool isValidSubClass = type.IsSubclassOf(typeof(DependencyObject));
             bool isValidPrimitive = type.IsPrimitive;
 
             if (isValidPrimitive || (isValidNamespace && isValidSubClass))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/Generated/ThicknessAnimation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/Generated/ThicknessAnimation.cs
@@ -44,36 +44,34 @@ namespace System.Windows.Media.Animation
         /// </summary>
         static ThicknessAnimation()
         {
-            Type typeofProp = typeof(Thickness?);
-            Type typeofThis = typeof(ThicknessAnimation);
             PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
             ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
 
             FromProperty = DependencyProperty.Register(
                 "From",
-                typeofProp,
-                typeofThis,
+                typeof(Thickness?),
+                typeof(ThicknessAnimation),
                 new PropertyMetadata((Thickness?)null, propCallback),
                 validateCallback);
 
             ToProperty = DependencyProperty.Register(
                 "To",
-                typeofProp,
-                typeofThis,
+                typeof(Thickness?),
+                typeof(ThicknessAnimation),
                 new PropertyMetadata((Thickness?)null, propCallback),
                 validateCallback);
 
             ByProperty = DependencyProperty.Register(
                 "By",
-                typeofProp,
-                typeofThis,
+                typeof(Thickness?),
+                typeof(ThicknessAnimation),
                 new PropertyMetadata((Thickness?)null, propCallback),
                 validateCallback);
 
             EasingFunctionProperty = DependencyProperty.Register(
                 "EasingFunction",
                 typeof(IEasingFunction),
-                typeofThis);
+                typeof(ThicknessAnimation));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentSignatureManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentSignatureManager.cs
@@ -1202,8 +1202,7 @@ namespace MS.Internal.Documents
             int error = 0;
 
             // Get the protected "HResult" field from the CryptographicException
-            Type t = typeof(CryptographicException);
-            PropertyInfo p = t.GetProperty("HResult", BindingFlags.NonPublic | BindingFlags.Instance);
+            PropertyInfo p = typeof(CryptographicException).GetProperty("HResult", BindingFlags.NonPublic | BindingFlags.Instance);
             error = (int)p.GetValue(ce, null);
 
             return error;

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/KeyTipControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/KeyTipControl.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -15,11 +15,10 @@ namespace Microsoft.Windows.Controls
     {
         static KeyTipControl()
         {
-            Type ownerType = typeof(KeyTipControl);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            IsHitTestVisibleProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
-            EventManager.RegisterClassHandler(ownerType, SizeChangedEvent, new SizeChangedEventHandler(OnSizeChanged), true);
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(KeyTipControl), new FrameworkPropertyMetadata(typeof(KeyTipControl)));
+            IsHitTestVisibleProperty.OverrideMetadata(typeof(KeyTipControl), new FrameworkPropertyMetadata(false));
+            FocusableProperty.OverrideMetadata(typeof(KeyTipControl), new FrameworkPropertyMetadata(false));
+            EventManager.RegisterClassHandler(typeof(KeyTipControl), SizeChangedEvent, new SizeChangedEventHandler(OnSizeChanged), true);
         }
 
         internal KeyTipAdorner KeyTipAdorner { get; set; }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Ribbon.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Ribbon.cs
@@ -89,34 +89,33 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static Ribbon()
         {
-            Type ownerType = typeof(Ribbon);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            ItemsPanelProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new ItemsPanelTemplate(new FrameworkElementFactory(typeof(RibbonTabsPanel)))));
-			FocusManager.IsFocusScopeProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            BorderBrushProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnBorderBrushChanged)));
-            EventManager.RegisterClassHandler(ownerType, Mouse.PreviewMouseDownOutsideCapturedElementEvent, new MouseButtonEventHandler(OnClickThroughThunk));
-            EventManager.RegisterClassHandler(ownerType, Mouse.LostMouseCaptureEvent, new MouseEventHandler(OnLostMouseCaptureThunk));
-            EventManager.RegisterClassHandler(ownerType, RibbonControlService.DismissPopupEvent, new RibbonDismissPopupEventHandler(OnDismissPopupThunk));
-            EventManager.RegisterClassHandler(ownerType, RibbonQuickAccessToolBar.CloneEvent, new RibbonQuickAccessToolBarCloneEventHandler(OnCloneThunk));
-            ContextMenuProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(Ribbon), new FrameworkPropertyMetadata(typeof(Ribbon)));
+            ItemsPanelProperty.OverrideMetadata(typeof(Ribbon), new FrameworkPropertyMetadata(new ItemsPanelTemplate(new FrameworkElementFactory(typeof(RibbonTabsPanel)))));
+			FocusManager.IsFocusScopeProperty.OverrideMetadata(typeof(Ribbon), new FrameworkPropertyMetadata(true));
+            BorderBrushProperty.OverrideMetadata(typeof(Ribbon), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnBorderBrushChanged)));
+            EventManager.RegisterClassHandler(typeof(Ribbon), Mouse.PreviewMouseDownOutsideCapturedElementEvent, new MouseButtonEventHandler(OnClickThroughThunk));
+            EventManager.RegisterClassHandler(typeof(Ribbon), Mouse.LostMouseCaptureEvent, new MouseEventHandler(OnLostMouseCaptureThunk));
+            EventManager.RegisterClassHandler(typeof(Ribbon), RibbonControlService.DismissPopupEvent, new RibbonDismissPopupEventHandler(OnDismissPopupThunk));
+            EventManager.RegisterClassHandler(typeof(Ribbon), RibbonQuickAccessToolBar.CloneEvent, new RibbonQuickAccessToolBarCloneEventHandler(OnCloneThunk));
+            ContextMenuProperty.OverrideMetadata(typeof(Ribbon), new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
 
-            CommandManager.RegisterClassCommandBinding(ownerType,
+            CommandManager.RegisterClassCommandBinding(typeof(Ribbon),
                 new CommandBinding(RibbonCommands.AddToQuickAccessToolBarCommand, AddToQATExecuted, AddToQATCanExecute));
-            CommandManager.RegisterClassCommandBinding(ownerType,
+            CommandManager.RegisterClassCommandBinding(typeof(Ribbon),
                 new CommandBinding(RibbonCommands.MaximizeRibbonCommand, MaximizeRibbonExecuted, MaximizeRibbonCanExecute));
-            CommandManager.RegisterClassCommandBinding(ownerType,
+            CommandManager.RegisterClassCommandBinding(typeof(Ribbon),
                 new CommandBinding(RibbonCommands.MinimizeRibbonCommand, MinimizeRibbonExecuted, MinimizeRibbonCanExecute));
-            CommandManager.RegisterClassCommandBinding(ownerType,
+            CommandManager.RegisterClassCommandBinding(typeof(Ribbon),
                 new CommandBinding(RibbonCommands.RemoveFromQuickAccessToolBarCommand, RemoveFromQATExecuted, RemoveFromQATCanExecute));
-            CommandManager.RegisterClassCommandBinding(ownerType,
+            CommandManager.RegisterClassCommandBinding(typeof(Ribbon),
                 new CommandBinding(RibbonCommands.ShowQuickAccessToolBarAboveRibbonCommand, ShowQATAboveExecuted, ShowQATAboveCanExecute));
-            CommandManager.RegisterClassCommandBinding(ownerType,
+            CommandManager.RegisterClassCommandBinding(typeof(Ribbon),
                 new CommandBinding(RibbonCommands.ShowQuickAccessToolBarBelowRibbonCommand, ShowQATBelowExecuted, ShowQATBelowCanExecute));
 
-            KeyboardNavigation.DirectionalNavigationProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(KeyboardNavigationMode.Contained));
-            KeyboardNavigation.TabNavigationProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(KeyboardNavigationMode.Cycle));
-            EventManager.RegisterClassHandler(ownerType, FrameworkElement.ContextMenuOpeningEvent, new ContextMenuEventHandler(OnContextMenuOpeningThunk), true);
-            EventManager.RegisterClassHandler(ownerType, FrameworkElement.ContextMenuClosingEvent, new ContextMenuEventHandler(OnContextMenuClosingThunk), true);
+            KeyboardNavigation.DirectionalNavigationProperty.OverrideMetadata(typeof(Ribbon), new FrameworkPropertyMetadata(KeyboardNavigationMode.Contained));
+            KeyboardNavigation.TabNavigationProperty.OverrideMetadata(typeof(Ribbon), new FrameworkPropertyMetadata(KeyboardNavigationMode.Cycle));
+            EventManager.RegisterClassHandler(typeof(Ribbon), FrameworkElement.ContextMenuOpeningEvent, new ContextMenuEventHandler(OnContextMenuOpeningThunk), true);
+            EventManager.RegisterClassHandler(typeof(Ribbon), FrameworkElement.ContextMenuClosingEvent, new ContextMenuEventHandler(OnContextMenuClosingThunk), true);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonApplicationMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonApplicationMenu.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -74,16 +74,14 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonApplicationMenu()
         {
-            Type ownerType = typeof(RibbonApplicationMenu);
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonApplicationMenu), new FrameworkPropertyMetadata(typeof(RibbonApplicationMenu)));
 
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
+            RibbonControlService.IsInControlGroupPropertyKey.OverrideMetadata(typeof(RibbonApplicationMenu), new FrameworkPropertyMetadata(false, null, new CoerceValueCallback(CoerceToFalse)));
+            RibbonControlService.IsInQuickAccessToolBarPropertyKey.OverrideMetadata(typeof(RibbonApplicationMenu), new FrameworkPropertyMetadata(false, null, new CoerceValueCallback(CoerceToFalse)));
+            RibbonControlService.CanAddToQuickAccessToolBarDirectlyProperty.OverrideMetadata(typeof(RibbonApplicationMenu), new FrameworkPropertyMetadata(false, null, new CoerceValueCallback(CoerceToFalse)));
 
-            RibbonControlService.IsInControlGroupPropertyKey.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false, null, new CoerceValueCallback(CoerceToFalse)));
-            RibbonControlService.IsInQuickAccessToolBarPropertyKey.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false, null, new CoerceValueCallback(CoerceToFalse)));
-            RibbonControlService.CanAddToQuickAccessToolBarDirectlyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false, null, new CoerceValueCallback(CoerceToFalse)));
-
-            RibbonMenuButton.CanUserResizeVerticallyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false, null, new CoerceValueCallback(CoerceToFalse)));
-            RibbonMenuButton.CanUserResizeHorizontallyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false, null, new CoerceValueCallback(CoerceToFalse)));
+            RibbonMenuButton.CanUserResizeVerticallyProperty.OverrideMetadata(typeof(RibbonApplicationMenu), new FrameworkPropertyMetadata(false, null, new CoerceValueCallback(CoerceToFalse)));
+            RibbonMenuButton.CanUserResizeHorizontallyProperty.OverrideMetadata(typeof(RibbonApplicationMenu), new FrameworkPropertyMetadata(false, null, new CoerceValueCallback(CoerceToFalse)));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonApplicationMenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonApplicationMenuItem.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -32,10 +32,8 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonApplicationMenuItem()
         {
-            Type ownerType = typeof(RibbonApplicationMenuItem);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            IsSubmenuOpenProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceIsSubmenuOpen)));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonApplicationMenuItem), new FrameworkPropertyMetadata(typeof(RibbonApplicationMenuItem)));
+            IsSubmenuOpenProperty.OverrideMetadata(typeof(RibbonApplicationMenuItem), new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceIsSubmenuOpen)));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonApplicationSplitMenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonApplicationSplitMenuItem.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -30,10 +30,8 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonApplicationSplitMenuItem()
         {
-            Type ownerType = typeof(RibbonApplicationSplitMenuItem);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            IsSubmenuOpenProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceIsSubmenuOpen)));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonApplicationSplitMenuItem), new FrameworkPropertyMetadata(typeof(RibbonApplicationSplitMenuItem)));
+            IsSubmenuOpenProperty.OverrideMetadata(typeof(RibbonApplicationSplitMenuItem), new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceIsSubmenuOpen)));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonButton.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -38,17 +38,15 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonButton()
         {
-            Type ownerType = typeof(RibbonButton);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceFocusable)));
-            ToolTipProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
-            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            CommandProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnCommandChanged));
-            ContextMenuProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
-            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonButton), new FrameworkPropertyMetadata(typeof(RibbonButton)));
+            FocusableProperty.OverrideMetadata(typeof(RibbonButton), new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceFocusable)));
+            ToolTipProperty.OverrideMetadata(typeof(RibbonButton), new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
+            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonButton), new FrameworkPropertyMetadata(true));
+            CommandProperty.OverrideMetadata(typeof(RibbonButton), new FrameworkPropertyMetadata(RibbonHelper.OnCommandChanged));
+            ContextMenuProperty.OverrideMetadata(typeof(RibbonButton), new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
+            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonButton), new FrameworkPropertyMetadata(true));
+            EventManager.RegisterClassHandler(typeof(RibbonButton), KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonButton), KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonCheckBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonCheckBox.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -38,17 +38,15 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonCheckBox()
         {
-            Type ownerType = typeof(RibbonCheckBox);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceFocusable)));
-            ToolTipProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
-            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            CommandProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnCommandChanged));
-            ContextMenuProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
-            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonCheckBox), new FrameworkPropertyMetadata(typeof(RibbonCheckBox)));
+            FocusableProperty.OverrideMetadata(typeof(RibbonCheckBox), new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceFocusable)));
+            ToolTipProperty.OverrideMetadata(typeof(RibbonCheckBox), new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
+            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonCheckBox), new FrameworkPropertyMetadata(true));
+            CommandProperty.OverrideMetadata(typeof(RibbonCheckBox), new FrameworkPropertyMetadata(RibbonHelper.OnCommandChanged));
+            ContextMenuProperty.OverrideMetadata(typeof(RibbonCheckBox), new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
+            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonCheckBox), new FrameworkPropertyMetadata(true));
+            EventManager.RegisterClassHandler(typeof(RibbonCheckBox), KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonCheckBox), KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonComboBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonComboBox.cs
@@ -43,10 +43,9 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonComboBox()
         {
-            Type ownerType = typeof(RibbonComboBox);
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonComboBox), new FrameworkPropertyMetadata(typeof(RibbonComboBox)));
+            IsTextSearchEnabledProperty.OverrideMetadata(typeof(RibbonComboBox), new FrameworkPropertyMetadata(true));
 
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            IsTextSearchEnabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
             InitializeStringContentTemplate();
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonContentPresenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonContentPresenter.cs
@@ -36,20 +36,18 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonContentPresenter()
         {
-            Type ownerType = typeof(RibbonContentPresenter);
-
-            IsInQuickAccessToolBarProperty.OverrideMetadata(ownerType,
+            IsInQuickAccessToolBarProperty.OverrideMetadata(typeof(RibbonContentPresenter),
                 new FrameworkPropertyMetadata(OnIsInQuickAccessToolBarChanged),
                 RibbonControlService.IsInQuickAccessToolBarPropertyKey);
 
-            IsInControlGroupProperty.OverrideMetadata(ownerType,
+            IsInControlGroupProperty.OverrideMetadata(typeof(RibbonContentPresenter),
                 new FrameworkPropertyMetadata(OnIsInControlGroupChanged),
                 RibbonControlService.IsInControlGroupPropertyKey);
 
-            ControlSizeDefinitionProperty.OverrideMetadata(ownerType,
+            ControlSizeDefinitionProperty.OverrideMetadata(typeof(RibbonContentPresenter),
                 new FrameworkPropertyMetadata(OnControlSizeDefinitionChanged, CoerceControlSizeDefinition));
 
-            RibbonControlService.RibbonPropertyKey.OverrideMetadata(ownerType,
+            RibbonControlService.RibbonPropertyKey.OverrideMetadata(typeof(RibbonContentPresenter),
                 new FrameworkPropertyMetadata(OnRibbonChanged));
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonContextMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonContextMenu.cs
@@ -41,14 +41,13 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonContextMenu()
         {
-            Type ownerType = typeof(RibbonContextMenu);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            IsOpenProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsOpenChanged)));
-            EventManager.RegisterClassHandler(ownerType, Mouse.PreviewMouseDownOutsideCapturedElementEvent, new MouseButtonEventHandler(OnClickThroughThunk));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonContextMenu), new FrameworkPropertyMetadata(typeof(RibbonContextMenu)));
+            IsOpenProperty.OverrideMetadata(typeof(RibbonContextMenu), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsOpenChanged)));
+            EventManager.RegisterClassHandler(typeof(RibbonContextMenu), Mouse.PreviewMouseDownOutsideCapturedElementEvent, new MouseButtonEventHandler(OnClickThroughThunk));
 
             ItemsPanelTemplate template = new ItemsPanelTemplate(new FrameworkElementFactory(typeof(RibbonMenuItemsPanel)));
             template.Seal();
-            ItemsPanelProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(template));
+            ItemsPanelProperty.OverrideMetadata(typeof(RibbonContextMenu), new FrameworkPropertyMetadata(template));
         }
 
         public RibbonContextMenu()

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonContextualTabGroupItemsControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonContextualTabGroupItemsControl.cs
@@ -27,17 +27,16 @@ namespace Microsoft.Windows.Controls.Ribbon
 
         static RibbonContextualTabGroupItemsControl()
         {
-            Type ownerType = typeof(RibbonContextualTabGroupItemsControl);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            ItemTemplateProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, OnNotifyPropertyChanged, CoerceItemTemplate));
-            ItemContainerStyleProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, OnNotifyPropertyChanged, CoerceItemContainerStyle));
-            VisibilityProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceVisibility)));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonContextualTabGroupItemsControl), new FrameworkPropertyMetadata(typeof(RibbonContextualTabGroupItemsControl)));
+            ItemTemplateProperty.OverrideMetadata(typeof(RibbonContextualTabGroupItemsControl), new FrameworkPropertyMetadata(null, OnNotifyPropertyChanged, CoerceItemTemplate));
+            ItemContainerStyleProperty.OverrideMetadata(typeof(RibbonContextualTabGroupItemsControl), new FrameworkPropertyMetadata(null, OnNotifyPropertyChanged, CoerceItemContainerStyle));
+            VisibilityProperty.OverrideMetadata(typeof(RibbonContextualTabGroupItemsControl), new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceVisibility)));
+            FocusableProperty.OverrideMetadata(typeof(RibbonContextualTabGroupItemsControl), new FrameworkPropertyMetadata(false));
 
             FrameworkElementFactory factory = new FrameworkElementFactory(typeof(RibbonContextualTabGroupsPanel));
             ItemsPanelTemplate itemsPanel = new ItemsPanelTemplate(factory);
             itemsPanel.Seal();
-            ItemsPanelProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(itemsPanel));
+            ItemsPanelProperty.OverrideMetadata(typeof(RibbonContextualTabGroupItemsControl), new FrameworkPropertyMetadata(itemsPanel));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControl.cs
@@ -42,23 +42,21 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonControl()
         {
-            Type ownerType = typeof(RibbonControl);
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonControl), new FrameworkPropertyMetadata(typeof(RibbonControl)));
+            FocusableProperty.OverrideMetadata(typeof(RibbonControl), new FrameworkPropertyMetadata(false));
 
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
-
-            IsInQuickAccessToolBarProperty.OverrideMetadata(ownerType,
+            IsInQuickAccessToolBarProperty.OverrideMetadata(typeof(RibbonControl),
                 new FrameworkPropertyMetadata(OnIsInQuickAccessToolBarChanged),
                 RibbonControlService.IsInQuickAccessToolBarPropertyKey);
 
-            IsInControlGroupProperty.OverrideMetadata(ownerType,
+            IsInControlGroupProperty.OverrideMetadata(typeof(RibbonControl),
                 new FrameworkPropertyMetadata(OnIsInControlGroupChanged),
                 RibbonControlService.IsInControlGroupPropertyKey);
 
-            ControlSizeDefinitionProperty.OverrideMetadata(ownerType,
+            ControlSizeDefinitionProperty.OverrideMetadata(typeof(RibbonControl),
                 new FrameworkPropertyMetadata(OnControlSizeDefinitionChanged, CoerceControlSizeDefinition));
             
-             ItemForItemContainerProperty.OverrideMetadata(ownerType,
+             ItemForItemContainerProperty.OverrideMetadata(typeof(RibbonControl),
                 new FrameworkPropertyMetadata(OnItemForItemContainerChanged));
 
 #if RIBBON_IN_FRAMEWORK

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControlGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControlGroup.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -30,18 +30,17 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonControlGroup()
         {
-            Type ownerType = typeof(RibbonControlGroup);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonControlGroup), new FrameworkPropertyMetadata(typeof(RibbonControlGroup)));
+            FocusableProperty.OverrideMetadata(typeof(RibbonControlGroup), new FrameworkPropertyMetadata(false));
 
             FrameworkElementFactory fef = new FrameworkElementFactory(typeof(StackPanel));
             fef.SetValue(StackPanel.OrientationProperty, Orientation.Horizontal);
             ItemsPanelTemplate template = new ItemsPanelTemplate(fef);
             template.Seal();
-            ItemsPanelProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(template));
+            ItemsPanelProperty.OverrideMetadata(typeof(RibbonControlGroup), new FrameworkPropertyMetadata(template));
 
-            RibbonControlService.DefaultControlSizeDefinitionProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceDefaultControlSizeDefinition)));
+            RibbonControlService.DefaultControlSizeDefinitionProperty.OverrideMetadata(typeof(RibbonControlGroup),
+                new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceDefaultControlSizeDefinition)));
         }
 
         #endregion Constructors

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonFilterMenuButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonFilterMenuButton.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -32,9 +32,8 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonFilterMenuButton()
         {
-            Type ownerType = typeof(RibbonFilterMenuButton);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            RibbonControlService.CanAddToQuickAccessToolBarDirectlyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonFilterMenuButton), new FrameworkPropertyMetadata(typeof(RibbonFilterMenuButton)));
+            RibbonControlService.CanAddToQuickAccessToolBarDirectlyProperty.OverrideMetadata(typeof(RibbonFilterMenuButton), new FrameworkPropertyMetadata(false));
         }
         
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGallery.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGallery.cs
@@ -55,26 +55,25 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonGallery()
         {
-            Type ownerType = typeof(RibbonGallery);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            ItemContainerStyleProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceItemContainerStyle)));
-            ItemTemplateProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceItemTemplate)));
-            EventManager.RegisterClassHandler(ownerType, MouseMoveEvent, new MouseEventHandler(OnMouseMove), true);
-            ToolTipProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
-            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            ContextMenuProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
-            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonGallery), new FrameworkPropertyMetadata(typeof(RibbonGallery)));
+            ItemContainerStyleProperty.OverrideMetadata(typeof(RibbonGallery), new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceItemContainerStyle)));
+            ItemTemplateProperty.OverrideMetadata(typeof(RibbonGallery), new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceItemTemplate)));
+            EventManager.RegisterClassHandler(typeof(RibbonGallery), MouseMoveEvent, new MouseEventHandler(OnMouseMove), true);
+            ToolTipProperty.OverrideMetadata(typeof(RibbonGallery), new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
+            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonGallery), new FrameworkPropertyMetadata(true));
+            ContextMenuProperty.OverrideMetadata(typeof(RibbonGallery), new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
+            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonGallery), new FrameworkPropertyMetadata(true));
 #if IN_RIBBON_GALLERY
-            ScrollViewer.VerticalScrollBarVisibilityProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceVerticalScrollBarVisibility)));
+            ScrollViewer.VerticalScrollBarVisibilityProperty.OverrideMetadata(typeof(RibbonGallery), new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceVerticalScrollBarVisibility)));
 #else
-            ScrollViewer.VerticalScrollBarVisibilityProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null));
+            ScrollViewer.VerticalScrollBarVisibilityProperty.OverrideMetadata(typeof(RibbonGallery), new FrameworkPropertyMetadata(null));
 #endif
-            EventManager.RegisterClassHandler(ownerType, RibbonControlService.DismissPopupEvent, new RibbonDismissPopupEventHandler(OnDismissPopupThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonGallery), RibbonControlService.DismissPopupEvent, new RibbonDismissPopupEventHandler(OnDismissPopupThunk));
 
-            FilterCommand = new RoutedCommand("Filter", ownerType);
-            CommandManager.RegisterClassCommandBinding(ownerType, new CommandBinding(FilterCommand, FilterExecuted, FilterCanExecute));
-            EventManager.RegisterClassHandler(ownerType, LoadedEvent, new RoutedEventHandler(OnLoaded));
-            EventManager.RegisterClassHandler(ownerType, UnloadedEvent, new RoutedEventHandler(OnUnloaded));
+            FilterCommand = new RoutedCommand("Filter", typeof(RibbonGallery));
+            CommandManager.RegisterClassCommandBinding(typeof(RibbonGallery), new CommandBinding(FilterCommand, FilterExecuted, FilterCanExecute));
+            EventManager.RegisterClassHandler(typeof(RibbonGallery), LoadedEvent, new RoutedEventHandler(OnLoaded));
+            EventManager.RegisterClassHandler(typeof(RibbonGallery), UnloadedEvent, new RoutedEventHandler(OnUnloaded));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGalleryCategory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGalleryCategory.cs
@@ -45,12 +45,11 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonGalleryCategory()
         {
-            Type ownerType = typeof(RibbonGalleryCategory);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            ItemTemplateProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new PropertyChangedCallback(OnNotifyPropertyChanged), new CoerceValueCallback(CoerceItemTemplate)));
-            ItemContainerStyleProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnNotifyPropertyChanged), new CoerceValueCallback(CoerceItemContainerStyle)));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonGalleryCategory), new FrameworkPropertyMetadata(typeof(RibbonGalleryCategory)));
+            ItemTemplateProperty.OverrideMetadata(typeof(RibbonGalleryCategory), new FrameworkPropertyMetadata(null, new PropertyChangedCallback(OnNotifyPropertyChanged), new CoerceValueCallback(CoerceItemTemplate)));
+            ItemContainerStyleProperty.OverrideMetadata(typeof(RibbonGalleryCategory), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnNotifyPropertyChanged), new CoerceValueCallback(CoerceItemContainerStyle)));
             
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
+            FocusableProperty.OverrideMetadata(typeof(RibbonGalleryCategory), new FrameworkPropertyMetadata(false));
 #if RIBBON_IN_FRAMEWORK
             AutomationProperties.IsOffscreenBehaviorProperty.OverrideMetadata(typeof(RibbonGalleryCategory), new FrameworkPropertyMetadata(IsOffscreenBehavior.FromClip));
 #endif

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGalleryItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGalleryItem.cs
@@ -36,16 +36,15 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonGalleryItem()
         {
-            Type ownerType = typeof(RibbonGalleryItem);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            ContentProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new PropertyChangedCallback(OnContentChanged), new CoerceValueCallback(CoerceContent)));
-            ToolTipProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
-            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonGalleryItem), new FrameworkPropertyMetadata(typeof(RibbonGalleryItem)));
+            ContentProperty.OverrideMetadata(typeof(RibbonGalleryItem), new FrameworkPropertyMetadata(null, new PropertyChangedCallback(OnContentChanged), new CoerceValueCallback(CoerceContent)));
+            ToolTipProperty.OverrideMetadata(typeof(RibbonGalleryItem), new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
+            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonGalleryItem), new FrameworkPropertyMetadata(true));
 #if RIBBON_IN_FRAMEWORK
             AutomationProperties.IsOffscreenBehaviorProperty.OverrideMetadata(typeof(RibbonGalleryItem), new FrameworkPropertyMetadata(IsOffscreenBehavior.FromClip));
 #endif
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonGalleryItem), KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonGalleryItem), KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
         }
 
         #endregion Constructors

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGroup.cs
@@ -54,30 +54,28 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonGroup()
         {
-            Type ownerType = typeof(RibbonGroup);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            ItemsPanelProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new ItemsPanelTemplate(new FrameworkElementFactory(typeof(RibbonGroupItemsPanel)))));
-            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            HeaderProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new PropertyChangedCallback(OnHeaderChanged)));
-            RibbonControlService.IsInQuickAccessToolBarPropertyKey.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsInQuickAccessToolBarChanged)));
-            ToolTipProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceToolTip)));
-            ContextMenuProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
-            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
-            ForegroundProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnForegroundChanged)));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonGroup), new FrameworkPropertyMetadata(typeof(RibbonGroup)));
+            ItemsPanelProperty.OverrideMetadata(typeof(RibbonGroup), new FrameworkPropertyMetadata(new ItemsPanelTemplate(new FrameworkElementFactory(typeof(RibbonGroupItemsPanel)))));
+            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonGroup), new FrameworkPropertyMetadata(true));
+            HeaderProperty.OverrideMetadata(typeof(RibbonGroup), new FrameworkPropertyMetadata(null, new PropertyChangedCallback(OnHeaderChanged)));
+            RibbonControlService.IsInQuickAccessToolBarPropertyKey.OverrideMetadata(typeof(RibbonGroup), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsInQuickAccessToolBarChanged)));
+            ToolTipProperty.OverrideMetadata(typeof(RibbonGroup), new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceToolTip)));
+            ContextMenuProperty.OverrideMetadata(typeof(RibbonGroup), new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
+            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonGroup), new FrameworkPropertyMetadata(true));
+            FocusableProperty.OverrideMetadata(typeof(RibbonGroup), new FrameworkPropertyMetadata(false));
+            ForegroundProperty.OverrideMetadata(typeof(RibbonGroup), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnForegroundChanged)));
 #if RIBBON_IN_FRAMEWORK
-            AutomationProperties.IsOffscreenBehaviorProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(IsOffscreenBehavior.FromClip));
+            AutomationProperties.IsOffscreenBehaviorProperty.OverrideMetadata(typeof(RibbonGroup), new FrameworkPropertyMetadata(IsOffscreenBehavior.FromClip));
 #endif
 
-            EventManager.RegisterClassHandler(ownerType, Mouse.PreviewMouseDownOutsideCapturedElementEvent, new MouseButtonEventHandler(OnClickThroughThunk));
-            EventManager.RegisterClassHandler(ownerType, Mouse.LostMouseCaptureEvent, new MouseEventHandler(OnLostMouseCaptureThunk), true /* handledEventsToo */);
-            EventManager.RegisterClassHandler(ownerType, RibbonControlService.DismissPopupEvent, new RibbonDismissPopupEventHandler(OnDismissPopupThunk));
-            EventManager.RegisterClassHandler(ownerType, Mouse.MouseDownEvent, new MouseButtonEventHandler(OnMouseDownThunk), true);
-            EventManager.RegisterClassHandler(ownerType, FrameworkElement.ContextMenuOpeningEvent, new ContextMenuEventHandler(OnContextMenuOpeningThunk), true);
-            EventManager.RegisterClassHandler(ownerType, FrameworkElement.ContextMenuClosingEvent, new ContextMenuEventHandler(OnContextMenuClosingThunk), true);
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonGroup), Mouse.PreviewMouseDownOutsideCapturedElementEvent, new MouseButtonEventHandler(OnClickThroughThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonGroup), Mouse.LostMouseCaptureEvent, new MouseEventHandler(OnLostMouseCaptureThunk), handledEventsToo: true);
+            EventManager.RegisterClassHandler(typeof(RibbonGroup), RibbonControlService.DismissPopupEvent, new RibbonDismissPopupEventHandler(OnDismissPopupThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonGroup), Mouse.MouseDownEvent, new MouseButtonEventHandler(OnMouseDownThunk), true);
+            EventManager.RegisterClassHandler(typeof(RibbonGroup), FrameworkElement.ContextMenuOpeningEvent, new ContextMenuEventHandler(OnContextMenuOpeningThunk), true);
+            EventManager.RegisterClassHandler(typeof(RibbonGroup), FrameworkElement.ContextMenuClosingEvent, new ContextMenuEventHandler(OnContextMenuClosingThunk), true);
+            EventManager.RegisterClassHandler(typeof(RibbonGroup), KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonGroup), KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonMenuButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonMenuButton.cs
@@ -47,40 +47,39 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonMenuButton()
         {
-            Type ownerType = typeof(RibbonMenuButton);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonMenuButton), new FrameworkPropertyMetadata(typeof(RibbonMenuButton)));
 
             ItemsPanelTemplate template = new ItemsPanelTemplate(new FrameworkElementFactory(typeof(RibbonMenuItemsPanel)));
             template.Seal();
-            ItemsPanelProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(template));
+            ItemsPanelProperty.OverrideMetadata(typeof(RibbonMenuButton), new FrameworkPropertyMetadata(template));
 
-            ToolTipProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
-            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            ContextMenuProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
-            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            IsMainMenuProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
+            ToolTipProperty.OverrideMetadata(typeof(RibbonMenuButton), new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
+            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonMenuButton), new FrameworkPropertyMetadata(true));
+            ContextMenuProperty.OverrideMetadata(typeof(RibbonMenuButton), new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
+            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonMenuButton), new FrameworkPropertyMetadata(true));
+            IsMainMenuProperty.OverrideMetadata(typeof(RibbonMenuButton), new FrameworkPropertyMetadata(false));
 
-            EventManager.RegisterClassHandler(ownerType, UIElement.LostMouseCaptureEvent, new MouseEventHandler(OnLostMouseCaptureThunk));
-            EventManager.RegisterClassHandler(ownerType, RibbonControlService.DismissPopupEvent, new RibbonDismissPopupEventHandler(OnDismissPopupThunk));
-            EventManager.RegisterClassHandler(ownerType, UIElement.GotKeyboardFocusEvent, new KeyboardFocusChangedEventHandler(OnGotKeyboardFocusThunk), true);
+            EventManager.RegisterClassHandler(typeof(RibbonMenuButton), UIElement.LostMouseCaptureEvent, new MouseEventHandler(OnLostMouseCaptureThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonMenuButton), RibbonControlService.DismissPopupEvent, new RibbonDismissPopupEventHandler(OnDismissPopupThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonMenuButton), UIElement.GotKeyboardFocusEvent, new KeyboardFocusChangedEventHandler(OnGotKeyboardFocusThunk), true);
 
-            EventManager.RegisterClassHandler(ownerType, Mouse.PreviewMouseDownOutsideCapturedElementEvent, new MouseButtonEventHandler(OnClickThroughThunk));
-            EventManager.RegisterClassHandler(ownerType, Mouse.MouseDownEvent, new MouseButtonEventHandler(OnMouseDownThunk), true);
+            EventManager.RegisterClassHandler(typeof(RibbonMenuButton), Mouse.PreviewMouseDownOutsideCapturedElementEvent, new MouseButtonEventHandler(OnClickThroughThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonMenuButton), Mouse.MouseDownEvent, new MouseButtonEventHandler(OnMouseDownThunk), true);
 
             // pseudo-inherited properties
-            IsInControlGroupProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(OnPseudoInheritedPropertyChanged), RibbonControlService.IsInControlGroupPropertyKey);
+            IsInControlGroupProperty.OverrideMetadata(typeof(RibbonMenuButton), new FrameworkPropertyMetadata(OnPseudoInheritedPropertyChanged), RibbonControlService.IsInControlGroupPropertyKey);
 
             // This should not be a focus scope since Ribbon will be a focus scope.
-            FocusManager.IsFocusScopeProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
+            FocusManager.IsFocusScopeProperty.OverrideMetadata(typeof(RibbonMenuButton), new FrameworkPropertyMetadata(false));
 
-            EventManager.RegisterClassHandler(ownerType, RibbonMenuButton.RibbonIsSelectedChangedEvent, new RoutedPropertyChangedEventHandler<bool>(OnRibbonIsSelectedChanged));
+            EventManager.RegisterClassHandler(typeof(RibbonMenuButton), RibbonMenuButton.RibbonIsSelectedChangedEvent, new RoutedPropertyChangedEventHandler<bool>(OnRibbonIsSelectedChanged));
 
-            KeyboardNavigation.DirectionalNavigationProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(KeyboardNavigationMode.Local));
+            KeyboardNavigation.DirectionalNavigationProperty.OverrideMetadata(typeof(RibbonMenuButton), new FrameworkPropertyMetadata(KeyboardNavigationMode.Local));
 
-            EventManager.RegisterClassHandler(ownerType, FrameworkElement.ContextMenuOpeningEvent, new ContextMenuEventHandler(OnContextMenuOpeningThunk), true);
-            EventManager.RegisterClassHandler(ownerType, FrameworkElement.ContextMenuClosingEvent, new ContextMenuEventHandler(OnContextMenuClosingThunk), true);
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonMenuButton), FrameworkElement.ContextMenuOpeningEvent, new ContextMenuEventHandler(OnContextMenuOpeningThunk), true);
+            EventManager.RegisterClassHandler(typeof(RibbonMenuButton), FrameworkElement.ContextMenuClosingEvent, new ContextMenuEventHandler(OnContextMenuClosingThunk), true);
+            EventManager.RegisterClassHandler(typeof(RibbonMenuButton), KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonMenuButton), KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonMenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonMenuItem.cs
@@ -46,30 +46,28 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonMenuItem()
         {
-            Type ownerType = typeof(RibbonMenuItem);
-
             ItemsPanelTemplate template = new ItemsPanelTemplate(new FrameworkElementFactory(typeof(RibbonMenuItemsPanel)));
             template.Seal();
-            ItemsPanelProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(template));
+            ItemsPanelProperty.OverrideMetadata(typeof(RibbonMenuItem), new FrameworkPropertyMetadata(template));
 
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            ToolTipProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
-            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            CommandProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnCommandChanged));
-            ContextMenuProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
-            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            IsSubmenuOpenProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false, new PropertyChangedCallback(OnIsSubmenuOpenChanged)));
-            IsCheckedProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false, new PropertyChangedCallback(OnIsCheckedChanged)));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonMenuItem), new FrameworkPropertyMetadata(typeof(RibbonMenuItem)));
+            ToolTipProperty.OverrideMetadata(typeof(RibbonMenuItem), new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
+            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonMenuItem), new FrameworkPropertyMetadata(true));
+            CommandProperty.OverrideMetadata(typeof(RibbonMenuItem), new FrameworkPropertyMetadata(RibbonHelper.OnCommandChanged));
+            ContextMenuProperty.OverrideMetadata(typeof(RibbonMenuItem), new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
+            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonMenuItem), new FrameworkPropertyMetadata(true));
+            IsSubmenuOpenProperty.OverrideMetadata(typeof(RibbonMenuItem), new FrameworkPropertyMetadata(false, new PropertyChangedCallback(OnIsSubmenuOpenChanged)));
+            IsCheckedProperty.OverrideMetadata(typeof(RibbonMenuItem), new FrameworkPropertyMetadata(false, new PropertyChangedCallback(OnIsCheckedChanged)));
             HasGalleryProperty.OverrideMetadata(typeof(RibbonMenuItem), new FrameworkPropertyMetadata(false, new PropertyChangedCallback(OnHasGalleryChanged)), RibbonMenuButton.HasGalleryPropertyKey);
-            HeaderProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new PropertyChangedCallback(OnHeaderChanged), new CoerceValueCallback(CoerceHeader)));
+            HeaderProperty.OverrideMetadata(typeof(RibbonMenuItem), new FrameworkPropertyMetadata(null, new PropertyChangedCallback(OnHeaderChanged), new CoerceValueCallback(CoerceHeader)));
             
-            EventManager.RegisterClassHandler(ownerType, Mouse.PreviewMouseDownOutsideCapturedElementEvent, new MouseButtonEventHandler(OnClickThroughThunk));
-            EventManager.RegisterClassHandler(ownerType, RibbonMenuButton.RibbonIsSelectedChangedEvent, new RoutedPropertyChangedEventHandler<bool>(OnRibbonIsSelectedChanged));
-            EventManager.RegisterClassHandler(ownerType, RibbonControlService.DismissPopupEvent, new RibbonDismissPopupEventHandler(OnDismissPopupThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
-            EventManager.RegisterClassHandler(ownerType, FrameworkElement.ContextMenuOpeningEvent, new ContextMenuEventHandler(OnContextMenuOpeningThunk), true);
-            EventManager.RegisterClassHandler(ownerType, FrameworkElement.ContextMenuClosingEvent, new ContextMenuEventHandler(OnContextMenuClosingThunk), true);
+            EventManager.RegisterClassHandler(typeof(RibbonMenuItem), Mouse.PreviewMouseDownOutsideCapturedElementEvent, new MouseButtonEventHandler(OnClickThroughThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonMenuItem), RibbonMenuButton.RibbonIsSelectedChangedEvent, new RoutedPropertyChangedEventHandler<bool>(OnRibbonIsSelectedChanged));
+            EventManager.RegisterClassHandler(typeof(RibbonMenuItem), RibbonControlService.DismissPopupEvent, new RibbonDismissPopupEventHandler(OnDismissPopupThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonMenuItem), KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonMenuItem), KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonMenuItem), FrameworkElement.ContextMenuOpeningEvent, new ContextMenuEventHandler(OnContextMenuOpeningThunk), true);
+            EventManager.RegisterClassHandler(typeof(RibbonMenuItem), FrameworkElement.ContextMenuClosingEvent, new ContextMenuEventHandler(OnContextMenuClosingThunk), true);
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonQuickAccessToolBar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonQuickAccessToolBar.cs
@@ -97,25 +97,24 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonQuickAccessToolBar()
         {
-            Type ownerType = typeof(RibbonQuickAccessToolBar);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonQuickAccessToolBar), new FrameworkPropertyMetadata(typeof(RibbonQuickAccessToolBar)));
+            FocusableProperty.OverrideMetadata(typeof(RibbonQuickAccessToolBar), new FrameworkPropertyMetadata(false));
 
             // If the DirectionalNaviation is default (Continue) then
             // in classic theme the first tab header is closer to first qat control than the
             // second qat control. Meaning a right arrow key from first qat control takes focus
             // to first tab header which is not expected. Hence setting the direction navigation
             // to Local so that a local search in qat is made before making a ribbon wide search.
-            KeyboardNavigation.DirectionalNavigationProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(KeyboardNavigationMode.Local));
+            KeyboardNavigation.DirectionalNavigationProperty.OverrideMetadata(typeof(RibbonQuickAccessToolBar), new FrameworkPropertyMetadata(KeyboardNavigationMode.Local));
 
-            EventManager.RegisterClassHandler(ownerType, Mouse.PreviewMouseDownOutsideCapturedElementEvent, new MouseButtonEventHandler(OnClickThroughThunk));
-            EventManager.RegisterClassHandler(ownerType, Mouse.LostMouseCaptureEvent, new MouseEventHandler(OnLostMouseCaptureThunk), true /* handledEventsToo */);
-            EventManager.RegisterClassHandler(ownerType, RibbonControlService.DismissPopupEvent, new RibbonDismissPopupEventHandler(OnDismissPopupThunk));
-            EventManager.RegisterClassHandler(ownerType, Mouse.MouseDownEvent, new MouseButtonEventHandler(OnMouseDownThunk), true);
-            EventManager.RegisterClassHandler(ownerType, FrameworkElement.ContextMenuOpeningEvent, new ContextMenuEventHandler(OnContextMenuOpeningThunk), true);
-            EventManager.RegisterClassHandler(ownerType, FrameworkElement.ContextMenuClosingEvent, new ContextMenuEventHandler(OnContextMenuClosingThunk), true);
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.PreviewKeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnPreviewKeyTipAccessedThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonQuickAccessToolBar), Mouse.PreviewMouseDownOutsideCapturedElementEvent, new MouseButtonEventHandler(OnClickThroughThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonQuickAccessToolBar), Mouse.LostMouseCaptureEvent, new MouseEventHandler(OnLostMouseCaptureThunk), handledEventsToo: true);
+            EventManager.RegisterClassHandler(typeof(RibbonQuickAccessToolBar), RibbonControlService.DismissPopupEvent, new RibbonDismissPopupEventHandler(OnDismissPopupThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonQuickAccessToolBar), Mouse.MouseDownEvent, new MouseButtonEventHandler(OnMouseDownThunk), true);
+            EventManager.RegisterClassHandler(typeof(RibbonQuickAccessToolBar), FrameworkElement.ContextMenuOpeningEvent, new ContextMenuEventHandler(OnContextMenuOpeningThunk), true);
+            EventManager.RegisterClassHandler(typeof(RibbonQuickAccessToolBar), FrameworkElement.ContextMenuClosingEvent, new ContextMenuEventHandler(OnContextMenuClosingThunk), true);
+            EventManager.RegisterClassHandler(typeof(RibbonQuickAccessToolBar), KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonQuickAccessToolBar), KeyTipService.PreviewKeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnPreviewKeyTipAccessedThunk));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonRadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonRadioButton.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -38,17 +38,15 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonRadioButton()
         {
-            Type ownerType = typeof(RibbonRadioButton);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceFocusable)));
-            ToolTipProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
-            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            CommandProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnCommandChanged));
-            ContextMenuProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
-            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonRadioButton), new FrameworkPropertyMetadata(typeof(RibbonRadioButton)));
+            FocusableProperty.OverrideMetadata(typeof(RibbonRadioButton), new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceFocusable)));
+            ToolTipProperty.OverrideMetadata(typeof(RibbonRadioButton), new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
+            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonRadioButton), new FrameworkPropertyMetadata(true));
+            CommandProperty.OverrideMetadata(typeof(RibbonRadioButton), new FrameworkPropertyMetadata(RibbonHelper.OnCommandChanged));
+            ContextMenuProperty.OverrideMetadata(typeof(RibbonRadioButton), new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
+            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonRadioButton), new FrameworkPropertyMetadata(true));
+            EventManager.RegisterClassHandler(typeof(RibbonRadioButton), KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonRadioButton), KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonSeparator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonSeparator.cs
@@ -31,11 +31,9 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonSeparator()
         {
-            Type ownerType = typeof(RibbonSeparator);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonSeparator), new FrameworkPropertyMetadata(typeof(RibbonSeparator)));
         }
-        
+
         #endregion Constructors
 
         #region Public Properties

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonSplitButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonSplitButton.cs
@@ -37,11 +37,10 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonSplitButton()
         {
-            Type ownerType = typeof(RibbonSplitButton);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            BorderThicknessProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new Thickness(), new PropertyChangedCallback(OnBorderThicknessChanged)));
-            ControlSizeDefinitionProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new PropertyChangedCallback(OnBorderThicknessChanged)));
-            IsInControlGroupProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false, new PropertyChangedCallback(OnBorderThicknessChanged)), RibbonControlService.IsInControlGroupPropertyKey);
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonSplitButton), new FrameworkPropertyMetadata(typeof(RibbonSplitButton)));
+            BorderThicknessProperty.OverrideMetadata(typeof(RibbonSplitButton), new FrameworkPropertyMetadata(new Thickness(), new PropertyChangedCallback(OnBorderThicknessChanged)));
+            ControlSizeDefinitionProperty.OverrideMetadata(typeof(RibbonSplitButton), new FrameworkPropertyMetadata(null, new PropertyChangedCallback(OnBorderThicknessChanged)));
+            IsInControlGroupProperty.OverrideMetadata(typeof(RibbonSplitButton), new FrameworkPropertyMetadata(false, new PropertyChangedCallback(OnBorderThicknessChanged)), RibbonControlService.IsInControlGroupPropertyKey);
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonSplitMenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonSplitMenuItem.cs
@@ -29,10 +29,9 @@ namespace Microsoft.Windows.Controls.Ribbon
 
         static RibbonSplitMenuItem()
         {
-            Type ownerType = typeof(RibbonSplitMenuItem);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            BorderThicknessProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new Thickness(), new PropertyChangedCallback(OnBorderThicknessChanged)));
-            IsCheckedProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsCheckedChanged)));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonSplitMenuItem), new FrameworkPropertyMetadata(typeof(RibbonSplitMenuItem)));
+            BorderThicknessProperty.OverrideMetadata(typeof(RibbonSplitMenuItem), new FrameworkPropertyMetadata(new Thickness(), new PropertyChangedCallback(OnBorderThicknessChanged)));
+            IsCheckedProperty.OverrideMetadata(typeof(RibbonSplitMenuItem), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsCheckedChanged)));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTab.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTab.cs
@@ -37,22 +37,20 @@ namespace Microsoft.Windows.Controls.Ribbon
         
         static RibbonTab()
         {
-            Type ownerType = typeof(RibbonTab);
-
-            IsEnabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsEnabledChanged)));
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            ItemsPanelProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new ItemsPanelTemplate(new FrameworkElementFactory(typeof(RibbonGroupsPanel)))));
-            HeaderProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnHeaderChanged)));
-            VisibilityProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(Visibility.Visible, new PropertyChangedCallback(OnVisibilityChanged), new CoerceValueCallback(CoerceVisibility)));
-            HeaderTemplateProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnNotifyHeaderPropertyChanged), new CoerceValueCallback(CoerceHeaderTemplate)));
-            HeaderTemplateSelectorProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnNotifyHeaderPropertyChanged)));
-            HeaderStringFormatProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnNotifyHeaderPropertyChanged)));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
-            KeyTipService.KeyTipProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnKeyTipChanged)));
+            IsEnabledProperty.OverrideMetadata(typeof(RibbonTab), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsEnabledChanged)));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonTab), new FrameworkPropertyMetadata(typeof(RibbonTab)));
+            ItemsPanelProperty.OverrideMetadata(typeof(RibbonTab), new FrameworkPropertyMetadata(new ItemsPanelTemplate(new FrameworkElementFactory(typeof(RibbonGroupsPanel)))));
+            HeaderProperty.OverrideMetadata(typeof(RibbonTab), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnHeaderChanged)));
+            VisibilityProperty.OverrideMetadata(typeof(RibbonTab), new FrameworkPropertyMetadata(Visibility.Visible, new PropertyChangedCallback(OnVisibilityChanged), new CoerceValueCallback(CoerceVisibility)));
+            HeaderTemplateProperty.OverrideMetadata(typeof(RibbonTab), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnNotifyHeaderPropertyChanged), new CoerceValueCallback(CoerceHeaderTemplate)));
+            HeaderTemplateSelectorProperty.OverrideMetadata(typeof(RibbonTab), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnNotifyHeaderPropertyChanged)));
+            HeaderStringFormatProperty.OverrideMetadata(typeof(RibbonTab), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnNotifyHeaderPropertyChanged)));
+            FocusableProperty.OverrideMetadata(typeof(RibbonTab), new FrameworkPropertyMetadata(false));
+            EventManager.RegisterClassHandler(typeof(RibbonTab), KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonTab), KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
+            KeyTipService.KeyTipProperty.OverrideMetadata(typeof(RibbonTab), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnKeyTipChanged)));
 #if RIBBON_IN_FRAMEWORK
-            AutomationProperties.IsOffscreenBehaviorProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(IsOffscreenBehavior.FromClip));
+            AutomationProperties.IsOffscreenBehaviorProperty.OverrideMetadata(typeof(RibbonTab), new FrameworkPropertyMetadata(IsOffscreenBehavior.FromClip));
 #endif
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTabHeader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTabHeader.cs
@@ -31,21 +31,20 @@ namespace Microsoft.Windows.Controls.Ribbon
 
         static RibbonTabHeader()
         {
-            Type ownerType = typeof(RibbonTabHeader);
-            IsEnabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceIsEnabled)));
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            VisibilityProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceVisibility)));
-            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            StyleProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(OnNotifyPropertyChanged, CoerceStyle));
-            ContentProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(OnNotifyPropertyChanged, CoerceContent));
-            ContentTemplateProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(OnNotifyPropertyChanged, CoerceContentTemplate));
-            ContentTemplateSelectorProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(OnNotifyPropertyChanged, CoerceContentTemplateSelector));
-            ContentStringFormatProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(OnNotifyPropertyChanged, CoerceStringFormat));
-            KeyTipService.KeyTipProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceKeyTip)));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
+            IsEnabledProperty.OverrideMetadata(typeof(RibbonTabHeader), new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceIsEnabled)));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonTabHeader), new FrameworkPropertyMetadata(typeof(RibbonTabHeader)));
+            VisibilityProperty.OverrideMetadata(typeof(RibbonTabHeader), new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceVisibility)));
+            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonTabHeader), new FrameworkPropertyMetadata(true));
+            StyleProperty.OverrideMetadata(typeof(RibbonTabHeader), new FrameworkPropertyMetadata(OnNotifyPropertyChanged, CoerceStyle));
+            ContentProperty.OverrideMetadata(typeof(RibbonTabHeader), new FrameworkPropertyMetadata(OnNotifyPropertyChanged, CoerceContent));
+            ContentTemplateProperty.OverrideMetadata(typeof(RibbonTabHeader), new FrameworkPropertyMetadata(OnNotifyPropertyChanged, CoerceContentTemplate));
+            ContentTemplateSelectorProperty.OverrideMetadata(typeof(RibbonTabHeader), new FrameworkPropertyMetadata(OnNotifyPropertyChanged, CoerceContentTemplateSelector));
+            ContentStringFormatProperty.OverrideMetadata(typeof(RibbonTabHeader), new FrameworkPropertyMetadata(OnNotifyPropertyChanged, CoerceStringFormat));
+            KeyTipService.KeyTipProperty.OverrideMetadata(typeof(RibbonTabHeader), new FrameworkPropertyMetadata(null, new CoerceValueCallback(CoerceKeyTip)));
+            EventManager.RegisterClassHandler(typeof(RibbonTabHeader), KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonTabHeader), KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
 #if RIBBON_IN_FRAMEWORK
-            AutomationProperties.IsOffscreenBehaviorProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(IsOffscreenBehavior.FromClip));
+            AutomationProperties.IsOffscreenBehaviorProperty.OverrideMetadata(typeof(RibbonTabHeader), new FrameworkPropertyMetadata(IsOffscreenBehavior.FromClip));
 #endif
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTabHeaderItemsControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTabHeaderItemsControl.cs
@@ -28,12 +28,11 @@ namespace Microsoft.Windows.Controls.Ribbon
 
         static RibbonTabHeaderItemsControl()
         {
-            Type ownerType = typeof(RibbonTabHeaderItemsControl);
-            ItemsPanelProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new ItemsPanelTemplate(new FrameworkElementFactory(typeof(RibbonTabHeadersPanel)))));
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(typeof(RibbonTabHeaderItemsControl)));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
-            KeyboardNavigation.TabNavigationProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(KeyboardNavigationMode.Once));
-            KeyboardNavigation.ControlTabNavigationProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(KeyboardNavigationMode.Once));
+            ItemsPanelProperty.OverrideMetadata(typeof(RibbonTabHeaderItemsControl), new FrameworkPropertyMetadata(new ItemsPanelTemplate(new FrameworkElementFactory(typeof(RibbonTabHeadersPanel)))));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonTabHeaderItemsControl), new FrameworkPropertyMetadata(typeof(RibbonTabHeaderItemsControl)));
+            FocusableProperty.OverrideMetadata(typeof(RibbonTabHeaderItemsControl), new FrameworkPropertyMetadata(false));
+            KeyboardNavigation.TabNavigationProperty.OverrideMetadata(typeof(RibbonTabHeaderItemsControl), new FrameworkPropertyMetadata(KeyboardNavigationMode.Once));
+            KeyboardNavigation.ControlTabNavigationProperty.OverrideMetadata(typeof(RibbonTabHeaderItemsControl), new FrameworkPropertyMetadata(KeyboardNavigationMode.Once));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTextBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTextBox.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -40,14 +40,13 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonTextBox()
         {
-            Type ownerType = typeof(RibbonTextBox);
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            ToolTipProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
-            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            ContextMenuProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
-            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonTextBox), new FrameworkPropertyMetadata(typeof(RibbonTextBox)));
+            ToolTipProperty.OverrideMetadata(typeof(RibbonTextBox), new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
+            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonTextBox), new FrameworkPropertyMetadata(true));
+            ContextMenuProperty.OverrideMetadata(typeof(RibbonTextBox), new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
+            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonTextBox), new FrameworkPropertyMetadata(true));
+            EventManager.RegisterClassHandler(typeof(RibbonTextBox), KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonTextBox), KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
         }
 
         public RibbonTextBox()

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonToggleButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonToggleButton.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -39,19 +39,17 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonToggleButton()
         {
-            Type ownerType = typeof(RibbonToggleButton);
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonToggleButton), new FrameworkPropertyMetadata(typeof(RibbonToggleButton)));
+            FocusableProperty.OverrideMetadata(typeof(RibbonToggleButton), new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceFocusable)));
+            ToolTipProperty.OverrideMetadata(typeof(RibbonToggleButton), new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
+            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonToggleButton), new FrameworkPropertyMetadata(true));
+            CommandProperty.OverrideMetadata(typeof(RibbonToggleButton), new FrameworkPropertyMetadata(RibbonHelper.OnCommandChanged));
+            ContextMenuProperty.OverrideMetadata(typeof(RibbonToggleButton), new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
+            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(typeof(RibbonToggleButton), new FrameworkPropertyMetadata(true));
+            EventManager.RegisterClassHandler(typeof(RibbonToggleButton), KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
+            EventManager.RegisterClassHandler(typeof(RibbonToggleButton), KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
 
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(OnCoerceFocusable)));
-            ToolTipProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(null, new CoerceValueCallback(RibbonHelper.CoerceRibbonToolTip)));
-            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            CommandProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnCommandChanged));
-            ContextMenuProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(RibbonHelper.OnContextMenuChanged, RibbonHelper.OnCoerceContextMenu));
-            ContextMenuService.ShowOnDisabledProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(true));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.ActivatingKeyTipEvent, new ActivatingKeyTipEventHandler(OnActivatingKeyTipThunk));
-            EventManager.RegisterClassHandler(ownerType, KeyTipService.KeyTipAccessedEvent, new KeyTipAccessedEventHandler(OnKeyTipAccessedThunk));
-
-            IsCheckedProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsCheckedChanged)));
+            IsCheckedProperty.OverrideMetadata(typeof(RibbonToggleButton), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsCheckedChanged)));
         }
 
         private static void OnIsCheckedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonToolTip.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonToolTip.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -33,11 +33,9 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonToolTip()
         {
-            Type ownerType = typeof(RibbonToolTip);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            IsOpenProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsOpenChanged), new CoerceValueCallback(CoerceIsOpen)));
-            PlacementTargetProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(OnPlacementTargetPropertyChanged));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonToolTip), new FrameworkPropertyMetadata(typeof(RibbonToolTip)));
+            IsOpenProperty.OverrideMetadata(typeof(RibbonToolTip), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsOpenChanged), new CoerceValueCallback(CoerceIsOpen)));
+            PlacementTargetProperty.OverrideMetadata(typeof(RibbonToolTip), new FrameworkPropertyMetadata(OnPlacementTargetPropertyChanged));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTwoLineText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTwoLineText.cs
@@ -37,10 +37,8 @@ namespace Microsoft.Windows.Controls.Ribbon
         
         static RibbonTwoLineText()
         {
-            Type ownerType = typeof(RibbonTwoLineText);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
-            FocusableProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonTwoLineText), new FrameworkPropertyMetadata(typeof(RibbonTwoLineText)));
+            FocusableProperty.OverrideMetadata(typeof(RibbonTwoLineText), new FrameworkPropertyMetadata(false));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonWindow.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonWindow.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #region Using declarations
@@ -44,18 +44,16 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         static RibbonWindow()
         {
-            Type ownerType = typeof(RibbonWindow);
-
-            DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new ComponentResourceKey(typeof(Ribbon), "RibbonWindowStyle")));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(RibbonWindow), new FrameworkPropertyMetadata(new ComponentResourceKey(typeof(Ribbon), "RibbonWindowStyle")));
 
             // We override Window.Title metadata so that we can receive change notifications and then coerce Ribbon.Title.
-            Window.TitleProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(String.Empty, new PropertyChangedCallback(OnTitleChangedCallback)));
+            Window.TitleProperty.OverrideMetadata(typeof(RibbonWindow), new FrameworkPropertyMetadata(String.Empty, new PropertyChangedCallback(OnTitleChangedCallback)));
 
-            CommandManager.RegisterClassCommandBinding(ownerType, new CommandBinding(_minimizeWindowCommand, MinimizeWindowExecuted, MinimizeWindowCanExecute));
-            CommandManager.RegisterClassCommandBinding(ownerType, new CommandBinding(_maximizeWindowCommand, MaximizeWindowExecuted, MaximizeWindowCanExecute));
-            CommandManager.RegisterClassCommandBinding(ownerType, new CommandBinding(_restoreWindowCommand, RestoreWindowExecuted, RestoreWindowCanExecute));
-            CommandManager.RegisterClassCommandBinding(ownerType, new CommandBinding(_closeWindowCommand, CloseWindowExecuted, CloseWindowCanExecute));
-            CommandManager.RegisterClassCommandBinding(ownerType, new CommandBinding(_showSystemMenuCommand, SystemMenuExecuted, SystemMenuCanExecute));
+            CommandManager.RegisterClassCommandBinding(typeof(RibbonWindow), new CommandBinding(_minimizeWindowCommand, MinimizeWindowExecuted, MinimizeWindowCanExecute));
+            CommandManager.RegisterClassCommandBinding(typeof(RibbonWindow), new CommandBinding(_maximizeWindowCommand, MaximizeWindowExecuted, MaximizeWindowCanExecute));
+            CommandManager.RegisterClassCommandBinding(typeof(RibbonWindow), new CommandBinding(_restoreWindowCommand, RestoreWindowExecuted, RestoreWindowCanExecute));
+            CommandManager.RegisterClassCommandBinding(typeof(RibbonWindow), new CommandBinding(_closeWindowCommand, CloseWindowExecuted, CloseWindowCanExecute));
+            CommandManager.RegisterClassCommandBinding(typeof(RibbonWindow), new CommandBinding(_showSystemMenuCommand, SystemMenuExecuted, SystemMenuCanExecute));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/CurrentChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/CurrentChangedEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Manager for the CurrentChanged event in the "weak event listener"
@@ -123,14 +123,13 @@ namespace System.ComponentModel
         {
             get
             {
-                Type managerType = typeof(CurrentChangedEventManager);
-                CurrentChangedEventManager manager = (CurrentChangedEventManager)GetCurrentManager(managerType);
+                CurrentChangedEventManager manager = (CurrentChangedEventManager)GetCurrentManager(typeof(CurrentChangedEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new CurrentChangedEventManager();
-                    SetCurrentManager(managerType, manager);
+                    SetCurrentManager(typeof(CurrentChangedEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/CurrentChangingEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/CurrentChangingEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Manager for the CurrentChanging event in the "weak event listener"
@@ -123,14 +123,13 @@ namespace System.ComponentModel
         {
             get
             {
-                Type managerType = typeof(CurrentChangingEventManager);
-                CurrentChangingEventManager manager = (CurrentChangingEventManager)GetCurrentManager(managerType);
+                CurrentChangingEventManager manager = (CurrentChangingEventManager)GetCurrentManager(typeof(CurrentChangingEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new CurrentChangingEventManager();
-                    SetCurrentManager(managerType, manager);
+                    SetCurrentManager(typeof(CurrentChangingEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/ErrorsChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/ErrorsChangedEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Manager for the ErrorsChanged event in the "weak event listener"
@@ -100,14 +100,13 @@ namespace System.ComponentModel
         {
             get
             {
-                Type managerType = typeof(ErrorsChangedEventManager);
-                ErrorsChangedEventManager manager = (ErrorsChangedEventManager)GetCurrentManager(managerType);
+                ErrorsChangedEventManager manager = (ErrorsChangedEventManager)GetCurrentManager(typeof(ErrorsChangedEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new ErrorsChangedEventManager();
-                    SetCurrentManager(managerType, manager);
+                    SetCurrentManager(typeof(ErrorsChangedEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyChangedEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Manager for the PropertyChanged event in the "weak event listener"
@@ -315,14 +315,13 @@ namespace System.ComponentModel
         {
             get
             {
-                Type managerType = typeof(PropertyChangedEventManager);
-                PropertyChangedEventManager manager = (PropertyChangedEventManager)GetCurrentManager(managerType);
+                PropertyChangedEventManager manager = (PropertyChangedEventManager)GetCurrentManager(typeof(PropertyChangedEventManager));
 
                 // at first use, create and register a new manager
                 if (manager == null)
                 {
                     manager = new PropertyChangedEventManager();
-                    SetCurrentManager(managerType, manager);
+                    SetCurrentManager(typeof(PropertyChangedEventManager), manager);
                 }
 
                 return manager;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
@@ -998,7 +998,7 @@ namespace System.Windows
             {
                 // Null values are invalid for value-types
                 if (propertyType.IsValueType &&
-                    !(propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == NullableType))
+                    !(propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(Nullable<>)))
                 {
                     return false;
                 }
@@ -1173,9 +1173,6 @@ namespace System.Windows
 
         // Global, cross-object synchronization
         internal static readonly Lock Synchronized = new();
-
-        // Nullable Type
-        private static Type NullableType = typeof(Nullable<>);
 
         /// <summary>
         ///     Returns the number of all registered properties.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManagerT.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManagerT.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -101,7 +101,6 @@ namespace System.Windows
         // get the event manager for the current thread
         private static WeakEventManager<TEventSource, TEventArgs> CurrentManager(string eventName)
         {
-            Type managerType = typeof(WeakEventManager<TEventSource, TEventArgs>);
             WeakEventManager<TEventSource, TEventArgs> manager = (WeakEventManager<TEventSource, TEventArgs>)GetCurrentManager(typeof(TEventSource), eventName);
 
             // at first use, create and register a new manager

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/AnimationTemplate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/AnimationTemplate.cs
@@ -153,36 +153,34 @@ namespace MS.Internal.MilCodeGen.ResourceModel
                                     /// </summary>
                                     static [[instance.TypeName]]Animation()
                                     {
-                                        Type typeofProp = typeof([[propertyTypeName]]);
-                                        Type typeofThis = typeof([[instance.TypeName]]Animation);
                                         PropertyChangedCallback propCallback = new PropertyChangedCallback(AnimationFunction_Changed);
                                         ValidateValueCallback validateCallback = new ValidateValueCallback(ValidateFromToOrByValue);
                                         
                                         FromProperty = DependencyProperty.Register(
                                             "From",
-                                            typeofProp,
-                                            typeofThis,
+                                            typeof([[propertyTypeName]]),
+                                            typeof([[instance.TypeName]]Animation),
                                             new PropertyMetadata(([[propertyTypeName]])null, propCallback),
                                             validateCallback);
                                         
                                         ToProperty = DependencyProperty.Register(
                                             "To",
-                                            typeofProp,
-                                            typeofThis,
+                                            typeof([[propertyTypeName]]),
+                                            typeof([[instance.TypeName]]Animation),
                                             new PropertyMetadata(([[propertyTypeName]])null, propCallback),
                                             validateCallback);
                                         
                                         ByProperty = DependencyProperty.Register(
                                             "By",
-                                            typeofProp,
-                                            typeofThis,
+                                            typeof([[propertyTypeName]]),
+                                            typeof([[instance.TypeName]]Animation),
                                             new PropertyMetadata(([[propertyTypeName]])null, propCallback),
                                             validateCallback);
 
                                         EasingFunctionProperty = DependencyProperty.Register(
                                             "EasingFunction",
                                             typeof(IEasingFunction),
-                                            typeofThis);
+                                            typeof([[instance.TypeName]]Animation));
                                     }
                                     
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/Elements.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/Elements.cs
@@ -65,8 +65,6 @@ namespace MS.Internal.MilCodeGen.Generators
                             {
                                 public partial class [[e.Name]] [[(e.ImplementsIAnimatable ? ": IAnimatable" : "")]]
                                 {
-                                    static private readonly Type _typeofThis = typeof([[e.Name]]);
-
                                     [[(e.ImplementsIAnimatable ? IAnimatableHelper.WriteImplementation() : "")]]
 
                                     [[WriteCommands(e)]]
@@ -628,7 +626,7 @@ namespace MS.Internal.MilCodeGen.Generators
                     cs.WriteBlock(
                         [[inline]]
                             [[property.Name]]PropertyKey.OverrideMetadata(
-                                                _typeofThis,
+                                                typeof([[element.Name]]),
                                                 [[WritePropertyMetadata(property)]]);
                         [[/inline]]);
                 }
@@ -792,7 +790,7 @@ namespace MS.Internal.MilCodeGen.Generators
                             /// <summary>
                             ///     Declaration of the routed event reporting [[evt.Comment]]
                             /// </summary>
-                            public static readonly RoutedEvent [[evt.AliasedRoutedEventName]] = EventManager.RegisterRoutedEvent("[[evt.ClrEventName]]", RoutingStrategy.Direct, typeof([[evt.HandlerType]]), _typeofThis);
+                            public static readonly RoutedEvent [[evt.AliasedRoutedEventName]] = EventManager.RegisterRoutedEvent("[[evt.ClrEventName]]", RoutingStrategy.Direct, typeof([[evt.HandlerType]]), typeof([[element.Name]]));
                         [[/inline]]);
                 }
                 else
@@ -803,7 +801,7 @@ namespace MS.Internal.MilCodeGen.Generators
                             /// <summary>
                             ///     Alias to the [[evt.RoutedEventName]].
                             /// </summary>
-                            public static readonly RoutedEvent [[evt.AliasedRoutedEventName]] = [[evt.RoutedEventName]].AddOwner(_typeofThis);
+                            public static readonly RoutedEvent [[evt.AliasedRoutedEventName]] = [[evt.RoutedEventName]].AddOwner(typeof([[element.Name]]));
                         [[/inline]]);
                 }
 
@@ -886,7 +884,7 @@ namespace MS.Internal.MilCodeGen.Generators
                                         DependencyProperty.RegisterReadOnly(
                                                     "[[property.PropertyName]]",
                                                     typeof([[property.Type]]),
-                                                    _typeofThis,
+                                                    typeof([[element.Name]]),
                                                     [[WritePropertyMetadata(property)]]);
                         [[/inline]]);
                 }
@@ -911,7 +909,7 @@ namespace MS.Internal.MilCodeGen.Generators
                 {
                     cs.WriteBlock(
                         [[inline]]
-                            public static readonly DependencyProperty [[property.PropertyName]]Property = [[property.Name]]Property.AddOwner(_typeofThis);
+                            public static readonly DependencyProperty [[property.PropertyName]]Property = [[property.Name]]Property.AddOwner(typeof([[element.Name]]));
                         [[/inline]]);
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/ManagedResource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/ManagedResource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1002,7 +1002,7 @@ namespace MS.Internal.MilCodeGen.Generators
                         [[field.DPPropertyName]] =
                               RegisterProperty("[[field.PropertyName]]",
                                                typeof([[field.Type.ManagedName]]),
-                                               typeofThis,
+                                               typeof([[resource.Name]]),
                                                [[GetDefaultValue(field)]],
                                                [[propertyChangedCallback]],
                     [[/inline]]
@@ -1225,7 +1225,7 @@ namespace MS.Internal.MilCodeGen.Generators
             string staticCtorText = _staticCtorText.ToString();
             if (resource.UseStaticInitialize)
             {
-                staticCtorText = "StaticInitialize(typeofThis);\n" + staticCtorText;
+                staticCtorText = "StaticInitialize();\n\n" + staticCtorText;
             }
             
             if (!cs.IsEmpty || !_staticCtorText.IsEmpty)
@@ -1241,7 +1241,6 @@ namespace MS.Internal.MilCodeGen.Generators
                             [[cs]]
 
                             // Initializations
-                            Type typeofThis = typeof([[resource.Name]]);
                             [[staticCtorText]]
                         }
 


### PR DESCRIPTION
## Description

There are a lot of instances, mostly in generated code, that we cache the result of the `typeof(T)`. This is basically an anti-pattern for a few versions now as `typeof` is a JIT-time constant and the data is stored on the frozen heap.

Previously it was a cool optimization, now it is actually a de-optimization that increases code size and in some cases results in having additional fields stored. What this PR will mostly do is speed up the static init of core objects.

First commit contains generated changes via `MilCodeGen`, second/third are manual replacements which could use a review.

## Customer Impact

Decreased code size, slightly improved performance on startup.

## Regression

No.

## Testing

Local build.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10715)