### PR TITLE
Don't redistribute inbox msbuild dependencies

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,11 +58,6 @@
     <MicrosoftSourceLinkGitHubVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkGitHubVersion>
     <MicrosoftSourceLinkAzureReposGitVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkAzureReposGitVersion>
   </PropertyGroup>
-  <!-- These are minimum versions used for netfx-targeted components that run in Visual Studio because in those cases,
-       Visual Studio is providing those assemblies, and we should work with whichever version it ships. -->
-  <PropertyGroup>
-    <SystemCodeDomToolsetPackageVersion>8.0.0</SystemCodeDomToolsetPackageVersion>
-  </PropertyGroup>
   <!-- Other Packages that require manual updating-->
   <PropertyGroup>
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,10 +58,10 @@
     <MicrosoftSourceLinkGitHubVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkGitHubVersion>
     <MicrosoftSourceLinkAzureReposGitVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkAzureReposGitVersion>
   </PropertyGroup>
-  <!-- Maintain System.CodeDom PackageVersion at 4.4.0. See https://github.com/Microsoft/msbuild/issues/3627 -->
-  <!-- Pin specific versions of S.Memory so that it would supply AssemblyVersion=4.0.1.0. See https://github.com/dotnet/runtime/issues/31672 -->
+  <!-- These are minimum versions used for netfx-targeted components that run in Visual Studio because in those cases,
+       Visual Studio is providing those assemblies, and we should work with whichever version it ships. -->
   <PropertyGroup>
-    <SystemCodeDomPackageVersionForPresentationBuildTasks>4.5.0</SystemCodeDomPackageVersionForPresentationBuildTasks>
+    <SystemCodeDomToolsetPackageVersion>8.0.0</SystemCodeDomToolsetPackageVersion>
   </PropertyGroup>
   <!-- Other Packages that require manual updating-->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,7 +49,7 @@
        Visual Studio is providing those assemblies, and we should work with whichever version it ships. -->
   <PropertyGroup>
     <SystemReflectionMetadataLoadContextToolsetVersion>8.0.0</SystemReflectionMetadataLoadContextToolsetVersion>
-  </PropertyGorup>
+  </PropertyGroup>
   <!-- Docs / Intellisense -->
   <PropertyGroup>
     <MicrosoftPrivateIntellisenseVersion>9.0.0-preview-20241010.1</MicrosoftPrivateIntellisenseVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,6 +45,11 @@
     <SystemSecurityPermissionsPackageVersion>10.0.0-preview.4.25205.3</SystemSecurityPermissionsPackageVersion>
     <SystemWindowsExtensionsPackageVersion>10.0.0-preview.4.25205.3</SystemWindowsExtensionsPackageVersion>
   </PropertyGroup>
+  <!-- These are minimum versions used for netfx-targeted components that run in Visual Studio because in those cases,
+       Visual Studio is providing those assemblies, and we should work with whichever version it ships. -->
+  <PropertyGroup>
+    <SystemReflectionMetadataLoadContextToolsetVersion>8.0.0</SystemReflectionMetadataLoadContextToolsetVersion>
+  </PropertyGorup>
   <!-- Docs / Intellisense -->
   <PropertyGroup>
     <MicrosoftPrivateIntellisenseVersion>9.0.0-preview-20241010.1</MicrosoftPrivateIntellisenseVersion>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -301,8 +301,8 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" IncludeAssets="compile" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" IncludeAssets="compile" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="$(SystemReflectionMetadataLoadContextVersion)" IncludeAssets="compile" />
-    <!-- Use minimum supported version as this component runs inside MSBuild.  -->
-    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomToolsetPackageVersion)" />
+    <!-- System.CodeDom live version is provided by the SDK. Don't redistribute it. -->
+    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomToolsetPackageVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" IncludeAssets="compile" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -300,9 +300,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" IncludeAssets="compile" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" IncludeAssets="compile" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="$(SystemReflectionMetadataLoadContextVersion)" IncludeAssets="compile" />
-    <!-- System.CodeDom live version is provided by the SDK. Don't redistribute it. -->
-    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomToolsetPackageVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" IncludeAssets="compile" />
+
+    <!-- Reference (don't redistribute) the live version of SRM on .NETCoreApp and fallback to the toolset version for .NET Framework. -->
+    <PackageReference Include="System.Reflection.MetadataLoadContext" IncludeAssets="compile">
+      <Version Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">$(SystemReflectionMetadataLoadContextVersion)</Version>
+      <Version Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">$(SystemReflectionMetadataLoadContextToolsetVersion)</Version>
+    </PackageReference>
+    <!-- System.CodeDom live version is provided by the SDK. Use latest and don't redistribute it. -->
+    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" IncludeAssets="compile" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -47,19 +47,9 @@
     <PackagingContent Include="$(MSBuildThisFileDirectory)Microsoft.WinFX.targets" SubFolder="root\targets" />
   </ItemGroup>
 
-  <!--
-    Limit the assemblies that are packaged into Microsoft.NET.Sdk.WindowsDesktop
-  -->
-  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
-    <PackagingAssemblyContent Include="System.Collections.Immutable.dll" />
-    <PackagingAssemblyContent Include="System.Memory.dll" />
-    <PackagingAssemblyContent Include="System.Numerics.Vectors.dll" />
-    <PackagingAssemblyContent Include="System.Reflection.Metadata.dll" />
-    <PackagingAssemblyContent Include="System.Runtime.CompilerServices.Unsafe.dll" />
-  </ItemGroup>
+  <!-- Limit the assemblies that are packaged into Microsoft.NET.Sdk.WindowsDesktop -->
   <ItemGroup>
     <PackagingAssemblyContent Include="PresentationBuildTasks.dll" />
-    <PackagingAssemblyContent Include="System.Reflection.MetadataLoadContext.dll" />
   </ItemGroup>
 
   <ItemGroup>
@@ -308,14 +298,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="$(SystemReflectionMetadataLoadContextVersion)" />
-
-    <!--
-      Provide specific/old versions for PresentationBuildTasks which needs to run inside MSBuild
-    -->
-    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersionForPresentationBuildTasks)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" IncludeAssets="compile" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="$(SystemReflectionMetadataLoadContextVersion)" IncludeAssets="compile" />
+    <!-- Use minimum supported version as this component runs inside MSBuild.  -->
+    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomToolsetPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/10721

System.CodeDom is only used on .NETCoreApp and its live version is available in the SDK directory. Therefore, we shouldn't need to pin it to an older version.