### PR TITLE
Adding more MessageBox buttons and result values

### DIFF
--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
@@ -984,8 +984,8 @@ namespace System.Windows
         OK = 0,
         OKCancel = 1,
         RetryCancel = 5,
-        YesNoCancel = 3,
         YesNo = 4,
+        YesNoCancel = 3,
     }
     public enum MessageBoxImage
     {
@@ -2067,7 +2067,7 @@ namespace System.Windows
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.ThemeModeConverter))]
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("WPF0001")]
         public System.Windows.ThemeMode ThemeMode { get { throw null; } set { } }
-        
+
         [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Title)]
         public string Title { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute("System.Windows.LengthConverter, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, Custom=null")]

--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
@@ -183,7 +183,7 @@ namespace System.Windows
         bool System.Windows.Markup.IQueryAmbient.IsAmbientPropertyAvailable(string propertyName) { throw null; }
         public object TryFindResource(object resourceKey) { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Method, AllowMultiple=false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Method, AllowMultiple = false)]
     public sealed partial class AttachedPropertyBrowsableForChildrenAttribute : System.Windows.AttachedPropertyBrowsableAttribute
     {
         public AttachedPropertyBrowsableForChildrenAttribute() { }
@@ -305,19 +305,19 @@ namespace System.Windows
     }
     public partial class DataTemplateKey : System.Windows.TemplateKey
     {
-        public DataTemplateKey() : base (default(System.Windows.TemplateKey.TemplateType)) { }
-        public DataTemplateKey(object dataType) : base (default(System.Windows.TemplateKey.TemplateType)) { }
+        public DataTemplateKey() : base(default(System.Windows.TemplateKey.TemplateType)) { }
+        public DataTemplateKey(object dataType) : base(default(System.Windows.TemplateKey.TemplateType)) { }
     }
     [System.Windows.Markup.ContentPropertyAttribute("Setters")]
     [System.Windows.Markup.XamlSetMarkupExtensionAttribute("ReceiveMarkupExtension")]
     public partial class DataTrigger : System.Windows.TriggerBase, System.Windows.Markup.IAddChild
     {
         public DataTrigger() { }
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         public System.Windows.Data.BindingBase Binding { get { throw null; } set { } }
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Content)]
         public System.Windows.SetterBaseCollection Setters { get { throw null; } }
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         [System.Windows.Markup.DependsOnAttribute("Binding")]
         public object Value { get { throw null; } set { } }
         public static void ReceiveMarkupExtension(object targetObject, System.Windows.Markup.XamlSetMarkupExtensionEventArgs eventArgs) { }
@@ -477,7 +477,7 @@ namespace System.Windows
     [System.Windows.Markup.RuntimeNamePropertyAttribute("Name")]
     [System.Windows.Markup.UsableDuringInitializationAttribute(true)]
     [System.Windows.Markup.XmlLangPropertyAttribute("Language")]
-    [System.Windows.StyleTypedPropertyAttribute(Property="FocusVisualStyle", StyleTargetType=typeof(System.Windows.Controls.Control))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "FocusVisualStyle", StyleTargetType = typeof(System.Windows.Controls.Control))]
     public partial class FrameworkContentElement : System.Windows.ContentElement, System.ComponentModel.ISupportInitialize, System.Windows.IFrameworkInputElement, System.Windows.IInputElement, System.Windows.Markup.IQueryAmbient
     {
         public static readonly System.Windows.DependencyProperty BindingGroupProperty;
@@ -580,7 +580,7 @@ namespace System.Windows
     [System.Windows.Markup.RuntimeNamePropertyAttribute("Name")]
     [System.Windows.Markup.UsableDuringInitializationAttribute(true)]
     [System.Windows.Markup.XmlLangPropertyAttribute("Language")]
-    [System.Windows.StyleTypedPropertyAttribute(Property="FocusVisualStyle", StyleTargetType=typeof(System.Windows.Controls.Control))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "FocusVisualStyle", StyleTargetType = typeof(System.Windows.Controls.Control))]
     public partial class FrameworkElement : System.Windows.UIElement, System.ComponentModel.ISupportInitialize, System.Windows.IFrameworkInputElement, System.Windows.IInputElement, System.Windows.Markup.IQueryAmbient
     {
         public static readonly System.Windows.DependencyProperty ActualHeightProperty;
@@ -636,7 +636,7 @@ namespace System.Windows
         public System.Windows.Style FocusVisualStyle { get { throw null; } set { } }
         public bool ForceCursor { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.LengthConverter))]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         public double Height { get { throw null; } set { } }
         public System.Windows.HorizontalAlignment HorizontalAlignment { get { throw null; } set { } }
         protected internal System.Windows.InheritanceBehavior InheritanceBehavior { get { throw null; } set { } }
@@ -649,16 +649,16 @@ namespace System.Windows
         protected internal virtual System.Collections.IEnumerator LogicalChildren { get { throw null; } }
         public System.Windows.Thickness Margin { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.LengthConverter))]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         public double MaxHeight { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.LengthConverter))]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         public double MaxWidth { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.LengthConverter))]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         public double MinHeight { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.LengthConverter))]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         public double MinWidth { get { throw null; } set { } }
         [System.ComponentModel.MergablePropertyAttribute(false)]
         [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.NeverLocalize)]
@@ -682,7 +682,7 @@ namespace System.Windows
         public System.Windows.VerticalAlignment VerticalAlignment { get { throw null; } set { } }
         protected override int VisualChildrenCount { get { throw null; } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.LengthConverter))]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         public double Width { get { throw null; } set { } }
         public event System.Windows.Controls.ContextMenuEventHandler ContextMenuClosing { add { } remove { } }
         public event System.Windows.Controls.ContextMenuEventHandler ContextMenuOpening { add { } remove { } }
@@ -889,7 +889,7 @@ namespace System.Windows
         public System.Windows.DataTemplate ItemTemplate { get { throw null; } set { } }
         public System.Windows.Controls.DataTemplateSelector ItemTemplateSelector { get { throw null; } set { } }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public enum HorizontalAlignment
     {
         Center = 1,
@@ -979,10 +979,13 @@ namespace System.Windows
     }
     public enum MessageBoxButton
     {
+        AbortRetryIgnore = 2,
+        CancelTryContinue = 6,
         OK = 0,
         OKCancel = 1,
-        YesNo = 4,
+        RetryCancel = 5,
         YesNoCancel = 3,
+        YesNo = 4,
     }
     public enum MessageBoxImage
     {
@@ -1007,10 +1010,15 @@ namespace System.Windows
     }
     public enum MessageBoxResult
     {
+        Abort = 3,
         Cancel = 2,
+        Continue = 11,
+        Ignore = 5,
         No = 7,
         None = 0,
         OK = 1,
+        Retry = 4,
+        TryAgain = 10,
         Yes = 6,
     }
     [System.Windows.Markup.ContentPropertyAttribute("Setters")]
@@ -1037,7 +1045,7 @@ namespace System.Windows
     }
     public partial class NullableBoolConverter : System.ComponentModel.NullableConverter
     {
-        public NullableBoolConverter() : base (default(System.Type)) { }
+        public NullableBoolConverter() : base(default(System.Type)) { }
         public override System.ComponentModel.TypeConverter.StandardValuesCollection GetStandardValues(System.ComponentModel.ITypeDescriptorContext context) { throw null; }
         public override bool GetStandardValuesExclusive(System.ComponentModel.ITypeDescriptorContext context) { throw null; }
         public override bool GetStandardValuesSupported(System.ComponentModel.ITypeDescriptorContext context) { throw null; }
@@ -1077,7 +1085,7 @@ namespace System.Windows
         protected override void InvokeEventHandler(System.Delegate genericHandler, object genericTarget) { }
     }
     public delegate void RequestBringIntoViewEventHandler(object sender, System.Windows.RequestBringIntoViewEventArgs e);
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public enum ResizeMode
     {
         CanMinimize = 1,
@@ -1168,14 +1176,14 @@ namespace System.Windows
         public Setter(System.Windows.DependencyProperty property, object value) { }
         public Setter(System.Windows.DependencyProperty property, object value, string targetName) { }
         [System.ComponentModel.DefaultValueAttribute(null)]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Modifiability=System.Windows.Modifiability.Unmodifiable, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Modifiability = System.Windows.Modifiability.Unmodifiable, Readability = System.Windows.Readability.Unreadable)]
         [System.Windows.Markup.AmbientAttribute]
         public System.Windows.DependencyProperty Property { get { throw null; } set { } }
         [System.ComponentModel.DefaultValueAttribute(null)]
         [System.Windows.Markup.AmbientAttribute]
         public string TargetName { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.Markup.SetterTriggerConditionValueConverter))]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         [System.Windows.Markup.DependsOnAttribute("Property")]
         [System.Windows.Markup.DependsOnAttribute("TargetName")]
         public object Value { get { throw null; } set { } }
@@ -1262,7 +1270,7 @@ namespace System.Windows
         bool System.Windows.Markup.IQueryAmbient.IsAmbientPropertyAvailable(string propertyName) { throw null; }
         public void UnregisterName(string name) { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = true)]
     public sealed partial class StyleTypedPropertyAttribute : System.Attribute
     {
         public StyleTypedPropertyAttribute() { }
@@ -1788,14 +1796,14 @@ namespace System.Windows
             TableTemplate = 1,
         }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = true)]
     public sealed partial class TemplatePartAttribute : System.Attribute
     {
         public TemplatePartAttribute() { }
         public string Name { get { throw null; } set { } }
         public System.Type Type { get { throw null; } set { } }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = true)]
     public sealed partial class TemplateVisualStateAttribute : System.Attribute
     {
         public TemplateVisualStateAttribute() { }
@@ -1843,7 +1851,7 @@ namespace System.Windows
         public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext typeDescriptorContext, System.Globalization.CultureInfo cultureInfo, object value, System.Type destinationType) { throw null; }
     }
     [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.ThicknessConverter))]
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public partial struct Thickness : System.IEquatable<System.Windows.Thickness>
     {
         private int _dummyPrimitive;
@@ -1873,7 +1881,7 @@ namespace System.Windows
     public partial class Trigger : System.Windows.TriggerBase, System.ComponentModel.ISupportInitialize, System.Windows.Markup.IAddChild
     {
         public Trigger() { }
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Modifiability=System.Windows.Modifiability.Unmodifiable, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Modifiability = System.Windows.Modifiability.Unmodifiable, Readability = System.Windows.Readability.Unreadable)]
         [System.Windows.Markup.AmbientAttribute]
         public System.Windows.DependencyProperty Property { get { throw null; } set { } }
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Content)]
@@ -1882,7 +1890,7 @@ namespace System.Windows
         [System.Windows.Markup.AmbientAttribute]
         public string SourceName { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.Markup.SetterTriggerConditionValueConverter))]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         [System.Windows.Markup.DependsOnAttribute("Property")]
         [System.Windows.Markup.DependsOnAttribute("SourceName")]
         public object Value { get { throw null; } set { } }
@@ -1925,7 +1933,7 @@ namespace System.Windows
         void System.Collections.IList.Insert(int index, object value) { }
         void System.Collections.IList.Remove(object value) { }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public abstract partial class TriggerBase : System.Windows.DependencyObject
     {
         internal TriggerBase() { }
@@ -1934,7 +1942,7 @@ namespace System.Windows
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Content)]
         public System.Windows.TriggerActionCollection ExitActions { get { throw null; } }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public sealed partial class TriggerCollection : System.Collections.ObjectModel.Collection<System.Windows.TriggerBase>
     {
         internal TriggerCollection() { }
@@ -1957,7 +1965,7 @@ namespace System.Windows
         public static bool operator ==(System.Windows.ValueSource vs1, System.Windows.ValueSource vs2) { throw null; }
         public static bool operator !=(System.Windows.ValueSource vs1, System.Windows.ValueSource vs2) { throw null; }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public enum VerticalAlignment
     {
         Bottom = 2,
@@ -2113,7 +2121,7 @@ namespace System.Windows
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
         void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public enum WindowStartupLocation
     {
         CenterOwner = 2,
@@ -2353,7 +2361,7 @@ namespace System.Windows.Automation.Peers
 {
     public partial class ButtonAutomationPeer : System.Windows.Automation.Peers.ButtonBaseAutomationPeer, System.Windows.Automation.Provider.IInvokeProvider
     {
-        public ButtonAutomationPeer(System.Windows.Controls.Button owner) : base (default(System.Windows.Controls.Primitives.ButtonBase)) { }
+        public ButtonAutomationPeer(System.Windows.Controls.Button owner) : base(default(System.Windows.Controls.Primitives.ButtonBase)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         public override object GetPattern(System.Windows.Automation.Peers.PatternInterface patternInterface) { throw null; }
@@ -2361,14 +2369,14 @@ namespace System.Windows.Automation.Peers
     }
     public abstract partial class ButtonBaseAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        protected ButtonBaseAutomationPeer(System.Windows.Controls.Primitives.ButtonBase owner) : base (default(System.Windows.FrameworkElement)) { }
+        protected ButtonBaseAutomationPeer(System.Windows.Controls.Primitives.ButtonBase owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override string GetAcceleratorKeyCore() { throw null; }
         protected override string GetAutomationIdCore() { throw null; }
         protected override string GetNameCore() { throw null; }
     }
     public sealed partial class CalendarAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer, System.Windows.Automation.Provider.IGridProvider, System.Windows.Automation.Provider.IItemContainerProvider, System.Windows.Automation.Provider.IMultipleViewProvider, System.Windows.Automation.Provider.ISelectionProvider, System.Windows.Automation.Provider.ITableProvider
     {
-        public CalendarAutomationPeer(System.Windows.Controls.Calendar owner) : base (default(System.Windows.FrameworkElement)) { }
+        public CalendarAutomationPeer(System.Windows.Controls.Calendar owner) : base(default(System.Windows.FrameworkElement)) { }
         int System.Windows.Automation.Provider.IGridProvider.ColumnCount { get { throw null; } }
         int System.Windows.Automation.Provider.IGridProvider.RowCount { get { throw null; } }
         int System.Windows.Automation.Provider.IMultipleViewProvider.CurrentView { get { throw null; } }
@@ -2391,20 +2399,20 @@ namespace System.Windows.Automation.Peers
     }
     public sealed partial class CalendarButtonAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public CalendarButtonAutomationPeer(System.Windows.Controls.Button owner) : base (default(System.Windows.FrameworkElement)) { }
+        public CalendarButtonAutomationPeer(System.Windows.Controls.Button owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         protected override string GetLocalizedControlTypeCore() { throw null; }
     }
     public partial class CheckBoxAutomationPeer : System.Windows.Automation.Peers.ToggleButtonAutomationPeer
     {
-        public CheckBoxAutomationPeer(System.Windows.Controls.CheckBox owner) : base (default(System.Windows.Controls.Primitives.ToggleButton)) { }
+        public CheckBoxAutomationPeer(System.Windows.Controls.CheckBox owner) : base(default(System.Windows.Controls.Primitives.ToggleButton)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class ComboBoxAutomationPeer : System.Windows.Automation.Peers.SelectorAutomationPeer, System.Windows.Automation.Provider.IExpandCollapseProvider, System.Windows.Automation.Provider.IValueProvider
     {
-        public ComboBoxAutomationPeer(System.Windows.Controls.ComboBox owner) : base (default(System.Windows.Controls.Primitives.Selector)) { }
+        public ComboBoxAutomationPeer(System.Windows.Controls.ComboBox owner) : base(default(System.Windows.Controls.Primitives.Selector)) { }
         System.Windows.Automation.ExpandCollapseState System.Windows.Automation.Provider.IExpandCollapseProvider.ExpandCollapseState { get { throw null; } }
         bool System.Windows.Automation.Provider.IValueProvider.IsReadOnly { get { throw null; } }
         string System.Windows.Automation.Provider.IValueProvider.Value { get { throw null; } }
@@ -2420,18 +2428,18 @@ namespace System.Windows.Automation.Peers
     }
     public abstract partial class ContentTextAutomationPeer : System.Windows.Automation.Peers.FrameworkContentElementAutomationPeer
     {
-        protected ContentTextAutomationPeer(System.Windows.FrameworkContentElement owner) : base (default(System.Windows.FrameworkContentElement)) { }
+        protected ContentTextAutomationPeer(System.Windows.FrameworkContentElement owner) : base(default(System.Windows.FrameworkContentElement)) { }
     }
     public partial class ContextMenuAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public ContextMenuAutomationPeer(System.Windows.Controls.ContextMenu owner) : base (default(System.Windows.FrameworkElement)) { }
+        public ContextMenuAutomationPeer(System.Windows.Controls.ContextMenu owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         protected override bool IsContentElementCore() { throw null; }
     }
     public sealed partial class DataGridAutomationPeer : System.Windows.Automation.Peers.ItemsControlAutomationPeer, System.Windows.Automation.Provider.IGridProvider, System.Windows.Automation.Provider.ISelectionProvider, System.Windows.Automation.Provider.ITableProvider
     {
-        public DataGridAutomationPeer(System.Windows.Controls.DataGrid owner) : base (default(System.Windows.Controls.ItemsControl)) { }
+        public DataGridAutomationPeer(System.Windows.Controls.DataGrid owner) : base(default(System.Windows.Controls.ItemsControl)) { }
         int System.Windows.Automation.Provider.IGridProvider.ColumnCount { get { throw null; } }
         int System.Windows.Automation.Provider.IGridProvider.RowCount { get { throw null; } }
         bool System.Windows.Automation.Provider.ISelectionProvider.CanSelectMultiple { get { throw null; } }
@@ -2449,7 +2457,7 @@ namespace System.Windows.Automation.Peers
     }
     public sealed partial class DataGridCellAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public DataGridCellAutomationPeer(System.Windows.Controls.DataGridCell owner) : base (default(System.Windows.FrameworkElement)) { }
+        public DataGridCellAutomationPeer(System.Windows.Controls.DataGridCell owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
@@ -2503,14 +2511,14 @@ namespace System.Windows.Automation.Peers
     }
     public sealed partial class DataGridColumnHeaderAutomationPeer : System.Windows.Automation.Peers.ButtonBaseAutomationPeer
     {
-        public DataGridColumnHeaderAutomationPeer(System.Windows.Controls.Primitives.DataGridColumnHeader owner) : base (default(System.Windows.Controls.Primitives.ButtonBase)) { }
+        public DataGridColumnHeaderAutomationPeer(System.Windows.Controls.Primitives.DataGridColumnHeader owner) : base(default(System.Windows.Controls.Primitives.ButtonBase)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         protected override bool IsContentElementCore() { throw null; }
     }
     public partial class DataGridColumnHeaderItemAutomationPeer : System.Windows.Automation.Peers.ItemAutomationPeer, System.Windows.Automation.Provider.IInvokeProvider, System.Windows.Automation.Provider.IScrollItemProvider, System.Windows.Automation.Provider.ITransformProvider, System.Windows.Automation.Provider.IVirtualizedItemProvider
     {
-        public DataGridColumnHeaderItemAutomationPeer(object item, System.Windows.Controls.DataGridColumn column, System.Windows.Automation.Peers.DataGridColumnHeadersPresenterAutomationPeer peer) : base (default(object), default(System.Windows.Automation.Peers.ItemsControlAutomationPeer)) { }
+        public DataGridColumnHeaderItemAutomationPeer(object item, System.Windows.Controls.DataGridColumn column, System.Windows.Automation.Peers.DataGridColumnHeadersPresenterAutomationPeer peer) : base(default(object), default(System.Windows.Automation.Peers.ItemsControlAutomationPeer)) { }
         bool System.Windows.Automation.Provider.ITransformProvider.CanMove { get { throw null; } }
         bool System.Windows.Automation.Provider.ITransformProvider.CanResize { get { throw null; } }
         bool System.Windows.Automation.Provider.ITransformProvider.CanRotate { get { throw null; } }
@@ -2527,7 +2535,7 @@ namespace System.Windows.Automation.Peers
     }
     public sealed partial class DataGridColumnHeadersPresenterAutomationPeer : System.Windows.Automation.Peers.ItemsControlAutomationPeer, System.Windows.Automation.Provider.IItemContainerProvider
     {
-        public DataGridColumnHeadersPresenterAutomationPeer(System.Windows.Controls.Primitives.DataGridColumnHeadersPresenter owner) : base (default(System.Windows.Controls.ItemsControl)) { }
+        public DataGridColumnHeadersPresenterAutomationPeer(System.Windows.Controls.Primitives.DataGridColumnHeadersPresenter owner) : base(default(System.Windows.Controls.ItemsControl)) { }
         protected override System.Windows.Automation.Peers.ItemAutomationPeer CreateItemAutomationPeer(object column) { throw null; }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
@@ -2537,12 +2545,12 @@ namespace System.Windows.Automation.Peers
     }
     public sealed partial class DataGridDetailsPresenterAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public DataGridDetailsPresenterAutomationPeer(System.Windows.Controls.Primitives.DataGridDetailsPresenter owner) : base (default(System.Windows.FrameworkElement)) { }
+        public DataGridDetailsPresenterAutomationPeer(System.Windows.Controls.Primitives.DataGridDetailsPresenter owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override string GetClassNameCore() { throw null; }
     }
     public sealed partial class DataGridItemAutomationPeer : System.Windows.Automation.Peers.ItemAutomationPeer, System.Windows.Automation.Provider.IInvokeProvider, System.Windows.Automation.Provider.IItemContainerProvider, System.Windows.Automation.Provider.IScrollItemProvider, System.Windows.Automation.Provider.ISelectionItemProvider, System.Windows.Automation.Provider.ISelectionProvider
     {
-        public DataGridItemAutomationPeer(object item, System.Windows.Automation.Peers.DataGridAutomationPeer dataGridPeer) : base (default(object), default(System.Windows.Automation.Peers.ItemsControlAutomationPeer)) { }
+        public DataGridItemAutomationPeer(object item, System.Windows.Automation.Peers.DataGridAutomationPeer dataGridPeer) : base(default(object), default(System.Windows.Automation.Peers.ItemsControlAutomationPeer)) { }
         bool System.Windows.Automation.Provider.ISelectionItemProvider.IsSelected { get { throw null; } }
         System.Windows.Automation.Provider.IRawElementProviderSimple System.Windows.Automation.Provider.ISelectionItemProvider.SelectionContainer { get { throw null; } }
         bool System.Windows.Automation.Provider.ISelectionProvider.CanSelectMultiple { get { throw null; } }
@@ -2562,21 +2570,21 @@ namespace System.Windows.Automation.Peers
     }
     public sealed partial class DataGridRowAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public DataGridRowAutomationPeer(System.Windows.Controls.DataGridRow owner) : base (default(System.Windows.FrameworkElement)) { }
+        public DataGridRowAutomationPeer(System.Windows.Controls.DataGridRow owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public sealed partial class DataGridRowHeaderAutomationPeer : System.Windows.Automation.Peers.ButtonBaseAutomationPeer
     {
-        public DataGridRowHeaderAutomationPeer(System.Windows.Controls.Primitives.DataGridRowHeader owner) : base (default(System.Windows.Controls.Primitives.ButtonBase)) { }
+        public DataGridRowHeaderAutomationPeer(System.Windows.Controls.Primitives.DataGridRowHeader owner) : base(default(System.Windows.Controls.Primitives.ButtonBase)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         protected override bool IsContentElementCore() { throw null; }
     }
     public sealed partial class DatePickerAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer, System.Windows.Automation.Provider.IExpandCollapseProvider, System.Windows.Automation.Provider.IValueProvider
     {
-        public DatePickerAutomationPeer(System.Windows.Controls.DatePicker owner) : base (default(System.Windows.FrameworkElement)) { }
+        public DatePickerAutomationPeer(System.Windows.Controls.DatePicker owner) : base(default(System.Windows.FrameworkElement)) { }
         System.Windows.Automation.ExpandCollapseState System.Windows.Automation.Provider.IExpandCollapseProvider.ExpandCollapseState { get { throw null; } }
         bool System.Windows.Automation.Provider.IValueProvider.IsReadOnly { get { throw null; } }
         string System.Windows.Automation.Provider.IValueProvider.Value { get { throw null; } }
@@ -2636,7 +2644,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class DocumentAutomationPeer : System.Windows.Automation.Peers.ContentTextAutomationPeer
     {
-        public DocumentAutomationPeer(System.Windows.FrameworkContentElement owner) : base (default(System.Windows.FrameworkContentElement)) { }
+        public DocumentAutomationPeer(System.Windows.FrameworkContentElement owner) : base(default(System.Windows.FrameworkContentElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Windows.Rect GetBoundingRectangleCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
@@ -2648,19 +2656,19 @@ namespace System.Windows.Automation.Peers
     }
     public partial class DocumentPageViewAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public DocumentPageViewAutomationPeer(System.Windows.Controls.Primitives.DocumentPageView owner) : base (default(System.Windows.FrameworkElement)) { }
+        public DocumentPageViewAutomationPeer(System.Windows.Controls.Primitives.DocumentPageView owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override string GetAutomationIdCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
     }
     public partial class DocumentViewerAutomationPeer : System.Windows.Automation.Peers.DocumentViewerBaseAutomationPeer
     {
-        public DocumentViewerAutomationPeer(System.Windows.Controls.DocumentViewer owner) : base (default(System.Windows.Controls.Primitives.DocumentViewerBase)) { }
+        public DocumentViewerAutomationPeer(System.Windows.Controls.DocumentViewer owner) : base(default(System.Windows.Controls.Primitives.DocumentViewerBase)) { }
         protected override string GetClassNameCore() { throw null; }
         public override object GetPattern(System.Windows.Automation.Peers.PatternInterface patternInterface) { throw null; }
     }
     public partial class DocumentViewerBaseAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public DocumentViewerBaseAutomationPeer(System.Windows.Controls.Primitives.DocumentViewerBase owner) : base (default(System.Windows.FrameworkElement)) { }
+        public DocumentViewerBaseAutomationPeer(System.Windows.Controls.Primitives.DocumentViewerBase owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
@@ -2668,7 +2676,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class ExpanderAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer, System.Windows.Automation.Provider.IExpandCollapseProvider
     {
-        public ExpanderAutomationPeer(System.Windows.Controls.Expander owner) : base (default(System.Windows.FrameworkElement)) { }
+        public ExpanderAutomationPeer(System.Windows.Controls.Expander owner) : base(default(System.Windows.FrameworkElement)) { }
         System.Windows.Automation.ExpandCollapseState System.Windows.Automation.Provider.IExpandCollapseProvider.ExpandCollapseState { get { throw null; } }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
@@ -2680,19 +2688,19 @@ namespace System.Windows.Automation.Peers
     }
     public partial class FixedPageAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public FixedPageAutomationPeer(System.Windows.Documents.FixedPage owner) : base (default(System.Windows.FrameworkElement)) { }
+        public FixedPageAutomationPeer(System.Windows.Documents.FixedPage owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class FlowDocumentPageViewerAutomationPeer : System.Windows.Automation.Peers.DocumentViewerBaseAutomationPeer
     {
-        public FlowDocumentPageViewerAutomationPeer(System.Windows.Controls.FlowDocumentPageViewer owner) : base (default(System.Windows.Controls.Primitives.DocumentViewerBase)) { }
+        public FlowDocumentPageViewerAutomationPeer(System.Windows.Controls.FlowDocumentPageViewer owner) : base(default(System.Windows.Controls.Primitives.DocumentViewerBase)) { }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class FlowDocumentReaderAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer, System.Windows.Automation.Provider.IMultipleViewProvider
     {
-        public FlowDocumentReaderAutomationPeer(System.Windows.Controls.FlowDocumentReader owner) : base (default(System.Windows.FrameworkElement)) { }
+        public FlowDocumentReaderAutomationPeer(System.Windows.Controls.FlowDocumentReader owner) : base(default(System.Windows.FrameworkElement)) { }
         int System.Windows.Automation.Provider.IMultipleViewProvider.CurrentView { get { throw null; } }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
@@ -2703,7 +2711,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class FlowDocumentScrollViewerAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public FlowDocumentScrollViewerAutomationPeer(System.Windows.Controls.FlowDocumentScrollViewer owner) : base (default(System.Windows.FrameworkElement)) { }
+        public FlowDocumentScrollViewerAutomationPeer(System.Windows.Controls.FlowDocumentScrollViewer owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
@@ -2711,27 +2719,27 @@ namespace System.Windows.Automation.Peers
     }
     public partial class FrameAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public FrameAutomationPeer(System.Windows.Controls.Frame owner) : base (default(System.Windows.FrameworkElement)) { }
+        public FrameAutomationPeer(System.Windows.Controls.Frame owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class FrameworkContentElementAutomationPeer : System.Windows.Automation.Peers.ContentElementAutomationPeer
     {
-        public FrameworkContentElementAutomationPeer(System.Windows.FrameworkContentElement owner) : base (default(System.Windows.ContentElement)) { }
+        public FrameworkContentElementAutomationPeer(System.Windows.FrameworkContentElement owner) : base(default(System.Windows.ContentElement)) { }
         protected override string GetAutomationIdCore() { throw null; }
         protected override string GetHelpTextCore() { throw null; }
         protected override System.Windows.Automation.Peers.AutomationPeer GetLabeledByCore() { throw null; }
     }
     public partial class FrameworkElementAutomationPeer : System.Windows.Automation.Peers.UIElementAutomationPeer
     {
-        public FrameworkElementAutomationPeer(System.Windows.FrameworkElement owner) : base (default(System.Windows.UIElement)) { }
+        public FrameworkElementAutomationPeer(System.Windows.FrameworkElement owner) : base(default(System.Windows.UIElement)) { }
         protected override string GetAutomationIdCore() { throw null; }
         protected override string GetHelpTextCore() { throw null; }
         protected override string GetNameCore() { throw null; }
     }
     public partial class GridSplitterAutomationPeer : System.Windows.Automation.Peers.ThumbAutomationPeer, System.Windows.Automation.Provider.ITransformProvider
     {
-        public GridSplitterAutomationPeer(System.Windows.Controls.GridSplitter owner) : base (default(System.Windows.Controls.Primitives.Thumb)) { }
+        public GridSplitterAutomationPeer(System.Windows.Controls.GridSplitter owner) : base(default(System.Windows.Controls.Primitives.Thumb)) { }
         bool System.Windows.Automation.Provider.ITransformProvider.CanMove { get { throw null; } }
         bool System.Windows.Automation.Provider.ITransformProvider.CanResize { get { throw null; } }
         bool System.Windows.Automation.Provider.ITransformProvider.CanRotate { get { throw null; } }
@@ -2759,7 +2767,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class GridViewCellAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer, System.Windows.Automation.Provider.IGridItemProvider, System.Windows.Automation.Provider.ITableItemProvider
     {
-        internal GridViewCellAutomationPeer() : base (default(System.Windows.FrameworkElement)) { }
+        internal GridViewCellAutomationPeer() : base(default(System.Windows.FrameworkElement)) { }
         int System.Windows.Automation.Provider.IGridItemProvider.Column { get { throw null; } }
         int System.Windows.Automation.Provider.IGridItemProvider.ColumnSpan { get { throw null; } }
         System.Windows.Automation.Provider.IRawElementProviderSimple System.Windows.Automation.Provider.IGridItemProvider.ContainingGrid { get { throw null; } }
@@ -2774,7 +2782,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class GridViewColumnHeaderAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer, System.Windows.Automation.Provider.IInvokeProvider, System.Windows.Automation.Provider.ITransformProvider
     {
-        public GridViewColumnHeaderAutomationPeer(System.Windows.Controls.GridViewColumnHeader owner) : base (default(System.Windows.FrameworkElement)) { }
+        public GridViewColumnHeaderAutomationPeer(System.Windows.Controls.GridViewColumnHeader owner) : base(default(System.Windows.FrameworkElement)) { }
         bool System.Windows.Automation.Provider.ITransformProvider.CanMove { get { throw null; } }
         bool System.Windows.Automation.Provider.ITransformProvider.CanResize { get { throw null; } }
         bool System.Windows.Automation.Provider.ITransformProvider.CanRotate { get { throw null; } }
@@ -2789,7 +2797,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class GridViewHeaderRowPresenterAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public GridViewHeaderRowPresenterAutomationPeer(System.Windows.Controls.GridViewHeaderRowPresenter owner) : base (default(System.Windows.FrameworkElement)) { }
+        public GridViewHeaderRowPresenterAutomationPeer(System.Windows.Controls.GridViewHeaderRowPresenter owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
@@ -2797,21 +2805,21 @@ namespace System.Windows.Automation.Peers
     }
     public partial class GridViewItemAutomationPeer : System.Windows.Automation.Peers.ListBoxItemAutomationPeer
     {
-        public GridViewItemAutomationPeer(object owner, System.Windows.Automation.Peers.ListViewAutomationPeer listviewAP) : base (default(object), default(System.Windows.Automation.Peers.SelectorAutomationPeer)) { }
+        public GridViewItemAutomationPeer(object owner, System.Windows.Automation.Peers.ListViewAutomationPeer listviewAP) : base(default(object), default(System.Windows.Automation.Peers.SelectorAutomationPeer)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class GroupBoxAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public GroupBoxAutomationPeer(System.Windows.Controls.GroupBox owner) : base (default(System.Windows.FrameworkElement)) { }
+        public GroupBoxAutomationPeer(System.Windows.Controls.GroupBox owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         protected override string GetNameCore() { throw null; }
     }
     public partial class GroupItemAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public GroupItemAutomationPeer(System.Windows.Controls.GroupItem owner) : base (default(System.Windows.FrameworkElement)) { }
+        public GroupItemAutomationPeer(System.Windows.Controls.GroupItem owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
@@ -2822,7 +2830,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class HyperlinkAutomationPeer : System.Windows.Automation.Peers.TextElementAutomationPeer, System.Windows.Automation.Provider.IInvokeProvider
     {
-        public HyperlinkAutomationPeer(System.Windows.Documents.Hyperlink owner) : base (default(System.Windows.Documents.TextElement)) { }
+        public HyperlinkAutomationPeer(System.Windows.Documents.Hyperlink owner) : base(default(System.Windows.Documents.TextElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         protected override string GetNameCore() { throw null; }
@@ -2832,19 +2840,19 @@ namespace System.Windows.Automation.Peers
     }
     public partial class ImageAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public ImageAutomationPeer(System.Windows.Controls.Image owner) : base (default(System.Windows.FrameworkElement)) { }
+        public ImageAutomationPeer(System.Windows.Controls.Image owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class InkCanvasAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public InkCanvasAutomationPeer(System.Windows.Controls.InkCanvas owner) : base (default(System.Windows.FrameworkElement)) { }
+        public InkCanvasAutomationPeer(System.Windows.Controls.InkCanvas owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class InkPresenterAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public InkPresenterAutomationPeer(System.Windows.Controls.InkPresenter owner) : base (default(System.Windows.FrameworkElement)) { }
+        public InkPresenterAutomationPeer(System.Windows.Controls.InkPresenter owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
@@ -2880,7 +2888,7 @@ namespace System.Windows.Automation.Peers
     }
     public abstract partial class ItemsControlAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer, System.Windows.Automation.Provider.IItemContainerProvider
     {
-        protected ItemsControlAutomationPeer(System.Windows.Controls.ItemsControl owner) : base (default(System.Windows.FrameworkElement)) { }
+        protected ItemsControlAutomationPeer(System.Windows.Controls.ItemsControl owner) : base(default(System.Windows.FrameworkElement)) { }
         protected virtual bool IsVirtualized { get { throw null; } }
         protected abstract System.Windows.Automation.Peers.ItemAutomationPeer CreateItemAutomationPeer(object item);
         protected internal virtual System.Windows.Automation.Peers.ItemAutomationPeer FindOrCreateItemAutomationPeer(object item) { throw null; }
@@ -2899,20 +2907,20 @@ namespace System.Windows.Automation.Peers
     }
     public partial class LabelAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public LabelAutomationPeer(System.Windows.Controls.Label owner) : base (default(System.Windows.FrameworkElement)) { }
+        public LabelAutomationPeer(System.Windows.Controls.Label owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         protected override string GetNameCore() { throw null; }
     }
     public partial class ListBoxAutomationPeer : System.Windows.Automation.Peers.SelectorAutomationPeer
     {
-        public ListBoxAutomationPeer(System.Windows.Controls.ListBox owner) : base (default(System.Windows.Controls.Primitives.Selector)) { }
+        public ListBoxAutomationPeer(System.Windows.Controls.ListBox owner) : base(default(System.Windows.Controls.Primitives.Selector)) { }
         protected override System.Windows.Automation.Peers.ItemAutomationPeer CreateItemAutomationPeer(object item) { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class ListBoxItemAutomationPeer : System.Windows.Automation.Peers.SelectorItemAutomationPeer, System.Windows.Automation.Provider.IScrollItemProvider
     {
-        public ListBoxItemAutomationPeer(object owner, System.Windows.Automation.Peers.SelectorAutomationPeer selectorAutomationPeer) : base (default(object), default(System.Windows.Automation.Peers.SelectorAutomationPeer)) { }
+        public ListBoxItemAutomationPeer(object owner, System.Windows.Automation.Peers.SelectorAutomationPeer selectorAutomationPeer) : base(default(object), default(System.Windows.Automation.Peers.SelectorAutomationPeer)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         public override object GetPattern(System.Windows.Automation.Peers.PatternInterface patternInterface) { throw null; }
@@ -2920,13 +2928,13 @@ namespace System.Windows.Automation.Peers
     }
     public partial class ListBoxItemWrapperAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public ListBoxItemWrapperAutomationPeer(System.Windows.Controls.ListBoxItem owner) : base (default(System.Windows.FrameworkElement)) { }
+        public ListBoxItemWrapperAutomationPeer(System.Windows.Controls.ListBoxItem owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class ListViewAutomationPeer : System.Windows.Automation.Peers.ListBoxAutomationPeer
     {
-        public ListViewAutomationPeer(System.Windows.Controls.ListView owner) : base (default(System.Windows.Controls.ListBox)) { }
+        public ListViewAutomationPeer(System.Windows.Controls.ListView owner) : base(default(System.Windows.Controls.ListBox)) { }
         protected internal System.Windows.Automation.Peers.IViewAutomationPeer ViewAutomationPeer { get { throw null; } set { } }
         protected override System.Windows.Automation.Peers.ItemAutomationPeer CreateItemAutomationPeer(object item) { throw null; }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
@@ -2936,20 +2944,20 @@ namespace System.Windows.Automation.Peers
     }
     public partial class MediaElementAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public MediaElementAutomationPeer(System.Windows.Controls.MediaElement owner) : base (default(System.Windows.FrameworkElement)) { }
+        public MediaElementAutomationPeer(System.Windows.Controls.MediaElement owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class MenuAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public MenuAutomationPeer(System.Windows.Controls.Menu owner) : base (default(System.Windows.FrameworkElement)) { }
+        public MenuAutomationPeer(System.Windows.Controls.Menu owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         protected override bool IsContentElementCore() { throw null; }
     }
     public partial class MenuItemAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer, System.Windows.Automation.Provider.IExpandCollapseProvider, System.Windows.Automation.Provider.IInvokeProvider, System.Windows.Automation.Provider.IToggleProvider
     {
-        public MenuItemAutomationPeer(System.Windows.Controls.MenuItem owner) : base (default(System.Windows.FrameworkElement)) { }
+        public MenuItemAutomationPeer(System.Windows.Controls.MenuItem owner) : base(default(System.Windows.FrameworkElement)) { }
         System.Windows.Automation.ExpandCollapseState System.Windows.Automation.Provider.IExpandCollapseProvider.ExpandCollapseState { get { throw null; } }
         System.Windows.Automation.ToggleState System.Windows.Automation.Provider.IToggleProvider.ToggleState { get { throw null; } }
         protected override string GetAccessKeyCore() { throw null; }
@@ -2965,12 +2973,12 @@ namespace System.Windows.Automation.Peers
     }
     public partial class NavigationWindowAutomationPeer : System.Windows.Automation.Peers.WindowAutomationPeer
     {
-        public NavigationWindowAutomationPeer(System.Windows.Navigation.NavigationWindow owner) : base (default(System.Windows.Window)) { }
+        public NavigationWindowAutomationPeer(System.Windows.Navigation.NavigationWindow owner) : base(default(System.Windows.Window)) { }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class PasswordBoxAutomationPeer : System.Windows.Automation.Peers.TextAutomationPeer, System.Windows.Automation.Provider.IValueProvider
     {
-        public PasswordBoxAutomationPeer(System.Windows.Controls.PasswordBox owner) : base (default(System.Windows.FrameworkElement)) { }
+        public PasswordBoxAutomationPeer(System.Windows.Controls.PasswordBox owner) : base(default(System.Windows.FrameworkElement)) { }
         bool System.Windows.Automation.Provider.IValueProvider.IsReadOnly { get { throw null; } }
         string System.Windows.Automation.Provider.IValueProvider.Value { get { throw null; } }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
@@ -2981,7 +2989,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class ProgressBarAutomationPeer : System.Windows.Automation.Peers.RangeBaseAutomationPeer, System.Windows.Automation.Provider.IRangeValueProvider
     {
-        public ProgressBarAutomationPeer(System.Windows.Controls.ProgressBar owner) : base (default(System.Windows.Controls.Primitives.RangeBase)) { }
+        public ProgressBarAutomationPeer(System.Windows.Controls.ProgressBar owner) : base(default(System.Windows.Controls.Primitives.RangeBase)) { }
         bool System.Windows.Automation.Provider.IRangeValueProvider.IsReadOnly { get { throw null; } }
         double System.Windows.Automation.Provider.IRangeValueProvider.LargeChange { get { throw null; } }
         double System.Windows.Automation.Provider.IRangeValueProvider.SmallChange { get { throw null; } }
@@ -2992,7 +3000,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class RadioButtonAutomationPeer : System.Windows.Automation.Peers.ToggleButtonAutomationPeer, System.Windows.Automation.Provider.ISelectionItemProvider
     {
-        public RadioButtonAutomationPeer(System.Windows.Controls.RadioButton owner) : base (default(System.Windows.Controls.Primitives.ToggleButton)) { }
+        public RadioButtonAutomationPeer(System.Windows.Controls.RadioButton owner) : base(default(System.Windows.Controls.Primitives.ToggleButton)) { }
         bool System.Windows.Automation.Provider.ISelectionItemProvider.IsSelected { get { throw null; } }
         System.Windows.Automation.Provider.IRawElementProviderSimple System.Windows.Automation.Provider.ISelectionItemProvider.SelectionContainer { get { throw null; } }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
@@ -3004,7 +3012,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class RangeBaseAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer, System.Windows.Automation.Provider.IRangeValueProvider
     {
-        public RangeBaseAutomationPeer(System.Windows.Controls.Primitives.RangeBase owner) : base (default(System.Windows.FrameworkElement)) { }
+        public RangeBaseAutomationPeer(System.Windows.Controls.Primitives.RangeBase owner) : base(default(System.Windows.FrameworkElement)) { }
         bool System.Windows.Automation.Provider.IRangeValueProvider.IsReadOnly { get { throw null; } }
         double System.Windows.Automation.Provider.IRangeValueProvider.LargeChange { get { throw null; } }
         double System.Windows.Automation.Provider.IRangeValueProvider.Maximum { get { throw null; } }
@@ -3016,7 +3024,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class RepeatButtonAutomationPeer : System.Windows.Automation.Peers.ButtonBaseAutomationPeer, System.Windows.Automation.Provider.IInvokeProvider
     {
-        public RepeatButtonAutomationPeer(System.Windows.Controls.Primitives.RepeatButton owner) : base (default(System.Windows.Controls.Primitives.ButtonBase)) { }
+        public RepeatButtonAutomationPeer(System.Windows.Controls.Primitives.RepeatButton owner) : base(default(System.Windows.Controls.Primitives.ButtonBase)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         public override object GetPattern(System.Windows.Automation.Peers.PatternInterface patternInterface) { throw null; }
@@ -3024,7 +3032,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class RichTextBoxAutomationPeer : System.Windows.Automation.Peers.TextAutomationPeer
     {
-        public RichTextBoxAutomationPeer(System.Windows.Controls.RichTextBox owner) : base (default(System.Windows.FrameworkElement)) { }
+        public RichTextBoxAutomationPeer(System.Windows.Controls.RichTextBox owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
@@ -3032,7 +3040,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class ScrollBarAutomationPeer : System.Windows.Automation.Peers.RangeBaseAutomationPeer
     {
-        public ScrollBarAutomationPeer(System.Windows.Controls.Primitives.ScrollBar owner) : base (default(System.Windows.Controls.Primitives.RangeBase)) { }
+        public ScrollBarAutomationPeer(System.Windows.Controls.Primitives.ScrollBar owner) : base(default(System.Windows.Controls.Primitives.RangeBase)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         protected override System.Windows.Point GetClickablePointCore() { throw null; }
@@ -3041,7 +3049,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class ScrollViewerAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer, System.Windows.Automation.Provider.IScrollProvider
     {
-        public ScrollViewerAutomationPeer(System.Windows.Controls.ScrollViewer owner) : base (default(System.Windows.FrameworkElement)) { }
+        public ScrollViewerAutomationPeer(System.Windows.Controls.ScrollViewer owner) : base(default(System.Windows.FrameworkElement)) { }
         bool System.Windows.Automation.Provider.IScrollProvider.HorizontallyScrollable { get { throw null; } }
         double System.Windows.Automation.Provider.IScrollProvider.HorizontalScrollPercent { get { throw null; } }
         double System.Windows.Automation.Provider.IScrollProvider.HorizontalViewSize { get { throw null; } }
@@ -3057,7 +3065,7 @@ namespace System.Windows.Automation.Peers
     }
     public abstract partial class SelectorAutomationPeer : System.Windows.Automation.Peers.ItemsControlAutomationPeer, System.Windows.Automation.Provider.ISelectionProvider
     {
-        protected SelectorAutomationPeer(System.Windows.Controls.Primitives.Selector owner) : base (default(System.Windows.Controls.ItemsControl)) { }
+        protected SelectorAutomationPeer(System.Windows.Controls.Primitives.Selector owner) : base(default(System.Windows.Controls.ItemsControl)) { }
         bool System.Windows.Automation.Provider.ISelectionProvider.CanSelectMultiple { get { throw null; } }
         bool System.Windows.Automation.Provider.ISelectionProvider.IsSelectionRequired { get { throw null; } }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
@@ -3066,7 +3074,7 @@ namespace System.Windows.Automation.Peers
     }
     public abstract partial class SelectorItemAutomationPeer : System.Windows.Automation.Peers.ItemAutomationPeer, System.Windows.Automation.Provider.ISelectionItemProvider
     {
-        protected SelectorItemAutomationPeer(object owner, System.Windows.Automation.Peers.SelectorAutomationPeer selectorAutomationPeer) : base (default(object), default(System.Windows.Automation.Peers.ItemsControlAutomationPeer)) { }
+        protected SelectorItemAutomationPeer(object owner, System.Windows.Automation.Peers.SelectorAutomationPeer selectorAutomationPeer) : base(default(object), default(System.Windows.Automation.Peers.ItemsControlAutomationPeer)) { }
         bool System.Windows.Automation.Provider.ISelectionItemProvider.IsSelected { get { throw null; } }
         System.Windows.Automation.Provider.IRawElementProviderSimple System.Windows.Automation.Provider.ISelectionItemProvider.SelectionContainer { get { throw null; } }
         public override object GetPattern(System.Windows.Automation.Peers.PatternInterface patternInterface) { throw null; }
@@ -3076,34 +3084,34 @@ namespace System.Windows.Automation.Peers
     }
     public partial class SeparatorAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public SeparatorAutomationPeer(System.Windows.Controls.Separator owner) : base (default(System.Windows.FrameworkElement)) { }
+        public SeparatorAutomationPeer(System.Windows.Controls.Separator owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         protected override bool IsContentElementCore() { throw null; }
     }
     public partial class SliderAutomationPeer : System.Windows.Automation.Peers.RangeBaseAutomationPeer
     {
-        public SliderAutomationPeer(System.Windows.Controls.Slider owner) : base (default(System.Windows.Controls.Primitives.RangeBase)) { }
+        public SliderAutomationPeer(System.Windows.Controls.Slider owner) : base(default(System.Windows.Controls.Primitives.RangeBase)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         protected override System.Windows.Point GetClickablePointCore() { throw null; }
     }
     public partial class StatusBarAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public StatusBarAutomationPeer(System.Windows.Controls.Primitives.StatusBar owner) : base (default(System.Windows.FrameworkElement)) { }
+        public StatusBarAutomationPeer(System.Windows.Controls.Primitives.StatusBar owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class StatusBarItemAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public StatusBarItemAutomationPeer(System.Windows.Controls.Primitives.StatusBarItem owner) : base (default(System.Windows.FrameworkElement)) { }
+        public StatusBarItemAutomationPeer(System.Windows.Controls.Primitives.StatusBarItem owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class TabControlAutomationPeer : System.Windows.Automation.Peers.SelectorAutomationPeer, System.Windows.Automation.Provider.ISelectionProvider
     {
-        public TabControlAutomationPeer(System.Windows.Controls.TabControl owner) : base (default(System.Windows.Controls.Primitives.Selector)) { }
+        public TabControlAutomationPeer(System.Windows.Controls.TabControl owner) : base(default(System.Windows.Controls.Primitives.Selector)) { }
         bool System.Windows.Automation.Provider.ISelectionProvider.IsSelectionRequired { get { throw null; } }
         protected override System.Windows.Automation.Peers.ItemAutomationPeer CreateItemAutomationPeer(object item) { throw null; }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
@@ -3112,7 +3120,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class TabItemAutomationPeer : System.Windows.Automation.Peers.SelectorItemAutomationPeer, System.Windows.Automation.Provider.ISelectionItemProvider
     {
-        public TabItemAutomationPeer(object owner, System.Windows.Automation.Peers.TabControlAutomationPeer tabControlAutomationPeer) : base (default(object), default(System.Windows.Automation.Peers.SelectorAutomationPeer)) { }
+        public TabItemAutomationPeer(object owner, System.Windows.Automation.Peers.TabControlAutomationPeer tabControlAutomationPeer) : base(default(object), default(System.Windows.Automation.Peers.SelectorAutomationPeer)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
@@ -3121,11 +3129,11 @@ namespace System.Windows.Automation.Peers
     }
     public partial class TabItemWrapperAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public TabItemWrapperAutomationPeer(System.Windows.Controls.TabItem owner) : base (default(System.Windows.FrameworkElement)) { }
+        public TabItemWrapperAutomationPeer(System.Windows.Controls.TabItem owner) : base(default(System.Windows.FrameworkElement)) { }
     }
     public partial class TableAutomationPeer : System.Windows.Automation.Peers.TextElementAutomationPeer, System.Windows.Automation.Provider.IGridProvider
     {
-        public TableAutomationPeer(System.Windows.Documents.Table owner) : base (default(System.Windows.Documents.TextElement)) { }
+        public TableAutomationPeer(System.Windows.Documents.Table owner) : base(default(System.Windows.Documents.TextElement)) { }
         int System.Windows.Automation.Provider.IGridProvider.ColumnCount { get { throw null; } }
         int System.Windows.Automation.Provider.IGridProvider.RowCount { get { throw null; } }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
@@ -3136,7 +3144,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class TableCellAutomationPeer : System.Windows.Automation.Peers.TextElementAutomationPeer, System.Windows.Automation.Provider.IGridItemProvider
     {
-        public TableCellAutomationPeer(System.Windows.Documents.TableCell owner) : base (default(System.Windows.Documents.TextElement)) { }
+        public TableCellAutomationPeer(System.Windows.Documents.TableCell owner) : base(default(System.Windows.Documents.TextElement)) { }
         int System.Windows.Automation.Provider.IGridItemProvider.Column { get { throw null; } }
         int System.Windows.Automation.Provider.IGridItemProvider.ColumnSpan { get { throw null; } }
         System.Windows.Automation.Provider.IRawElementProviderSimple System.Windows.Automation.Provider.IGridItemProvider.ContainingGrid { get { throw null; } }
@@ -3150,12 +3158,12 @@ namespace System.Windows.Automation.Peers
     }
     public abstract partial class TextAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        protected TextAutomationPeer(System.Windows.FrameworkElement owner) : base (default(System.Windows.FrameworkElement)) { }
+        protected TextAutomationPeer(System.Windows.FrameworkElement owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override string GetNameCore() { throw null; }
     }
     public partial class TextBlockAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public TextBlockAutomationPeer(System.Windows.Controls.TextBlock owner) : base (default(System.Windows.FrameworkElement)) { }
+        public TextBlockAutomationPeer(System.Windows.Controls.TextBlock owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
@@ -3163,7 +3171,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class TextBoxAutomationPeer : System.Windows.Automation.Peers.TextAutomationPeer, System.Windows.Automation.Provider.IValueProvider
     {
-        public TextBoxAutomationPeer(System.Windows.Controls.TextBox owner) : base (default(System.Windows.FrameworkElement)) { }
+        public TextBoxAutomationPeer(System.Windows.Controls.TextBox owner) : base(default(System.Windows.FrameworkElement)) { }
         bool System.Windows.Automation.Provider.IValueProvider.IsReadOnly { get { throw null; } }
         string System.Windows.Automation.Provider.IValueProvider.Value { get { throw null; } }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
@@ -3173,7 +3181,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class TextElementAutomationPeer : System.Windows.Automation.Peers.ContentTextAutomationPeer
     {
-        public TextElementAutomationPeer(System.Windows.Documents.TextElement owner) : base (default(System.Windows.FrameworkContentElement)) { }
+        public TextElementAutomationPeer(System.Windows.Documents.TextElement owner) : base(default(System.Windows.FrameworkContentElement)) { }
         protected override System.Windows.Rect GetBoundingRectangleCore() { throw null; }
         protected override System.Collections.Generic.List<System.Windows.Automation.Peers.AutomationPeer> GetChildrenCore() { throw null; }
         protected override System.Windows.Point GetClickablePointCore() { throw null; }
@@ -3181,14 +3189,14 @@ namespace System.Windows.Automation.Peers
     }
     public partial class ThumbAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public ThumbAutomationPeer(System.Windows.Controls.Primitives.Thumb owner) : base (default(System.Windows.FrameworkElement)) { }
+        public ThumbAutomationPeer(System.Windows.Controls.Primitives.Thumb owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
         protected override bool IsContentElementCore() { throw null; }
     }
     public partial class ToggleButtonAutomationPeer : System.Windows.Automation.Peers.ButtonBaseAutomationPeer, System.Windows.Automation.Provider.IToggleProvider
     {
-        public ToggleButtonAutomationPeer(System.Windows.Controls.Primitives.ToggleButton owner) : base (default(System.Windows.Controls.Primitives.ButtonBase)) { }
+        public ToggleButtonAutomationPeer(System.Windows.Controls.Primitives.ToggleButton owner) : base(default(System.Windows.Controls.Primitives.ButtonBase)) { }
         System.Windows.Automation.ToggleState System.Windows.Automation.Provider.IToggleProvider.ToggleState { get { throw null; } }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
@@ -3197,19 +3205,19 @@ namespace System.Windows.Automation.Peers
     }
     public partial class ToolBarAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public ToolBarAutomationPeer(System.Windows.Controls.ToolBar owner) : base (default(System.Windows.FrameworkElement)) { }
+        public ToolBarAutomationPeer(System.Windows.Controls.ToolBar owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class ToolTipAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public ToolTipAutomationPeer(System.Windows.Controls.ToolTip owner) : base (default(System.Windows.FrameworkElement)) { }
+        public ToolTipAutomationPeer(System.Windows.Controls.ToolTip owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class TreeViewAutomationPeer : System.Windows.Automation.Peers.ItemsControlAutomationPeer, System.Windows.Automation.Provider.ISelectionProvider
     {
-        public TreeViewAutomationPeer(System.Windows.Controls.TreeView owner) : base (default(System.Windows.Controls.ItemsControl)) { }
+        public TreeViewAutomationPeer(System.Windows.Controls.TreeView owner) : base(default(System.Windows.Controls.ItemsControl)) { }
         bool System.Windows.Automation.Provider.ISelectionProvider.CanSelectMultiple { get { throw null; } }
         bool System.Windows.Automation.Provider.ISelectionProvider.IsSelectionRequired { get { throw null; } }
         protected override System.Windows.Automation.Peers.ItemAutomationPeer CreateItemAutomationPeer(object item) { throw null; }
@@ -3221,7 +3229,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class TreeViewDataItemAutomationPeer : System.Windows.Automation.Peers.ItemAutomationPeer, System.Windows.Automation.Provider.IExpandCollapseProvider, System.Windows.Automation.Provider.IScrollItemProvider, System.Windows.Automation.Provider.ISelectionItemProvider
     {
-        public TreeViewDataItemAutomationPeer(object item, System.Windows.Automation.Peers.ItemsControlAutomationPeer itemsControlAutomationPeer, System.Windows.Automation.Peers.TreeViewDataItemAutomationPeer parentDataItemAutomationPeer) : base (default(object), default(System.Windows.Automation.Peers.ItemsControlAutomationPeer)) { }
+        public TreeViewDataItemAutomationPeer(object item, System.Windows.Automation.Peers.ItemsControlAutomationPeer itemsControlAutomationPeer, System.Windows.Automation.Peers.TreeViewDataItemAutomationPeer parentDataItemAutomationPeer) : base(default(object), default(System.Windows.Automation.Peers.ItemsControlAutomationPeer)) { }
         public System.Windows.Automation.Peers.TreeViewDataItemAutomationPeer ParentDataItemAutomationPeer { get { throw null; } }
         System.Windows.Automation.ExpandCollapseState System.Windows.Automation.Provider.IExpandCollapseProvider.ExpandCollapseState { get { throw null; } }
         bool System.Windows.Automation.Provider.ISelectionItemProvider.IsSelected { get { throw null; } }
@@ -3238,7 +3246,7 @@ namespace System.Windows.Automation.Peers
     }
     public partial class TreeViewItemAutomationPeer : System.Windows.Automation.Peers.ItemsControlAutomationPeer, System.Windows.Automation.Provider.IExpandCollapseProvider, System.Windows.Automation.Provider.IScrollItemProvider, System.Windows.Automation.Provider.ISelectionItemProvider
     {
-        public TreeViewItemAutomationPeer(System.Windows.Controls.TreeViewItem owner) : base (default(System.Windows.Controls.ItemsControl)) { }
+        public TreeViewItemAutomationPeer(System.Windows.Controls.TreeViewItem owner) : base(default(System.Windows.Controls.ItemsControl)) { }
         System.Windows.Automation.ExpandCollapseState System.Windows.Automation.Provider.IExpandCollapseProvider.ExpandCollapseState { get { throw null; } }
         bool System.Windows.Automation.Provider.ISelectionItemProvider.IsSelected { get { throw null; } }
         System.Windows.Automation.Provider.IRawElementProviderSimple System.Windows.Automation.Provider.ISelectionItemProvider.SelectionContainer { get { throw null; } }
@@ -3257,19 +3265,19 @@ namespace System.Windows.Automation.Peers
     }
     public partial class UserControlAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public UserControlAutomationPeer(System.Windows.Controls.UserControl owner) : base (default(System.Windows.FrameworkElement)) { }
+        public UserControlAutomationPeer(System.Windows.Controls.UserControl owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class Viewport3DAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public Viewport3DAutomationPeer(System.Windows.Controls.Viewport3D owner) : base (default(System.Windows.FrameworkElement)) { }
+        public Viewport3DAutomationPeer(System.Windows.Controls.Viewport3D owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
     }
     public partial class WindowAutomationPeer : System.Windows.Automation.Peers.FrameworkElementAutomationPeer
     {
-        public WindowAutomationPeer(System.Windows.Window owner) : base (default(System.Windows.FrameworkElement)) { }
+        public WindowAutomationPeer(System.Windows.Window owner) : base(default(System.Windows.FrameworkElement)) { }
         protected override System.Windows.Automation.Peers.AutomationControlType GetAutomationControlTypeCore() { throw null; }
         protected override System.Windows.Rect GetBoundingRectangleCore() { throw null; }
         protected override string GetClassNameCore() { throw null; }
@@ -3322,7 +3330,7 @@ namespace System.Windows.Controls
         public char AccessKey { get { throw null; } }
         public System.Windows.Media.Brush Background { get { throw null; } set { } }
         public double BaselineOffset { get { throw null; } set { } }
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Font, Modifiability=System.Windows.Modifiability.Unmodifiable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Font, Modifiability = System.Windows.Modifiability.Unmodifiable)]
         public System.Windows.Media.FontFamily FontFamily { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.FontSizeConverter))]
         [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None)]
@@ -3420,8 +3428,8 @@ namespace System.Windows.Controls
         protected override void OnClick() { }
         protected override System.Windows.Automation.Peers.AutomationPeer OnCreateAutomationPeer() { throw null; }
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_CalendarItem", Type=typeof(System.Windows.Controls.Primitives.CalendarItem))]
-    [System.Windows.TemplatePartAttribute(Name="PART_Root", Type=typeof(System.Windows.Controls.Panel))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_CalendarItem", Type = typeof(System.Windows.Controls.Primitives.CalendarItem))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Root", Type = typeof(System.Windows.Controls.Panel))]
     public partial class Calendar : System.Windows.Controls.Control
     {
         public static readonly System.Windows.DependencyProperty CalendarButtonStyleProperty;
@@ -3611,9 +3619,9 @@ namespace System.Windows.Controls
         void System.Collections.IList.Remove(object value) { }
     }
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.ComboBox)]
-    [System.Windows.StyleTypedPropertyAttribute(Property="ItemContainerStyle", StyleTargetType=typeof(System.Windows.Controls.ComboBoxItem))]
-    [System.Windows.TemplatePartAttribute(Name="PART_EditableTextBox", Type=typeof(System.Windows.Controls.TextBox))]
-    [System.Windows.TemplatePartAttribute(Name="PART_Popup", Type=typeof(System.Windows.Controls.Primitives.Popup))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "ItemContainerStyle", StyleTargetType = typeof(System.Windows.Controls.ComboBoxItem))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_EditableTextBox", Type = typeof(System.Windows.Controls.TextBox))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Popup", Type = typeof(System.Windows.Controls.Primitives.Popup))]
     public partial class ComboBox : System.Windows.Controls.Primitives.Selector
     {
         public static readonly System.Windows.DependencyProperty IsDropDownOpenProperty;
@@ -3675,7 +3683,7 @@ namespace System.Windows.Controls
         protected override void OnMouseLeftButtonUp(System.Windows.Input.MouseButtonEventArgs e) { }
     }
     [System.ComponentModel.DefaultPropertyAttribute("Content")]
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     [System.Windows.Markup.ContentPropertyAttribute("Content")]
     public partial class ContentControl : System.Windows.Controls.Control, System.Windows.Markup.IAddChild
     {
@@ -3709,7 +3717,7 @@ namespace System.Windows.Controls
         void System.Windows.Markup.IAddChild.AddChild(object value) { }
         void System.Windows.Markup.IAddChild.AddText(string text) { }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public partial class ContentPresenter : System.Windows.FrameworkElement
     {
         public static readonly System.Windows.DependencyProperty ContentProperty;
@@ -3924,7 +3932,7 @@ namespace System.Windows.Controls
         protected virtual void OnTemplateChanged(System.Windows.Controls.ControlTemplate oldTemplate, System.Windows.Controls.ControlTemplate newTemplate) { }
         public override string ToString() { throw null; }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     [System.Windows.Markup.DictionaryKeyPropertyAttribute("TargetType")]
     public partial class ControlTemplate : System.Windows.FrameworkTemplate
     {
@@ -4342,7 +4350,7 @@ namespace System.Windows.Controls
     }
     public partial class DataGridColumnReorderingEventArgs : System.Windows.Controls.DataGridColumnEventArgs
     {
-        public DataGridColumnReorderingEventArgs(System.Windows.Controls.DataGridColumn dataGridColumn) : base (default(System.Windows.Controls.DataGridColumn)) { }
+        public DataGridColumnReorderingEventArgs(System.Windows.Controls.DataGridColumn dataGridColumn) : base(default(System.Windows.Controls.DataGridColumn)) { }
         public bool Cancel { get { throw null; } set { } }
         public System.Windows.Controls.Control DragIndicator { get { throw null; } set { } }
         public System.Windows.Controls.Control DropLocationIndicator { get { throw null; } set { } }
@@ -4442,7 +4450,7 @@ namespace System.Windows.Controls
         public bool Equals(System.Windows.Controls.DataGridLength other) { throw null; }
         public override int GetHashCode() { throw null; }
         public static bool operator ==(System.Windows.Controls.DataGridLength gl1, System.Windows.Controls.DataGridLength gl2) { throw null; }
-        public static implicit operator System.Windows.Controls.DataGridLength (double value) { throw null; }
+        public static implicit operator System.Windows.Controls.DataGridLength(double value) { throw null; }
         public static bool operator !=(System.Windows.Controls.DataGridLength gl1, System.Windows.Controls.DataGridLength gl2) { throw null; }
         public override string ToString() { throw null; }
     }
@@ -4566,7 +4574,7 @@ namespace System.Windows.Controls
     }
     public partial class DataGridSortingEventArgs : System.Windows.Controls.DataGridColumnEventArgs
     {
-        public DataGridSortingEventArgs(System.Windows.Controls.DataGridColumn column) : base (default(System.Windows.Controls.DataGridColumn)) { }
+        public DataGridSortingEventArgs(System.Windows.Controls.DataGridColumn column) : base(default(System.Windows.Controls.DataGridColumn)) { }
         public bool Handled { get { throw null; } set { } }
     }
     public delegate void DataGridSortingEventHandler(object sender, System.Windows.Controls.DataGridSortingEventArgs e);
@@ -4614,10 +4622,10 @@ namespace System.Windows.Controls
         public DataTemplateSelector() { }
         public virtual System.Windows.DataTemplate SelectTemplate(object item, System.Windows.DependencyObject container) { throw null; }
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_Button", Type=typeof(System.Windows.Controls.Button))]
-    [System.Windows.TemplatePartAttribute(Name="PART_Popup", Type=typeof(System.Windows.Controls.Primitives.Popup))]
-    [System.Windows.TemplatePartAttribute(Name="PART_Root", Type=typeof(System.Windows.Controls.Grid))]
-    [System.Windows.TemplatePartAttribute(Name="PART_TextBox", Type=typeof(System.Windows.Controls.Primitives.DatePickerTextBox))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Button", Type = typeof(System.Windows.Controls.Button))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Popup", Type = typeof(System.Windows.Controls.Primitives.Popup))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Root", Type = typeof(System.Windows.Controls.Grid))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_TextBox", Type = typeof(System.Windows.Controls.Primitives.DatePickerTextBox))]
     public partial class DatePicker : System.Windows.Controls.Control
     {
         public static readonly System.Windows.DependencyProperty CalendarStyleProperty;
@@ -4668,7 +4676,7 @@ namespace System.Windows.Controls
         Long = 0,
         Short = 1,
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Ignore, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Ignore, Readability = System.Windows.Readability.Unreadable)]
     [System.Windows.Markup.ContentPropertyAttribute("Child")]
     public partial class Decorator : System.Windows.FrameworkElement, System.Windows.Markup.IAddChild
     {
@@ -4709,8 +4717,8 @@ namespace System.Windows.Controls
         protected override System.Windows.Size MeasureOverride(System.Windows.Size constraint) { throw null; }
         public static void SetDock(System.Windows.UIElement element, System.Windows.Controls.Dock dock) { }
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_ContentHost", Type=typeof(System.Windows.Controls.ScrollViewer))]
-    [System.Windows.TemplatePartAttribute(Name="PART_FindToolBarHost", Type=typeof(System.Windows.Controls.ContentControl))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_ContentHost", Type = typeof(System.Windows.Controls.ScrollViewer))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_FindToolBarHost", Type = typeof(System.Windows.Controls.ContentControl))]
     public partial class DocumentViewer : System.Windows.Controls.Primitives.DocumentViewerBase
     {
         public static readonly System.Windows.DependencyProperty CanDecreaseZoomProperty;
@@ -4810,7 +4818,7 @@ namespace System.Windows.Controls
         Right = 3,
         Up = 1,
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public partial class Expander : System.Windows.Controls.HeaderedContentControl
     {
         public static readonly System.Windows.RoutedEvent CollapsedEvent;
@@ -4831,7 +4839,7 @@ namespace System.Windows.Controls
         protected override System.Windows.Automation.Peers.AutomationPeer OnCreateAutomationPeer() { throw null; }
         protected virtual void OnExpanded() { }
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_FindToolBarHost", Type=typeof(System.Windows.Controls.Decorator))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_FindToolBarHost", Type = typeof(System.Windows.Controls.Decorator))]
     public partial class FlowDocumentPageViewer : System.Windows.Controls.Primitives.DocumentViewerBase
     {
         public static readonly System.Windows.DependencyProperty CanDecreaseZoomProperty;
@@ -4881,8 +4889,8 @@ namespace System.Windows.Controls
         protected virtual void OnPrintCompleted() { }
     }
     [System.Windows.Markup.ContentPropertyAttribute("Document")]
-    [System.Windows.TemplatePartAttribute(Name="PART_ContentHost", Type=typeof(System.Windows.Controls.Decorator))]
-    [System.Windows.TemplatePartAttribute(Name="PART_FindToolBarHost", Type=typeof(System.Windows.Controls.Decorator))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_ContentHost", Type = typeof(System.Windows.Controls.Decorator))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_FindToolBarHost", Type = typeof(System.Windows.Controls.Decorator))]
     public partial class FlowDocumentReader : System.Windows.Controls.Control, System.Windows.Markup.IAddChild
     {
         public static readonly System.Windows.DependencyProperty CanDecreaseZoomProperty;
@@ -4962,9 +4970,9 @@ namespace System.Windows.Controls
         TwoPage = 1,
     }
     [System.Windows.Markup.ContentPropertyAttribute("Document")]
-    [System.Windows.TemplatePartAttribute(Name="PART_ContentHost", Type=typeof(System.Windows.Controls.ScrollViewer))]
-    [System.Windows.TemplatePartAttribute(Name="PART_FindToolBarHost", Type=typeof(System.Windows.Controls.Decorator))]
-    [System.Windows.TemplatePartAttribute(Name="PART_ToolBarHost", Type=typeof(System.Windows.Controls.Decorator))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_ContentHost", Type = typeof(System.Windows.Controls.ScrollViewer))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_FindToolBarHost", Type = typeof(System.Windows.Controls.Decorator))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_ToolBarHost", Type = typeof(System.Windows.Controls.Decorator))]
     public partial class FlowDocumentScrollViewer : System.Windows.Controls.Control, System.IServiceProvider, System.Windows.Markup.IAddChild
     {
         public static readonly System.Windows.DependencyProperty CanDecreaseZoomProperty;
@@ -5024,7 +5032,7 @@ namespace System.Windows.Controls
     [System.ComponentModel.DefaultPropertyAttribute("Source")]
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Ignore)]
     [System.Windows.Markup.ContentPropertyAttribute]
-    [System.Windows.TemplatePartAttribute(Name="PART_FrameCP", Type=typeof(System.Windows.Controls.ContentPresenter))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_FrameCP", Type = typeof(System.Windows.Controls.ContentPresenter))]
     public partial class Frame : System.Windows.Controls.ContentControl, System.Windows.Markup.IAddChild, System.Windows.Markup.IUriContext
     {
         public static readonly System.Windows.DependencyProperty BackStackProperty;
@@ -5129,7 +5137,7 @@ namespace System.Windows.Controls
         Columns = 1,
         Rows = 2,
     }
-    [System.Windows.StyleTypedPropertyAttribute(Property="PreviewStyle", StyleTargetType=typeof(System.Windows.Controls.Control))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "PreviewStyle", StyleTargetType = typeof(System.Windows.Controls.Control))]
     public partial class GridSplitter : System.Windows.Controls.Primitives.Thumb
     {
         public static readonly System.Windows.DependencyProperty DragIncrementProperty;
@@ -5151,7 +5159,7 @@ namespace System.Windows.Controls
         protected internal override void OnRenderSizeChanged(System.Windows.SizeChangedInfo sizeInfo) { }
     }
     [System.Windows.Markup.ContentPropertyAttribute("Columns")]
-    [System.Windows.StyleTypedPropertyAttribute(Property="ColumnHeaderContainerStyle", StyleTargetType=typeof(System.Windows.Controls.GridViewColumnHeader))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "ColumnHeaderContainerStyle", StyleTargetType = typeof(System.Windows.Controls.GridViewColumnHeader))]
     public partial class GridView : System.Windows.Controls.ViewBase, System.Windows.Markup.IAddChild
     {
         public static readonly System.Windows.DependencyProperty AllowsColumnReorderProperty;
@@ -5191,9 +5199,9 @@ namespace System.Windows.Controls
         void System.Windows.Markup.IAddChild.AddText(string text) { }
         public override string ToString() { throw null; }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     [System.Windows.Markup.ContentPropertyAttribute("Header")]
-    [System.Windows.StyleTypedPropertyAttribute(Property="HeaderContainerStyle", StyleTargetType=typeof(System.Windows.Controls.GridViewColumnHeader))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "HeaderContainerStyle", StyleTargetType = typeof(System.Windows.Controls.GridViewColumnHeader))]
     public partial class GridViewColumn : System.Windows.DependencyObject, System.ComponentModel.INotifyPropertyChanged
     {
         public static readonly System.Windows.DependencyProperty CellTemplateProperty;
@@ -5233,8 +5241,8 @@ namespace System.Windows.Controls
         protected override void RemoveItem(int index) { }
         protected override void SetItem(int index, System.Windows.Controls.GridViewColumn column) { }
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_FloatingHeaderCanvas", Type=typeof(System.Windows.Controls.Canvas))]
-    [System.Windows.TemplatePartAttribute(Name="PART_HeaderGripper", Type=typeof(System.Windows.Controls.Primitives.Thumb))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_FloatingHeaderCanvas", Type = typeof(System.Windows.Controls.Canvas))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_HeaderGripper", Type = typeof(System.Windows.Controls.Primitives.Thumb))]
     public partial class GridViewColumnHeader : System.Windows.Controls.Primitives.ButtonBase
     {
         public static readonly System.Windows.DependencyProperty ColumnProperty;
@@ -5262,7 +5270,7 @@ namespace System.Windows.Controls
         Normal = 0,
         Padding = 2,
     }
-    [System.Windows.StyleTypedPropertyAttribute(Property="ColumnHeaderContainerStyle", StyleTargetType=typeof(System.Windows.Controls.GridViewColumnHeader))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "ColumnHeaderContainerStyle", StyleTargetType = typeof(System.Windows.Controls.GridViewColumnHeader))]
     public partial class GridViewHeaderRowPresenter : System.Windows.Controls.Primitives.GridViewRowPresenterBase
     {
         public static readonly System.Windows.DependencyProperty AllowsColumnReorderProperty;
@@ -5299,7 +5307,7 @@ namespace System.Windows.Controls
         protected override System.Windows.Size MeasureOverride(System.Windows.Size constraint) { throw null; }
         public override string ToString() { throw null; }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public partial class GroupBox : System.Windows.Controls.HeaderedContentControl
     {
         public GroupBox() { }
@@ -5324,7 +5332,7 @@ namespace System.Windows.Controls
         object System.Windows.Controls.Primitives.IContainItemStorage.ReadItemValue(object item, System.Windows.DependencyProperty dp) { throw null; }
         void System.Windows.Controls.Primitives.IContainItemStorage.StoreItemValue(object item, System.Windows.DependencyProperty dp, object value) { }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public partial class GroupStyle : System.ComponentModel.INotifyPropertyChanged
     {
         public static readonly System.Windows.Controls.ItemsPanelTemplate DefaultGroupPanel;
@@ -5452,7 +5460,7 @@ namespace System.Windows.Controls
         public static bool operator ==(System.Windows.Controls.HierarchicalVirtualizationItemDesiredSizes itemDesiredSizes1, System.Windows.Controls.HierarchicalVirtualizationItemDesiredSizes itemDesiredSizes2) { throw null; }
         public static bool operator !=(System.Windows.Controls.HierarchicalVirtualizationItemDesiredSizes itemDesiredSizes1, System.Windows.Controls.HierarchicalVirtualizationItemDesiredSizes itemDesiredSizes2) { throw null; }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public partial class Image : System.Windows.FrameworkElement, System.Windows.Markup.IUriContext
     {
         public static readonly System.Windows.RoutedEvent DpiChangedEvent;
@@ -5692,7 +5700,7 @@ namespace System.Windows.Controls
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Ignore)]
     public sealed partial class ItemCollection : System.Windows.Data.CollectionView, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.ICollectionViewLiveShaping, System.ComponentModel.IEditableCollectionView, System.ComponentModel.IEditableCollectionViewAddNewItem, System.ComponentModel.IItemProperties, System.Windows.IWeakEventListener
     {
-        internal ItemCollection() : base (default(System.Collections.IEnumerable)) { }
+        internal ItemCollection() : base(default(System.Collections.IEnumerable)) { }
         public bool CanChangeLiveFiltering { get { throw null; } }
         public bool CanChangeLiveGrouping { get { throw null; } }
         public bool CanChangeLiveSorting { get { throw null; } }
@@ -5796,8 +5804,8 @@ namespace System.Windows.Controls
     }
     public partial class ItemContainerTemplateKey : System.Windows.TemplateKey
     {
-        public ItemContainerTemplateKey() : base (default(System.Windows.TemplateKey.TemplateType)) { }
-        public ItemContainerTemplateKey(object dataType) : base (default(System.Windows.TemplateKey.TemplateType)) { }
+        public ItemContainerTemplateKey() : base(default(System.Windows.TemplateKey.TemplateType)) { }
+        public ItemContainerTemplateKey(object dataType) : base(default(System.Windows.TemplateKey.TemplateType)) { }
     }
     public abstract partial class ItemContainerTemplateSelector
     {
@@ -5806,9 +5814,9 @@ namespace System.Windows.Controls
     }
     [System.ComponentModel.DefaultEventAttribute("OnItemsChanged")]
     [System.ComponentModel.DefaultPropertyAttribute("Items")]
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     [System.Windows.Markup.ContentPropertyAttribute("Items")]
-    [System.Windows.StyleTypedPropertyAttribute(Property="ItemContainerStyle", StyleTargetType=typeof(System.Windows.FrameworkElement))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "ItemContainerStyle", StyleTargetType = typeof(System.Windows.FrameworkElement))]
     public partial class ItemsControl : System.Windows.Controls.Control, System.Windows.Controls.Primitives.IContainItemStorage, System.Windows.Markup.IAddChild
     {
         public static readonly System.Windows.DependencyProperty AlternationCountProperty;
@@ -5941,7 +5949,7 @@ namespace System.Windows.Controls
         protected override System.Windows.Automation.Peers.AutomationPeer OnCreateAutomationPeer() { throw null; }
     }
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.ListBox)]
-    [System.Windows.StyleTypedPropertyAttribute(Property="ItemContainerStyle", StyleTargetType=typeof(System.Windows.Controls.ListBoxItem))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "ItemContainerStyle", StyleTargetType = typeof(System.Windows.Controls.ListBoxItem))]
     public partial class ListBox : System.Windows.Controls.Primitives.Selector
     {
         public static readonly System.Windows.DependencyProperty SelectedItemsProperty;
@@ -5988,7 +5996,7 @@ namespace System.Windows.Controls
         protected virtual void OnUnselected(System.Windows.RoutedEventArgs e) { }
         protected internal override void OnVisualParentChanged(System.Windows.DependencyObject oldParent) { }
     }
-    [System.Windows.StyleTypedPropertyAttribute(Property="ItemContainerStyle", StyleTargetType=typeof(System.Windows.Controls.ListViewItem))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "ItemContainerStyle", StyleTargetType = typeof(System.Windows.Controls.ListViewItem))]
     public partial class ListView : System.Windows.Controls.ListBox
     {
         public static readonly System.Windows.DependencyProperty ViewProperty;
@@ -6084,8 +6092,8 @@ namespace System.Windows.Controls
     }
     [System.ComponentModel.DefaultEventAttribute("Click")]
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Menu)]
-    [System.Windows.StyleTypedPropertyAttribute(Property="ItemContainerStyle", StyleTargetType=typeof(System.Windows.Controls.MenuItem))]
-    [System.Windows.TemplatePartAttribute(Name="PART_Popup", Type=typeof(System.Windows.Controls.Primitives.Popup))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "ItemContainerStyle", StyleTargetType = typeof(System.Windows.Controls.MenuItem))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Popup", Type = typeof(System.Windows.Controls.Primitives.Popup))]
     public partial class MenuItem : System.Windows.Controls.HeaderedItemsControl, System.Windows.Input.ICommandSource
     {
         public static readonly System.Windows.RoutedEvent CheckedEvent;
@@ -6211,7 +6219,7 @@ namespace System.Windows.Controls
         public NotifyDataErrorValidationRule() { }
         public override System.Windows.Controls.ValidationResult Validate(object value, System.Globalization.CultureInfo cultureInfo) { throw null; }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public enum Orientation
     {
         Horizontal = 0,
@@ -6240,7 +6248,7 @@ namespace System.Windows.Controls
         public object Content { get { throw null; } set { } }
         [System.ComponentModel.BindableAttribute(true)]
         [System.ComponentModel.CategoryAttribute("Appearance")]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Font, Modifiability=System.Windows.Modifiability.Unmodifiable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Font, Modifiability = System.Windows.Modifiability.Unmodifiable)]
         public System.Windows.Media.FontFamily FontFamily { get { throw null; } set { } }
         [System.ComponentModel.BindableAttribute(true)]
         [System.ComponentModel.CategoryAttribute("Appearance")]
@@ -6340,7 +6348,7 @@ namespace System.Windows.Controls
         VerticalFirst = 5,
         VerticalOnly = 2,
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_ContentHost", Type=typeof(System.Windows.FrameworkElement))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_ContentHost", Type = typeof(System.Windows.FrameworkElement))]
     public sealed partial class PasswordBox : System.Windows.Controls.Control
     {
         public static readonly System.Windows.DependencyProperty CaretBrushProperty;
@@ -6420,9 +6428,9 @@ namespace System.Windows.Controls
         public PrintDialogException(string message) { }
         public PrintDialogException(string message, System.Exception innerException) { }
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_GlowRect", Type=typeof(System.Windows.FrameworkElement))]
-    [System.Windows.TemplatePartAttribute(Name="PART_Indicator", Type=typeof(System.Windows.FrameworkElement))]
-    [System.Windows.TemplatePartAttribute(Name="PART_Track", Type=typeof(System.Windows.FrameworkElement))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_GlowRect", Type = typeof(System.Windows.FrameworkElement))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Indicator", Type = typeof(System.Windows.FrameworkElement))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Track", Type = typeof(System.Windows.FrameworkElement))]
     public partial class ProgressBar : System.Windows.Controls.Primitives.RangeBase
     {
         public static readonly System.Windows.DependencyProperty IsIndeterminateProperty;
@@ -6590,9 +6598,9 @@ namespace System.Windows.Controls
     }
     [System.ComponentModel.DefaultEventAttribute("ScrollChangedEvent")]
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Ignore)]
-    [System.Windows.TemplatePartAttribute(Name="PART_HorizontalScrollBar", Type=typeof(System.Windows.Controls.Primitives.ScrollBar))]
-    [System.Windows.TemplatePartAttribute(Name="PART_ScrollContentPresenter", Type=typeof(System.Windows.Controls.ScrollContentPresenter))]
-    [System.Windows.TemplatePartAttribute(Name="PART_VerticalScrollBar", Type=typeof(System.Windows.Controls.Primitives.ScrollBar))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_HorizontalScrollBar", Type = typeof(System.Windows.Controls.Primitives.ScrollBar))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_ScrollContentPresenter", Type = typeof(System.Windows.Controls.ScrollContentPresenter))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_VerticalScrollBar", Type = typeof(System.Windows.Controls.Primitives.ScrollBar))]
     public partial class ScrollViewer : System.Windows.Controls.ContentControl
     {
         public static readonly System.Windows.DependencyProperty CanContentScrollProperty;
@@ -6731,7 +6739,7 @@ namespace System.Windows.Controls
         None = 0,
         Vertical = 2,
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public partial class Separator : System.Windows.Controls.Control
     {
         public Separator() { }
@@ -6740,8 +6748,8 @@ namespace System.Windows.Controls
     [System.ComponentModel.DefaultEventAttribute("ValueChanged")]
     [System.ComponentModel.DefaultPropertyAttribute("Value")]
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Ignore)]
-    [System.Windows.TemplatePartAttribute(Name="PART_SelectionRange", Type=typeof(System.Windows.FrameworkElement))]
-    [System.Windows.TemplatePartAttribute(Name="PART_Track", Type=typeof(System.Windows.Controls.Primitives.Track))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_SelectionRange", Type = typeof(System.Windows.FrameworkElement))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Track", Type = typeof(System.Windows.Controls.Primitives.Track))]
     public partial class Slider : System.Windows.Controls.Primitives.RangeBase
     {
         public static readonly System.Windows.DependencyProperty AutoToolTipPlacementProperty;
@@ -6895,16 +6903,16 @@ namespace System.Windows.Controls
         public void SetHorizontalOffset(double offset) { }
         public void SetVerticalOffset(double offset) { }
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_CloseButton", Type=typeof(System.Windows.Controls.Button))]
-    [System.Windows.TemplatePartAttribute(Name="PART_ContentControl", Type=typeof(System.Windows.Controls.ContentControl))]
-    [System.Windows.TemplatePartAttribute(Name="PART_CopyMenuItem", Type=typeof(System.Windows.Controls.MenuItem))]
-    [System.Windows.TemplatePartAttribute(Name="PART_EraseMenuItem", Type=typeof(System.Windows.Controls.MenuItem))]
-    [System.Windows.TemplatePartAttribute(Name="PART_IconButton", Type=typeof(System.Windows.Controls.Button))]
-    [System.Windows.TemplatePartAttribute(Name="PART_InkMenuItem", Type=typeof(System.Windows.Controls.MenuItem))]
-    [System.Windows.TemplatePartAttribute(Name="PART_PasteMenuItem", Type=typeof(System.Windows.Controls.MenuItem))]
-    [System.Windows.TemplatePartAttribute(Name="PART_ResizeBottomRightThumb", Type=typeof(System.Windows.Controls.Primitives.Thumb))]
-    [System.Windows.TemplatePartAttribute(Name="PART_SelectMenuItem", Type=typeof(System.Windows.Controls.MenuItem))]
-    [System.Windows.TemplatePartAttribute(Name="PART_TitleThumb", Type=typeof(System.Windows.Controls.Primitives.Thumb))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_CloseButton", Type = typeof(System.Windows.Controls.Button))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_ContentControl", Type = typeof(System.Windows.Controls.ContentControl))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_CopyMenuItem", Type = typeof(System.Windows.Controls.MenuItem))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_EraseMenuItem", Type = typeof(System.Windows.Controls.MenuItem))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_IconButton", Type = typeof(System.Windows.Controls.Button))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_InkMenuItem", Type = typeof(System.Windows.Controls.MenuItem))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_PasteMenuItem", Type = typeof(System.Windows.Controls.MenuItem))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_ResizeBottomRightThumb", Type = typeof(System.Windows.Controls.Primitives.Thumb))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_SelectMenuItem", Type = typeof(System.Windows.Controls.MenuItem))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_TitleThumb", Type = typeof(System.Windows.Controls.Primitives.Thumb))]
     public sealed partial class StickyNoteControl : System.Windows.Controls.Control
     {
         internal StickyNoteControl() { }
@@ -6956,8 +6964,8 @@ namespace System.Windows.Controls
         public StyleSelector() { }
         public virtual System.Windows.Style SelectStyle(object item, System.Windows.DependencyObject container) { throw null; }
     }
-    [System.Windows.StyleTypedPropertyAttribute(Property="ItemContainerStyle", StyleTargetType=typeof(System.Windows.Controls.TabItem))]
-    [System.Windows.TemplatePartAttribute(Name="PART_SelectedContentHost", Type=typeof(System.Windows.Controls.ContentPresenter))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "ItemContainerStyle", StyleTargetType = typeof(System.Windows.Controls.TabItem))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_SelectedContentHost", Type = typeof(System.Windows.Controls.ContentPresenter))]
     public partial class TabControl : System.Windows.Controls.Primitives.Selector
     {
         public static readonly System.Windows.DependencyProperty ContentStringFormatProperty;
@@ -7135,7 +7143,7 @@ namespace System.Windows.Controls
         public int LineCount { get { throw null; } }
         protected internal override System.Collections.IEnumerator LogicalChildren { get { throw null; } }
         [System.ComponentModel.DefaultValueAttribute(0)]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Modifiability=System.Windows.Modifiability.Unmodifiable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Modifiability = System.Windows.Modifiability.Unmodifiable)]
         public int MaxLength { get { throw null; } set { } }
         [System.ComponentModel.DefaultValueAttribute(2147483647)]
         public int MaxLines { get { throw null; } set { } }
@@ -7208,8 +7216,8 @@ namespace System.Windows.Controls
         public static void SetText(System.Windows.DependencyObject element, string text) { }
         public static void SetTextPath(System.Windows.DependencyObject element, string path) { }
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_ToolBarOverflowPanel", Type=typeof(System.Windows.Controls.Primitives.ToolBarOverflowPanel))]
-    [System.Windows.TemplatePartAttribute(Name="PART_ToolBarPanel", Type=typeof(System.Windows.Controls.Primitives.ToolBarPanel))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_ToolBarOverflowPanel", Type = typeof(System.Windows.Controls.Primitives.ToolBarOverflowPanel))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_ToolBarPanel", Type = typeof(System.Windows.Controls.Primitives.ToolBarPanel))]
     public partial class ToolBar : System.Windows.Controls.HeaderedItemsControl
     {
         public static readonly System.Windows.DependencyProperty BandIndexProperty;
@@ -7238,7 +7246,7 @@ namespace System.Windows.Controls
         public static System.Windows.ResourceKey TextBoxStyleKey { get { throw null; } }
         public static System.Windows.ResourceKey ToggleButtonStyleKey { get { throw null; } }
         public static bool GetIsOverflowItem(System.Windows.DependencyObject element) { throw null; }
-        [System.Windows.AttachedPropertyBrowsableForChildrenAttribute(IncludeDescendants=true)]
+        [System.Windows.AttachedPropertyBrowsableForChildrenAttribute(IncludeDescendants = true)]
         public static System.Windows.Controls.OverflowMode GetOverflowMode(System.Windows.DependencyObject element) { throw null; }
         protected override System.Windows.Size MeasureOverride(System.Windows.Size constraint) { throw null; }
         protected override System.Windows.Automation.Peers.AutomationPeer OnCreateAutomationPeer() { throw null; }
@@ -7393,7 +7401,7 @@ namespace System.Windows.Controls
         public static void SetToolTip(System.Windows.DependencyObject element, object value) { }
         public static void SetVerticalOffset(System.Windows.DependencyObject element, double value) { }
     }
-    [System.Windows.StyleTypedPropertyAttribute(Property="ItemContainerStyle", StyleTargetType=typeof(System.Windows.Controls.TreeViewItem))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "ItemContainerStyle", StyleTargetType = typeof(System.Windows.Controls.TreeViewItem))]
     public partial class TreeView : System.Windows.Controls.ItemsControl
     {
         public static readonly System.Windows.RoutedEvent SelectedItemChangedEvent;
@@ -7427,9 +7435,9 @@ namespace System.Windows.Controls
         protected override void OnKeyDown(System.Windows.Input.KeyEventArgs e) { }
         protected virtual void OnSelectedItemChanged(System.Windows.RoutedPropertyChangedEventArgs<object> e) { }
     }
-    [System.Windows.StyleTypedPropertyAttribute(Property="ItemContainerStyle", StyleTargetType=typeof(System.Windows.Controls.TreeViewItem))]
-    [System.Windows.TemplatePartAttribute(Name="ItemsHost", Type=typeof(System.Windows.Controls.ItemsPresenter))]
-    [System.Windows.TemplatePartAttribute(Name="PART_Header", Type=typeof(System.Windows.FrameworkElement))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "ItemContainerStyle", StyleTargetType = typeof(System.Windows.Controls.TreeViewItem))]
+    [System.Windows.TemplatePartAttribute(Name = "ItemsHost", Type = typeof(System.Windows.Controls.ItemsPresenter))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Header", Type = typeof(System.Windows.FrameworkElement))]
     public partial class TreeViewItem : System.Windows.Controls.HeaderedItemsControl, System.Windows.Controls.Primitives.IHierarchicalVirtualizationAndScrollInfo
     {
         public static readonly System.Windows.RoutedEvent CollapsedEvent;
@@ -7890,14 +7898,14 @@ namespace System.Windows.Controls.Primitives
         public bool IsToday { get { throw null; } }
         protected override System.Windows.Automation.Peers.AutomationPeer OnCreateAutomationPeer() { throw null; }
     }
-    [System.Windows.TemplatePartAttribute(Name="DayTitleTemplate", Type=typeof(System.Windows.DataTemplate))]
-    [System.Windows.TemplatePartAttribute(Name="PART_DisabledVisual", Type=typeof(System.Windows.FrameworkElement))]
-    [System.Windows.TemplatePartAttribute(Name="PART_HeaderButton", Type=typeof(System.Windows.Controls.Button))]
-    [System.Windows.TemplatePartAttribute(Name="PART_MonthView", Type=typeof(System.Windows.Controls.Grid))]
-    [System.Windows.TemplatePartAttribute(Name="PART_NextButton", Type=typeof(System.Windows.Controls.Button))]
-    [System.Windows.TemplatePartAttribute(Name="PART_PreviousButton", Type=typeof(System.Windows.Controls.Button))]
-    [System.Windows.TemplatePartAttribute(Name="PART_Root", Type=typeof(System.Windows.FrameworkElement))]
-    [System.Windows.TemplatePartAttribute(Name="PART_YearView", Type=typeof(System.Windows.Controls.Grid))]
+    [System.Windows.TemplatePartAttribute(Name = "DayTitleTemplate", Type = typeof(System.Windows.DataTemplate))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_DisabledVisual", Type = typeof(System.Windows.FrameworkElement))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_HeaderButton", Type = typeof(System.Windows.Controls.Button))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_MonthView", Type = typeof(System.Windows.Controls.Grid))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_NextButton", Type = typeof(System.Windows.Controls.Button))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_PreviousButton", Type = typeof(System.Windows.Controls.Button))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Root", Type = typeof(System.Windows.FrameworkElement))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_YearView", Type = typeof(System.Windows.Controls.Grid))]
     public sealed partial class CalendarItem : System.Windows.Controls.Control
     {
         public CalendarItem() { }
@@ -7933,8 +7941,8 @@ namespace System.Windows.Controls.Primitives
         protected override void OnRender(System.Windows.Media.DrawingContext drawingContext) { }
         protected override void PrepareContainerForItemOverride(System.Windows.DependencyObject element, object item) { }
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_LeftHeaderGripper", Type=typeof(System.Windows.Controls.Primitives.Thumb))]
-    [System.Windows.TemplatePartAttribute(Name="PART_RightHeaderGripper", Type=typeof(System.Windows.Controls.Primitives.Thumb))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_LeftHeaderGripper", Type = typeof(System.Windows.Controls.Primitives.Thumb))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_RightHeaderGripper", Type = typeof(System.Windows.Controls.Primitives.Thumb))]
     public partial class DataGridColumnHeader : System.Windows.Controls.Primitives.ButtonBase
     {
         public static readonly System.Windows.DependencyProperty CanUserSortProperty;
@@ -7961,7 +7969,7 @@ namespace System.Windows.Controls.Primitives
         protected override void OnMouseLeftButtonUp(System.Windows.Input.MouseButtonEventArgs e) { }
         protected override void OnMouseMove(System.Windows.Input.MouseEventArgs e) { }
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_FillerColumnHeader", Type=typeof(System.Windows.Controls.Primitives.DataGridColumnHeader))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_FillerColumnHeader", Type = typeof(System.Windows.Controls.Primitives.DataGridColumnHeader))]
     public partial class DataGridColumnHeadersPresenter : System.Windows.Controls.ItemsControl
     {
         public DataGridColumnHeadersPresenter() { }
@@ -7986,8 +7994,8 @@ namespace System.Windows.Controls.Primitives
         protected override void OnRender(System.Windows.Media.DrawingContext drawingContext) { }
         protected internal override void OnVisualParentChanged(System.Windows.DependencyObject oldParent) { }
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_BottomHeaderGripper", Type=typeof(System.Windows.Controls.Primitives.Thumb))]
-    [System.Windows.TemplatePartAttribute(Name="PART_TopHeaderGripper", Type=typeof(System.Windows.Controls.Primitives.Thumb))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_BottomHeaderGripper", Type = typeof(System.Windows.Controls.Primitives.Thumb))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_TopHeaderGripper", Type = typeof(System.Windows.Controls.Primitives.Thumb))]
     public partial class DataGridRowHeader : System.Windows.Controls.Primitives.ButtonBase
     {
         public static readonly System.Windows.DependencyProperty IsRowSelectedProperty;
@@ -8012,7 +8020,7 @@ namespace System.Windows.Controls.Primitives
         protected override void OnIsItemsHostChanged(bool oldIsItemsHost, bool newIsItemsHost) { }
         protected override void OnViewportSizeChanged(System.Windows.Size oldViewportSize, System.Windows.Size newViewportSize) { }
     }
-    [System.Windows.TemplatePartAttribute(Name="PART_Watermark", Type=typeof(System.Windows.Controls.ContentControl))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Watermark", Type = typeof(System.Windows.Controls.ContentControl))]
     public sealed partial class DatePickerTextBox : System.Windows.Controls.TextBox
     {
         public DatePickerTextBox() { }
@@ -8236,7 +8244,7 @@ namespace System.Windows.Controls.Primitives
         public static System.Windows.Rect GetLayoutSlot(System.Windows.FrameworkElement element) { throw null; }
     }
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Menu)]
-    [System.Windows.StyleTypedPropertyAttribute(Property="ItemContainerStyle", StyleTargetType=typeof(System.Windows.Controls.MenuItem))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "ItemContainerStyle", StyleTargetType = typeof(System.Windows.Controls.MenuItem))]
     public abstract partial class MenuBase : System.Windows.Controls.ItemsControl
     {
         public static readonly System.Windows.DependencyProperty ItemContainerTemplateSelectorProperty;
@@ -8265,7 +8273,7 @@ namespace System.Windows.Controls.Primitives
         public void SelectAll() { }
         public void UnselectAll() { }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public enum PlacementMode
     {
         Absolute = 0,
@@ -8421,7 +8429,7 @@ namespace System.Windows.Controls.Primitives
         public ResizeGrip() { }
     }
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.NeverLocalize)]
-    [System.Windows.TemplatePartAttribute(Name="PART_Track", Type=typeof(System.Windows.Controls.Primitives.Track))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_Track", Type = typeof(System.Windows.Controls.Primitives.Track))]
     public partial class ScrollBar : System.Windows.Controls.Primitives.RangeBase
     {
         public static readonly System.Windows.Input.RoutedCommand DeferScrollToHorizontalOffsetCommand;
@@ -8490,7 +8498,7 @@ namespace System.Windows.Controls.Primitives
     }
     [System.ComponentModel.DefaultEventAttribute("SelectionChanged")]
     [System.ComponentModel.DefaultPropertyAttribute("SelectedIndex")]
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public abstract partial class Selector : System.Windows.Controls.ItemsControl
     {
         public static readonly System.Windows.DependencyProperty IsSelectedProperty;
@@ -8545,7 +8553,7 @@ namespace System.Windows.Controls.Primitives
         public static void RemoveUnselectedHandler(System.Windows.DependencyObject element, System.Windows.RoutedEventHandler handler) { }
         public static void SetIsSelected(System.Windows.DependencyObject element, bool isSelected) { }
     }
-    [System.Windows.StyleTypedPropertyAttribute(Property="ItemContainerStyle", StyleTargetType=typeof(System.Windows.Controls.Primitives.StatusBarItem))]
+    [System.Windows.StyleTypedPropertyAttribute(Property = "ItemContainerStyle", StyleTargetType = typeof(System.Windows.Controls.Primitives.StatusBarItem))]
     public partial class StatusBar : System.Windows.Controls.ItemsControl
     {
         public static readonly System.Windows.DependencyProperty ItemContainerTemplateSelectorProperty;
@@ -8574,7 +8582,7 @@ namespace System.Windows.Controls.Primitives
         protected override System.Windows.Size MeasureOverride(System.Windows.Size constraint) { throw null; }
     }
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Text)]
-    [System.Windows.TemplatePartAttribute(Name="PART_ContentHost", Type=typeof(System.Windows.FrameworkElement))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_ContentHost", Type = typeof(System.Windows.FrameworkElement))]
     public abstract partial class TextBoxBase : System.Windows.Controls.Control
     {
         internal TextBoxBase() { }
@@ -8694,7 +8702,7 @@ namespace System.Windows.Controls.Primitives
         protected override void OnMouseLeftButtonUp(System.Windows.Input.MouseButtonEventArgs e) { }
         protected override void OnMouseMove(System.Windows.Input.MouseEventArgs e) { }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public partial class TickBar : System.Windows.FrameworkElement
     {
         public static readonly System.Windows.DependencyProperty FillProperty;
@@ -8767,7 +8775,7 @@ namespace System.Windows.Controls.Primitives
         public ToggleButton() { }
         [System.ComponentModel.CategoryAttribute("Appearance")]
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.NullableBoolConverter))]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         public System.Nullable<bool> IsChecked { get { throw null; } set { } }
         [System.ComponentModel.BindableAttribute(true)]
         [System.ComponentModel.CategoryAttribute("Behavior")]
@@ -8801,7 +8809,7 @@ namespace System.Windows.Controls.Primitives
         protected override System.Windows.Size ArrangeOverride(System.Windows.Size arrangeSize) { throw null; }
         protected override System.Windows.Size MeasureOverride(System.Windows.Size constraint) { throw null; }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public partial class Track : System.Windows.FrameworkElement
     {
         public static readonly System.Windows.DependencyProperty IsDirectionReversedProperty;
@@ -8904,7 +8912,7 @@ namespace System.Windows.Data
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public bool ShouldSerializeValidationRules() { throw null; }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Modifiability=System.Windows.Modifiability.Unmodifiable, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Modifiability = System.Windows.Modifiability.Unmodifiable, Readability = System.Windows.Readability.Unreadable)]
     [System.Windows.Markup.MarkupExtensionReturnTypeAttribute(typeof(object))]
     public abstract partial class BindingBase : System.Windows.Markup.MarkupExtension
     {
@@ -8977,7 +8985,7 @@ namespace System.Windows.Data
     }
     public sealed partial class BindingListCollectionView : System.Windows.Data.CollectionView, System.Collections.IComparer, System.ComponentModel.ICollectionViewLiveShaping, System.ComponentModel.IEditableCollectionView, System.ComponentModel.IItemProperties
     {
-        public BindingListCollectionView(System.ComponentModel.IBindingList list) : base (default(System.Collections.IEnumerable)) { }
+        public BindingListCollectionView(System.ComponentModel.IBindingList list) : base(default(System.Collections.IEnumerable)) { }
         public bool CanAddNew { get { throw null; } }
         public bool CanCancelEdit { get { throw null; } }
         public bool CanChangeLiveFiltering { get { throw null; } }
@@ -9297,7 +9305,7 @@ namespace System.Windows.Data
     }
     public partial class ListCollectionView : System.Windows.Data.CollectionView, System.Collections.IComparer, System.ComponentModel.ICollectionViewLiveShaping, System.ComponentModel.IEditableCollectionView, System.ComponentModel.IEditableCollectionViewAddNewItem, System.ComponentModel.IItemProperties
     {
-        public ListCollectionView(System.Collections.IList list) : base (default(System.Collections.IEnumerable)) { }
+        public ListCollectionView(System.Collections.IList list) : base(default(System.Collections.IEnumerable)) { }
         protected System.Collections.IComparer ActiveComparer { get { throw null; } set { } }
         protected System.Predicate<object> ActiveFilter { get { throw null; } set { } }
         public bool CanAddNew { get { throw null; } }
@@ -9509,7 +9517,7 @@ namespace System.Windows.Data
         LostFocus = 2,
         PropertyChanged = 1,
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = true)]
     public sealed partial class ValueConversionAttribute : System.Attribute
     {
         public ValueConversionAttribute(System.Type sourceType, System.Type targetType) { }
@@ -9526,7 +9534,7 @@ namespace System.Windows.Data
         public ValueUnavailableException(string message) { }
         public ValueUnavailableException(string message, System.Exception innerException) { }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     [System.Windows.Markup.ContentPropertyAttribute("XmlSerializer")]
     public partial class XmlDataProvider : System.Windows.Data.DataSourceProvider, System.Windows.Markup.IUriContext
     {
@@ -9570,7 +9578,7 @@ namespace System.Windows.Data
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.NeverLocalize)]
     public partial class XmlNamespaceMappingCollection : System.Xml.XmlNamespaceManager, System.Collections.Generic.ICollection<System.Windows.Data.XmlNamespaceMapping>, System.Collections.Generic.IEnumerable<System.Windows.Data.XmlNamespaceMapping>, System.Collections.IEnumerable, System.Windows.Markup.IAddChild
     {
-        public XmlNamespaceMappingCollection() : base (default(System.Xml.XmlNameTable)) { }
+        public XmlNamespaceMappingCollection() : base(default(System.Xml.XmlNameTable)) { }
         public int Count { get { throw null; } }
         public bool IsReadOnly { get { throw null; } }
         public void Add(System.Windows.Data.XmlNamespaceMapping mapping) { }
@@ -9840,9 +9848,9 @@ namespace System.Windows.Documents
         public static readonly System.Windows.DependencyProperty VerticalOffsetProperty;
         public static readonly System.Windows.DependencyProperty WidthProperty;
         public static readonly System.Windows.DependencyProperty WrapDirectionProperty;
-        public Figure() : base (default(System.Windows.Documents.Block), default(System.Windows.Documents.TextPointer)) { }
-        public Figure(System.Windows.Documents.Block childBlock) : base (default(System.Windows.Documents.Block), default(System.Windows.Documents.TextPointer)) { }
-        public Figure(System.Windows.Documents.Block childBlock, System.Windows.Documents.TextPointer insertionPosition) : base (default(System.Windows.Documents.Block), default(System.Windows.Documents.TextPointer)) { }
+        public Figure() : base(default(System.Windows.Documents.Block), default(System.Windows.Documents.TextPointer)) { }
+        public Figure(System.Windows.Documents.Block childBlock) : base(default(System.Windows.Documents.Block), default(System.Windows.Documents.TextPointer)) { }
+        public Figure(System.Windows.Documents.Block childBlock, System.Windows.Documents.TextPointer insertionPosition) : base(default(System.Windows.Documents.Block), default(System.Windows.Documents.TextPointer)) { }
         public bool CanDelayPlacement { get { throw null; } set { } }
         public System.Windows.FigureLength Height { get { throw null; } set { } }
         public System.Windows.FigureHorizontalAnchor HorizontalAnchor { get { throw null; } set { } }
@@ -9942,14 +9950,14 @@ namespace System.Windows.Documents
     {
         public static readonly System.Windows.DependencyProperty HorizontalAlignmentProperty;
         public static readonly System.Windows.DependencyProperty WidthProperty;
-        public Floater() : base (default(System.Windows.Documents.Block), default(System.Windows.Documents.TextPointer)) { }
-        public Floater(System.Windows.Documents.Block childBlock) : base (default(System.Windows.Documents.Block), default(System.Windows.Documents.TextPointer)) { }
-        public Floater(System.Windows.Documents.Block childBlock, System.Windows.Documents.TextPointer insertionPosition) : base (default(System.Windows.Documents.Block), default(System.Windows.Documents.TextPointer)) { }
+        public Floater() : base(default(System.Windows.Documents.Block), default(System.Windows.Documents.TextPointer)) { }
+        public Floater(System.Windows.Documents.Block childBlock) : base(default(System.Windows.Documents.Block), default(System.Windows.Documents.TextPointer)) { }
+        public Floater(System.Windows.Documents.Block childBlock, System.Windows.Documents.TextPointer insertionPosition) : base(default(System.Windows.Documents.Block), default(System.Windows.Documents.TextPointer)) { }
         public System.Windows.HorizontalAlignment HorizontalAlignment { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.LengthConverter))]
         public double Width { get { throw null; } set { } }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Inherit, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Inherit, Readability = System.Windows.Readability.Unreadable)]
     [System.Windows.Markup.ContentPropertyAttribute("Blocks")]
     public partial class FlowDocument : System.Windows.FrameworkContentElement, System.IServiceProvider, System.Windows.Documents.IDocumentPaginatorSource, System.Windows.Markup.IAddChild
     {
@@ -9985,19 +9993,19 @@ namespace System.Windows.Documents
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Content)]
         public System.Windows.Documents.BlockCollection Blocks { get { throw null; } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.LengthConverter))]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         public double ColumnGap { get { throw null; } set { } }
         public System.Windows.Media.Brush ColumnRuleBrush { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.LengthConverter))]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         public double ColumnRuleWidth { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.LengthConverter))]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
         public double ColumnWidth { get { throw null; } set { } }
         public System.Windows.Documents.TextPointer ContentEnd { get { throw null; } }
         public System.Windows.Documents.TextPointer ContentStart { get { throw null; } }
         public System.Windows.FlowDirection FlowDirection { get { throw null; } set { } }
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Font, Modifiability=System.Windows.Modifiability.Unmodifiable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Font, Modifiability = System.Windows.Modifiability.Unmodifiable)]
         public System.Windows.Media.FontFamily FontFamily { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.FontSizeConverter))]
         [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None)]
@@ -10048,7 +10056,7 @@ namespace System.Windows.Documents
     }
     public partial class FrameworkTextComposition : System.Windows.Input.TextComposition
     {
-        internal FrameworkTextComposition() : base (default(System.Windows.Input.InputManager), default(System.Windows.IInputElement), default(string)) { }
+        internal FrameworkTextComposition() : base(default(System.Windows.Input.InputManager), default(System.Windows.IInputElement), default(string)) { }
         public int CompositionLength { get { throw null; } }
         public int CompositionOffset { get { throw null; } }
         public int ResultLength { get { throw null; } }
@@ -10057,7 +10065,7 @@ namespace System.Windows.Documents
     }
     public sealed partial class GetPageRootCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
     {
-        internal GetPageRootCompletedEventArgs() : base (default(System.Exception), default(bool), default(object)) { }
+        internal GetPageRootCompletedEventArgs() : base(default(System.Exception), default(bool), default(object)) { }
         public System.Windows.Documents.FixedPage Result { get { throw null; } }
     }
     public delegate void GetPageRootCompletedEventHandler(object sender, System.Windows.Documents.GetPageRootCompletedEventArgs e);
@@ -10097,7 +10105,7 @@ namespace System.Windows.Documents
         protected override void OnRender(System.Windows.Media.DrawingContext context) { }
         public System.Windows.Media.GlyphRun ToGlyphRun() { throw null; }
     }
-    [System.Windows.Documents.TextElementEditingBehaviorAttribute(IsMergeable=false, IsTypographicOnly=false)]
+    [System.Windows.Documents.TextElementEditingBehaviorAttribute(IsMergeable = false, IsTypographicOnly = false)]
     public partial class Hyperlink : System.Windows.Documents.Span, System.Windows.Input.ICommandSource, System.Windows.Markup.IUriContext
     {
         public static readonly System.Windows.RoutedEvent ClickEvent;
@@ -10129,7 +10137,7 @@ namespace System.Windows.Documents
         public System.Uri NavigateUri { get { throw null; } set { } }
         System.Uri System.Windows.Markup.IUriContext.BaseUri { get { throw null; } set { } }
         [System.ComponentModel.BindableAttribute(true)]
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Modifiability=System.Windows.Modifiability.Unmodifiable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Modifiability = System.Windows.Modifiability.Unmodifiable)]
         public string TargetName { get { throw null; } set { } }
         [System.ComponentModel.CategoryAttribute("Behavior")]
         public event System.Windows.RoutedEventHandler Click { add { } remove { } }
@@ -10141,7 +10149,7 @@ namespace System.Windows.Documents
         protected internal override void OnMouseLeftButtonDown(System.Windows.Input.MouseButtonEventArgs e) { }
         protected internal override void OnMouseLeftButtonUp(System.Windows.Input.MouseButtonEventArgs e) { }
     }
-    [System.Windows.Documents.TextElementEditingBehaviorAttribute(IsMergeable=true, IsTypographicOnly=true)]
+    [System.Windows.Documents.TextElementEditingBehaviorAttribute(IsMergeable = true, IsTypographicOnly = true)]
     public abstract partial class Inline : System.Windows.Documents.TextElement
     {
         public static readonly System.Windows.DependencyProperty BaselineAlignmentProperty;
@@ -10166,7 +10174,7 @@ namespace System.Windows.Documents
         public void Add(string text) { }
         public void Add(System.Windows.UIElement uiElement) { }
     }
-    [System.Windows.Documents.TextElementEditingBehaviorAttribute(IsMergeable=false)]
+    [System.Windows.Documents.TextElementEditingBehaviorAttribute(IsMergeable = false)]
     [System.Windows.Markup.ContentPropertyAttribute("Child")]
     public partial class InlineUIContainer : System.Windows.Documents.Inline
     {
@@ -10589,7 +10597,7 @@ namespace System.Windows.Documents
         public System.Windows.Documents.TextPointer ContentStart { get { throw null; } }
         public System.Windows.Documents.TextPointer ElementEnd { get { throw null; } }
         public System.Windows.Documents.TextPointer ElementStart { get { throw null; } }
-        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Font, Modifiability=System.Windows.Modifiability.Unmodifiable)]
+        [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.Font, Modifiability = System.Windows.Modifiability.Unmodifiable)]
         public System.Windows.Media.FontFamily FontFamily { get { throw null; } set { } }
         [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.FontSizeConverter))]
         [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None)]
@@ -10717,7 +10725,7 @@ namespace System.Windows.Documents
     }
     public sealed partial class TextSelection : System.Windows.Documents.TextRange
     {
-        internal TextSelection() : base (default(System.Windows.Documents.TextPointer), default(System.Windows.Documents.TextPointer)) { }
+        internal TextSelection() : base(default(System.Windows.Documents.TextPointer), default(System.Windows.Documents.TextPointer)) { }
     }
     public sealed partial class Typography
     {
@@ -11177,7 +11185,7 @@ namespace System.Windows.Documents.Serialization
     public delegate void WritingCancelledEventHandler(object sender, System.Windows.Documents.Serialization.WritingCancelledEventArgs e);
     public partial class WritingCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
     {
-        public WritingCompletedEventArgs(bool cancelled, object state, System.Exception exception) : base (default(System.Exception), default(bool), default(object)) { }
+        public WritingCompletedEventArgs(bool cancelled, object state, System.Exception exception) : base(default(System.Exception), default(bool), default(object)) { }
     }
     public delegate void WritingCompletedEventHandler(object sender, System.Windows.Documents.Serialization.WritingCompletedEventArgs e);
     public partial class WritingPrintTicketRequiredEventArgs : System.EventArgs
@@ -11190,7 +11198,7 @@ namespace System.Windows.Documents.Serialization
     public delegate void WritingPrintTicketRequiredEventHandler(object sender, System.Windows.Documents.Serialization.WritingPrintTicketRequiredEventArgs e);
     public partial class WritingProgressChangedEventArgs : System.ComponentModel.ProgressChangedEventArgs
     {
-        public WritingProgressChangedEventArgs(System.Windows.Documents.Serialization.WritingProgressChangeLevel writingLevel, int number, int progressPercentage, object state) : base (default(int), default(object)) { }
+        public WritingProgressChangedEventArgs(System.Windows.Documents.Serialization.WritingProgressChangeLevel writingLevel, int number, int progressPercentage, object state) : base(default(int), default(object)) { }
         public int Number { get { throw null; } }
         public System.Windows.Documents.Serialization.WritingProgressChangeLevel WritingLevel { get { throw null; } }
     }
@@ -11396,7 +11404,7 @@ namespace System.Windows.Markup
         public string XmlLang { get { throw null; } set { } }
         public System.Windows.Markup.XmlnsDictionary XmlnsDictionary { get { throw null; } }
         public string XmlSpace { get { throw null; } set { } }
-        public static implicit operator System.Xml.XmlParserContext (System.Windows.Markup.ParserContext parserContext) { throw null; }
+        public static implicit operator System.Xml.XmlParserContext(System.Windows.Markup.ParserContext parserContext) { throw null; }
         public static System.Xml.XmlParserContext ToXmlParserContext(System.Windows.Markup.ParserContext parserContext) { throw null; }
     }
     public partial class ResourceReferenceExpressionConverter : System.Windows.ExpressionConverter
@@ -11702,7 +11710,7 @@ namespace System.Windows.Media
 {
     public partial class AdornerHitTestResult : System.Windows.Media.PointHitTestResult
     {
-        internal AdornerHitTestResult() : base (default(System.Windows.Media.Visual), default(System.Windows.Point)) { }
+        internal AdornerHitTestResult() : base(default(System.Windows.Media.Visual), default(System.Windows.Point)) { }
         public System.Windows.Documents.Adorner Adorner { get { throw null; } }
     }
     public static partial class TextOptions
@@ -12142,7 +12150,7 @@ namespace System.Windows.Navigation
         Visible = 1,
     }
     [System.Windows.Markup.ContentPropertyAttribute]
-    [System.Windows.TemplatePartAttribute(Name="PART_NavWinCP", Type=typeof(System.Windows.Controls.ContentPresenter))]
+    [System.Windows.TemplatePartAttribute(Name = "PART_NavWinCP", Type = typeof(System.Windows.Controls.ContentPresenter))]
     public partial class NavigationWindow : System.Windows.Window, System.Windows.Markup.IUriContext
     {
         public static readonly System.Windows.DependencyProperty BackStackProperty;
@@ -12303,7 +12311,7 @@ namespace System.Windows.Shapes
         protected override System.Windows.Size MeasureOverride(System.Windows.Size constraint) { throw null; }
         protected override void OnRender(System.Windows.Media.DrawingContext drawingContext) { }
     }
-    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
+    [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public abstract partial class Shape : System.Windows.FrameworkElement
     {
         public static readonly System.Windows.DependencyProperty FillProperty;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MessageBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MessageBox.cs
@@ -17,7 +17,7 @@ namespace System.Windows
     ///       user.
     ///    </para>
     /// </devdoc>
-    public sealed class MessageBox 
+    public sealed class MessageBox
     {
 #if NEVER
         class WindowWin32Window : IWin32Window
@@ -29,7 +29,7 @@ namespace System.Windows
             }
             IntPtr IWin32Window.Handle { get { return window.SourceWindow.Handle; } }
             IntPtr IWin32Window.Parent
-            {   
+            {
                 get
                 {
                     return ((IWin32Window)window).Parent;
@@ -41,38 +41,50 @@ namespace System.Windows
             }
         }
 #endif
-        private const int IDOK             = 1;
-        private const int IDCANCEL         = 2;
-        private const int IDABORT          = 3;
-        private const int IDRETRY          = 4;
-        private const int IDIGNORE         = 5;
-        private const int IDYES            = 6;
-        private const int IDNO             = 7;
-        private const int DEFAULT_BUTTON1  = 0x00000000;
-        private const int DEFAULT_BUTTON2  = 0x00000100;
-        private const int DEFAULT_BUTTON3  = 0x00000200;
+        private const int IDOK = 1;
+        private const int IDCANCEL = 2;
+        private const int IDABORT = 3;
+        private const int IDRETRY = 4;
+        private const int IDIGNORE = 5;
+        private const int IDYES = 6;
+        private const int IDNO = 7;
+        private const int IDTRYAGAIN = 10;
+        private const int IDCONTINUE = 11;
+        private const int DEFAULT_BUTTON1 = 0x00000000;
+        private const int DEFAULT_BUTTON2 = 0x00000100;
+        private const int DEFAULT_BUTTON3 = 0x00000200;
 
         /// <devdoc>
         ///     This constructor is private so people aren't tempted to try and create
         ///     instances of these -- they should just use the static show
         ///     methods.
         /// </devdoc>
-        private MessageBox() 
+        private MessageBox()
         {
         }
 
-        private static MessageBoxResult Win32ToMessageBoxResult(int value) 
+        private static MessageBoxResult Win32ToMessageBoxResult(int value)
         {
-            switch (value) 
+            switch (value)
             {
                 case IDOK:
                     return MessageBoxResult.OK;
                 case IDCANCEL:
                     return MessageBoxResult.Cancel;
+                case IDABORT:
+                    return MessageBoxResult.Abort;
+                case IDRETRY:
+                    return MessageBoxResult.Retry;
+                case IDIGNORE:
+                    return MessageBoxResult.Ignore;
                 case IDYES:
                     return MessageBoxResult.Yes;
                 case IDNO:
                     return MessageBoxResult.No;
+                case IDTRYAGAIN:
+                    return MessageBoxResult.TryAgain;
+                case IDCONTINUE:
+                    return MessageBoxResult.Continue;
                 default:
                     return MessageBoxResult.No;
             }
@@ -85,12 +97,12 @@ namespace System.Windows
         ///    </para>
         /// </devdoc>
         public static MessageBoxResult Show(
-            string messageBoxText, 
-            string caption, 
-            MessageBoxButton button, 
-            MessageBoxImage icon, 
-            MessageBoxResult defaultResult, 
-            MessageBoxOptions options) 
+            string messageBoxText,
+            string caption,
+            MessageBoxButton button,
+            MessageBoxImage icon,
+            MessageBoxResult defaultResult,
+            MessageBoxOptions options)
         {
             return ShowCore(IntPtr.Zero, messageBoxText, caption, button, icon, defaultResult, options);
         }
@@ -101,11 +113,11 @@ namespace System.Windows
         ///    </para>
         /// </devdoc>
         public static MessageBoxResult Show(
-            string messageBoxText, 
-            string caption, 
-            MessageBoxButton button, 
-            MessageBoxImage icon, 
-            MessageBoxResult defaultResult) 
+            string messageBoxText,
+            string caption,
+            MessageBoxButton button,
+            MessageBoxImage icon,
+            MessageBoxResult defaultResult)
         {
             return ShowCore(IntPtr.Zero, messageBoxText, caption, button, icon, defaultResult, 0);
         }
@@ -116,10 +128,10 @@ namespace System.Windows
         ///    </para>
         /// </devdoc>
         public static MessageBoxResult Show(
-            string messageBoxText, 
-            string caption, 
-            MessageBoxButton button, 
-            MessageBoxImage icon) 
+            string messageBoxText,
+            string caption,
+            MessageBoxButton button,
+            MessageBoxImage icon)
         {
             return ShowCore(IntPtr.Zero, messageBoxText, caption, button, icon, 0, 0);
         }
@@ -130,9 +142,9 @@ namespace System.Windows
         ///    </para>
         /// </devdoc>
         public static MessageBoxResult Show(
-            string messageBoxText, 
-            string caption, 
-            MessageBoxButton button) 
+            string messageBoxText,
+            string caption,
+            MessageBoxButton button)
         {
             return ShowCore(IntPtr.Zero, messageBoxText, caption, button, MessageBoxImage.None, 0, 0);
         }
@@ -142,7 +154,7 @@ namespace System.Windows
         ///       Displays a message box with specified text and caption.
         ///    </para>
         /// </devdoc>
-        public static MessageBoxResult Show(string messageBoxText, string caption) 
+        public static MessageBoxResult Show(string messageBoxText, string caption)
         {
             return ShowCore(IntPtr.Zero, messageBoxText, caption, MessageBoxButton.OK, MessageBoxImage.None, 0, 0);
         }
@@ -152,7 +164,7 @@ namespace System.Windows
         ///       Displays a message box with specified text.
         ///    </para>
         /// </devdoc>
-        public static MessageBoxResult Show(string messageBoxText) 
+        public static MessageBoxResult Show(string messageBoxText)
         {
             return ShowCore(IntPtr.Zero, messageBoxText, String.Empty, MessageBoxButton.OK, MessageBoxImage.None, 0, 0);
         }
@@ -165,9 +177,9 @@ namespace System.Windows
         ///       Displays a message box with specified text, caption, and style.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        public static MessageBoxResult Show(IWin32Window owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon, 
-            MessageBoxResult defaultResult, MessageBoxOptions options) 
+        /// <ExternalAPI/>
+        public static MessageBoxResult Show(IWin32Window owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon,
+            MessageBoxResult defaultResult, MessageBoxOptions options)
         {
             return ShowCore(owner, messageBoxText, caption, button, icon, defaultResult, options);
         }
@@ -177,9 +189,9 @@ namespace System.Windows
         ///       Displays a message box with specified text, caption, and style.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        public static MessageBoxResult Show(IWin32Window owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon, 
-            MessageBoxResult defaultResult) 
+        /// <ExternalAPI/>
+        public static MessageBoxResult Show(IWin32Window owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon,
+            MessageBoxResult defaultResult)
         {
             return ShowCore(owner, messageBoxText, caption, button, icon, defaultResult, 0);
         }
@@ -189,8 +201,8 @@ namespace System.Windows
         ///       Displays a message box with specified text, caption, and style.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        public static MessageBoxResult Show(IWin32Window owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon) 
+        /// <ExternalAPI/>
+        public static MessageBoxResult Show(IWin32Window owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon)
         {
             return ShowCore(owner, messageBoxText, caption, button, icon, 0, 0);
         }
@@ -200,8 +212,8 @@ namespace System.Windows
         ///       Displays a message box with specified text, caption, and style.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        public static MessageBoxResult Show(IWin32Window owner, string messageBoxText, string caption, MessageBoxButton button) 
+        /// <ExternalAPI/>
+        public static MessageBoxResult Show(IWin32Window owner, string messageBoxText, string caption, MessageBoxButton button)
         {
             return ShowCore(owner, messageBoxText, caption, button, MessageBoxImage.None, 0, 0);
         }
@@ -211,8 +223,8 @@ namespace System.Windows
         ///       Displays a message box with specified text and caption.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        public static MessageBoxResult Show(IWin32Window owner, string messageBoxText, string caption) 
+        /// <ExternalAPI/>
+        public static MessageBoxResult Show(IWin32Window owner, string messageBoxText, string caption)
         {
             return ShowCore(owner, messageBoxText, caption, MessageBoxButton.OK, MessageBoxImage.None, 0, 0);
         }
@@ -222,8 +234,8 @@ namespace System.Windows
         ///       Displays a message box with specified text.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        public static MessageBoxResult Show(IWin32Window owner, string messageBoxText) 
+        /// <ExternalAPI/>
+        public static MessageBoxResult Show(IWin32Window owner, string messageBoxText)
         {
             return ShowCore(owner, messageBoxText, String.Empty, MessageBoxButton.OK, MessageBoxImage.None, 0, 0);
         }
@@ -236,12 +248,12 @@ namespace System.Windows
         ///    </para>
         /// </devdoc>
         public static MessageBoxResult Show(
-            Window owner, 
-            string messageBoxText, 
-            string caption, 
-            MessageBoxButton button, 
-            MessageBoxImage icon, MessageBoxResult defaultResult, 
-            MessageBoxOptions options) 
+            Window owner,
+            string messageBoxText,
+            string caption,
+            MessageBoxButton button,
+            MessageBoxImage icon, MessageBoxResult defaultResult,
+            MessageBoxOptions options)
         {
             return ShowCore((new WindowInteropHelper(owner)).Handle, messageBoxText, caption, button, icon, defaultResult, options);
         }
@@ -252,12 +264,12 @@ namespace System.Windows
         ///    </para>
         /// </devdoc>
         public static MessageBoxResult Show(
-            Window owner, 
-            string messageBoxText, 
-            string caption, 
-            MessageBoxButton button, 
-            MessageBoxImage icon, 
-            MessageBoxResult defaultResult) 
+            Window owner,
+            string messageBoxText,
+            string caption,
+            MessageBoxButton button,
+            MessageBoxImage icon,
+            MessageBoxResult defaultResult)
         {
             return ShowCore((new WindowInteropHelper (owner)).Handle, messageBoxText, caption, button, icon, defaultResult, 0);
         }
@@ -268,11 +280,11 @@ namespace System.Windows
         ///    </para>
         /// </devdoc>
         public static MessageBoxResult Show(
-            Window owner, 
-            string messageBoxText, 
-            string caption, 
-            MessageBoxButton button, 
-            MessageBoxImage icon) 
+            Window owner,
+            string messageBoxText,
+            string caption,
+            MessageBoxButton button,
+            MessageBoxImage icon)
         {
             return ShowCore((new WindowInteropHelper (owner)).Handle, messageBoxText, caption, button, icon, 0, 0);
         }
@@ -283,10 +295,10 @@ namespace System.Windows
         ///    </para>
         /// </devdoc>
         public static MessageBoxResult Show(
-            Window owner, 
-            string messageBoxText, 
-            string caption, 
-            MessageBoxButton button) 
+            Window owner,
+            string messageBoxText,
+            string caption,
+            MessageBoxButton button)
         {
             return ShowCore((new WindowInteropHelper (owner)).Handle, messageBoxText, caption, button, MessageBoxImage.None, 0, 0);
         }
@@ -296,7 +308,7 @@ namespace System.Windows
         ///       Displays a message box with specified text and caption.
         ///    </para>
         /// </devdoc>
-        public static MessageBoxResult Show(Window owner, string messageBoxText, string caption) 
+        public static MessageBoxResult Show(Window owner, string messageBoxText, string caption)
         {
             return ShowCore((new WindowInteropHelper (owner)).Handle, messageBoxText, caption, MessageBoxButton.OK, MessageBoxImage.None, 0, 0);
         }
@@ -306,7 +318,7 @@ namespace System.Windows
         ///       Displays a message box with specified text.
         ///    </para>
         /// </devdoc>
-        public static MessageBoxResult Show(Window owner, string messageBoxText) 
+        public static MessageBoxResult Show(Window owner, string messageBoxText)
         {
             return ShowCore((new WindowInteropHelper (owner)).Handle, messageBoxText, String.Empty, MessageBoxButton.OK, MessageBoxImage.None, 0, 0);
         }
@@ -330,65 +342,76 @@ namespace System.Windows
                     if (result == MessageBoxResult.No) return DEFAULT_BUTTON2;
                     if (result == MessageBoxResult.Cancel) return DEFAULT_BUTTON3;
                     return DEFAULT_BUTTON1;
+                case MessageBoxButton.RetryCancel:
+                    if (result == MessageBoxResult.Cancel) return DEFAULT_BUTTON2;
+                    return DEFAULT_BUTTON1;
+                case MessageBoxButton.AbortRetryIgnore:
+                    if (result == MessageBoxResult.Retry) return DEFAULT_BUTTON2;
+                    if (result == MessageBoxResult.Ignore) return DEFAULT_BUTTON3;
+                    return DEFAULT_BUTTON1;
+                case MessageBoxButton.CancelTryContinue:
+                    if (result == MessageBoxResult.TryAgain) return DEFAULT_BUTTON2;
+                    if (result == MessageBoxResult.Continue) return DEFAULT_BUTTON3;
+                    return DEFAULT_BUTTON1;
                 default:
                     return DEFAULT_BUTTON1;
             }
         }
 
         internal static MessageBoxResult ShowCore(
-            IntPtr owner, 
-            string messageBoxText, 
+            IntPtr owner,
+            string messageBoxText,
             string caption,
-            MessageBoxButton button, 
-            MessageBoxImage icon, 
+            MessageBoxButton button,
+            MessageBoxImage icon,
             MessageBoxResult defaultResult,
-            MessageBoxOptions options) 
+            MessageBoxOptions options)
         {
             if (!IsValidMessageBoxButton(button))
             {
-                throw new InvalidEnumArgumentException ("button", (int)button, typeof(MessageBoxButton));
+                throw new InvalidEnumArgumentException("button", (int)button, typeof(MessageBoxButton));
             }
             if (!IsValidMessageBoxImage(icon))
             {
-                throw new InvalidEnumArgumentException ("icon", (int)icon, typeof(MessageBoxImage));
+                throw new InvalidEnumArgumentException("icon", (int)icon, typeof(MessageBoxImage));
             }
             if (!IsValidMessageBoxResult(defaultResult))
             {
-                throw new InvalidEnumArgumentException ("defaultResult", (int)defaultResult, typeof(MessageBoxResult));
+                throw new InvalidEnumArgumentException("defaultResult", (int)defaultResult, typeof(MessageBoxResult));
             }
             if (!IsValidMessageBoxOptions(options))
             {
                 throw new InvalidEnumArgumentException("options", (int)options, typeof(MessageBoxOptions));
-            }            
-            
+            }
+
             // UserInteractive??
             //
             /*if (!SystemInformation.UserInteractive && (options & (MessageBoxOptions.ServiceNotification | MessageBoxOptions.DefaultDesktopOnly)) == 0) {
                 throw new InvalidOperationException("UNDONE: SR.GetString(SR.CantShowModalOnNonInteractive)");
             }*/
 
-            if ( (options & (MessageBoxOptions.ServiceNotification | MessageBoxOptions.DefaultDesktopOnly)) != 0) 
+            if ((options & (MessageBoxOptions.ServiceNotification | MessageBoxOptions.DefaultDesktopOnly)) != 0)
             {
                 if (owner != IntPtr.Zero)
                 {
                     throw new ArgumentException(SR.CantShowMBServiceWithOwner);
-                }                
+                }
             }
             else
-            {                                    
+            {
                 if (owner == IntPtr.Zero)
                 {
                     owner = UnsafeNativeMethods.GetActiveWindow();
-                }                
+                }
             }
-            
-            int style = (int) button | (int) icon | (int) DefaultResultToButtonNumber(defaultResult, button) | (int) options;
+
+            int style = (int)button | (int)icon | (int)DefaultResultToButtonNumber(defaultResult, button) | (int)options;
 
             // modal dialog notification?
             //
             //Application.BeginModalMessageLoop();
             //MessageBoxResult result = Win32ToMessageBoxResult(SafeNativeMethods.MessageBox(new HandleRef(owner, handle), messageBoxText, caption, style));
-            MessageBoxResult result = Win32ToMessageBoxResult (UnsafeNativeMethods.MessageBox (new HandleRef (null, owner), messageBoxText, caption, style));
+            MessageBoxResult result = Win32ToMessageBoxResult(UnsafeNativeMethods.MessageBox(new HandleRef(null, owner), messageBoxText, caption, style));
             // modal dialog notification?
             //
             //Application.EndModalMessageLoop();
@@ -400,8 +423,11 @@ namespace System.Windows
         {
             return value == MessageBoxButton.OK
                 || value == MessageBoxButton.OKCancel
+                || value == MessageBoxButton.AbortRetryIgnore
                 || value == MessageBoxButton.YesNo
-                || value == MessageBoxButton.YesNoCancel;
+                || value == MessageBoxButton.YesNoCancel
+                || value == MessageBoxButton.RetryCancel
+                || value == MessageBoxButton.CancelTryContinue;
         }
 
         private static bool IsValidMessageBoxImage(MessageBoxImage value)
@@ -423,16 +449,21 @@ namespace System.Windows
                 || value == MessageBoxResult.No
                 || value == MessageBoxResult.None
                 || value == MessageBoxResult.OK
-                || value == MessageBoxResult.Yes;
+                || value == MessageBoxResult.Yes
+                || value == MessageBoxResult.Abort
+                || value == MessageBoxResult.Retry
+                || value == MessageBoxResult.Ignore
+                || value == MessageBoxResult.TryAgain
+                || value == MessageBoxResult.Continue;
         }
 
         private static bool IsValidMessageBoxOptions(MessageBoxOptions value)
         {
-            int  mask = ~((int)MessageBoxOptions.ServiceNotification |
+            int mask = ~((int)MessageBoxOptions.ServiceNotification |
                          (int)MessageBoxOptions.DefaultDesktopOnly |
                          (int)MessageBoxOptions.RightAlign |
                          (int)MessageBoxOptions.RtlReading);
-            
+
             if (((int)value & mask) == 0)
                 return true;
             return false;
@@ -446,19 +477,19 @@ namespace System.Windows
     ///       indicate the return value of a dialog box.
     ///    </para>
     /// </devdoc>
-    /// <ExternalAPI/> 
-    public enum MessageBoxResult 
+    /// <ExternalAPI/>
+    public enum MessageBoxResult
     {
 
         /// <devdoc>
         ///    <para>
-        ///       
+        ///
         ///       Nothing is returned from the dialog box. This
         ///       means that the modal dialog continues running.
-        ///       
+        ///
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
+        /// <ExternalAPI/>
         None = 0,
 
         /// <devdoc>
@@ -466,10 +497,10 @@ namespace System.Windows
         ///       The
         ///       dialog box return value is
         ///       OK (usually sent from a button labeled OK).
-        ///       
+        ///
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
+        /// <ExternalAPI/>
         OK = 1,
 
         /// <devdoc>
@@ -477,31 +508,84 @@ namespace System.Windows
         ///       The
         ///       dialog box return value is Cancel (usually sent
         ///       from a button labeled Cancel).
-        ///       
+        ///
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
+        /// <ExternalAPI/>
         Cancel = 2,
+
+        /// <devdoc>
+        ///    <para>
+        ///       The
+        ///       dialog box return value is Abort (usually sent
+        ///       from a button labeled Abort).
+        ///
+        ///    </para>
+        /// </devdoc>
+        /// <ExternalAPI/>
+        Abort = 3,
+
+        /// <devdoc>
+        ///    <para>
+        ///       The
+        ///       dialog box return value is Retry (usually sent
+        ///       from a button labeled Retry).
+        ///
+        ///    </para>
+        /// </devdoc>
+        /// <ExternalAPI/>
+        Retry = 4,
+
+        /// <devdoc>
+        ///    <para>
+        ///       The
+        ///       dialog box return value is Ignore (usually sent
+        ///       from a button labeled Ignore).
+        ///
+        ///    </para>
+        /// </devdoc>
+        /// <ExternalAPI/>
+        Ignore = 5,
 
         /// <devdoc>
         ///    <para>
         ///       The dialog box return value is
         ///       Yes (usually sent from a button labeled Yes).
-        ///       
+        ///
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
+        /// <ExternalAPI/>
         Yes = 6,
 
         /// <devdoc>
         ///    <para>
         ///       The dialog box return value is
         ///       No (usually sent from a button labeled No).
-        ///       
+        ///
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
+        /// <ExternalAPI/>
         No = 7,
+
+        /// <devdoc>
+        ///    <para>
+        ///       The dialog box return value is
+        ///       TryAgain (usually sent from a button labeled Try Again).
+        ///
+        ///    </para>
+        /// </devdoc>
+        /// <ExternalAPI/>
+        TryAgain = 10,
+
+        /// <devdoc>
+        ///    <para>
+        ///       The dialog box return value is
+        ///       Continue (usually sent from a button labeled Continue).
+        ///
+        ///    </para>
+        /// </devdoc>
+        /// <ExternalAPI/>
+        Continue = 11,
 
         // NOTE: if you add or remove any values in this enum, be sure to update MessageBox.IsValidMessageBoxResult()
     }
@@ -509,7 +593,7 @@ namespace System.Windows
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
     [Flags]
-    public enum MessageBoxOptions 
+    public enum MessageBoxOptions
     {
         /// <devdoc>
         ///     <para>
@@ -518,21 +602,21 @@ namespace System.Windows
         /// </devdoc>
         /// <ExternalApi />
         None = 0x00000000,
-        
+
         /// <devdoc>
         ///    <para>
-        ///       Specifies that the message box is displayed on the active desktop. 
+        ///       Specifies that the message box is displayed on the active desktop.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
+        /// <ExternalAPI/>
         ServiceNotification = 0x00200000,
 
         /// <devdoc>
         ///    <para>
-        ///       Specifies that the message box is displayed on the active desktop. 
+        ///       Specifies that the message box is displayed on the active desktop.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
+        /// <ExternalAPI/>
         DefaultDesktopOnly = 0x00020000,
 
         /// <devdoc>
@@ -540,71 +624,71 @@ namespace System.Windows
         ///       Specifies that the message box text is right-aligned.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        RightAlign         = 0x00080000,
+        /// <ExternalAPI/>
+        RightAlign = 0x00080000,
 
         /// <devdoc>
         ///    <para>
         ///       Specifies that the message box text is displayed with Rtl reading order.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        RtlReading         = 0x00100000,
+        /// <ExternalAPI/>
+        RtlReading = 0x00100000,
     }
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
-    public enum MessageBoxImage 
+    public enum MessageBoxImage
     {
         /// <devdoc>
         ///    <para>
         ///       Specifies that the
-        ///       message box contain no symbols. 
+        ///       message box contain no symbols.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        None         = 0,
+        /// <ExternalAPI/>
+        None = 0,
 
         /// <devdoc>
         ///    <para>
         ///       Specifies that the
         ///       message box contains a
-        ///       hand symbol. 
+        ///       hand symbol.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        Hand         = 0x00000010,
+        /// <ExternalAPI/>
+        Hand = 0x00000010,
 
         /// <devdoc>
         ///    <para>
         ///       Specifies
         ///       that the message
         ///       box contains a question
-        ///       mark symbol. 
+        ///       mark symbol.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        Question     = 0x00000020,
+        /// <ExternalAPI/>
+        Question = 0x00000020,
 
         /// <devdoc>
         ///    <para>
         ///       Specifies that the
         ///       message box contains an
-        ///       exclamation symbol. 
+        ///       exclamation symbol.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        Exclamation  = 0x00000030,
+        /// <ExternalAPI/>
+        Exclamation = 0x00000030,
 
         /// <devdoc>
         ///    <para>
         ///       Specifies that the
         ///       message box contains an
-        ///       asterisk symbol. 
+        ///       asterisk symbol.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        Asterisk     = 0x00000040,
+        /// <ExternalAPI/>
+        Asterisk = 0x00000040,
 
         /// <devdoc>
         ///    <para>
@@ -612,43 +696,43 @@ namespace System.Windows
         ///       constant.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        Stop         = Hand,
+        /// <ExternalAPI/>
+        Stop = Hand,
 
         /// <devdoc>
         ///    <para>
         ///       Specifies that the
         ///       message box contains a
-        ///       hand icon. 
+        ///       hand icon.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        Error        = Hand,
+        /// <ExternalAPI/>
+        Error = Hand,
 
         /// <devdoc>
         ///    <para>
-        ///       Specifies that the message box contains an exclamation icon. 
+        ///       Specifies that the message box contains an exclamation icon.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        Warning      = Exclamation,
+        /// <ExternalAPI/>
+        Warning = Exclamation,
 
         /// <devdoc>
         ///    <para>
         ///       Specifies that the
         ///       message box contains an
-        ///       asterisk icon. 
+        ///       asterisk icon.
         ///    </para>
         /// </devdoc>
-        /// <ExternalAPI/> 
-        Information  = Asterisk,
+        /// <ExternalAPI/>
+        Information = Asterisk,
 
-        // NOTE: if you add or remove any values in this enum, be sure to update MessageBox.IsValidMessageBoxIcon()    
+        // NOTE: if you add or remove any values in this enum, be sure to update MessageBox.IsValidMessageBoxIcon()
     }
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
-    public enum MessageBoxButton 
+    public enum MessageBoxButton
     {
         /// <devdoc>
         ///    <para>
@@ -657,7 +741,7 @@ namespace System.Windows
         ///       constant.
         ///    </para>
         /// </devdoc>
-        OK               = 0x00000000,
+        OK = 0x00000000,
 
         /// <devdoc>
         ///    <para>
@@ -667,7 +751,17 @@ namespace System.Windows
         ///       constant.
         ///    </para>
         /// </devdoc>
-        OKCancel         = 0x00000001,
+        OKCancel = 0x00000001,
+
+        /// <devdoc>
+        ///    <para>
+        ///       Specifies that the
+        ///       message box contains Abort, Retry and Ignore button. This field
+        ///       is
+        ///       constant.
+        ///    </para>
+        /// </devdoc>
+        AbortRetryIgnore = 0x00000002,
 
         /// <devdoc>
         ///    <para>
@@ -677,7 +771,7 @@ namespace System.Windows
         ///       constant.
         ///    </para>
         /// </devdoc>
-        YesNoCancel      = 0x00000003,
+        YesNoCancel = 0x00000003,
 
         /// <devdoc>
         ///    <para>
@@ -686,7 +780,27 @@ namespace System.Windows
         ///       constant.
         ///    </para>
         /// </devdoc>
-        YesNo            = 0x00000004,
+        YesNo = 0x00000004,
+
+        /// <devdoc>
+        ///    <para>
+        ///       Specifies that the
+        ///       message box contains Retry and Cancel button. This field
+        ///       is
+        ///       constant.
+        ///    </para>
+        /// </devdoc>
+        RetryCancel = 0x00000005,
+
+        /// <devdoc>
+        ///    <para>
+        ///       Specifies that the
+        ///       message box contains Cancel, Retry and Continue button. This field
+        ///       is
+        ///       constant.
+        ///    </para>
+        /// </devdoc>
+        CancelTryContinue = 0x00000006,
 
         // NOTE: if you add or remove any values in this enum, be sure to update MessageBox.IsValidMessageBoxButton()
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -974,8 +974,11 @@ namespace System.Windows
     {
         OK = 0,
         OKCancel = 1,
+        AbortRetryIgnore = 2,
         YesNoCancel = 3,
         YesNo = 4,
+        RetryCancel = 5,
+        CancelTryContinue = 6,
     }
     public enum MessageBoxImage
     {
@@ -1003,8 +1006,13 @@ namespace System.Windows
         None = 0,
         OK = 1,
         Cancel = 2,
+        Abort = 3,
+        Retry = 4,
+        Ignore = 5,
         Yes = 6,
         No = 7,
+        TryAgain = 10,
+        Continue = 11,
     }
     [System.Windows.Markup.ContentPropertyAttribute("Setters")]
     public sealed partial class MultiDataTrigger : System.Windows.TriggerBase, System.Windows.Markup.IAddChild


### PR DESCRIPTION
Fixes #9613 

## Description

The purpose with the pull request is to streamline the `MessageBox.Show` overloads between WinForms and WPF thus making it more intuitive and easier to migrate a WinForms applicatio to WPF.
Also, since (on Windows), both WinForms and WPF call into the same underlying Windows API functions, there is in my opinion only little reason not to streamline them.

## Customer Impact

The customer impact of not taking this fix is that a migration from WinForms to WPF becomes a bit more complex when it comes to using MessageBox.Show with more options than just Yes/No or OK/Cancel. With the extension of both `MessageBoxButton` and `MessageBoxResult` enumerations, a more generous set of options is available for the application after showing `MessageBox.Show (...)` method.

## Regression

This is no regression.

## Testing

I tested the extensions of `MessageBoxButton` and `MessageBoxResult` enumerations with a sample Wpf application targeting a locally build version of Wpf. It simply had a set of `Button` and `TextBlock` controls in `MainWindow`, and each of these buttons uses the `MessageBoxButton` enumeration value as indicated by the button title. The result of `MessageBox.Show` is then assigned to the corresponding `TextBlock` control.

## Risk

The risk of taking this fix is minimal (if not even none). The WinForms repository already contains these extensions, and they are building upon an existing Windows API.
