### PR TITLE
[StyleCleanUp] Static holder types should be `static` or `sealed` (CA1052)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -17,9 +17,6 @@ csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 # CA1036: Override methods on comparable types
 dotnet_diagnostic.CA1036.severity = suggestion
 
-# CA1052: Static holder types should be Static or NotInheritable
-dotnet_diagnostic.CA1052.severity = suggestion
-
 # NOTE: If existing public API, CA1066 should be suppressed individually
 # in the GlobalSuppressions file.
 

--- a/src/Microsoft.DotNet.Wpf/src/Common/Graphics/wgx_core_types.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/Graphics/wgx_core_types.cs
@@ -780,7 +780,7 @@ internal enum MILCMD
 #endif
 };
 
-    internal partial class DUCE
+    internal static partial class DUCE
     {
         //
         // The MILCE resource type enumeration.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/Win32/UnsafeNativeMethodsPointer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/Win32/UnsafeNativeMethodsPointer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -14,7 +14,7 @@ namespace MS.Win32.Pointer
     /// For WM_POINTER <see cref="https://msdn.microsoft.com/en-us/library/windows/desktop/hh454916(v=vs.85).aspx"/>
     /// For InteractionContext <see cref="https://msdn.microsoft.com/en-us/library/windows/desktop/hh448840(v=vs.85).aspx"/>
     /// </summary>
-    internal class UnsafeNativeMethods
+    internal static class UnsafeNativeMethods
     {
         #region Enumerations
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/Compress.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/Compress.cs
@@ -1,11 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //#define OLD_ISF
 
 namespace MS.Internal.Ink.InkSerializedFormat
 {
-    internal class Compressor 
+    internal static class Compressor 
 #if OLD_ISF
         : IDisposable
 #endif

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/MediaTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/MediaTrace.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace MS.Internal
@@ -25,7 +25,7 @@ namespace MS.Internal
         public static MediaTrace QueueItems = new MediaTrace("MILQueueItems");
         public static MediaTrace Statistics = new MediaTrace("Statistics");
         
-        public class ChangeQueue
+        public static class ChangeQueue
         {
             public static MediaTrace ApplyChange = new MediaTrace("Change queue: Apply Change");
             public static MediaTrace Enqueue = new MediaTrace("Change queue: Enqueue");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerStylusPointPropertyInfoHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerStylusPointPropertyInfoHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -9,7 +9,7 @@ namespace System.Windows.Input.StylusPointer
     /// <summary>
     /// Contains a WM_POINTER specific functions to parse out stylus property info
     /// </summary>
-    internal class PointerStylusPointPropertyInfoHelper
+    internal static class PointerStylusPointPropertyInfoHelper
     {
         #region Constants
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionHelper.cs
@@ -26,24 +26,9 @@ namespace MS.Internal.Annotations.Anchoring
     ///     represent these TextAnchors and can generate TextAnchors from
     ///     the locator parts.
     /// </summary>  
-    internal class TextSelectionHelper
+    internal static class TextSelectionHelper
     {
-        //------------------------------------------------------
-        //
-        //  Constructors
-        //
-        //------------------------------------------------------
 
-        #region Constructors
-
-        /// <summary>
-        /// This ctor is added to prevent the compiler from
-        /// generating a public default ctor. This class
-        /// should not be instantiated
-        /// </summary>
-        private TextSelectionHelper() { }
-
-        #endregion Constructors
 
         //------------------------------------------------------
         //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/ActiveXHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/ActiveXHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -19,7 +19,7 @@ namespace MS.Internal.Controls
     // It also has types that make sense only for ActiveX hosting classes.
     // In other words, this is a helper class for the ActiveX hosting classes.
     //
-    internal class ActiveXHelper
+    internal static class ActiveXHelper
     {
         //
         // Types:
@@ -55,11 +55,6 @@ namespace MS.Internal.Controls
         private static int logPixelsX = -1;
         private static int logPixelsY = -1;
         private const int HMperInch = 2540;
-
-        // Prevent compiler from generating public CTOR
-        private ActiveXHelper()
-        {
-        }
 
         //
         // Static helper methods:

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/ExceptionHelpers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/ExceptionHelpers.cs
@@ -372,7 +372,7 @@ namespace WinRT
         }
     }
 
-    internal class ErrorStrings
+    internal static class ErrorStrings
     {
         internal static string Format(string format, params object[] args) => String.Format(format, args);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/Marshalers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/Marshalers.cs
@@ -603,7 +603,7 @@ namespace WinRT
         }
     }
 
-    internal class MarshalInterfaceHelper<T>
+    internal static class MarshalInterfaceHelper<T>
     {
         internal struct MarshalerArray
         {
@@ -974,7 +974,7 @@ namespace WinRT
         public static unsafe void DisposeAbiArray(object box) => MarshalInterfaceHelper<object>.DisposeAbiArray(box);
     }
 
-    internal class Marshaler<T>
+    internal static class Marshaler<T>
     {
         static Marshaler()
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/MsSpellCheckLib/RCW.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/MsSpellCheckLib/RCW.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Documents
 {
     namespace MsSpellCheckLib
     {
-        internal class RCW
+        internal static class RCW
         {
             #region WORDLIST_TYPE
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextTreeDumper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextTreeDumper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -16,22 +16,8 @@ namespace System.Windows.Documents
     //  TextTreeDumper.DumpTree(texttree);
     //  TextTreeDumper.DumpNode(someNode);
     //
-    internal class TextTreeDumper
+    internal static class TextTreeDumper
     {
-        //------------------------------------------------------
-        //
-        //  Constructors
-        //
-        //------------------------------------------------------
-
-    #region Constructors
- 
-        // Static class.
-        private TextTreeDumper()
-        {
-        }
-
-        #endregion Constructors
 
         //------------------------------------------------------
         //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/WpfXamlLoader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/WpfXamlLoader.cs
@@ -12,7 +12,7 @@ using System.Windows.Data;
 
 namespace System.Windows.Markup
 {
-    internal class WpfXamlLoader
+    internal static class WpfXamlLoader
     {
         private static Lazy<XamlMember> XmlSpace = new Lazy<XamlMember>(() => new WpfXamlMember(XmlAttributeProperties.XmlSpaceProperty, true));
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrintSchema.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrintSchema.cs
@@ -1864,10 +1864,8 @@ namespace MS.Internal.Printing.Configuration
     /// <summary>
     /// Internal class to hold standard namespaces used by Print Schema
     /// </summary>
-    internal class PrintSchemaNamespaces
+    internal static class PrintSchemaNamespaces
     {
-        private PrintSchemaNamespaces() {}
-
         public const string Framework = "http://schemas.microsoft.com/windows/2003/08/printing/printschemaframework";
         public const string StandardKeywordSet = "http://schemas.microsoft.com/windows/2003/08/printing/printschemakeywords";
         public const string xsi = "http://www.w3.org/2001/XMLSchema-instance";
@@ -1883,10 +1881,8 @@ namespace MS.Internal.Printing.Configuration
     /// <summary>
     /// Internal class to hold prefixes for Print Schema standard namespaces
     /// </summary>
-    internal class PrintSchemaPrefixes
+    internal static class PrintSchemaPrefixes
     {
-        private PrintSchemaPrefixes() {}
-
         public const string Framework =             "psf";
         public const string StandardKeywordSet =    "psk";
         public const string xsi =                   "xsi";
@@ -1897,10 +1893,8 @@ namespace MS.Internal.Printing.Configuration
     /// <summary>
     /// Internal class to hold const strings for standard xsi types
     /// </summary>
-    internal class PrintSchemaXsiTypes
+    internal static class PrintSchemaXsiTypes
     {
-        private PrintSchemaXsiTypes() {}
-
         public const string Integer = "integer";
         public const string String =  "string";
         public const string QName =   "QName";
@@ -1909,10 +1903,8 @@ namespace MS.Internal.Printing.Configuration
     /// <summary>
     /// Internal class to hold public Print Schema constant keywords
     /// </summary>
-    internal class PrintSchemaTags
+    internal static class PrintSchemaTags
     {
-        private PrintSchemaTags() {}
-
         internal struct MapEntry
         {
             public string SchemaName;
@@ -1924,10 +1916,8 @@ namespace MS.Internal.Printing.Configuration
             }
         }
 
-        internal class Framework
+        internal static class Framework
         {
-            private Framework() {}
-
             internal const decimal SchemaVersion = 1;
 
             internal const string PrintTicketRoot =   "PrintTicket";
@@ -1969,34 +1959,26 @@ namespace MS.Internal.Printing.Configuration
                 "</" + PrintSchemaPrefixes.Framework + ":" + PrintSchemaTags.Framework.PrintTicketRoot + ">";
         }
 
-        internal class Keywords
+        internal static class Keywords
         {
-            private Keywords() {}
-
-            internal class CollateKeys
+            internal static class CollateKeys
             {
-                private CollateKeys() { }
-
                 internal const string DocumentCollate = "DocumentCollate";
 
                 internal static string[] CollationNames = Enum.GetNames(typeof(Collation));
                 internal static int[] CollationEnums = (int[])(Array)Enum.GetValues<Collation>();
             }
 
-            internal class DuplexKeys
+            internal static class DuplexKeys
             {
-                private DuplexKeys() { }
-
                 internal const string JobDuplex = "JobDuplexAllDocumentsContiguously";
 
                 internal static string[] DuplexNames = Enum.GetNames(typeof(Duplexing));
                 internal static int[] DuplexEnums = (int[])(Array)Enum.GetValues<Duplexing>();
             }
 
-            internal class NUpKeys
+            internal static class NUpKeys
             {
-                private NUpKeys() {}
-
                 internal const string JobNUp = "JobNUpAllDocumentsContiguously";
                 internal const string PagesPerSheet = "PagesPerSheet";
                 internal const string PresentationDirection = "PresentationDirection";
@@ -2005,30 +1987,24 @@ namespace MS.Internal.Printing.Configuration
                 internal static int[] DirectionEnums = (int[])(Array)Enum.GetValues<PagesPerSheetDirection>();
             }
 
-            internal class StapleKeys
+            internal static class StapleKeys
             {
-                private StapleKeys() {}
-
                 internal const string JobStaple = "JobStapleAllDocuments";
 
                 internal static string[] StaplingNames = Enum.GetNames(typeof(Stapling));
                 internal static int[] StaplingEnums = (int[])(Array)Enum.GetValues<Stapling>();
             }
 
-            internal class PageDeviceFontSubstitutionKeys
+            internal static class PageDeviceFontSubstitutionKeys
             {
-                private PageDeviceFontSubstitutionKeys() {}
-
                 internal const string Self = "PageDeviceFontSubstitution";
 
                 internal static string[] SubstitutionNames = Enum.GetNames(typeof(DeviceFontSubstitution));
                 internal static int[] SubstitutionEnums = (int[])(Array)Enum.GetValues<DeviceFontSubstitution>();
             }
 
-            internal class PageMediaSizeKeys
+            internal static class PageMediaSizeKeys
             {
-                private PageMediaSizeKeys() { }
-
                 internal const string Self =                  "PageMediaSize";
                 internal const string MediaSizeWidth        = "MediaSizeWidth";
                 internal const string MediaSizeHeight       = "MediaSizeHeight";
@@ -2044,10 +2020,8 @@ namespace MS.Internal.Printing.Configuration
                 internal static int[] MediaSizeEnums = (int[])(Array)Enum.GetValues<PageMediaSizeName>();
             }
 
-            internal class PageImageableSizeKeys
+            internal static class PageImageableSizeKeys
             {
-                private PageImageableSizeKeys() { }
-
                 internal const string Self                   = "PageImageableSize";
                 internal const string ImageableSizeWidth     = "ImageableSizeWidth";
                 internal const string ImageableSizeHeight    = "ImageableSizeHeight";
@@ -2060,40 +2034,32 @@ namespace MS.Internal.Printing.Configuration
                 internal const string ExtentHeight       =     "ExtentHeight";
             }
 
-            internal class PageMediaTypeKeys
+            internal static class PageMediaTypeKeys
             {
-                private PageMediaTypeKeys() {}
-
                 internal const string Self =         "PageMediaType";
 
                 internal static string[] MediaTypeNames = Enum.GetNames(typeof(PageMediaType));
                 internal static int[] MediaTypeEnums = (int[])(Array)Enum.GetValues<PageMediaType>();
             }
 
-            internal class PageOrientationKeys
+            internal static class PageOrientationKeys
             {
-                private PageOrientationKeys() {}
-
                 internal const string Self = "PageOrientation";
 
                 internal static string[] OrientationNames = Enum.GetNames(typeof(PageOrientation));
                 internal static int[] OrientationEnums = (int[])(Array)Enum.GetValues<PageOrientation>();
             }
 
-            internal class PageOutputColorKeys
+            internal static class PageOutputColorKeys
             {
-                private PageOutputColorKeys() {}
-
                 internal const string Self =   "PageOutputColor";
 
                 internal static string[] ColorNames = Enum.GetNames(typeof(OutputColor));
                 internal static int[] ColorEnums = (int[])(Array)Enum.GetValues<OutputColor>();
             }
 
-            internal class PageResolutionKeys
+            internal static class PageResolutionKeys
             {
-                private PageResolutionKeys() {}
-
                 internal const string Self =                  "PageResolution";
                 internal const string ResolutionX =           "ResolutionX";
                 internal const string ResolutionY =           "ResolutionY";
@@ -2103,10 +2069,8 @@ namespace MS.Internal.Printing.Configuration
                 internal static int[] QualityEnums = (int[])(Array)Enum.GetValues<PageQualitativeResolution>();
             }
 
-            internal class PageScalingKeys
+            internal static class PageScalingKeys
             {
-                private PageScalingKeys() { }
-
                 internal const string Self =               "PageScaling";
                 internal const string CustomScaleWidth   = "ScaleWidth";
                 internal const string CustomScaleHeight  = "ScaleHeight";
@@ -2116,60 +2080,48 @@ namespace MS.Internal.Printing.Configuration
                 internal static int[] ScalingEnums = (int[])(Array)Enum.GetValues<PageScaling>();
             }
 
-            internal class PageTrueTypeFontModeKeys
+            internal static class PageTrueTypeFontModeKeys
             {
-                private PageTrueTypeFontModeKeys() { }
-
                 internal const string Self = "PageTrueTypeFontMode";
 
                 internal static string[] ModeNames = Enum.GetNames(typeof(TrueTypeFontMode));
                 internal static int[] ModeEnums = (int[])(Array)Enum.GetValues<TrueTypeFontMode>();
             }
 
-            internal class JobPageOrderKeys
+            internal static class JobPageOrderKeys
             {
-                private JobPageOrderKeys() { }
-
                 internal const string Self = "JobPageOrder";
 
                 internal static string[] PageOrderNames = Enum.GetNames(typeof(PageOrder));
                 internal static int[] PageOrderEnums = (int[])(Array)Enum.GetValues<PageOrder>();
             }
 
-            internal class PagePhotoPrintingIntentKeys
+            internal static class PagePhotoPrintingIntentKeys
             {
-                private PagePhotoPrintingIntentKeys() { }
-
                 internal const string Self = "PagePhotoPrintingIntent";
 
                 internal static string[] PhotoIntentNames = Enum.GetNames(typeof(PhotoPrintingIntent));
                 internal static int[] PhotoIntentEnums = (int[])(Array)Enum.GetValues<PhotoPrintingIntent>();
             }
 
-            internal class PageBorderlessKeys
+            internal static class PageBorderlessKeys
             {
-                private PageBorderlessKeys() { }
-
                 internal const string Self = "PageBorderless";
 
                 internal static string[] BorderlessNames = Enum.GetNames(typeof(PageBorderless));
                 internal static int[] BorderlessEnums = (int[])(Array)Enum.GetValues<PageBorderless>();
             }
 
-            internal class PageOutputQualityKeys
+            internal static class PageOutputQualityKeys
             {
-                private PageOutputQualityKeys() { }
-
                 internal const string Self = "PageOutputQuality";
 
                 internal static string[] OutputQualityNames = Enum.GetNames(typeof(OutputQuality));
                 internal static int[] OutputQualityEnums = (int[])(Array)Enum.GetValues<OutputQuality>();
             }
 
-            internal class InputBinKeys
+            internal static class InputBinKeys
             {
-                private InputBinKeys() { }
-
                 internal const string JobInputBin = "JobInputBin";
                 internal const string DocumentInputBin = "DocumentInputBin";
                 internal const string PageInputBin = "PageInputBin";
@@ -2178,19 +2130,15 @@ namespace MS.Internal.Printing.Configuration
                 internal static int[] InputBinEnums = (int[])(Array)Enum.GetValues<InputBin>();
             }
 
-            internal class ParameterProps
+            internal static class ParameterProps
             {
-                private ParameterProps() {}
-
                 internal const string DefaultValue = "DefaultValue";
                 internal const string MinValue =     "MinValue";
                 internal const string MaxValue =     "MaxValue";
             }
 
-            internal class ParameterDefs
+            internal static class ParameterDefs
             {
-                private ParameterDefs() {}
-
                 internal const string JobCopyCount = "JobCopiesAllDocuments";
 
                 // for non-PS custom media size.
@@ -2245,9 +2193,8 @@ namespace MS.Internal.Printing.Configuration
         }
     }
 
-    internal class UnitConverter
+    internal static class UnitConverter
     {
-        private UnitConverter() {}
 
         /// <summary>
         /// Converts internal micron length value to DIP length value (in 1/96 inch unit).

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrtCap_Reader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrtCap_Reader.cs
@@ -511,14 +511,9 @@ namespace MS.Internal.Printing.Configuration
     /// <summary>
     /// QName helper class for XMLTextReader
     /// </summary>
-    internal class XmlReaderQName
+    internal static class XmlReaderQName
     {
-        #region Constructors
 
-        // Never need to use an instance. All static methods.
-        private XmlReaderQName() {}
-
-        #endregion Constructors
 
         #region Public Methods
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrtTicket_Editor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrtTicket_Editor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /*++
@@ -17,11 +17,10 @@ using System.Globalization;
 
 namespace MS.Internal.Printing.Configuration
 {
-    internal class PrintTicketEditor
+    internal static class PrintTicketEditor
     {
-        #region Constructors
 
-        private PrintTicketEditor() {}
+        #region Constructors
 
         #endregion Constructors
 
@@ -405,11 +404,10 @@ namespace MS.Internal.Printing.Configuration
         #endregion Private Methods
     }
 
-    internal class XmlDocQName
+    internal static class XmlDocQName
     {
-        #region Constructors
 
-        private XmlDocQName() {}
+        #region Constructors
 
         #endregion Constructors
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsLiterals.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsLiterals.cs
@@ -16,14 +16,8 @@ using MS.Internal;
 
 namespace System.Windows.Xps.Packaging
 {
-    internal class XpsNamedProperties
+    internal static class XpsNamedProperties
     {
-        private
-        XpsNamedProperties(
-            )
-        {
-        }
-
         public
         static
         String
@@ -56,7 +50,7 @@ namespace System.Windows.Xps.Packaging
         String  _clrProperty         = "Property";
     };
 
-    internal class XpsS0Markup
+    internal static class XpsS0Markup
     {
         public
         static
@@ -1233,14 +1227,8 @@ namespace System.Windows.Xps.Packaging
         string  _versionExtensiblityNamespace           ="http://schemas.openxmlformats.org/markup-compatibility/2006";
     };
 
-    internal class XmlTags
+    internal static class XmlTags
     {
-        private
-        XmlTags(
-            )
-        {
-        }
-
         public
         static
         String

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/TextServicesLoader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/TextServicesLoader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -30,21 +30,9 @@ namespace MS.Internal
 {
     // Creates ITfThreadMgr instances, the root object of the Text Services
     // Framework.
-    internal class TextServicesLoader
+    internal static class TextServicesLoader
     {
-        //------------------------------------------------------
-        //
-        //  Constructors
-        //
-        //------------------------------------------------------
 
-        #region Constructors
-
-        // Private ctor to prevent anyone from instantiating this static class.
-        private TextServicesLoader() {}
-
-        #endregion Constructors
- 
         //------------------------------------------------------
         //
         //  Public Methods
@@ -68,7 +56,7 @@ namespace MS.Internal
         //  Protected Methods
         //
         //------------------------------------------------------
- 
+
         //------------------------------------------------------
         //
         //  Internal Methods
@@ -82,7 +70,7 @@ namespace MS.Internal
         //------------------------------------------------------
 
         #region Internal Properties
-        
+
         /// <summary>
         /// Loads an instance of the Text Services Framework.
         /// </summary>

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsOther.cs
@@ -8,7 +8,7 @@ using Microsoft.Win32.SafeHandles;
 
 namespace MS.Win32
 {
-    internal partial class NativeMethods
+    internal static partial class NativeMethods
     {
         // Translates Win32 error codes into HRESULTs.
         public static int MakeHRFromErrorCode(int errorCode)

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
@@ -39,7 +39,7 @@ using MS.Internal.Drt;
 
 namespace MS.Win32
 {
-    internal partial class UnsafeNativeMethods
+    internal static partial class UnsafeNativeMethods
     {
 
         [DllImport(ExternDll.Uxtheme, CharSet = CharSet.Auto, BestFitMapping = false)]

--- a/src/Microsoft.DotNet.Wpf/src/Shared/Telemetry/Managed/EventSourceActivity.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/Telemetry/Managed/EventSourceActivity.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.Tracing;
@@ -351,26 +351,21 @@ namespace MS.Internal.Telemetry
         }
 
         [EventData]
-        private class EmptyStruct
+        private sealed class EmptyStruct
         {
-            private EmptyStruct()
-            {
-
-            }
+            private EmptyStruct() { }
 
             internal static EmptyStruct Instance
             {
                 get
                 {
-                    if (_instance == null)
-                    {
-                        _instance = new EmptyStruct();
-                    }
-                    return _instance;
+                    s_instance ??= new EmptyStruct();
+
+                    return s_instance;
                 }
             }
 
-            private static EmptyStruct _instance;
+            private static EmptyStruct s_instance;
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Win32/externdll.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Win32/externdll.cs
@@ -1,14 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace MS.Win32
 {
-    internal class ExternDll
+    internal static class ExternDll
     {
-        // To appease the FxCop
-        private ExternDll()
-        { }
-
         internal const string Gdiplus = "gdiplus.dll";
         internal const string User32 = "user32.dll";
         internal const string Shfolder = "shfolder.dll";

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackagingExtensions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackagingExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO.Packaging;
@@ -16,7 +16,7 @@ namespace MS.Internal.IO.Packaging.Extensions
         }
     }
     
-    internal class PackageRelationship
+    internal static class PackageRelationship
     {
         public static Uri ContainerRelationshipPartName => System.IO.Packaging.PackUriHelper.CreatePartUri(new Uri("/_rels/.rels", UriKind.Relative));
     }


### PR DESCRIPTION
Currently blocked via #10680 hence draft.

Fixes #10717 

## Description

Fixes classes (usually) with private ctors to be `static` or `sealed` (in case of singletons).

## Customer Impact

Cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low, these are all `internal` classes.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10718)