### PR TITLE
[StyleCleanUp] Use literals where appropriate (CA1802)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/.editorconfig
+++ b/src/Microsoft.DotNet.Wpf/src/.editorconfig
@@ -71,9 +71,6 @@ dotnet_diagnostic.CA5394.severity = suggestion
 # CA1725: Parameter names should match base declaration
 dotnet_diagnostic.CA1725.severity = suggestion
 
-# CA1802: Use literals where appropriate
-dotnet_diagnostic.CA1802.severity = suggestion
-
 # CA1805: Do not initialize unnecessarily
 dotnet_diagnostic.CA1805.severity = suggestion
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedPageProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedPageProcessor.cs
@@ -273,7 +273,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     is done by the framework and does not need to be repeated.  Use this
         ///     string in markup as a value for SubTreeProcessorIdProperty.
         /// </summary>
-        public static readonly String Id = "FixedPage";
+        public const String Id = "FixedPage";
 
         #endregion Public Properties
 
@@ -334,7 +334,7 @@ namespace MS.Internal.Annotations.Anchoring
         #region Private Fields
 
         // Name of the value attribute containing the hash
-        private static readonly String ValueAttributeName = "Value";
+        private const String ValueAttributeName = "Value";
 
         // Name of the locator part produced by this processor.
         private static readonly XmlQualifiedName PageNumberElementName = new XmlQualifiedName("PageNumber", AnnotationXmlConstants.Namespaces.BaseSchemaNamespace);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -321,7 +321,7 @@ namespace MS.Internal.AppModel
 
         private static readonly Dictionary<string, ResourceManagerWrapper> s_registeredResourceManagers = new(StringComparer.Ordinal);
         private static readonly Dictionary<string, ResourceManagerWrapper>.AlternateLookup<ReadOnlySpan<char>> s_registeredResourceManagersLookup = s_registeredResourceManagers.GetAlternateLookup<ReadOnlySpan<char>>();
-        private static readonly FileShare s_fileShare = FileShare.Read;
+        private const FileShare s_fileShare = FileShare.Read;
 
         private static ResourceManagerWrapper s_applicationResourceManagerWrapper = null;
         private static bool s_assemblyLoadHandlerAttached = false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/StaticPropertyChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/StaticPropertyChangedEventManager.cs
@@ -243,8 +243,8 @@ namespace MS.Internal.Data
 
         #endregion Private Methods
 
-        private static readonly string AllListenersKey = "<All Listeners>"; // not a legal property name
-        private static readonly string StaticPropertyChanged = "StaticPropertyChanged";
+        private const string AllListenersKey = "<All Listeners>"; // not a legal property name
+        private const string StaticPropertyChanged = "StaticPropertyChanged";
 
         #region TypeRecord
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/ContentDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/ContentDescriptor.cs
@@ -77,8 +77,8 @@ namespace MS.Internal.IO.Packaging
         private string      _baseName;
         private string      _xmlNamespace;
 
-        public static readonly string  XamlNamespace = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
-        public static readonly string  FixedMarkupNamespace = "http://schemas.microsoft.com/xps/2005/06";
+        public const string XamlNamespace = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+        public const string FixedMarkupNamespace = "http://schemas.microsoft.com/xps/2005/06";
     }
                 
     ///<summary>Content-location information for an element.</summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/LineMetrics.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/LineMetrics.cs
@@ -143,9 +143,9 @@ namespace MS.Internal.Text
         // ------------------------------------------------------------------
         internal TextLineBreak TextLineBreak { get { return _textLineBreak; } }
         private TextLineBreak _textLineBreak;
-       
-        private static readonly uint HasBeenUpdatedMask = 0x40000000;
-        private static readonly uint LengthMask = 0x3FFFFFFF;
-        private static readonly uint HasInlineObjectsMask = 0x80000000;
+
+        private const uint HasBeenUpdatedMask = 0x40000000;
+        private const uint LengthMask = 0x3FFFFFFF;
+        private const uint HasInlineObjectsMask = 0x80000000;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/ExceptionHelpers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/ExceptionHelpers.cs
@@ -376,23 +376,23 @@ namespace WinRT
     {
         internal static string Format(string format, params object[] args) => String.Format(format, args);
 
-        internal static readonly string Arg_IndexOutOfRangeException = "Index was outside the bounds of the array.";
-        internal static readonly string Arg_KeyNotFound = "The given key was not present in the dictionary.";
-        internal static readonly string Arg_KeyNotFoundWithKey = "The given key '{0}' was not present in the dictionary.";
-        internal static readonly string Arg_RankMultiDimNotSupported = "Only single dimensional arrays are supported for the requested action.";
-        internal static readonly string Argument_AddingDuplicate = "An item with the same key has already been added.";
-        internal static readonly string Argument_AddingDuplicateWithKey = "An item with the same key has already been added. Key: {0}";
-        internal static readonly string Argument_IndexOutOfArrayBounds = "The specified index is out of bounds of the specified array.";
-        internal static readonly string Argument_InsufficientSpaceToCopyCollection = "The specified space is not sufficient to copy the elements from this Collection.";
-        internal static readonly string ArgumentOutOfRange_Index = "Index was out of range. Must be non-negative and less than the size of the collection.";
-        internal static readonly string ArgumentOutOfRange_IndexLargerThanMaxValue = "This collection cannot work with indices larger than Int32.MaxValue - 1 (0x7FFFFFFF - 1).";
-        internal static readonly string InvalidOperation_CannotRemoveLastFromEmptyCollection = "Cannot remove the last element from an empty collection.";
-        internal static readonly string InvalidOperation_CollectionBackingDictionaryTooLarge = "The collection backing this Dictionary contains too many elements.";
-        internal static readonly string InvalidOperation_CollectionBackingListTooLarge = "The collection backing this List contains too many elements.";
-        internal static readonly string InvalidOperation_EnumEnded = "Enumeration already finished.";
-        internal static readonly string InvalidOperation_EnumFailedVersion = "Collection was modified; enumeration operation may not execute.";
-        internal static readonly string InvalidOperation_EnumNotStarted = "Enumeration has not started. Call MoveNext.";
-        internal static readonly string NotSupported_KeyCollectionSet = "Mutating a key collection derived from a dictionary is not allowed.";
-        internal static readonly string NotSupported_ValueCollectionSet = "Mutating a value collection derived from a dictionary is not allowed.";
+        internal const string Arg_IndexOutOfRangeException = "Index was outside the bounds of the array.";
+        internal const string Arg_KeyNotFound = "The given key was not present in the dictionary.";
+        internal const string Arg_KeyNotFoundWithKey = "The given key '{0}' was not present in the dictionary.";
+        internal const string Arg_RankMultiDimNotSupported = "Only single dimensional arrays are supported for the requested action.";
+        internal const string Argument_AddingDuplicate = "An item with the same key has already been added.";
+        internal const string Argument_AddingDuplicateWithKey = "An item with the same key has already been added. Key: {0}";
+        internal const string Argument_IndexOutOfArrayBounds = "The specified index is out of bounds of the specified array.";
+        internal const string Argument_InsufficientSpaceToCopyCollection = "The specified space is not sufficient to copy the elements from this Collection.";
+        internal const string ArgumentOutOfRange_Index = "Index was out of range. Must be non-negative and less than the size of the collection.";
+        internal const string ArgumentOutOfRange_IndexLargerThanMaxValue = "This collection cannot work with indices larger than Int32.MaxValue - 1 (0x7FFFFFFF - 1).";
+        internal const string InvalidOperation_CannotRemoveLastFromEmptyCollection = "Cannot remove the last element from an empty collection.";
+        internal const string InvalidOperation_CollectionBackingDictionaryTooLarge = "The collection backing this Dictionary contains too many elements.";
+        internal const string InvalidOperation_CollectionBackingListTooLarge = "The collection backing this List contains too many elements.";
+        internal const string InvalidOperation_EnumEnded = "Enumeration already finished.";
+        internal const string InvalidOperation_EnumFailedVersion = "Collection was modified; enumeration operation may not execute.";
+        internal const string InvalidOperation_EnumNotStarted = "Enumeration has not started. Call MoveNext.";
+        internal const string NotSupported_KeyCollectionSet = "Mutating a key collection derived from a dictionary is not allowed.";
+        internal const string NotSupported_ValueCollectionSet = "Mutating a value collection derived from a dictionary is not allowed.";
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Windows/Data/Text/WordsSegmenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Windows/Data/Text/WordsSegmenter.cs
@@ -105,7 +105,7 @@ namespace MS.Internal.WindowsRuntime
             };
 
 
-            public static readonly string Undetermined = "und";
+            public const string Undetermined = "und";
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextMapOffsetErrorLogger.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextMapOffsetErrorLogger.cs
@@ -38,7 +38,7 @@ namespace System.Windows.Documents
         /// </remarks>
         private partial class TextMapOffsetErrorLogger
         {
-            private static readonly string TextMapOffsetError = "TextMapOffsetError";
+            private const string TextMapOffsetError = "TextMapOffsetError";
 
             private DebugInfo _debugInfo;
             public enum CalculationModes : int
@@ -52,7 +52,7 @@ namespace System.Windows.Documents
             /// expected for various indices and offsets is -1. Therefore -2 can act as a handy way to 
             /// represent an "unset" or "uninitialized" value;
             /// </summary>
-            private static readonly int UnsetValue = -2;
+            private const int UnsetValue = -2;
 
             public TextMapOffsetErrorLogger(LogicalDirection direction, TextMap textMap, ArrayList segments, int positionInSegmentList, int leftWordBreak, int rightWordBreak, int contentOffset)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Tracing/SpellerCOMActionTraceLogger.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Tracing/SpellerCOMActionTraceLogger.cs
@@ -46,7 +46,7 @@ namespace System.Windows.Documents.Tracing
         /// <summary>
         /// The name of the event that will be logged by this class
         /// </summary>
-        private static readonly string SpellerCOMLatencyMeasurement = nameof(SpellerCOMLatencyMeasurement);
+        private const string SpellerCOMLatencyMeasurement = nameof(SpellerCOMLatencyMeasurement);
 
         /// <summary>
         /// Various actions that we track in this logger

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006KeyRecord.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006KeyRecord.cs
@@ -129,7 +129,7 @@ namespace System.Windows.Baml2006
         private bool _isStatic;
         private bool _isType;
 
-        private static readonly byte TypeExtensionValueMask = 0x01;
-        private static readonly byte StaticExtensionValueMask = 0x02;
+        private const byte TypeExtensionValueMask = 0x01;
+        private const byte StaticExtensionValueMask = 0x02;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecords.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecords.cs
@@ -2448,9 +2448,9 @@ namespace System.Windows.Markup
         private short _extensionTypeId = 0;
         private short _valueId = 0;
 
-        private static readonly short ExtensionIdMask = 0x0FFF;
-        private static readonly short TypeExtensionValueMask = 0x4000;
-        private static readonly short StaticExtensionValueMask = 0x2000;
+        private const short ExtensionIdMask = 0x0FFF;
+        private const short TypeExtensionValueMask = 0x4000;
+        private const short StaticExtensionValueMask = 0x2000;
         #endregion Data
     }
 
@@ -2888,11 +2888,11 @@ namespace System.Windows.Markup
         }
 #endif
 
-#endregion Properties
+        #endregion Properties
 
-#region Data
+        #region Data
 
-        internal static readonly short TypeIdValueMask = 0x4000;
+        internal const short TypeIdValueMask = 0x4000;
 
         private short                  _attributeId = 0;
         private short                  _serializerTypeId = 0;
@@ -3658,8 +3658,8 @@ namespace System.Windows.Markup
 
         private short _valueId = 0;
 
-        private static readonly byte TypeExtensionValueMask = 0x01;
-        private static readonly byte StaticExtensionValueMask = 0x02;
+        private const byte TypeExtensionValueMask = 0x01;
+        private const byte StaticExtensionValueMask = 0x02;
 
         // Allocate space in _flags.
         private static BitVector32.Section _isValueTypeExtensionSection

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlAttributeProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlAttributeProperties.cs
@@ -339,9 +339,9 @@ namespace System.Windows.Markup
         }
 
         // These are special attributes that aren't mapped like other properties
-        internal static readonly string XmlSpaceString = "xml:space";
-        internal static readonly string XmlLangString  = "xml:lang";
-        internal static readonly string XmlnsDefinitionString = "xmlns";
+        internal const string XmlSpaceString = "xml:space";
+        internal const string XmlLangString = "xml:lang";
+        internal const string XmlnsDefinitionString = "xmlns";
         private static MethodInfo _xmlSpaceSetter = null;
 #endregion Internal
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/WindowChrome.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/WindowChrome.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Windows.Shell
                 (d, e) => ((WindowChrome)d)._OnPropertyChangedThatRequiresRepaint()),
             _NonClientFrameEdgesAreValid);
 
-        private static readonly NonClientFrameEdges NonClientFrameEdges_All = NonClientFrameEdges.Left | NonClientFrameEdges.Top | NonClientFrameEdges.Right | NonClientFrameEdges.Bottom;
+        private const NonClientFrameEdges NonClientFrameEdges_All = NonClientFrameEdges.Left | NonClientFrameEdges.Top | NonClientFrameEdges.Right | NonClientFrameEdges.Bottom;
 
         private static bool _NonClientFrameEdgesAreValid(object value)
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/NativeDirectoryServicesQueryAPIs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/NativeDirectoryServicesQueryAPIs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: NativeDirectoryServicesQueryAPIs contains managed wrappers 
@@ -166,20 +166,20 @@ namespace MS.Internal.Documents
 
             // CommonQuery parameters (from cmnquery.h) used in OpenQueryWindowParams to define the
             // state of the People Picker when invoked.
-            internal static readonly uint OQWF_OKCANCEL = 0x00000001; // = 1 => Provide OK/Cancel buttons
-            internal static readonly uint OQWF_DEFAULTFORM = 0x00000002; // = 1 => clsidDefaultQueryForm is valid        
-            internal static readonly uint OQWF_SINGLESELECT = 0x00000004; // = 1 => allow single selection only
-            internal static readonly uint OQWF_REMOVEFORMS = 0x00000020; // = 1 => remove form picker from dialog
-            internal static readonly uint OQWF_SHOWOPTIONAL = 0x00000080; // = 1 => list optional forms by default
-            internal static readonly uint OQWF_HIDEMENUS = 0x00000400; // = 1 => no menu bar displayed
+            internal const uint OQWF_OKCANCEL = 0x00000001; // = 1 => Provide OK/Cancel buttons
+            internal const uint OQWF_DEFAULTFORM = 0x00000002; // = 1 => clsidDefaultQueryForm is valid        
+            internal const uint OQWF_SINGLESELECT = 0x00000004; // = 1 => allow single selection only
+            internal const uint OQWF_REMOVEFORMS = 0x00000020; // = 1 => remove form picker from dialog
+            internal const uint OQWF_SHOWOPTIONAL = 0x00000080; // = 1 => list optional forms by default
+            internal const uint OQWF_HIDEMENUS = 0x00000400; // = 1 => no menu bar displayed
 
             // Clipboard formats (from winuser.h)
-            internal static readonly String CFSTR_DSOBJECTNAMES = "DsObjectNames";
+            internal const String CFSTR_DSOBJECTNAMES = "DsObjectNames";
 
             // Success/Failure codes
-            internal static readonly uint S_OK = 0x00000000;
-            internal static readonly uint S_FALSE = 0x00000001;
-            internal static readonly uint E_FAIL = 0x80000008;
+            internal const uint S_OK = 0x00000000;
+            internal const uint S_FALSE = 0x00000001;
+            internal const uint E_FAIL = 0x80000008;
 
         }
     }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/MS/Internal/Printing/Configuration/DevModeDitherTypes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/MS/Internal/Printing/Configuration/DevModeDitherTypes.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /*++
@@ -16,32 +16,32 @@ namespace MS.Internal.Printing.Configuration
         /// <summary>
         /// No dithering
         /// </summary>
-        public static readonly uint DMDITHER_NONE = 0x00000001;
+        public const uint DMDITHER_NONE = 0x00000001;
 
         /// <summary>
         /// Dithering with a coarse brush.
         /// </summary>
-        public static readonly uint DMDITHER_COARSE = 0x00000002;
+        public const uint DMDITHER_COARSE = 0x00000002;
 
         /// <summary>
         /// Dithering with a fine brush.
         /// </summary>
-        public static readonly uint DMDITHER_FINE = 0x00000003;
+        public const uint DMDITHER_FINE = 0x00000003;
 
         /// <summary>
         /// Line art dithering.
         /// </summary>
-        public static readonly uint DMDITHER_LINEART = 0x00000004;
+        public const uint DMDITHER_LINEART = 0x00000004;
 
         /// <summary>
         /// Windows 95/98/Me: Dithering in which an algorithm is used to spread, or diffuse, the error of approximating a specified color over adjacent pixels.
         /// In contrast, DMDITHER_COARSE, DMDITHER_FINE, and DMDITHER_LINEART use patterned halftoning to approximate a color.
         /// </summary>
-        public static readonly uint DMDITHER_ERRORDIFFUSION = 0x00000005;
+        public const uint DMDITHER_ERRORDIFFUSION = 0x00000005;
 
         /// <summary>
         /// Device does gray scaling.
         /// </summary>
-        public static readonly uint DMDITHER_GRAYSCALE = 0x0000000A;
+        public const uint DMDITHER_GRAYSCALE = 0x0000000A;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/MS/Internal/Printing/Configuration/DevModeICMIntents.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/MS/Internal/Printing/Configuration/DevModeICMIntents.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /*++
@@ -16,21 +16,21 @@ namespace MS.Internal.Printing.Configuration
         /// <summary>
         /// Color matching should optimize for color saturation. This value is the most appropriate choice for business graphs when dithering is not desired.
         /// </summary>
-        public static readonly uint DMICM_SATURATE = 1;
+        public const uint DMICM_SATURATE = 1;
 
         /// <summary>
         /// Color matching should optimize for color contrast. This value is the most appropriate choice for scanned or photographic images when dithering is desired.
         /// </summary>
-        public static readonly uint DMICM_CONTRAST = 2;
+        public const uint DMICM_CONTRAST = 2;
 
         /// <summary>
         /// Color matching should optimize to match the exact color requested. This value is most appropriate for use with business logos or other images when an exact color match is desired.
         /// </summary>
-        public static readonly uint DMICM_COLORIMETRIC = 3;
+        public const uint DMICM_COLORIMETRIC = 3;
 
         /// <summary>
         /// Color matching should optimize to match the exact color requested without white point mapping. This value is most appropriate for use with proofing.
         /// </summary>
-        public static readonly uint DMICM_ABS_COLORIMETRIC = 4;
+        public const uint DMICM_ABS_COLORIMETRIC = 4;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/MS/Internal/Printing/Configuration/DevModeMediaTypes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/MS/Internal/Printing/Configuration/DevModeMediaTypes.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /*++
@@ -33,6 +33,6 @@ namespace MS.Internal.Printing.Configuration
         /// </summary>
         public const uint DMMEDIA_GLOSSY = 0x0003;
 
-        private static readonly uint DMMEDIA_USER = 0x100;
+        private const uint DMMEDIA_USER = 0x100;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ImageSourceTypeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ImageSourceTypeConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /*++
@@ -508,8 +508,8 @@ namespace System.Windows.Xps.Serialization
         #endregion Private static helper methods
 
         #region Private static data
-        
-        private static readonly int _readBlockSize = 1048576; //1MB
+
+        private const int _readBlockSize = 1_048_576; //1MB
 
         /// <summary>
         /// Cached hash values for image tables

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/XpsFontSubsetter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/XpsFontSubsetter.cs
@@ -731,7 +731,7 @@ namespace System.Windows.Xps.Serialization
         private GlyphTypeface           _glyphTypeface;
         private bool                    _streamWritten; 
         private Uri _fontUri;
-        private static readonly int _readBlockSize = 1048576; //1MB
+        private const int _readBlockSize = 1_048_576; //1MB
 
         #endregion Private data
     }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/IO/Packaging/PackagingUtilities.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/IO/Packaging/PackagingUtilities.cs
@@ -24,7 +24,7 @@ namespace MS.Internal.IO.Packaging
         //  Internal Fields
         //
         //------------------------------------------------------
-        internal static readonly string RelationshipNamespaceUri = "http://schemas.openxmlformats.org/package/2006/relationships";
+        internal const string RelationshipNamespaceUri = "http://schemas.openxmlformats.org/package/2006/relationships";
         internal static readonly ContentType RelationshipPartContentType
             = new ContentType("application/vnd.openxmlformats-package.relationships+xml");
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/Telemetry/Managed/TraceLoggers/ControlsTraceLogger.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/Telemetry/Managed/TraceLoggers/ControlsTraceLogger.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.Tracing;
@@ -70,7 +70,7 @@ namespace MS.Internal.Telemetry.PresentationFramework
             _telemetryControls |= control;
         }
 
-        private static readonly string ControlsUsed = "ControlsUsed";
+        private const string ControlsUsed = "ControlsUsed";
         private static TelemetryControls _telemetryControls = TelemetryControls.None;
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/Telemetry/Managed/TraceLoggers/XpsOMPrintingTraceLogger.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/Telemetry/Managed/TraceLoggers/XpsOMPrintingTraceLogger.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.Tracing;
@@ -27,6 +27,6 @@ namespace MS.Internal.Telemetry.PresentationCore
         /// <summary>
         /// Event name for logging Xps OM Printing enabled/disabled
         /// </summary>
-        private static readonly string XpsOMEnabled = "XpsOMEnabled";
+        private const string XpsOMEnabled = "XpsOMEnabled";
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/Telemetry/Managed/TraceLoggingProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/Telemetry/Managed/TraceLoggingProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.Tracing;
@@ -59,12 +59,12 @@ namespace MS.Internal.Telemetry
         /// <summary>
         /// Presentation Core provider name
         /// </summary>
-        private static readonly string ProviderName = "Microsoft.DOTNET.WPF.PresentationCore";
+        private const string ProviderName = "Microsoft.DOTNET.WPF.PresentationCore";
 #elif PRESENTATIONFRAMEWORK
         /// <summary>
         /// Presentation Framework provider name
         /// </summary>
-        private static readonly string ProviderName = "Microsoft.DOTNET.WPF.PresentationFramework";
+        private const string ProviderName = "Microsoft.DOTNET.WPF.PresentationFramework";
 #endif
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/WindowShowOrOpenTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/WindowShowOrOpenTracker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Class used to track new UI appearing and make sure any events
@@ -98,7 +98,7 @@ namespace MS.Internal.Automation
 
         #region Private Fields
 
-        private static readonly string _wcpClassName = "HwndWrapper";
+        private const string _wcpClassName = "HwndWrapper";
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Certificate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Certificate.cs
@@ -162,9 +162,9 @@ namespace MS.Internal.IO.Packaging
         // certificate part constants
         private static readonly ContentType _certificatePartContentType =
             new ContentType("application/vnd.openxmlformats-package.digital-signature-certificate");
-        private static readonly string _certificatePartNamePrefix = "/package/services/digital-signature/certificate/";
-        private static readonly string _certificatePartNameExtension = ".cer";
-        private static readonly string _certificatePartRelationshipType = "http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/certificate";
+        private const string _certificatePartNamePrefix = "/package/services/digital-signature/certificate/";
+        private const string _certificatePartNameExtension = ".cer";
+        private const string _certificatePartRelationshipType = "http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/certificate";
         private static long             _maximumCertificateStreamLength = 0x40000;   // 4MB
         #endregion Private Members
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompressionTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompressionTransform.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -113,7 +113,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         //------------------------------------------------------
         private TransformEnvironment _transformEnvironment;
         private VersionedStreamOwner _versionedStreamOwner;     // our instance data stream wrapped
-        private static readonly string _featureName = "Microsoft.Metadata.CompressionTransform";
+        private const string _featureName = "Microsoft.Metadata.CompressionTransform";
 
         private static readonly VersionPair _currentFeatureVersion = new VersionPair(1, 0);
         private static readonly VersionPair _minimumReaderVersion = new VersionPair(1, 0);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/ContainerUtilities.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/ContainerUtilities.cs
@@ -27,13 +27,13 @@ namespace MS.Internal.IO.Packaging.CompoundFile
     /// </summary>
     internal static class ContainerUtilities
     {
-        private static readonly Int32 _int16Size = sizeof(Int16);
-        private static readonly Int32 _int32Size = sizeof(Int32);
+        private const Int32 _int16Size = sizeof(Int16);
+        private const Int32 _int32Size = sizeof(Int32);
         private static readonly byte[] _paddingBuf = new byte[4];        // for writing DWORD padding
 
 
 #if !PBTCOMPILER
-        private static readonly Int32 _int64Size = sizeof(Int64);
+        private const Int32 _int64Size = sizeof(Int64);
 
         /// Used by ConvertBackSlashPathToStringArrayPath and 
         ///     ConvertStringArrayPathToBackSlashPath to separate path elements.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/InternalRelationshipCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/InternalRelationshipCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description:
@@ -62,11 +62,11 @@ namespace MS.Internal.IO.Packaging
         //------------------------------------------------------
 
 
-        private static readonly string RelationshipTagName      = "Relationship";
-        private static readonly string TargetAttributeName      = "Target";
-        private static readonly string TypeAttributeName        = "Type";
-        private static readonly string IdAttributeName          = "Id";
-        private static readonly string TargetModeAttributeName  = "TargetMode";
+        private const string RelationshipTagName = "Relationship";
+        private const string TargetAttributeName = "Target";
+        private const string TypeAttributeName = "Type";
+        private const string IdAttributeName = "Id";
+        private const string TargetModeAttributeName = "TargetMode";
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
@@ -296,7 +296,7 @@ namespace MS.Internal.IO.Packaging
         private static readonly Uri _packageRootUri = new Uri("/", UriKind.Relative);
 
         //Rels segment and extension
-        private static readonly string _relationshipPartExtensionName = ".rels";
+        private const string _relationshipPartExtensionName = ".rels";
 
         #endregion Private Members
 
@@ -564,8 +564,8 @@ namespace MS.Internal.IO.Packaging
 
             //String Uppercase variants
 
-            private static readonly string _relationshipPartUpperCaseExtension   = ".RELS";
-            private static readonly string _relationshipPartUpperCaseSegmentName = "_RELS";
+            private const string _relationshipPartUpperCaseExtension = ".RELS";
+            private const string _relationshipPartUpperCaseSegmentName = "_RELS";
             private static readonly string _relsrelsUpperCaseExtension = String.Concat(_relationshipPartUpperCaseExtension, _relationshipPartUpperCaseExtension);
 
             //need to use the private constructor to initialize this particular partUri as we need this in the 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyChangedEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Manager for the PropertyChanged event in the "weak event listener"
@@ -613,7 +613,7 @@ namespace System.ComponentModel
 
         private ListenerList _proposedAllListenersList;
         private List<String> _toRemove = new List<String>();
-        private static readonly string AllListenersKey = "<All Listeners>"; // not a legal property name
+        private const string AllListenersKey = "<All Listeners>"; // not a legal property name
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/DataSpaceManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/DataSpaceManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -34,11 +34,11 @@ namespace System.IO.Packaging
     private const string TransformDefinitions = "TransformInfo";
     private const string TransformPrimaryInfo = "\x0006Primary";
 
-    // The string used in FormatVersion
-    private static readonly string DataSpaceVersionIdentifier = "Microsoft.Container.DataSpaces";
+        // The string used in FormatVersion
+        private const string DataSpaceVersionIdentifier = "Microsoft.Container.DataSpaces";
 
-    // Version Writer - 1.0, Reader - 1.0, Updater - 1.0
-    private static readonly VersionPair DataSpaceCurrentWriterVersion  = new VersionPair(major: 1, minor: 0);
+        // Version Writer - 1.0, Reader - 1.0, Updater - 1.0
+        private static readonly VersionPair DataSpaceCurrentWriterVersion  = new VersionPair(major: 1, minor: 0);
     private static readonly VersionPair DataSpaceCurrentReaderVersion  = new VersionPair(major: 1, minor: 0);
     private static readonly VersionPair DataSpaceCurrentUpdaterVersion = new VersionPair(major: 1, minor: 0);
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageInfo.cs
@@ -97,17 +97,17 @@ public class StorageInfo
     /// </summary>
     internal StorageInfoCore core;
 
-    // Instance name for the compression transform
-    private static readonly string sc_compressionTransformName = "CompressionTransform";
+        // Instance name for the compression transform
+        private const string sc_compressionTransformName = "CompressionTransform";
 
-    //Dataspace label definitions for compression and encryption combinations while creating a stream
-    private static readonly string sc_dataspaceLabelNoEncryptionNormalCompression = "NoEncryptionNormalCompression";
-    private static readonly string sc_dataspaceLabelRMEncryptionNormalCompression = "RMEncryptionNormalCompression";
+        //Dataspace label definitions for compression and encryption combinations while creating a stream
+        private const string sc_dataspaceLabelNoEncryptionNormalCompression = "NoEncryptionNormalCompression";
+        private const string sc_dataspaceLabelRMEncryptionNormalCompression = "RMEncryptionNormalCompression";
 
-    /// <summary>
-    /// We can have three valid enumerator types.
-    /// </summary>
-    private enum EnumeratorTypes
+        /// <summary>
+        /// We can have three valid enumerator types.
+        /// </summary>
+        private enum EnumeratorTypes
     {
         Everything,
         OnlyStorages,

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
@@ -1357,12 +1357,12 @@ namespace System.IO.Packaging
 
         private static readonly ContentType _originPartContentType = new ContentType("application/vnd.openxmlformats-package.digital-signature-origin");
 
-        private static readonly String _guidStorageFormatString = @"N";     // N - simple format without adornments
-        private static readonly String _defaultHashAlgorithm =  "http://www.w3.org/2001/04/xmlenc#sha256";
-        private static readonly String _originRelationshipType = "http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/origin";
-        private static readonly String _originToSignatureRelationshipType = "http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/signature";
-        private static readonly String _defaultSignaturePartNamePrefix = "/package/services/digital-signature/xml-signature/";
-        private static readonly String _defaultSignaturePartNameExtension = ".psdsxs";
+        private const String _guidStorageFormatString = @"N";     // N - simple format without adornments
+        private const String _defaultHashAlgorithm = "http://www.w3.org/2001/04/xmlenc#sha256";
+        private const String _originRelationshipType = "http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/origin";
+        private const String _originToSignatureRelationshipType = "http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/signature";
+        private const String _defaultSignaturePartNamePrefix = "/package/services/digital-signature/xml-signature/";
+        private const String _defaultSignaturePartNameExtension = ".psdsxs";
         #endregion Private Members
     }
 }


### PR DESCRIPTION
I've prepared this PR but then just realized that #10382 needs to be done first to prevent havoc, so gonna draft this.

## Description

Swaps use of `static readonly` fields for `const` where appropriate. This in some cases saves allocations.

## Customer Impact

Decreased allocations, a bit of perf.

## Regression

No.

## Testing

Local build.

## Risk

Low, just an analyzer fix. The only issue would be reflection-based changes that will no longer be possible but there's no point of supporting these anyways, we'd never move anywhere.
