### PR TITLE
Swap Dictionary<K, V> with HashSet<ICyclicBrush> in TreeWalkProgress

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/TreeWalkProgress.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/TreeWalkProgress.cs
@@ -1,36 +1,29 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/*++
-
-    Abstract:
-        This file implements the TreeWalkProgress
-        used by the Xps Serialization APIs for tracking cycles in a visual tree.
---*/
 using System.Windows.Media;
 
-namespace System.Windows.Xps.Serialization
+namespace System.Windows.Xps.Serialization;
+
+/// <summary>
+/// This class is used by the Xps Serialization APIs for tracking cycles in a visual tree.
+/// </summary>
+internal sealed class TreeWalkProgress
 {
-    /// <summary>
-    /// This class is used by the Xps Serialization APIs for tracking cycles in a visual tree.
-    /// </summary>
-    internal sealed class TreeWalkProgress
+    private readonly HashSet<ICyclicBrush> _cyclicBrushes = new();
+
+    public bool EnterTreeWalk(ICyclicBrush brush)
     {
-        private readonly HashSet<ICyclicBrush> _cyclicBrushes = new();
+        return _cyclicBrushes.Add(brush);
+    }
 
-        public bool EnterTreeWalk(ICyclicBrush brush)
-        {
-            return _cyclicBrushes.Add(brush);
-        }
+    public void ExitTreeWalk(ICyclicBrush brush)
+    {
+        _cyclicBrushes.Remove(brush);
+    }
 
-        public void ExitTreeWalk(ICyclicBrush brush)
-        {
-            _cyclicBrushes.Remove(brush);
-        }
-
-        public bool IsTreeWalkInProgress(ICyclicBrush brush)
-        {
-            return _cyclicBrushes.Contains(brush);
-        }
+    public bool IsTreeWalkInProgress(ICyclicBrush brush)
+    {
+        return _cyclicBrushes.Contains(brush);
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/TreeWalkProgress.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/TreeWalkProgress.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /*++
@@ -15,15 +15,17 @@ namespace System.Windows.Xps.Serialization
     /// This class  is used by the Xps Serialization APIs for tracking cycles in a visual tree.
     /// </summary>
     internal class TreeWalkProgress
-    {        
+    {
+        private readonly HashSet<ICyclicBrush> _cyclicBrushes = new();
+
         public bool EnterTreeWalk(ICyclicBrush brush)
         {
-            if(this._cyclicBrushes.ContainsKey(brush))
+            if(this._cyclicBrushes.Contains(brush))
             {
                 return false;
             }
             
-            this._cyclicBrushes.Add(brush, EmptyStruct.Default);
+            this._cyclicBrushes.Add(brush);
             return true;
         }
             
@@ -34,18 +36,7 @@ namespace System.Windows.Xps.Serialization
             
         public bool IsTreeWalkInProgress(ICyclicBrush brush)
         {
-            return this._cyclicBrushes.ContainsKey(brush);
-        }
-        
-        // We use the keys of this dictionary to simulate a set
-        // We do not use HashSet<K,V> to avoid a perf regression by loading System.Core.dll
-        // It also makes the fix easier to backport to pre .net 3.5 releases
-        private IDictionary<ICyclicBrush, EmptyStruct> _cyclicBrushes = new Dictionary<ICyclicBrush, EmptyStruct>();
-        
-        // A struct that when optimized does not consume per instance heap\stack space 
-        private struct EmptyStruct
-        {
-            public static EmptyStruct Default = new EmptyStruct();
+            return this._cyclicBrushes.Contains(brush);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/TreeWalkProgress.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/TreeWalkProgress.cs
@@ -12,21 +12,15 @@ using System.Windows.Media;
 namespace System.Windows.Xps.Serialization
 {
     /// <summary>
-    /// This class  is used by the Xps Serialization APIs for tracking cycles in a visual tree.
+    /// This class is used by the Xps Serialization APIs for tracking cycles in a visual tree.
     /// </summary>
-    internal class TreeWalkProgress
+    internal sealed class TreeWalkProgress
     {
         private readonly HashSet<ICyclicBrush> _cyclicBrushes = new();
 
         public bool EnterTreeWalk(ICyclicBrush brush)
         {
-            if (_cyclicBrushes.Contains(brush))
-            {
-                return false;
-            }
-
-            _cyclicBrushes.Add(brush);
-            return true;
+            return _cyclicBrushes.Add(brush);
         }
 
         public void ExitTreeWalk(ICyclicBrush brush)

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/TreeWalkProgress.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/TreeWalkProgress.cs
@@ -20,23 +20,23 @@ namespace System.Windows.Xps.Serialization
 
         public bool EnterTreeWalk(ICyclicBrush brush)
         {
-            if(this._cyclicBrushes.Contains(brush))
+            if (_cyclicBrushes.Contains(brush))
             {
                 return false;
             }
-            
-            this._cyclicBrushes.Add(brush);
+
+            _cyclicBrushes.Add(brush);
             return true;
         }
-            
+
         public void ExitTreeWalk(ICyclicBrush brush)
         {
-            this._cyclicBrushes.Remove(brush);
+            _cyclicBrushes.Remove(brush);
         }
-            
+
         public bool IsTreeWalkInProgress(ICyclicBrush brush)
         {
-            return this._cyclicBrushes.Contains(brush);
+            return _cyclicBrushes.Contains(brush);
         }
     }
 }


### PR DESCRIPTION
## Description

Swaps `Dictionary<ICyclicBrush, EmptyStruct>` with `HashSet<ICyclicBrush>` for improved performance and decreased allocations. The conditions under which this was written do no longer apply.

Also removes the double lookup on addition.

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build.

## Risk

Low.
