### PR TITLE
Use `Debug.Fail("message")` over `Debug.Assert(false, "message")`

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/CustomAttributeSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/CustomAttributeSerializer.cs
@@ -938,7 +938,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                                             }
                                             default:
                                             {
-                                                Debug.Assert(false, "Missing case statement!");
+                                                Debug.Fail("Missing case statement!");
                                                 break;
                                             }
                                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/DrawingAttributeSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/DrawingAttributeSerializer.cs
@@ -279,7 +279,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                     }
                     catch (InvalidOperationException) // Matrix.Parse failed.
                     {
-                        System.Diagnostics.Debug.Assert(false, "Corrupt Matrix in the ExtendedPropertyCollection!");
+                        System.Diagnostics.Debug.Fail("Corrupt Matrix in the ExtendedPropertyCollection!");
                     }
                     finally
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/StrokeSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/StrokeSerializer.cs
@@ -288,7 +288,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
 
                                 byte[] out_buffer = Compressor.DecompressPropertyData(in_buffer);
 
-                                System.Diagnostics.Debug.Assert(false, "ExtendedProperties for points are not supported");
+                                System.Diagnostics.Debug.Fail("ExtendedProperties for points are not supported");
 
                                 // skip the bytes in both success & failure cases
                                 // Note: Point ExtendedProperties are discarded

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNode.cs
@@ -256,7 +256,7 @@ namespace MS.Internal.Ink
 
                     if (i == maxCount)
                     {
-                        Debug.Assert(false, "StrokeNodeOperations.GetPointsAtStartOfSegment failed to find the D position");
+                        Debug.Fail("StrokeNodeOperations.GetPointsAtStartOfSegment failed to find the D position");
                         //we didn't find the d point, return
                         return;
                     }
@@ -369,7 +369,7 @@ namespace MS.Internal.Ink
 
                     if (i == maxCount)
                     {
-                        Debug.Assert(false, "StrokeNodeOperations.GetPointsAtEndOfSegment failed to find the B position");
+                        Debug.Fail("StrokeNodeOperations.GetPointsAtEndOfSegment failed to find the B position");
                         //we didn't find the d point, return
                         return;
                     }
@@ -636,7 +636,7 @@ namespace MS.Internal.Ink
 
                             if (indexA == -1 || indexB == -1 || indexC == -1 || indexD == -1)
                             {
-                                Debug.Assert(false, "Couldn't find all 4 indexes in StrokeNodeOperations.GetPointsAtMiddleSegment");
+                                Debug.Fail("Couldn't find all 4 indexes in StrokeNodeOperations.GetPointsAtMiddleSegment");
                                 return;
                             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Shaping/OpenTypeCommon.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Shaping/OpenTypeCommon.cs
@@ -591,7 +591,7 @@ namespace MS.Internal.Shaping
                         break;
                     }
                     default:
-                        Debug.Assert(false,"Unknown OpenType layout table!");
+                        Debug.Fail("Unknown OpenType layout table!");
                         break;
                 }
             }
@@ -1072,7 +1072,7 @@ namespace MS.Internal.Shaping
                                     break;
 
                                 case 7: //Extension lookup
-                                    Debug.Assert(false,"Ext.Lookup processed earlier!");
+                                    Debug.Fail("Ext.Lookup processed earlier!");
                                     break;
 
                                 case 8: //ReverseCahiningSubst
@@ -1157,7 +1157,7 @@ namespace MS.Internal.Shaping
                                     break;
 
                                 case 9: //Extension lookup
-                                    Debug.Assert(false,"Ext.Lookup processed earlier!");
+                                    Debug.Fail("Ext.Lookup processed earlier!");
                                     break;
 
                                 default:
@@ -1170,7 +1170,7 @@ namespace MS.Internal.Shaping
                         }
 
                         default:
-                            Debug.Assert(false,"Unknown OpenType layout table!");
+                            Debug.Fail("Unknown OpenType layout table!");
                             break;
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Shaping/TypefaceMap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Shaping/TypefaceMap.cs
@@ -214,7 +214,7 @@ namespace MS.Internal.Shaping
                 typefaceIndexSpanRider.At(ichRange + ich);
                 if((int)typefaceIndexSpanRider.CurrentValue < 0)
                 {
-                    Debug.Assert(false, "Invalid font face spans");
+                    Debug.Fail("Invalid font face spans");
                     return;
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Shaping/UshortList2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Shaping/UshortList2.cs
@@ -131,24 +131,24 @@ namespace MS.Internal.Shaping
 
         public virtual ushort[] ToArray()
         {
-            Debug.Assert(false, "Not supported");
+            Debug.Fail("Not supported");
             return null;
         }
 
         public virtual ushort[] GetSubsetCopy(int index, int count)
         {
-            Debug.Assert(false, "Not supported");
+            Debug.Fail("Not supported");
             return null;
         }
 
         public virtual void Insert(int index, int count, int length)
         {
-            Debug.Assert(false, "Not supported");
+            Debug.Fail("Not supported");
         }
 
         public virtual void Remove(int index, int count, int length)
         {
-            Debug.Assert(false, "Not supported");
+            Debug.Fail("Not supported");
         }
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/LineServicesCallbacks.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/LineServicesCallbacks.cs
@@ -1234,7 +1234,7 @@ namespace MS.Internal.TextFormatting
                     break;
 
                 default:
-                    Debug.Assert(false, "Not supported TextDecorationUnit");
+                    Debug.Fail("Not supported TextDecorationUnit");
                     break;
             }
 
@@ -1261,7 +1261,7 @@ namespace MS.Internal.TextFormatting
                     break;
 
                 default:
-                    Debug.Assert(false, "Not supported TextDecorationUnit");
+                    Debug.Fail("Not supported TextDecorationUnit");
                     break;
             }
 
@@ -2312,7 +2312,7 @@ namespace MS.Internal.TextFormatting
                         break;
 
                     default:
-                        Debug.Assert(false, "Unsupported installed object!");
+                        Debug.Fail("Unsupported installed object!");
                         break;
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextMarkerSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextMarkerSource.cs
@@ -124,7 +124,7 @@ namespace MS.Internal.TextFormatting
             }
             else
             {
-                Debug.Assert(false, "Invalid marker style");
+                Debug.Fail("Invalid marker style");
             }
 
             if(symbolString != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/IO/Packaging/PackWebResponse.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/IO/Packaging/PackWebResponse.cs
@@ -608,7 +608,7 @@ namespace System.IO.Packaging
                         // full container request?
                         if (_parent._partName == null)
                         {
-                            Debug.Assert(false, "Cannot return full-container stream from cached container object");
+                            Debug.Fail("Cannot return full-container stream from cached container object");
                         }
                         else
                         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DragEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DragEventArgs.cs
@@ -41,17 +41,17 @@ namespace System.Windows
         {
             if (!DragDrop.IsValidDragDropKeyStates(dragDropKeyStates))
             {
-                Debug.Assert(false, "Invalid dragDropKeyStates");
+                Debug.Fail("Invalid dragDropKeyStates");
             }
 
             if (!DragDrop.IsValidDragDropEffects(allowedEffects))
             {
-                Debug.Assert(false, "Invalid allowedEffects");
+                Debug.Fail("Invalid allowedEffects");
             }
 
             if (target == null)
             {
-                Debug.Assert(false, "Invalid target");
+                Debug.Fail("Invalid target");
             }
 
             this._data = data;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/GiveFeedbackEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/GiveFeedbackEventArgs.cs
@@ -37,7 +37,7 @@ namespace System.Windows
         {
             if (!DragDrop.IsValidDragDropEffects(effects))
             {
-                Debug.Assert(false, "Invalid effects");
+                Debug.Fail("Invalid effects");
             }
 
             this._effects = effects;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/IncrementalHitTester.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/IncrementalHitTester.cs
@@ -201,7 +201,7 @@ namespace System.Windows.Ink
             //validate our cache
             if (_strokes.Count != _strokeInfos.Count)
             {
-                Debug.Assert(false, "Benign assert.  IncrementalHitTester's _strokeInfos cache is out of sync, rebuilding.");
+                Debug.Fail("Benign assert.  IncrementalHitTester's _strokeInfos cache is out of sync, rebuilding.");
                 RebuildStrokeInfoCache();
                 return;
             }
@@ -209,7 +209,7 @@ namespace System.Windows.Ink
             {
                 if (_strokeInfos[i].Stroke != _strokes[i])
                 {
-                    Debug.Assert(false, "Benign assert.  IncrementalHitTester's _strokeInfos cache is out of sync, rebuilding.");
+                    Debug.Fail("Benign assert.  IncrementalHitTester's _strokeInfos cache is out of sync, rebuilding.");
                     RebuildStrokeInfoCache();
                     return;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputMethod.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputMethod.cs
@@ -711,7 +711,7 @@ namespace System.Windows.Input
                     }
                     else
                     {
-                        Debug.Assert(false, "Unknown Speech Mode");
+                        Debug.Fail("Unknown Speech Mode");
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputMethodStateTypeInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputMethodStateTypeInfo.cs
@@ -88,7 +88,7 @@ namespace System.Windows.Input
                      return im._inputmethodstatetype;
              }
 
-             Debug.Assert(false, "The guid does not match.");
+             Debug.Fail("The guid does not match.");
              return InputMethodStateType.Invalid;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusLogic.cs
@@ -764,7 +764,7 @@ namespace System.Windows.Input
                     break;
                 default:
                     {
-                        Debug.Assert(false, "Unknown Flick Action encountered");
+                        Debug.Fail("Unknown Flick Action encountered");
                     }
                     break;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenThreadPool.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenThreadPool.cs
@@ -140,7 +140,7 @@ namespace System.Windows.Input
             {
                 StylusTraceLogger.LogReentrancyRetryLimitReached();
 
-                Debug.Assert(false, "Retry limit reached when acquiring PenThread");
+                Debug.Fail("Retry limit reached when acquiring PenThread");
             }
 
             return selectedPenThread;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispTabletDeviceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispTabletDeviceCollection.cs
@@ -264,7 +264,7 @@ namespace System.Windows.Input.StylusWisp
             // There was an error acquiring a PenThread, do no work here.
             if (penThread == null)
             {
-                Debug.Assert(false, "Error acquiring PenThread in UpdateTabletsImpl()");
+                Debug.Fail("Error acquiring PenThread in UpdateTabletsImpl()");
                 return;
             }
 
@@ -412,7 +412,7 @@ namespace System.Windows.Input.StylusWisp
             // There was an error acquiring a PenThread, return true to force a complete tablet refresh
             if (penThread == null)
             {
-                Debug.Assert(false, "Error acquiring PenThread in HandleTabletAdded()");
+                Debug.Fail("Error acquiring PenThread in HandleTabletAdded()");
                 return true;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimeManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimeManager.cs
@@ -572,7 +572,7 @@ namespace System.Windows.Media.Animation
 
                 default:
 
-                    Debug.Assert(false, "Unrecognized TimeState enumeration value");
+                    Debug.Fail("Unrecognized TimeState enumeration value");
                     return TimeSpan.Zero;
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimelineClockCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/TimelineClockCollection.cs
@@ -423,7 +423,7 @@ namespace System.Windows.Media.Animation
         /// </summary>
         private ClockCollection()
         {
-            Debug.Assert(false, "Parameterless constructor is illegal for ClockCollection.");
+            Debug.Fail("Parameterless constructor is illegal for ClockCollection.");
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Visual.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Visual.cs
@@ -153,7 +153,7 @@ namespace System.Windows.Media
                 break;
 
             default:
-                Debug.Assert(false, "TYPE_VISUAL or TYPE_VIEWPORT3DVISUAL expected.");
+                Debug.Fail("TYPE_VISUAL or TYPE_VIEWPORT3DVISUAL expected.");
                 break;
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/QueryContinueDragEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/QueryContinueDragEventArgs.cs
@@ -30,7 +30,7 @@ namespace System.Windows
         {
             if (!DragDrop.IsValidDragDropKeyStates(dragDropKeyStates))
             {
-                Debug.Assert(false, "Invalid dragDropKeyStates");
+                Debug.Fail("Invalid dragDropKeyStates");
             }
 
             this._escapePressed = escapePressed;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Component/AnnotationHighlightLayer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Component/AnnotationHighlightLayer.cs
@@ -509,7 +509,7 @@ namespace MS.Internal.Annotations.Component
             }
 
             if ((startSeg < 0) || (endSeg < 0) || (startSeg > endSeg))
-                Debug.Assert(false, "Mismatched segment data");
+                Debug.Fail("Mismatched segment data");
         }
 
         #endregion Private Methods

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/StickyNote/StickyNoteAnnotations.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/StickyNote/StickyNoteAnnotations.cs
@@ -718,7 +718,7 @@ namespace MS.Internal.Controls.StickyNote
             if ((token == XmlToken.Ink && contentControl.Type != StickyNoteType.Ink)
                 || (token == XmlToken.Text && contentControl.Type != StickyNoteType.Text))
             {
-                Debug.Assert(false, "The annotation data does match with the current content control in StickyNote");
+                Debug.Fail("The annotation data does match with the current content control in StickyNote");
                 return;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CollectionViewGroupRoot.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CollectionViewGroupRoot.cs
@@ -633,7 +633,7 @@ namespace MS.Internal.Data
             // properties that the name depends on) without notification.
             // We don't support this - the Move is just a no-op.  But assert (in
             // debug builds) to help diagnose the problem if it arises.
-            Debug.Assert(false, "Failed to find item in expected subgroup after Move");
+            Debug.Fail("Failed to find item in expected subgroup after Move");
         }
 
         // move the item within its group

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CompositeCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CompositeCollectionView.cs
@@ -1649,12 +1649,12 @@ namespace MS.Internal.Data
             {
                 int x, y;
                 if (!ItemsControl.EqualsEx(CurrentItem, GetItem(CurrentPosition, out x, out y)) && !_collection.HasRepeatedCollection())
-                    Debug.Assert(false, "CurrentItem is not consistent with CurrentPosition");
+                    Debug.Fail("CurrentItem is not consistent with CurrentPosition");
             }
             else
             {
                 if ((CurrentItem != null) && !_collection.HasRepeatedCollection())
-                    Debug.Assert(false, "CurrentItem is not consistent with CurrentPosition");
+                    Debug.Fail("CurrentItem is not consistent with CurrentPosition");
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DataExtensionMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DataExtensionMethods.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -30,7 +30,7 @@ namespace MS.Internal.Data
             }
 
             // we should never get here, but the compiler doesn't know that
-            Debug.Assert(false, "Unsupported list passed to Search");
+            Debug.Fail("Unsupported list passed to Search");
             return 0;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/IndexedEnumerable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/IndexedEnumerable.cs
@@ -390,7 +390,7 @@ namespace MS.Internal.Data
                 }
                 catch (InvalidOperationException)
                 {
-                    Debug.Assert(false, "EnsureCacheCurrent: _enumerator.Current failed with InvalidOperationException");
+                    Debug.Fail("EnsureCacheCurrent: _enumerator.Current failed with InvalidOperationException");
                 }
                 Debug.Assert(System.Windows.Controls.ItemsControl.EqualsEx(_cachedItem, current), "EnsureCacheCurrent: _cachedItem out of sync with _enumerator.Current");
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/StaticPropertyChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/StaticPropertyChangedEventManager.cs
@@ -80,7 +80,7 @@ namespace MS.Internal.Data
         /// </summary>
         protected override void StartListening(object source)
         {
-            Debug.Assert(false, "Should never get here");
+            Debug.Fail("Should never get here");
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace MS.Internal.Data
         /// </summary>
         protected override void StopListening(object source)
         {
-            Debug.Assert(false, "Should never get here");
+            Debug.Fail("Should never get here");
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/LocalizableResourceBuilder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/LocalizableResourceBuilder.cs
@@ -512,7 +512,7 @@ namespace MS.Internal.Globalization
                     }
                 default:
                     {
-                        Debug.Assert(false, "Can't process localizability attribute on nodes other than Element, Property and LiteralContent.");
+                        Debug.Fail("Can't process localizability attribute on nodes other than Element, Property and LiteralContent.");
                         break;
                     }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/EditingCoordinator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/EditingCoordinator.cs
@@ -1175,7 +1175,7 @@ namespace MS.Internal.Ink
             }
             else
             {
-                Debug.Assert(false, "Unknown behavior");
+                Debug.Fail("Unknown behavior");
             }
 
             return flag;
@@ -1212,7 +1212,7 @@ namespace MS.Internal.Ink
             }
             else
             {
-                Debug.Assert(false, "Unknown behavior");
+                Debug.Fail("Unknown behavior");
             }
 
             return flag;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/EraserBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/EraserBehavior.cs
@@ -137,7 +137,7 @@ namespace MS.Internal.Ink
                         break;
                     }
                 default:
-                    Debug.Assert(false, "Unknown InkCanvasEditingMode!");
+                    Debug.Fail("Unknown InkCanvasEditingMode!");
                     break;
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/InkCanvasSelection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/InkCanvasSelection.cs
@@ -477,7 +477,7 @@ namespace MS.Internal.Ink
             }
             else
             {
-                Debug.Assert(false, "The updatedElement has to be the same type as the originalElement.");
+                Debug.Fail("The updatedElement has to be the same type as the originalElement.");
             }
         }
 
@@ -597,7 +597,7 @@ namespace MS.Internal.Ink
                 }
                 else
                 {
-                    Debug.Assert(false, "An unexpected single selected Element");
+                    Debug.Fail("An unexpected single selected Element");
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/InkCollectionBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/InkCollectionBehavior.cs
@@ -159,7 +159,7 @@ namespace MS.Internal.Ink
                         break;
                     }
                 default:
-                    Debug.Assert(false, "Unknown InkCanvasEditingMode!");
+                    Debug.Fail("Unknown InkCanvasEditingMode!");
                     break;
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoSelectionBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoSelectionBehavior.cs
@@ -93,7 +93,7 @@ namespace MS.Internal.Ink
                     }
                 case InkCanvasEditingMode.Select:
                     {
-                        Debug.Assert(false, "Cannot switch from Select to Select in mid-stroke");
+                        Debug.Fail("Cannot switch from Select to Select in mid-stroke");
                         break;
                     }
                 case InkCanvasEditingMode.None:
@@ -106,7 +106,7 @@ namespace MS.Internal.Ink
                         break;
                     }
                 default:
-                    Debug.Assert(false, "Unknown InkCanvasEditingMode!");
+                    Debug.Fail("Unknown InkCanvasEditingMode!");
                     break;
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/ErrorHandler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/ErrorHandler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -23,7 +23,7 @@ namespace MS.Internal.PtsHost
 #if DEBUG
             if (!condition)
             {
-                System.Diagnostics.Debug.Assert(false, message);
+                System.Diagnostics.Debug.Fail(message);
             }
 #endif
         }
@@ -37,7 +37,7 @@ namespace MS.Internal.PtsHost
             if (!condition)
             {
                 string message = String.Format(CultureInfo.InvariantCulture, format, args);
-                System.Diagnostics.Debug.Assert(false, message);
+                System.Diagnostics.Debug.Fail(message);
             }
 #endif
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FigureParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FigureParagraph.cs
@@ -302,7 +302,7 @@ namespace MS.Internal.PtsHost
             out int cfspt,                      // OUT: actual total number of vertices in all polygons
             out int fWrapThrough)               // OUT: fill text in empty areas within obstacles?
         {
-            Debug.Assert(false, "Tight wrap is not currently supported.");
+            Debug.Fail("Tight wrap is not currently supported.");
             ccVertices = cfspt = fWrapThrough = 0;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FloaterBaseParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FloaterBaseParagraph.cs
@@ -109,7 +109,7 @@ namespace MS.Internal.PtsHost
             out int cfspt,                      // OUT: actual total number of vertices in all polygons
             out int fWrapThrough)               // OUT: fill text in empty areas within obstacles?
         {
-            Debug.Assert(false, "Tight wrap is not currently supported.");
+            Debug.Fail("Tight wrap is not currently supported.");
             ccVertices = cfspt = fWrapThrough = 0;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FloaterParagraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FloaterParagraph.cs
@@ -809,7 +809,7 @@ namespace MS.Internal.PtsHost
                 }
                 else
                 {
-                    Debug.Assert(false, "Unknown type of anchor.");
+                    Debug.Fail("Unknown type of anchor.");
                     return HorizontalAlignment.Center;
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Pts.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Pts.cs
@@ -205,7 +205,7 @@ namespace MS.Internal.PtsHost.UnsafeNativeMethods
                     fskclear = FSKCLEAR.fskclearBoth;
                     break;
                 default:
-                    Debug.Assert(false, "Unknown WrapDirection value.");
+                    Debug.Fail("Unknown WrapDirection value.");
                     fskclear = FSKCLEAR.fskclearNone;
                     break;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsHost.cs
@@ -566,7 +566,7 @@ namespace MS.Internal.PtsHost
             int* rgcColumns,                    // OUT: arrays of number of columns spanned
             out int cAreasActual)               // OUT: actual number of segment-defined areas
         {
-            Debug.Assert(false, "PTS.GetSegmentDefinedColumnSpanAreaInfo is not implemented.");
+            Debug.Fail("PTS.GetSegmentDefinedColumnSpanAreaInfo is not implemented.");
             cAreasActual = 0;
             return PTS.fserrNotImplemented;
         }
@@ -578,7 +578,7 @@ namespace MS.Internal.PtsHost
             int* rgcColumns,                    // OUT: arrays of number of columns spanned
             out int cAreasActual)               // OUT: actual number of height-defined areas
         {
-            Debug.Assert(false, "PTS.GetHeightDefinedColumnSpanAreaInfo is not implemented.");
+            Debug.Fail("PTS.GetHeightDefinedColumnSpanAreaInfo is not implemented.");
             cAreasActual = 0;
             return PTS.fserrNotImplemented;
         }
@@ -866,7 +866,7 @@ namespace MS.Internal.PtsHost
             IntPtr nms,                         // IN:  name of section
             out int ccolEndnote)                // OUT: number of columns in endnote area
         {
-            Debug.Assert(false, "PTS.GetNumberEndnoteColumns is not implemented.");
+            Debug.Fail("PTS.GetNumberEndnoteColumns is not implemented.");
             ccolEndnote = 0;
             return PTS.fserrNotImplemented;
         }
@@ -878,7 +878,7 @@ namespace MS.Internal.PtsHost
             PTS.FSCOLUMNINFO* fscolinfoEndnote, // OUT: array of the colinfo structures
             out int ccolEndnote)                // OUT: actual number of the columns in footnote area
         {
-            Debug.Assert(false, "PTS.GetEndnoteColumnInfo is not implemented.");
+            Debug.Fail("PTS.GetEndnoteColumnInfo is not implemented.");
             ccolEndnote = 0;
             return PTS.fserrNotImplemented;
         }
@@ -889,7 +889,7 @@ namespace MS.Internal.PtsHost
             out IntPtr nmsFtnContSeparator,     // OUT: name of the ftn cont separator segment
             out IntPtr nmsFtnContNotice)        // OUT: name of the footnote cont notice segment
         {
-            Debug.Assert(false, "PTS.GetFootnoteSeparators is not implemented.");
+            Debug.Fail("PTS.GetFootnoteSeparators is not implemented.");
             nmsFtnSeparator = nmsFtnContSeparator = nmsFtnContNotice = IntPtr.Zero;
             return PTS.fserrNotImplemented;
         }
@@ -898,7 +898,7 @@ namespace MS.Internal.PtsHost
             IntPtr nms,                         // IN:  name of section
             out int fFootnoteBeneathText)       // OUT: position footnote right after text?
         {
-            Debug.Assert(false, "PTS.FFootnoteBeneathText is not implemented.");
+            Debug.Fail("PTS.FFootnoteBeneathText is not implemented.");
             fFootnoteBeneathText = 0;
             return PTS.fserrNotImplemented;
         }
@@ -907,7 +907,7 @@ namespace MS.Internal.PtsHost
             IntPtr nms,                         // IN:  name of section
             out int ccolFootnote)               // OUT: number of columns in footnote area
         {
-            Debug.Assert(false, "PTS.GetNumberFootnoteColumns is not implemented.");
+            Debug.Fail("PTS.GetNumberFootnoteColumns is not implemented.");
             ccolFootnote = 0;
             return PTS.fserrNotImplemented;
         }
@@ -919,7 +919,7 @@ namespace MS.Internal.PtsHost
             PTS.FSCOLUMNINFO* fscolinfoFootnote,// OUT: array of the colinfo structures
             out int ccolFootnote)               // OUT: actual number of the columns in footnote area
         {
-            Debug.Assert(false, "PTS.GetFootnoteColumnInfo is not implemented.");
+            Debug.Fail("PTS.GetFootnoteColumnInfo is not implemented.");
             ccolFootnote = 0;
             return PTS.fserrNotImplemented;
         }
@@ -928,7 +928,7 @@ namespace MS.Internal.PtsHost
             IntPtr nmftn,                       // IN:  name of footnote
             out IntPtr nmsFootnote)             // OUT: name of footnote segment
         {
-            Debug.Assert(false, "PTS.GetFootnoteSegment is not implemented.");
+            Debug.Fail("PTS.GetFootnoteSegment is not implemented.");
             nmsFootnote = IntPtr.Zero;
             return PTS.fserrNotImplemented;
         }
@@ -942,7 +942,7 @@ namespace MS.Internal.PtsHost
             out int fProposedRejectionOrderAccepted,    // OUT: agree with proposed order?
             IntPtr* rgFinalRejectionOrder)              // OUT: footnotes in final reject order
         {
-            Debug.Assert(false, "PTS.GetFootnotePresentationAndRejectionOrder is not implemented.");
+            Debug.Fail("PTS.GetFootnotePresentationAndRejectionOrder is not implemented.");
             fProposedPresentationOrderAccepted = fProposedRejectionOrderAccepted = 0;
             return PTS.fserrNotImplemented;
         }
@@ -951,7 +951,7 @@ namespace MS.Internal.PtsHost
             IntPtr nmftn,                       // IN:  name of footnote
             out int fAllow)                     // OUT: allow separating footnote from its reference
         {
-            Debug.Assert(false, "PTS.FAllowFootnoteSeparation is not implemented.");
+            Debug.Fail("PTS.FAllowFootnoteSeparation is not implemented.");
             fAllow = 0;
             return PTS.fserrNotImplemented;
         }
@@ -1249,7 +1249,7 @@ namespace MS.Internal.PtsHost
             int* rgdcp,                         // OUT: array of footnote refs in the range
             out int cFootnotes)                 // OUT: actual number of footnotes
         {
-            Debug.Assert(false, "PTS.GetFootnotes is not implemented.");
+            Debug.Fail("PTS.GetFootnotes is not implemented.");
             cFootnotes = 0;
             return PTS.fserrNotImplemented;
         }
@@ -1268,7 +1268,7 @@ namespace MS.Internal.PtsHost
             out int cVertices,                  // OUT: number of vertices
             out int durText)                    // OUT: distance from text
         {
-            Debug.Assert(false, "PTS.FormatDropCap is not implemented.");
+            Debug.Fail("PTS.FormatDropCap is not implemented.");
             pfsdropc = IntPtr.Zero;
             fInMargin = dur = dvr = cPolygons = cVertices = durText = 0;
             return PTS.fserrNotImplemented;
@@ -1286,7 +1286,7 @@ namespace MS.Internal.PtsHost
             out int cfspt,                      // OUT: actual total number of vertices in all polygons
             out int fWrapThrough)               // OUT: fill text in empty areas within obstacles?
         {
-            Debug.Assert(false, "PTS.GetDropCapPolygons is not implemented.");
+            Debug.Fail("PTS.GetDropCapPolygons is not implemented.");
             ccVertices = cfspt = fWrapThrough = 0;
             return PTS.fserrNotImplemented;
         }
@@ -1294,7 +1294,7 @@ namespace MS.Internal.PtsHost
             IntPtr pfsclient,                   // IN:  client opaque data
             IntPtr pfsdropc)                    // IN:  pointer to drop cap created by client
         {
-            Debug.Assert(false, "PTS.DestroyDropCap is not implemented.");
+            Debug.Fail("PTS.DestroyDropCap is not implemented.");
             return PTS.fserrNotImplemented;
         }
         internal int FormatBottomText(IntPtr pfsclient,                   // IN:  client opaque data
@@ -1702,7 +1702,7 @@ namespace MS.Internal.PtsHost
             int vrCurrent,                      // IN:  current vertical position
             out int vrNew)                      // OUT: snapped vertical position
         {
-            Debug.Assert(false, "PTS.SnapGridVertical is not implemented.");
+            Debug.Fail("PTS.SnapGridVertical is not implemented.");
             vrNew = 0;
             return PTS.fserrNotImplemented;
         }
@@ -1803,7 +1803,7 @@ namespace MS.Internal.PtsHost
             IntPtr nmp,                         // IN:  name of paragraph
             out int fChanged)                   // OUT: dropcap changed?
         {
-            Debug.Assert(false, "PTS.UpdGetDropCapChange is not implemented.");
+            Debug.Fail("PTS.UpdGetDropCapChange is not implemented.");
             fChanged = 0;
             return PTS.fserrNotImplemented;
         }
@@ -1904,7 +1904,7 @@ namespace MS.Internal.PtsHost
             int cLines,                         // IN:  number of lines - size of pre-allocated array
             int* rgdcp)                         // OUT: array of dcp's to fill
         {
-            Debug.Assert(false, "PTS.GetOptimalLineDcpCache is not implemented.");
+            Debug.Fail("PTS.GetOptimalLineDcpCache is not implemented.");
             return PTS.fserrNotImplemented;
         }
 
@@ -2930,7 +2930,7 @@ namespace MS.Internal.PtsHost
             PTS.FSFTNINFO* pfsftninf,           // IN/OUT: array of footnote info
             out int iftnLim)                    // OUT: lim index used by this paragraph
         {
-            Debug.Assert(false, "PTS.ObjGetFootnoteInfo is not implemented.");
+            Debug.Fail("PTS.ObjGetFootnoteInfo is not implemented.");
             iftnLim = 0;
             return PTS.fserrNotImplemented;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TableParaClient.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TableParaClient.cs
@@ -1969,7 +1969,7 @@ namespace MS.Internal.PtsHost
                         break;
 
                     default:
-                        Debug.Assert(false, "Unsupported unit type");
+                        Debug.Fail("Unsupported unit type");
                         break;
                 }
                 _durMinWidth += _calculatedColumns[i].DurMinWidth;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParaClient.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParaClient.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -128,7 +128,7 @@ namespace MS.Internal.PtsHost
             {
                 // (c) cached - when using ParaChache
                 Debug.Assert(textDetails.fsktd == PTS.FSKTEXTDETAILS.fsktdCached);
-                Debug.Assert(false, "Should not get here. ParaCache is not currently used.");
+                Debug.Fail("Should not get here. ParaCache is not currently used.");
             }
 
             // Mirror lines around the page.
@@ -226,7 +226,7 @@ namespace MS.Internal.PtsHost
             {
                 // (c) cached - when using ParaChache
                 Debug.Assert(textDetails.fsktd == PTS.FSKTEXTDETAILS.fsktdCached);
-                Debug.Assert(false, "Should not get here. ParaCache is not currently used.");
+                Debug.Fail("Should not get here. ParaCache is not currently used.");
             }
 
             // If nothing is hit, return the owner of the paragraph.
@@ -315,7 +315,7 @@ namespace MS.Internal.PtsHost
             {
                 // (c) cached - when using ParaChache
                 Debug.Assert(textDetails.fsktd == PTS.FSKTEXTDETAILS.fsktdCached);
-                Debug.Assert(false, "Should not get here. ParaCache is not currently used.");
+                Debug.Fail("Should not get here. ParaCache is not currently used.");
             }
 
             Invariant.Assert(rectangles != null);
@@ -368,7 +368,7 @@ namespace MS.Internal.PtsHost
             {
                 // (c) cached - when using ParaChache
                 Debug.Assert(textDetails.fsktd == PTS.FSKTEXTDETAILS.fsktdCached);
-                Debug.Assert(false, "Should not get here. ParaCache is not currently used.");
+                Debug.Fail("Should not get here. ParaCache is not currently used.");
             }
 
             return lines;
@@ -710,7 +710,7 @@ namespace MS.Internal.PtsHost
             {
                 // (c) cached - when using ParaChache
                 Debug.Assert(textDetails.fsktd == PTS.FSKTEXTDETAILS.fsktdCached);
-                Debug.Assert(false, "Should not get here. ParaCache is not currently used.");
+                Debug.Fail("Should not get here. ParaCache is not currently used.");
             }
 
             // Mirror back to page flow direction
@@ -791,7 +791,7 @@ namespace MS.Internal.PtsHost
             {
                 // (c) cached - when using ParaCache
                 Debug.Assert(textDetails.fsktd == PTS.FSKTEXTDETAILS.fsktdCached);
-                Debug.Assert(false, "Should not get here. ParaCache is not currently used.");
+                Debug.Fail("Should not get here. ParaCache is not currently used.");
             }
 
             //  at this point geometry contains only the text content related geometry
@@ -854,7 +854,7 @@ namespace MS.Internal.PtsHost
             {
                 // (c) cached - when using ParaChache
                 Debug.Assert(textDetails.fsktd == PTS.FSKTEXTDETAILS.fsktdCached);
-                Debug.Assert(false, "Should not get here. ParaCache is not currently used.");
+                Debug.Fail("Should not get here. ParaCache is not currently used.");
             }
 
             return isAtCaretUnitBoundary;
@@ -904,7 +904,7 @@ namespace MS.Internal.PtsHost
             {
                 // (c) cached - when using ParaChache
                 Debug.Assert(textDetails.fsktd == PTS.FSKTEXTDETAILS.fsktdCached);
-                Debug.Assert(false, "Should not get here. ParaCache is not currently used.");
+                Debug.Fail("Should not get here. ParaCache is not currently used.");
             }
 
             return nextCaretPosition;
@@ -1061,7 +1061,7 @@ namespace MS.Internal.PtsHost
             {
                 // (c) cached - when using ParaChache
                 Debug.Assert(textDetails.fsktd == PTS.FSKTEXTDETAILS.fsktdCached);
-                Debug.Assert(false, "Should not get here. ParaCache is not currently used.");
+                Debug.Fail("Should not get here. ParaCache is not currently used.");
             }
 
             // Recreate text line
@@ -1363,7 +1363,7 @@ namespace MS.Internal.PtsHost
             {
                 // (c) cached - when using ParaChache
                 Debug.Assert(textDetails.fsktd == PTS.FSKTEXTDETAILS.fsktdCached);
-                Debug.Assert(false, "Should not get here. ParaCache is not currently used.");
+                Debug.Fail("Should not get here. ParaCache is not currently used.");
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParaLineResult.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/TextParaLineResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/SystemDataHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/SystemDataHelper.cs
@@ -80,7 +80,7 @@ namespace MS.Internal
                 return nullProperty.GetValue(null, null);
             }
 
-            Debug.Assert(false, "Could not find Null field or property for SqlNullable type");
+            Debug.Fail("Could not find Null field or property for SqlNullable type");
             return null;
         }
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/TextLineResult.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/TextLineResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/HostedElements.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/HostedElements.cs
@@ -182,7 +182,7 @@ namespace System.Windows.Documents
                     default:
                         // Throw exception because this function should only be called after MoveNext, and not 
                         // if MoveNext returns false
-                        Debug.Assert(false, "Invalid state in HostedElements.cs");
+                        Debug.Fail("Invalid state in HostedElements.cs");
                         break;
                 }
                 return currentElement;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/RowCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/RowCache.cs
@@ -1059,7 +1059,7 @@ namespace MS.Internal.Documents
             //Check for invalid indices.  If it's out of range then we just return.
             if (index > _rowCache.Count)
             {
-                Debug.Assert(false, "Requested to update a non-existent row.");
+                Debug.Fail("Requested to update a non-existent row.");
                 return;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TableTextElementCollectionInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TableTextElementCollectionInternal.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -338,7 +338,7 @@ namespace MS.Internal.Documents
                 else
                 {
                     // We handle junk in the tree, but it really shouldn't be there.                                       
-                    Debug.Assert(false, "Garbage in logical tree.");
+                    Debug.Fail("Garbage in logical tree.");
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/UndoManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/UndoManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlAutomationPeer.cs
@@ -616,7 +616,7 @@ namespace System.Windows.Automation.Peers
                     if(!_hashtable.ContainsKey(item) && value is not null)
                         _hashtable[item] = value;
                     else
-                        Debug.Assert(false,"it must not add already present Item");
+                        Debug.Fail("it must not add already present Item");
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCellsPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCellsPanel.cs
@@ -772,7 +772,7 @@ namespace System.Windows.Controls
                         }
                     }
 
-                    Debug.Assert(false, "We should have found a child");
+                    Debug.Fail("We should have found a child");
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumn.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -421,7 +421,7 @@ namespace System.Windows.Controls
             {
                 if (Double.IsNaN(value) || Double.IsInfinity(value) || value < 0.0)
                 {
-                    Debug.Assert(false, "Invalid value for ActualWidth.");
+                    Debug.Fail("Invalid value for ActualWidth.");
                 }
                 else if (_actualWidth != value)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumnHeader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumnHeader.cs
@@ -286,7 +286,7 @@ namespace System.Windows.Controls
             if (IsInternalGenerated)
             {
                 // we should never reach here since this header is instantiated by HeaderRowPresenter.
-                Debug.Assert(false, "Method ShouldSerializeProperty is called on an internally generated GridViewColumnHeader.");
+                Debug.Fail("Method ShouldSerializeProperty is called on an internally generated GridViewColumnHeader.");
 
                 // nothing should be serialized from this object.
                 return false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewHeaderRowPresenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewHeaderRowPresenter.cs
@@ -934,7 +934,7 @@ namespace System.Windows.Controls
                                 }
                                 else
                                 {
-                                    Debug.Assert(false, "Head is container for itself, but parent is neither GridViewHeaderRowPresenter nor null.");
+                                    Debug.Fail("Head is container for itself, but parent is neither GridViewHeaderRowPresenter nor null.");
                                 }
                             }
                             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemContainerGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemContainerGenerator.cs
@@ -276,7 +276,7 @@ namespace System.Windows.Controls
             if (_itemMap == null)
             {
                 // ignore reentrant call (during RemoveAllInternal)
-                Debug.Assert(false, "Unexpected reentrant call to ICG.Remove");
+                Debug.Fail("Unexpected reentrant call to ICG.Remove");
                 return;
             }
 
@@ -2441,7 +2441,7 @@ namespace System.Windows.Controls
             {
                 // reentrant call (from RemoveAllInternal) shouldn't happen,
                 // but if it does, don't crash
-                Debug.Assert(false, "unexpected reentrant call to OnItemAdded");
+                Debug.Fail("unexpected reentrant call to OnItemAdded");
                 return;
             }
 
@@ -2631,7 +2631,7 @@ namespace System.Windows.Controls
             {
                 // reentrant call (from RemoveAllInternal) shouldn't happen,
                 // but if it does, don't crash
-                Debug.Assert(false, "unexpected reentrant call to OnItemMoved");
+                Debug.Fail("unexpected reentrant call to OnItemMoved");
                 return;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordTextNavigator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordTextNavigator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Documents;
@@ -466,7 +466,7 @@ namespace System.Windows.Controls
 
             if (offset < 0 || offset > this.Container.SymbolCount)
             {
-                Debug.Assert(false, "Bad distance!");
+                Debug.Fail("Bad distance!");
             }
 
             this.Container.RemovePosition(this);
@@ -505,7 +505,7 @@ namespace System.Windows.Controls
         void ITextPointer.MoveToElementEdge(ElementEdge edge)
         {
             Debug.Assert(!_isFrozen, "Can't reposition a frozen pointer!");
-            Debug.Assert(false, "No scoping element!");
+            Debug.Fail("No scoping element!");
         }
 
         // <see cref="TextPointer.MoveToLineBoundary"/>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Thumb.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Thumb.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -240,7 +240,7 @@ namespace System.Windows.Controls.Primitives
                 // This is weird, Thumb shouldn't get MouseLeftButtonDown event while dragging.
                 // This may be the case that something ate MouseLeftButtonUp event, so Thumb never had a chance to
                 // reset IsDragging property
-                Debug.Assert(false,"Got MouseLeftButtonDown event while dragging!");
+                Debug.Fail("Got MouseLeftButtonDown event while dragging!");
             }
             base.OnMouseLeftButtonDown(e);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/SelectedDatesCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/SelectedDatesCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
@@ -6457,7 +6457,7 @@ namespace System.Windows.Controls
             object item = GetItemFromContainer(child);
             if (item == DependencyProperty.UnsetValue)
             {
-                Debug.Assert(false, "SetInset should only be called for a container");
+                Debug.Fail("SetInset should only be called for a container");
                 return;
             }
 
@@ -9253,7 +9253,7 @@ namespace System.Windows.Controls
                         }
                     }
 
-                    Debug.Assert(false, "We should have found a child");
+                    Debug.Fail("We should have found a child");
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingGroup.cs
@@ -1321,7 +1321,7 @@ namespace System.Windows.Data
                     RemoveAllBindingExpressions();
                     break;  // nothing to do - order within the collection doesn't matter
                 default:
-                    Debug.Assert(false, "Unexpected change event");
+                    Debug.Fail("Unexpected change event");
                     break;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
@@ -1682,7 +1682,7 @@ namespace System.Windows.Data
                     if (args.Action != NotifyCollectionChangedAction.Remove && args.NewStartingIndex < 0
                         || args.Action != NotifyCollectionChangedAction.Add && args.OldStartingIndex < 0)
                     {
-                        Debug.Assert(false, "Cannot update collection view from outside UIContext without index in event args");
+                        Debug.Fail("Cannot update collection view from outside UIContext without index in event args");
                         return;     // support cross-thread changes from all collections
                     }
                     else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/MultiBinding.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/MultiBinding.cs
@@ -106,7 +106,7 @@ public class MultiBinding : BindingBase, IAddChild
                 case BindingFlags.OneTime:          return BindingMode.OneTime;
                 case BindingFlags.PropDefault:      return BindingMode.Default;
             }
-            Debug.Assert(false, "Unexpected BindingMode value");
+            Debug.Fail("Unexpected BindingMode value");
             return 0;
         }
         set
@@ -129,7 +129,7 @@ public class MultiBinding : BindingBase, IAddChild
                 case BindingFlags.UpdateExplicitly:     return UpdateSourceTrigger.Explicit;
                 case BindingFlags.UpdateDefault:        return UpdateSourceTrigger.Default;
             }
-            Debug.Assert(false, "Unexpected UpdateSourceTrigger value");
+            Debug.Fail("Unexpected UpdateSourceTrigger value");
             return 0;
         }
         set

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceHighlightLayer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceHighlightLayer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using MS.Internal.Documents;
@@ -48,7 +48,7 @@ namespace System.Windows.Documents
         // Method is not implemented.  Should not need to be called for constructing the event args.
         internal override object GetHighlightValue(StaticTextPointer staticTextPointer, LogicalDirection direction)
         {
-            Debug.Assert(false, "This method is not implemented and not expected to be called.");
+            Debug.Fail("This method is not implemented and not expected to be called.");
             return null;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextContainer.cs
@@ -431,7 +431,7 @@ namespace System.Windows.Documents
                 cdb = cdb.PreviousBlock;
             }
 
-            Debug.Assert(false, "should never be here");
+            Debug.Fail("should never be here");
             return 0;
         }
         #endregion Internal Methods

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextPointer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentSequenceTextPointer.cs
@@ -1079,7 +1079,7 @@ namespace System.Windows.Documents
                         break;
 
                     default:
-                        Debug.Assert(false, "invalid TextPointerContext");
+                        Debug.Fail("invalid TextPointerContext");
                         break;
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedDSBuilder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedDSBuilder.cs
@@ -104,7 +104,7 @@ namespace System.Windows.Documents
             if (_visitedArray[index])
             {
                 // this has already been added to the document structure
-                // Debug.Assert(false, "An element is referenced in the document structure multiple times");
+                // Debug.Fail("An element is referenced in the document structure multiple times");
                 return; // ignore this reference
             }
             FixedNode fn = (FixedNode)_fixedNodes[index];

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedPageStructure.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedPageStructure.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Media;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedSOMPageConstructor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedSOMPageConstructor.cs
@@ -189,7 +189,7 @@ namespace System.Windows.Documents
 
         internal override void SetClosedState(bool closed)
         {
-            Debug.Assert(false, "It should not be called");
+            Debug.Fail("It should not be called");
         }
 
         internal override void SetFigureCount(int figureCount)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/NullTextContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/NullTextContainer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using MS.Internal.Documents;
@@ -213,7 +213,7 @@ namespace System.Windows.Documents
             get
             {
                 //agurcan: The following line makes it hard to use debugger on FDS code so I'm commenting it out
-                //Debug.Assert(false, "Unexpected Highlights access on NullTextContainer!");
+                //Debug.Fail("Unexpected Highlights access on NullTextContainer!");
                 return null;
             }
         }
@@ -248,7 +248,7 @@ namespace System.Windows.Documents
 
             set
             {
-                Debug.Assert(false, "Unexpected call to NullTextContainer.set_TextView!");
+                Debug.Fail("Unexpected call to NullTextContainer.set_TextView!");
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/NullTextNavigator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/NullTextNavigator.cs
@@ -265,7 +265,7 @@ namespace System.Windows.Documents
         {
             Debug.Assert(!_isFrozen, "Can't reposition a frozen pointer!");
 
-            Debug.Assert(false, "No scoping element!");
+            Debug.Fail("No scoping element!");
         }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace System.Windows.Documents
         /// </summary>
         int ITextPointer.MoveToLineBoundary(int count)
         {
-            Debug.Assert(false, "NullTextPointer does not expect layout dependent method calls!");
+            Debug.Fail("NullTextPointer does not expect layout dependent method calls!");
             return 0;
         }
 
@@ -282,7 +282,7 @@ namespace System.Windows.Documents
         /// </summary>
         Rect ITextPointer.GetCharacterRect(LogicalDirection direction)
         {
-            Debug.Assert(false, "NullTextPointer does not expect layout dependent method calls!");
+            Debug.Fail("NullTextPointer does not expect layout dependent method calls!");
             return new Rect();
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/PageContentAsyncResult.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/PageContentAsyncResult.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlLexer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlLexer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkTemplate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkTemplate.cs
@@ -825,7 +825,7 @@ namespace System.Windows
                 }
                 else
                 {
-                    Debug.Assert(false, "We do not have support for DynamicResource within unshared template content");
+                    Debug.Fail("We do not have support for DynamicResource within unshared template content");
                 }
             }
 
@@ -1047,7 +1047,7 @@ namespace System.Windows
                             break;
 
                         default:
-                            Debug.Assert(false, "Unknown enum value");
+                            Debug.Fail("Unknown enum value");
                             break;
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordHelper.cs
@@ -127,7 +127,7 @@ namespace System.Windows.Markup
                     return false;
 
                 default:
-                    Debug.Assert(false, "Unhandled case in DoesRecordTypeHaveDebugExtension");
+                    Debug.Fail("Unhandled case in DoesRecordTypeHaveDebugExtension");
                     return false;
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -4983,7 +4983,7 @@ namespace System.Windows.Markup
                         }
                         else
                         {
-                            Debug.Assert(false, "The only remaining option is attached property, which is not allowed in xaml for content properties");
+                            Debug.Fail("The only remaining option is attached property, which is not allowed in xaml for content properties");
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecords.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecords.cs
@@ -684,7 +684,7 @@ namespace System.Windows.Markup
                 case BamlRecordType.TypeSerializerInfo:
                 case BamlRecordType.AttributeInfo:
                 case BamlRecordType.StringInfo:
-                    Debug.Assert(false,"Assembly, Type and Attribute records are not cached, so don't ask for one.");
+                    Debug.Fail("Assembly, Type and Attribute records are not cached, so don't ask for one.");
                     record = null;
                     break;
                 case BamlRecordType.StaticResourceStart:
@@ -709,7 +709,7 @@ namespace System.Windows.Markup
                     record = new BamlPropertyWithStaticResourceIdRecord();
                     break;
                 default:
-                    Debug.Assert(false,"Unknown RecordType");
+                    Debug.Fail("Unknown RecordType");
                     record = null;
                     break;
             }
@@ -861,7 +861,7 @@ namespace System.Windows.Markup
         {
             get
             {
-                Debug.Assert(false, "Must override RecordType");
+                Debug.Fail("Must override RecordType");
                 return BamlRecordType.Unknown;
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlParser.cs
@@ -520,7 +520,7 @@ namespace System.Windows.Markup
                     WriteConstructorParameterType(xamlConstructorParameterTypeNode);
                     break;
                 default:
-                    Debug.Assert(false,"Unknown Xaml Token.");
+                    Debug.Fail("Unknown Xaml Token.");
                     break;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -5309,7 +5309,7 @@ namespace System.Windows.Markup
                 }
                 else
                 {
-                    Debug.Assert(false, "XmlReader doesn't support LineNumber");
+                    Debug.Fail("XmlReader doesn't support LineNumber");
                     return 0;
                 }
             }
@@ -5340,7 +5340,7 @@ namespace System.Windows.Markup
                 }
                 else
                 {
-                    Debug.Assert(false, "XmlReader doesn't support LinePosition");
+                    Debug.Fail("XmlReader doesn't support LinePosition");
                     return 0;
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlStream.cs
@@ -780,7 +780,7 @@ namespace System.Windows.Markup
         /// </summary>
         public override void Close()
         {
-            Debug.Assert(false,"Close called on ReaderStream");
+            Debug.Fail("Close called on ReaderStream");
         }
 
         /// <summary>
@@ -788,7 +788,7 @@ namespace System.Windows.Markup
         /// </summary>
         public override void Flush()
         {
-            Debug.Assert(false,"Flush called on ReaderStream");
+            Debug.Fail("Flush called on ReaderStream");
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
@@ -3147,7 +3147,7 @@ namespace System.Windows.Markup
                 if (_xmlnsCache == null)
                 {
 #if PBTCOMPILER
-                    Debug.Assert(false, "Should initialize cache prior to compiling");
+                    Debug.Fail("Should initialize cache prior to compiling");
 #else
                     _xmlnsCache = new XmlnsCache();
 #endif
@@ -3418,7 +3418,7 @@ namespace System.Windows.Markup
             if (_xmlnsCache == null)
             {
 #if PBTCOMPILER
-                Debug.Assert(false, "Should initialize cache prior to compiling");
+                Debug.Fail("Should initialize cache prior to compiling");
 #else
                 _xmlnsCache = new XmlnsCache();
 #endif

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1287,7 +1287,7 @@ namespace System.Windows
                     }
                     else
                     {
-                        Debug.Assert(false, "StaticResources[] entry is not a StaticResource not OptimizedStaticResource");
+                        Debug.Fail("StaticResources[] entry is not a StaticResource not OptimizedStaticResource");
                         continue;  // other types of entries are not processed.
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/Debug.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/Debug.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Conditional to use more aggressive fail-fast behaviors when debugging.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -5799,7 +5799,7 @@ namespace System.Windows
         // GetHashCode, ==, and != are required when Equals is overridden, even though we don't expect to need them.
         public override int GetHashCode()
         {
-            Debug.Assert(false, "GetHashCode for value types will use reflection to generate the hashcode.  Write a better hash code generation algorithm if this struct is to be used in a hashtable, or remove this assert if it's decided that reflection is OK.");
+            Debug.Fail("GetHashCode for value types will use reflection to generate the hashcode.  Write a better hash code generation algorithm if this struct is to be used in a hashtable, or remove this assert if it's decided that reflection is OK.");
 
             return base.GetHashCode();
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateNameScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplateNameScope.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /***************************************************************************\
@@ -195,7 +195,7 @@ namespace System.Windows
         /// <param name="name">Name of the element</param>
         void INameScope.UnregisterName(string name)
         {
-            Debug.Assert(false, "Should never be trying to unregister via this interface for templates");
+            Debug.Fail("Should never be trying to unregister via this interface for templates");
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -4049,7 +4049,7 @@ namespace System.Windows
                     _Style |= NativeMethods.WS_THICKFRAME | NativeMethods.WS_MAXIMIZEBOX | NativeMethods.WS_MINIMIZEBOX;
                     break;
                 default:
-                    Debug.Assert(false, "Invalid value for ResizeMode");
+                    Debug.Fail("Invalid value for ResizeMode");
                     break;
             }
         }
@@ -5963,7 +5963,7 @@ namespace System.Windows
                     wp.rcNormalPosition_right = wp.rcNormalPosition_left + currentWidth;
                     break;
                 default:
-                    Debug.Assert(false, $"specifiedRestoreBounds can't be {specifiedRestoreBounds}");
+                    Debug.Fail($"specifiedRestoreBounds can't be {specifiedRestoreBounds}");
                     break;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/BrushProxy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/BrushProxy.cs
@@ -672,7 +672,7 @@ namespace Microsoft.Internal.AlphaFlattener
 
             if (_brush != null)
             {
-                Debug.Assert(false, "IsOpaque(" + _brush.GetType() + ") not handled");
+                Debug.Fail("IsOpaque(" + _brush.GetType() + ") not handled");
             }
 
             if ((_brushList != null) && (_brushList.Count != 0))
@@ -768,7 +768,7 @@ namespace Microsoft.Internal.AlphaFlattener
 
             if (_brush != null)
             {
-                Debug.Assert(false, "IsTransparent not handled " + _brush.GetType());
+                Debug.Fail("IsTransparent not handled " + _brush.GetType());
             }
 
             return false;
@@ -1072,7 +1072,7 @@ namespace Microsoft.Internal.AlphaFlattener
             }
             else
             {
-                Debug.Assert(false, "Unexpected brush type");
+                Debug.Fail("Unexpected brush type");
                 depth = 2;
             }
 
@@ -1930,7 +1930,7 @@ namespace Microsoft.Internal.AlphaFlattener
 
             if (!brushHandled)
             {
-                Debug.Assert(false, "Unhandled GradientBrush type");
+                Debug.Fail("Unhandled GradientBrush type");
             }
 
             //
@@ -2886,7 +2886,7 @@ namespace Microsoft.Internal.AlphaFlattener
                     return false;
                 }
 
-                Debug.Assert(false, "Unhandled GradientBrush type");
+                Debug.Fail("Unhandled GradientBrush type");
                 return false;
             }
 
@@ -2911,7 +2911,7 @@ namespace Microsoft.Internal.AlphaFlattener
                 return false;
             }
 
-            Debug.Assert(false, "Unandled Brush type");
+            Debug.Fail("Unandled Brush type");
 
             return false;
         }
@@ -3200,7 +3200,7 @@ namespace Microsoft.Internal.AlphaFlattener
                     return db;
                 }
 
-                Debug.Assert(false, "Unhandled ImageBrush.ImageSource type");
+                Debug.Fail("Unhandled ImageBrush.ImageSource type");
             }
 
             return brush;
@@ -3342,7 +3342,7 @@ namespace Microsoft.Internal.AlphaFlattener
                 return brushB.BlendDrawingBrush(colorA, reverse);
             }
 
-            Debug.Assert(false, "Brush type not expected");
+            Debug.Fail("Brush type not expected");
 
             return brushB;
         }
@@ -3495,7 +3495,7 @@ namespace Microsoft.Internal.AlphaFlattener
                     }
                     else
                     {
-                        Debug.Assert(false, "Unexpected brush type");
+                        Debug.Fail("Unexpected brush type");
                     }
                 }
 
@@ -3615,7 +3615,7 @@ namespace Microsoft.Internal.AlphaFlattener
                 }
                 else
                 {
-                    Debug.Assert(false, "Single brush expected");
+                    Debug.Fail("Single brush expected");
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/DrawingContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/DrawingContext.cs
@@ -679,12 +679,12 @@ namespace Microsoft.Internal.AlphaFlattener
         {
             // BrushProxyDecomposer sends output directly to GDI, so opacity
             // is invalid by this point.
-            Debug.Assert(false, "Opacity invalid at BrushProxyDecomposer");
+            Debug.Fail("Opacity invalid at BrushProxyDecomposer");
         }
 
         void IProxyDrawingContext.Pop()
         {
-            Debug.Assert(false, "Opacity invalid at BrushProxyDecomposer");
+            Debug.Fail("Opacity invalid at BrushProxyDecomposer");
         }
 
         void IProxyDrawingContext.DrawGeometry(BrushProxy brush, PenProxy pen, Geometry geometry, Geometry clip, Matrix brushTrans, ProxyDrawingFlags flags)

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/Flattener.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/Flattener.cs
@@ -1171,7 +1171,7 @@ namespace Microsoft.Internal.AlphaFlattener
             }
             else
             {
-                Debug.Assert(false, "Wrong Primitive type");
+                Debug.Fail("Wrong Primitive type");
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/Primitive.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/Primitive.cs
@@ -1853,7 +1853,7 @@ namespace Microsoft.Internal.AlphaFlattener
 
         public override BrushProxy BlendBrush(BrushProxy brush)
         {
-            Debug.Assert(false, "Image over Brush?");
+            Debug.Fail("Image over Brush?");
             
             return brush;
         }
@@ -2024,25 +2024,25 @@ namespace Microsoft.Internal.AlphaFlattener
 
         public override Geometry GetShapeGeometry()
         {
-            Debug.Assert(false, "GetShapeGeometry on Canvas");
+            Debug.Fail("GetShapeGeometry on Canvas");
             return null;
         }
 
         public override void Exclude(Geometry g)
         {
-            Debug.Assert(false, "Exclude on Canvas");
+            Debug.Fail("Exclude on Canvas");
         }
 
         public override BrushProxy BlendBrush(BrushProxy brush)
         {
-            Debug.Assert(false, "BlendBrush on Canvas");
+            Debug.Fail("BlendBrush on Canvas");
 
             return brush;
         }
 
         public override void BlendOverImage(ImageProxy image, Matrix trans)
         {
-            Debug.Assert(false, "BlendOverImage on Canvas");
+            Debug.Fail("BlendOverImage on Canvas");
         }
 
         public override Primitive BlendOpacityMaskWithColor(BrushProxy color)

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/Utility.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/Utility.cs
@@ -957,7 +957,7 @@ namespace Microsoft.Internal.AlphaFlattener
             }
             else
             {
-                Debug.Assert(false, "Unsupported PathSegment");
+                Debug.Fail("Unsupported PathSegment");
                 size = 0;
             }
 
@@ -1594,7 +1594,7 @@ namespace Microsoft.Internal.AlphaFlattener
                 return bounds;
             }
 
-            Debug.Assert(false, "Unhandled TileBrush type");
+            Debug.Fail("Unhandled TileBrush type");
 
             return bounds;
         }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrintSchemaShim.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrintSchemaShim.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -655,7 +655,7 @@ namespace MS.Internal.Printing.Configuration
 
                 default:
                 {
-                    Debug.Assert(false, "PrintTicketScope enum is out of range");
+                    Debug.Fail("PrintTicketScope enum is out of range");
                     break;
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/VisualSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/VisualSerializer.cs
@@ -817,7 +817,7 @@ namespace System.Windows.Xps.Serialization
                 }
 
                 {
-                    Debug.Assert(false, "Brush not supported");
+                    Debug.Fail("Brush not supported");
                     WriteBrushHeader(brush.GetType().ToString(), brush);
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/InertiaProcessor2D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/InertiaProcessor2D.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
@@ -47,7 +47,7 @@ namespace System.Xaml
                 break;
 
             default:
-                Debug.Assert(false, "XamlNode Ctor missing data argument");
+                Debug.Fail("XamlNode Ctor missing data argument");
                 break;
             }
 #endif
@@ -84,7 +84,7 @@ namespace System.Xaml
                 break;
 
             default:
-                Debug.Assert(false, "XamlNode ctor, incorrect ctor called.");
+                Debug.Fail("XamlNode ctor, incorrect ctor called.");
                 break;
             }
 #endif

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
@@ -665,7 +665,7 @@ namespace MS.Internal.Xaml
                     }
                     else
                     {
-                        Debug.Assert(false, "Missing End Object in node sorter");
+                        Debug.Fail("Missing End Object in node sorter");
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/CacheHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/CacheHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Static class that manages prefetching and normalization
@@ -96,13 +96,13 @@ namespace MS.Internal.Automation
 
             if (index != response.TreeStructure.Length)
             {
-                Debug.Assert(false, "Internal error: got malformed tree description string (extra chars at end)");
+                Debug.Fail("Internal error: got malformed tree description string (extra chars at end)");
                 return null;
             }
 
             if (response.RequestedData != null && propIndex != response.RequestedData.GetLength(0))
             {
-                Debug.Assert(false, "Internal error: mismatch between count of property buckets and nodes claiming them");
+                Debug.Fail("Internal error: mismatch between count of property buckets and nodes claiming them");
                 return null;
             }
 
@@ -222,7 +222,7 @@ namespace MS.Internal.Automation
             // Ensure that end node tag is present...
             if (treeDescription[index] != ')')
             {
-                Debug.Assert(false, "Internal error: Got malformed tree description string, missing closing paren");
+                Debug.Fail("Internal error: Got malformed tree description string, missing closing paren");
                 return null;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ClientEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ClientEventManager.cs
@@ -458,7 +458,7 @@ namespace MS.Internal.Automation
                 return new FocusTracker();
             }
 
-            Debug.Assert(false, "GetNewRootTracker internal error: Unexpected Tracker value!");
+            Debug.Fail("GetNewRootTracker internal error: Unexpected Tracker value!");
             return null;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
@@ -372,7 +372,7 @@ namespace MS.Internal.Automation
 
                 default:
                 {
-                    Debug.Assert(false,"unexpected switch() case:");
+                    Debug.Fail("unexpected switch() case:");
                     throw new ArgumentException(SR.UnexpectedWindowState,nameof(state));
                 }
 
@@ -1415,7 +1415,7 @@ namespace MS.Internal.Automation
             if (SanityLoopCount == 0)
             {
                 // Should we come up with something better here?
-                Debug.Assert(false, "too many children or inf loop?");
+                Debug.Fail("too many children or inf loop?");
             }
         }
 
@@ -1873,7 +1873,7 @@ namespace MS.Internal.Automation
 
             if( SanityLoopCount == 0 )
             {
-                Debug.Assert(false, "too many children or inf loop?");
+                Debug.Fail("too many children or inf loop?");
                 return NativeMethods.HWND.NULL;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
@@ -146,7 +146,7 @@ namespace MS.Internal.Automation
 
             if (pi.ClientSideWrapper == null)
             {
-                Debug.Assert(false, "missing client-side pattern wrapper");
+                Debug.Fail("missing client-side pattern wrapper");
                 return null;
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ProxyManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ProxyManager.cs
@@ -678,7 +678,7 @@ namespace MS.Internal.Automation
                             break;
 
                         default:
-                            Debug.Assert(false, "unexpected switch() case:");
+                            Debug.Fail("unexpected switch() case:");
                             break;
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Schema.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Schema.cs
@@ -65,7 +65,7 @@ namespace MS.Internal.Automation
 
             if (!Schema.GetPropertyInfo(property, out pi))
             {
-                Debug.Assert(false, "GetDefaultValue was passed an unknown property");
+                Debug.Fail("GetDefaultValue was passed an unknown property");
                 return null;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
@@ -237,7 +237,7 @@ namespace MS.Internal.Automation
                         }
                         else
                         {
-                            Debug.Assert(false, "unsupported property should not have made it this far");
+                            Debug.Fail("unsupported property should not have made it this far");
                         }
                     }
 
@@ -640,7 +640,7 @@ namespace MS.Internal.Automation
             AutomationEvent eventId = AutomationEvent.LookupById(args._eventId);
             if (eventId == null)
             {
-                Debug.Assert(false, "Got unknown eventId from core: " + args._eventId);
+                Debug.Fail("Got unknown eventId from core: " + args._eventId);
                 return null;
             }
 
@@ -658,7 +658,7 @@ namespace MS.Internal.Automation
                         AutomationProperty propertyId = AutomationProperty.LookupById(pcargs._propertyId);
                         if (propertyId == null)
                         {
-                            Debug.Assert(false, "Got unknown propertyId from core: " + pcargs._propertyId);
+                            Debug.Fail("Got unknown propertyId from core: " + pcargs._propertyId);
                             return null;
                         }
 
@@ -699,7 +699,7 @@ namespace MS.Internal.Automation
                     }
             }
 
-            Debug.Assert(false, "Unknown event type from core:" + args._type);
+            Debug.Fail("Unknown event type from core:" + args._type);
             return null;
         }
         #endregion EventArgs translation

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AutomationElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AutomationElement.cs
@@ -383,7 +383,7 @@ namespace System.Windows.Automation
 
             //Not true - some AE's from properties and event args (eg. SelectionItem.SelectionContainer,
             //and FocuEventArgs's previousFocus) don't currently come through CacheReqest
-            //Debug.Assert(false, "Should always have runtimeID from cache at ctor.");
+            //Debug.Fail("Should always have runtimeID from cache at ctor.");
 
             // false -> return null (instead of throwing) if not available; true->wrap
             int [] val = LookupCachedValue(AutomationElement.RuntimeIdProperty, false, true) as int[];

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Accessible.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Accessible.cs
@@ -913,7 +913,7 @@ namespace MS.Internal.AutomationProxies
                     // Get the raw children because accNavigate doesn't work
                     if (UnsafeNativeMethods.AccessibleChildren(accessibleObject, 0, childCount, aChildren, out childrenReturned) == NativeMethods.E_INVALIDARG)
                     {
-                        System.Diagnostics.Debug.Assert(false, "Call to AccessibleChildren() returned E_INVALIDARG.");
+                        System.Diagnostics.Debug.Fail("Call to AccessibleChildren() returned E_INVALIDARG.");
                         throw new ElementNotAvailableException();
                     }
                 }
@@ -1370,7 +1370,7 @@ namespace MS.Internal.AutomationProxies
 
                     default:
                         // we want to know when we get an exception we haven't seen before
-                        Debug.Assert(false, string.Format(CultureInfo.CurrentCulture, "MsaaNativeProvider: IAccessible threw a COMException: {0}", e.Message));
+                        Debug.Fail(string.Format(CultureInfo.CurrentCulture, "MsaaNativeProvider: IAccessible threw a COMException: {0}", e.Message));
                         break;
                 }
             }
@@ -1387,7 +1387,7 @@ namespace MS.Internal.AutomationProxies
             else
             {
                 // we want to know when we get an exception we haven't seen before
-                Debug.Assert(false, string.Format(CultureInfo.CurrentCulture, "Unexpected IAccessible exception: {0}", e));
+                Debug.Fail(string.Format(CultureInfo.CurrentCulture, "Unexpected IAccessible exception: {0}", e));
             }
 
             // rethrow the exception

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/EventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/EventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Class to manage UIAutomation events and how they relate to winevents
@@ -100,7 +100,7 @@ namespace MS.Internal.AutomationProxies
                 default:
                     // Commented out to remove annoying asserts temporarily.
                     // (See work item PS1254940.)
-                    //System.Diagnostics.Debug.Assert(false, "Unexpected idObject " + idObject);
+                    //System.Diagnostics.Debug.Fail("Unexpected idObject " + idObject);
                     return;
             }
             

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/QueueProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/QueueProcessor.cs
@@ -124,7 +124,7 @@ namespace MS.Internal.AutomationProxies
                     int result = Misc.MsgWaitForMultipleObjects(handle, false, NativeMethods.INFINITE, NativeMethods.QS_ALLINPUT);
                     if (result == NativeMethods.WAIT_FAILED || result == NativeMethods.WAIT_TIMEOUT)
                     {
-                        Debug.Assert(false, "MsgWaitForMultipleObjects failed while WaitForWork");
+                        Debug.Fail("MsgWaitForMultipleObjects failed while WaitForWork");
                         break;
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WinEventTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WinEventTracker.cs
@@ -261,7 +261,7 @@ namespace MS.Internal.AutomationProxies
                                 catch (Exception e)
                                 {
                                     // If we get here there is a problem in a proxy that needs fixing.
-                                    Debug.Assert(false, "Exception raising event " + eventId + " for prop " + ecp._idProp + " on hwnd " + hwnd + "\n" + e.Message);
+                                    Debug.Fail("Exception raising event " + eventId + " for prop " + ecp._idProp + " on hwnd " + hwnd + "\n" + e.Message);
 
                                     if (Misc.IsCriticalException(e))
                                     {
@@ -306,7 +306,7 @@ namespace MS.Internal.AutomationProxies
                                 catch (Exception e)
                                 {
                                     // If we get here there is a problem in a proxy that needs fixing.
-                                    Debug.Assert(false, "Exception raising event " + eventId + " for prop " + ecp._idProp + " on hwnd " + hwnd + "\n" + e.Message);
+                                    Debug.Fail("Exception raising event " + eventId + " for prop " + ecp._idProp + " on hwnd " + hwnd + "\n" + e.Message);
 
                                     if (Misc.IsCriticalException(e))
                                     {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsEditBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsEditBox.cs
@@ -553,7 +553,7 @@ namespace MS.Internal.AutomationProxies
             int cb = Marshal.SizeOf(typeof(NativeMethods.LOGFONT));
             if (Misc.GetObjectW(hfont, cb, ref logfont) != cb)
             {
-                Debug.Assert(false, "WindowsEditBox.GetObject unexpected return value");
+                Debug.Fail("WindowsEditBox.GetObject unexpected return value");
             }
             return logfont;
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListViewGroupHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListViewGroupHelper.cs
@@ -408,7 +408,7 @@ namespace MS.Internal.AutomationProxies
                     {
                         // we had problem adding item to the needed group at this point it makes no
                         // sense to continue
-                        System.Diagnostics.Debug.Assert(false, "Cannot add item to the needed group");
+                        System.Diagnostics.Debug.Fail("Cannot add item to the needed group");
                         return null;
                     }
                 }
@@ -433,7 +433,7 @@ namespace MS.Internal.AutomationProxies
                     {
                         // we had problem adding item to the needed group at this point it makes no
                         // sense to continue
-                        System.Diagnostics.Debug.Assert(false, "Cannot add item to the needed group");
+                        System.Diagnostics.Debug.Fail("Cannot add item to the needed group");
                         return null;
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListViewItemStartMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListViewItemStartMenu.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Win32 ListView Item proxy for the Start Menu.
@@ -44,7 +44,7 @@ namespace MS.Internal.AutomationProxies
             }
             else
             {
-                System.Diagnostics.Debug.Assert(false, "The listview item on the Start Menu has an unexpected IAccessible role!");
+                System.Diagnostics.Debug.Fail("The listview item on the Start Menu has an unexpected IAccessible role!");
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -1347,7 +1347,7 @@ namespace MS.Internal.AutomationProxies
                         else
                         {
                             // Wrong logic, we should be able to find the Fxx combination we just built
-                            System.Diagnostics.Debug.Assert(false, "Cannot find back the accelerator in the menu!");
+                            System.Diagnostics.Debug.Fail("Cannot find back the accelerator in the menu!");
                             return menuRawText;
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTab.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTab.cs
@@ -1174,7 +1174,7 @@ namespace MS.Internal.AutomationProxies
 
                     if (!XSendMessage.GetItem(_hwnd, _item, ref TCItem))
                     {
-                        System.Diagnostics.Debug.Assert(false, "XSendMessage.GetItem() failed!");
+                        System.Diagnostics.Debug.Fail("XSendMessage.GetItem() failed!");
                         return false;
                     }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsToolbarAsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsToolbarAsMenu.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Some applications implement menus with toolbars.  This proxy
@@ -44,7 +44,7 @@ namespace MS.Internal.AutomationProxies
             }
             else
             {
-                System.Diagnostics.Debug.Assert(false, "Unexpected role " + role);
+                System.Diagnostics.Debug.Fail("Unexpected role " + role);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsToolbarItemAsMenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsToolbarItemAsMenuItem.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Some applications implement menus with toolbars.  This proxy
@@ -38,7 +38,7 @@ namespace MS.Internal.AutomationProxies
             }
             else
             {
-                System.Diagnostics.Debug.Assert(false, "Unexpected role " + role);
+                System.Diagnostics.Debug.Fail("Unexpected role " + role);
 
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/AutomationIdentifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/AutomationIdentifier.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Base class for Automation Idenfitiers (Property, Event, etc.)
@@ -165,7 +165,7 @@ namespace System.Windows.Automation
                     case UiaCoreTypesApi.AutomationIdType.Pattern:       autoid = new AutomationPattern(id, programmaticName);       break;
                     case UiaCoreTypesApi.AutomationIdType.ControlType:   autoid = new ControlType(id, programmaticName);             break;
 
-                    default: Debug.Assert(false, "Invalid type specified for AutomationIdentifier");
+                    default: Debug.Fail("Invalid type specified for AutomationIdentifier");
                         throw new InvalidOperationException("Invalid type specified for AutomationIdentifier");
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileReference.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileReference.cs
@@ -60,7 +60,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         int IComparable.CompareTo(object ob)
         {
             // this must be implemented by our inheritors
-            Debug.Assert(false, "subclasses must override this method");
+            Debug.Fail("subclasses must override this method");
             return 0;
         }
         #endregion
@@ -71,7 +71,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         public override bool Equals(object o)
         {
             // this must be implemented by our inheritors
-            Debug.Assert(false, "subclasses must override this method");
+            Debug.Fail("subclasses must override this method");
             return false;
         }
 
@@ -79,7 +79,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         public override int GetHashCode()
         {
             // this must be implemented by our inheritors
-            Debug.Assert(false, "subclasses must override this method");
+            Debug.Fail("subclasses must override this method");
             return 0;
         }
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/ClientSession.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/ClientSession.cs
@@ -862,7 +862,7 @@ namespace MS.Internal.Security.RightsManagement
             }
             else
             {
-                Debug.Assert(false,"Invalid Authentication type");
+                Debug.Fail("Invalid Authentication type");
                 return null;            // retail build might be ale to recover from SDK defaults                  
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Matrix.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Matrix.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using MS.Internal;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/ElementHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/ElementHost.cs
@@ -1602,7 +1602,7 @@ namespace System.Windows.Forms.Integration
                     case System.Windows.Input.FocusNavigationDirection.Last:
                         break;
                     default:
-                        Debug.Assert(false, "Unknown FocusNavigationDirection");
+                        Debug.Fail("Unknown FocusNavigationDirection");
                         break;
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/WindowsFormsHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/WindowsFormsHost.cs
@@ -866,7 +866,7 @@ namespace System.Windows.Forms.Integration
                     tabStopOnly = true;
                     break;
                 default:
-                    Debug.Assert(false, "Unknown FocusNavigationDirection");
+                    Debug.Fail("Unknown FocusNavigationDirection");
                     break;
             }
             _focusTarget.Enabled = false;


### PR DESCRIPTION
## Description

This is a standard practice in rutime repo and also makes more sense in terms of readibility in general.

`Fail` is what's called when condition in `Assert` evaluates to `false`. `false` indeed evaluates to `false`.

## Customer Impact

Cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

This was a simple search/replace, shouldn't introduce any risk.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10723)