### PR TITLE
[StyleCleanUp] Add readonly modifiers in WindowsBase

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CopyOnWriteList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CopyOnWriteList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -184,7 +184,7 @@ namespace MS.Internal
             }
         }
 
-        private object _syncRoot;
+        private readonly object _syncRoot;
         private ArrayList _LiveList = new ArrayList();
         private ArrayList _readonlyWrapper;
     }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CulturePreservingExecutionContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CulturePreservingExecutionContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -257,11 +257,11 @@ namespace MS.Internal
 
         #region Private Fields
 
-        private ExecutionContext _context;
+        private readonly ExecutionContext _context;
         private CultureAndContextManager _cultureAndContext;
 
         // static delegate to prevent repeated implicit allocations during Run
-        private static ContextCallback CallbackWrapperDelegate;
+        private static readonly ContextCallback CallbackWrapperDelegate;
 
         #endregion
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/IO/Packaging/PackagingUtilities.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/IO/Packaging/PackagingUtilities.cs
@@ -814,8 +814,8 @@ namespace MS.Internal.IO.Packaging
         /// Synchronize access to IsolatedStorage methods that can step on each-other
         /// </summary>
         /// <remarks>See PS 1468964 for details.</remarks>
-        private static Object _isoStoreSyncObject = new Object();
-        private static Object _isolatedStorageFileLock = new Object();
+        private static readonly Object _isoStoreSyncObject = new Object();
+        private static readonly Object _isolatedStorageFileLock = new Object();
         private static ReliableIsolatedStorageFileFolder _defaultFile;
         private const string XmlNamespace = "xmlns";
         private const string _encodingAttribute = "encoding";

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReaderWriterLockWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReaderWriterLockWrapper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description:
@@ -184,7 +184,7 @@ namespace MS.Internal
 
         #region Private Fields
 
-        private ReaderWriterLockSlim _rwLock;
+        private readonly ReaderWriterLockSlim _rwLock;
         private AutoReaderRelease _arr;
         private AutoWriterRelease _awr;
         private AutoReaderReleaseClass _arrc;
@@ -217,7 +217,7 @@ namespace MS.Internal
                 _wrapper.ReleaseWriterLock();
             }
 
-            private ReaderWriterLockWrapper _wrapper;
+            private readonly ReaderWriterLockWrapper _wrapper;
         }
 
         private struct AutoReaderRelease : IDisposable
@@ -232,7 +232,7 @@ namespace MS.Internal
                 _wrapper.ReleaseReaderLock();
             }
 
-            private ReaderWriterLockWrapper _wrapper;
+            private readonly ReaderWriterLockWrapper _wrapper;
         }
 
         private class AutoWriterReleaseClass : IDisposable
@@ -247,7 +247,7 @@ namespace MS.Internal
                 _wrapper.ReleaseWriterLock2();
             }
 
-            private ReaderWriterLockWrapper _wrapper;
+            private readonly ReaderWriterLockWrapper _wrapper;
         }
 
         private class AutoReaderReleaseClass : IDisposable
@@ -262,7 +262,7 @@ namespace MS.Internal
                 _wrapper.ReleaseReaderLock2();
             }
 
-            private ReaderWriterLockWrapper _wrapper;
+            private readonly ReaderWriterLockWrapper _wrapper;
         }
 
         // This SynchronizationContext waits without pumping messages, like

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
@@ -87,7 +87,7 @@ namespace System.Xaml
         // We use a callback on GC to purge out collected assemblies, so we don't grow indefinitely.
         //
         private static Dictionary<object, AssemblyName> _assemblies; // get key via GetKeyForAssembly
-        private static object syncObject = new object();
+        private static readonly object syncObject = new object();
         private static bool _isGCCallbackPending;
 
         // PERF: Cache delegate for CleanupCollectedAssemblies to avoid allocating it each time.
@@ -312,8 +312,8 @@ namespace System.Xaml
     // will kick off a thread-pool job that you can use to purge a weakref cache.
     internal class GCNotificationToken
     {
-        private WaitCallback callback;
-        private object state;
+        private readonly WaitCallback callback;
+        private readonly object state;
 
         private GCNotificationToken(WaitCallback callback, object state)
         {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/TextServicesLoader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/TextServicesLoader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -359,7 +359,7 @@ namespace MS.Internal
         // Writes are not thread safe, but we don't mind the neglible perf hit
         // of potentially writing it twice.
         private static InstallState s_servicesInstalled = InstallState.Unknown;
-        private static object s_servicesInstalledLock = new object();
+        private static readonly object s_servicesInstalledLock = new object();
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceEnumerator.cs
@@ -61,7 +61,7 @@ namespace MS.Internal
         }
 
         private int _i;
-        private ArrayList _List;
+        private readonly ArrayList _List;
         private object _StrongReference;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
@@ -213,7 +213,7 @@ namespace MS.Utility
             protected FrugalListBase<T> _store;
             protected int _validItemCount;
             protected int _previousEnd;
-            private int _newCount;
+            private readonly int _newCount;
         }
 
         #endregion Compacter
@@ -1612,9 +1612,9 @@ namespace MS.Utility
                 return _targetStore;
             }
 
-            private ArrayItemList<T> _targetStore;
-            private T[] _sourceArray;
-            private T[] _targetArray;
+            private readonly ArrayItemList<T> _targetStore;
+            private readonly T[] _sourceArray;
+            private readonly T[] _targetArray;
         }
 
         #endregion Compacter
@@ -1951,8 +1951,8 @@ namespace MS.Utility
                 }
             }
 
-            private FrugalObjectList<T> _list;
-            private FrugalListBase<T>.Compacter _storeCompacter;
+            private readonly FrugalObjectList<T> _list;
+            private readonly FrugalListBase<T>.Compacter _storeCompacter;
         }
         #endregion Compacter
     }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalMap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalMap.cs
@@ -1655,7 +1655,7 @@ namespace MS.Utility
         // Hashtable will return null from its indexer if the key is not
         // found OR if the value is null.  To distinguish between these
         // two cases we insert NullValue instead of null.
-        private static object NullValue = new object();
+        private static readonly object NullValue = new object();
 
         internal Dictionary<int, object> _entries;
     }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HandleCollector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HandleCollector.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -11,7 +11,7 @@ namespace MS.Win32
         private static HandleType[]             handleTypes;
         private static int                      handleTypeCount = 0;
 
-        private static Object handleMutex = new Object();
+        private static readonly Object handleMutex = new Object();
 
         /// <devdoc>
         ///     Adds the given handle to the handle collector.  This keeps the
@@ -78,7 +78,7 @@ namespace MS.Win32
         {
             internal readonly string name;
 
-            private int initialThreshHold;
+            private readonly int initialThreshHold;
             private int threshHold;
             private int handleCount;
             private readonly int deltaPercent;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
@@ -590,9 +590,9 @@ namespace MS.Win32
         /// By instantiating this delegate as a static variable we ensure that
         /// it will remain alive long enough to process messages.
         /// </summary>
-        private static NativeMethods.WndProc DefWndProcStub = new NativeMethods.WndProc(DefWndProcWrapper);
+        private static readonly NativeMethods.WndProc DefWndProcStub = new NativeMethods.WndProc(DefWndProcWrapper);
 
-        private static IntPtr DefWndProc;
+        private static readonly IntPtr DefWndProc;
 
         private IntPtr _hwndAttached;
         private HandleRef _hwndHandleRef;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
@@ -358,15 +358,15 @@ namespace MS.Win32
         private IntPtr _handle;
         private UInt16 _classAtom;
         private WeakReferenceList _hooks;
-        private int _ownerThreadID;
+        private readonly int _ownerThreadID;
         
-        private HwndWrapperHook _wndProc;
+        private readonly HwndWrapperHook _wndProc;
         private bool _isDisposed;
 
-        private bool _isInCreateWindow = false;     // debugging variable (temporary)
+        private readonly bool _isInCreateWindow = false;     // debugging variable (temporary)
 
         // Message to cause a dispose.  We need this to ensure we destroy the window on the right thread.
-        private static WindowMessage s_msgGCMemory;
+        private static readonly WindowMessage s_msgGCMemory;
     } // class RawWindow
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //#define LOGGING
@@ -238,7 +238,7 @@ namespace MS.Win32
         private static IntPtr _cachedDefWindowProcA = IntPtr.Zero;
         private static IntPtr _cachedDefWindowProcW = IntPtr.Zero;
 
-        private static Hashtable _hwndList = new Hashtable(10);
+        private static readonly Hashtable _hwndList = new Hashtable(10);
         private static bool _exiting = false;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsOther.cs
@@ -206,7 +206,7 @@ namespace MS.Win32
 
         internal abstract class WpfSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
         {
-            private int _collectorId;
+            private readonly int _collectorId;
 
             protected WpfSafeHandle(bool ownsHandle, int collectorId) : base(ownsHandle)
             {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -476,7 +476,7 @@ namespace System.Xaml
             return retassem;
         }
 
-        private static Hashtable _loadedAssembliesHash = new Hashtable(8);
+        private static readonly Hashtable _loadedAssembliesHash = new Hashtable(8);
 #else
         // returns true is sourceAssembly declares LocalAssemblyName as a friend
         internal static bool IsFriendAssembly(Assembly sourceAssembly)

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/TypeConverterHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/TypeConverterHelper.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Markup
     /// </summary>
     internal static class TypeConverterHelper
     {
-        private static CultureInfo invariantEnglishUS = CultureInfo.InvariantCulture;
+        private static readonly CultureInfo invariantEnglishUS = CultureInfo.InvariantCulture;
 
         internal static CultureInfo InvariantEnglishUS
         {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -1642,14 +1642,14 @@ namespace System.Windows.Markup
         /// </summary>
         private class CompatibilityScope
         {
-            private CompatibilityScope _previous;
-            private int _depth;
+            private readonly CompatibilityScope _previous;
+            private readonly int _depth;
             private bool _fallbackSeen;
             private bool _inAlternateContent;
             private bool _inProcessContent;
             private bool _choiceTaken;
             private bool _choiceSeen;
-            private XmlCompatibilityReader _reader;
+            private readonly XmlCompatibilityReader _reader;
             private Dictionary<string, object> _ignorables;
             private Dictionary<string, ProcessContentSet> _processContents;
             private Dictionary<string, PreserveItemSet> _preserveElements;
@@ -1948,8 +1948,8 @@ namespace System.Windows.Markup
         private class ProcessContentSet
         {
             private bool _all;
-            private string _namespaceName;
-            private XmlCompatibilityReader _reader;
+            private readonly string _namespaceName;
+            private readonly XmlCompatibilityReader _reader;
             private HashSet<string> _names;
 
             public ProcessContentSet(string namespaceName, XmlCompatibilityReader reader)
@@ -2003,8 +2003,8 @@ namespace System.Windows.Markup
         private class PreserveItemSet
         {
             private bool _all;
-            private string _namespaceName;
-            private XmlCompatibilityReader _reader;
+            private readonly string _namespaceName;
+            private readonly XmlCompatibilityReader _reader;
             private Dictionary<string, string> _names;
 
             public PreserveItemSet(string namespaceName, XmlCompatibilityReader reader)
@@ -2059,12 +2059,12 @@ namespace System.Windows.Markup
         #region Private Fields
         private bool _inAttribute; // for Save/Restore ReaderPosition
         private string _currentName; // for Save/Restore ReaderPosition
-        private IsXmlNamespaceSupportedCallback _namespaceCallback;
+        private readonly IsXmlNamespaceSupportedCallback _namespaceCallback;
         private Dictionary<string, object> _knownNamespaces;
-        private Dictionary<string, string> _namespaceMap = new Dictionary<string, string>();
         private Dictionary<string, object> _subsumingNamespaces;
-        private Dictionary<string, HandleElementCallback> _elementHandler = new Dictionary<string, HandleElementCallback>();
-        private Dictionary<string, HandleAttributeCallback> _attributeHandler = new Dictionary<string, HandleAttributeCallback>();
+        private readonly Dictionary<string, string> _namespaceMap = new Dictionary<string, string>();
+        private readonly Dictionary<string, HandleElementCallback> _elementHandler = new Dictionary<string, HandleElementCallback>();
+        private readonly Dictionary<string, HandleAttributeCallback> _attributeHandler = new Dictionary<string, HandleAttributeCallback>();
         private int _depthOffset; // offset for Depth method, to account for elements that should be ignored by client
         private int _ignoredAttributeCount;
         private int _attributePosition; // used for ScanForCompatibility / HandleIgnorable
@@ -2086,7 +2086,7 @@ namespace System.Windows.Markup
         private const string XmlnsDeclaration = "xmlns";
         private const string MarkupCompatibilityURI = "http://schemas.openxmlformats.org/markup-compatibility/2006";
 
-        private static string[] _predefinedNamespaces = new string[4]
+        private static readonly string[] _predefinedNamespaces = new string[4]
         {
             "http://www.w3.org/2000/xmlns/",
             "http://www.w3.org/XML/1998/namespace",

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -479,8 +479,8 @@ namespace MS.Internal
         private static bool _hasBeenRefreshed = false;
 
         // Delegates to create and remove the TraceSource instance
-        private GetTraceSourceDelegate _getTraceSourceDelegate;
-        private ClearTraceSourceDelegate _clearTraceSourceDelegate;
+        private readonly GetTraceSourceDelegate _getTraceSourceDelegate;
+        private readonly ClearTraceSourceDelegate _clearTraceSourceDelegate;
 
         // Cache of TraceSource instance; real value resides in PresentationTraceSources.
         private TraceSource _traceSource;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTraceDetails.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTraceDetails.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace MS.Internal
@@ -41,8 +41,8 @@ namespace MS.Internal
             }
         }
 
-        private int _id;
-        private string[] _labels;
+        private readonly int _id;
+        private readonly string[] _labels;
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTraceFormat.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTraceFormat.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace MS.Internal
@@ -22,7 +22,7 @@ namespace MS.Internal
             }
         }
 
-        private string _message;
+        private readonly string _message;
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/CleanupHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/CleanupHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Helper for classes that need to clean up data structures
@@ -116,16 +116,16 @@ namespace MS.Internal
         }
 
         private DispatcherTimer _cleanupTimer;
-        private DispatcherTimer _starvationTimer;
-        private DispatcherTimer _defaultCleanupTimer;
+        private readonly DispatcherTimer _starvationTimer;
+        private readonly DispatcherTimer _defaultCleanupTimer;
         private DispatcherPriority _cleanupTimerPriority;
 
         private int             _cleanupRequests;
         private bool            _waitingForGC;
 
-        private Func<bool,bool> _cleanupCallback;
-        private TimeSpan        _basePollingInterval;
-        private TimeSpan        _maxPollingInterval;
+        private readonly Func<bool, bool> _cleanupCallback;
+        private readonly TimeSpan _basePollingInterval;
+        private readonly TimeSpan _maxPollingInterval;
 
         // When an instance of this class is GC'd and finalized, it
         // tells the CleanupHelper that a GC has occurred.
@@ -141,7 +141,7 @@ namespace MS.Internal
                 _parent._waitingForGC = false;
             }
 
-            private CleanupHelper _parent;
+            private readonly CleanupHelper _parent;
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/APCustomTypeDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/APCustomTypeDescriptor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -284,10 +284,10 @@ namespace MS.Internal.ComponentModel
         #region Private Fields
         
 
-        private ICustomTypeDescriptor _parent;
-        private DependencyObject _instance;
+        private readonly ICustomTypeDescriptor _parent;
+        private readonly DependencyObject _instance;
 
-        private static object _syncLock = new object();
+        private static readonly object _syncLock = new object();
 
         // Synchronized by "_syncLock"
         private static int _dpCacheCount = 0;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DPCustomTypeDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DPCustomTypeDescriptor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -372,16 +372,16 @@ namespace MS.Internal.ComponentModel
 
         #region Private Fields
         
-        private ICustomTypeDescriptor _parent;
-        private Type _objectType;
-        private object _instance;
+        private readonly ICustomTypeDescriptor _parent;
+        private readonly Type _objectType;
+        private readonly object _instance;
 
         // Synchronized by "_propertyMap"
-        private static Dictionary<PropertyDescriptor, DependencyObjectPropertyDescriptor> _propertyMap = 
+        private static readonly Dictionary<PropertyDescriptor, DependencyObjectPropertyDescriptor> _propertyMap = 
             new Dictionary<PropertyDescriptor, DependencyObjectPropertyDescriptor>(new PropertyDescriptorComparer());
 
         // Synchronized by "_typeProperties"
-        private static Hashtable _typeProperties = new Hashtable();
+        private static readonly Hashtable _typeProperties = new Hashtable();
 
         private const PropertyFilterOptions _anySet = PropertyFilterOptions.SetValues | PropertyFilterOptions.UnsetValues;
         private const PropertyFilterOptions _anyValid = PropertyFilterOptions.Valid;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyObjectPropertyDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyObjectPropertyDescriptor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -810,29 +810,29 @@ namespace MS.Internal.ComponentModel
 
         #region Private Fields
         
-        private static Binder _dpBinder = new AttachedPropertyMethodSelector();
+        private static readonly Binder _dpBinder = new AttachedPropertyMethodSelector();
 
-        private static object _nullMethodSentinel = new object();
+        private static readonly object _nullMethodSentinel = new object();
 
         // Synchronized by "_getMethodCache".  Note these are "reflection"
         // member infos and should only be passed types returned from
         // GetReflectionType.
-        private static Hashtable _getMethodCache = new Hashtable();
+        private static readonly Hashtable _getMethodCache = new Hashtable();
 
         // Synchronized by "_setMethodCache".  Note these are "reflection"
         // member infos and should only be passed types returned from
         // GetReflectionType.
-        private static Hashtable _setMethodCache = new Hashtable();
+        private static readonly Hashtable _setMethodCache = new Hashtable();
 
         // Synchronization object for Attributes property.  This would be better to be a
         // member than a static value, but the need for a lock on Attributes is very
         // rare and isn't worth the additional space this would take up as a member
-        private static object _attributeSyncLock = new object();
+        private static readonly object _attributeSyncLock = new object();
 
-        private PropertyDescriptor _property;
-        private DependencyProperty _dp;
-        private Type _componentType;
-        private PropertyMetadata _metadata;
+        private readonly PropertyDescriptor _property;
+        private readonly DependencyProperty _dp;
+        private readonly Type _componentType;
+        private readonly PropertyMetadata _metadata;
         private bool _queriedShouldSerializeMethod;
         private bool _queriedResetMethod;
         private Dictionary<DependencyObject, PropertyChangeTracker> _trackers;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyObjectProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyObjectProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -256,13 +256,13 @@ namespace MS.Internal.ComponentModel
         private static readonly UncommonField<IDictionary> _cacheSlot = new UncommonField<IDictionary>(null);
 
         // Synchronized by "_propertyMap"
-        private static Dictionary<PropertyKey, DependencyObjectPropertyDescriptor> _propertyMap = new Dictionary<PropertyKey, DependencyObjectPropertyDescriptor>();
+        private static readonly Dictionary<PropertyKey, DependencyObjectPropertyDescriptor> _propertyMap = new Dictionary<PropertyKey, DependencyObjectPropertyDescriptor>();
 
         // Synchronized by "_propertyKindMap"
-        private static Dictionary<PropertyKey, DependencyPropertyKind> _propertyKindMap = new Dictionary<PropertyKey, DependencyPropertyKind>();
+        private static readonly Dictionary<PropertyKey, DependencyPropertyKind> _propertyKindMap = new Dictionary<PropertyKey, DependencyPropertyKind>();
 
         // Synchronized by "_attachInfoMap"
-        private static Hashtable _attachInfoMap = new Hashtable();
+        private static readonly Hashtable _attachInfoMap = new Hashtable();
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyPropertyAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows;
@@ -135,8 +135,8 @@ namespace MS.Internal.ComponentModel
 
         #region Private Fields
         
-        private DependencyProperty _dp;
-        private bool _isAttached;
+        private readonly DependencyProperty _dp;
+        private readonly bool _isAttached;
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/PropertyKey.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/PropertyKey.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
@@ -644,9 +644,9 @@ namespace MS.Internal
         private string _contentType = null;
         private string _type    = String.Empty;
         private string _subType = String.Empty;
-        private string _originalString;
+        private readonly string _originalString;
         private Dictionary<string, string> _parameterDictionary = null;
-        private bool   _isInitialized = false;
+        private readonly bool _isInitialized;
 
         private const string     _quote              = "\"";
         private const char       _semicolonSeparator = ';';

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Certificate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Certificate.cs
@@ -156,7 +156,7 @@ namespace MS.Internal.IO.Packaging
         //  Private Fields
         //
         //------------------------------------------------------
-        private PackagePart             _part;          // part that houses the certificate
+        private readonly PackagePart _part;          // part that houses the certificate
         private X509Certificate2       _certificate;   // certificate itself
 
         // certificate part constants
@@ -165,7 +165,7 @@ namespace MS.Internal.IO.Packaging
         private static readonly string _certificatePartNamePrefix = "/package/services/digital-signature/certificate/";
         private static readonly string _certificatePartNameExtension = ".cer";
         private static readonly string _certificatePartRelationshipType = "http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/certificate";
-        private static long             _maximumCertificateStreamLength = 0x40000;   // 4MB
+        private static readonly long _maximumCertificateStreamLength = 0x40000;   // 4MB
         #endregion Private Members
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CFStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CFStream.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description:
@@ -341,7 +341,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
     //
     //------------------------------------------------------
     private IStream _safeIStream;
-    private FileAccess access;
+    private readonly FileAccess access;
 
     /// <summary>
     /// If only this stream object is held open, and the rest of the container
@@ -349,6 +349,6 @@ namespace MS.Internal.IO.Packaging.CompoundFile
     /// tree open because the CLR GC doesn't realize that our IStream has
     /// a dependency on the rest of the container object tree.
     /// </summary>
-    private StreamInfo backReference;
+    private readonly StreamInfo backReference;
 }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileDeflateTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileDeflateTransform.cs
@@ -424,7 +424,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         //------------------------------------------------------
 
         // for reading each block header
-        private byte[] _headerBuf = new byte[_blockHeaderSize];         // 3 ulongs
+        private readonly byte[] _headerBuf = new byte[_blockHeaderSize];         // 3 ulongs
 
         // static
         private const int _defaultBlockSize = 0x1000;         // 4k default

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompressionTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompressionTransform.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -111,8 +111,8 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         //  Private Data
         //
         //------------------------------------------------------
-        private TransformEnvironment _transformEnvironment;
-        private VersionedStreamOwner _versionedStreamOwner;     // our instance data stream wrapped
+        private readonly TransformEnvironment _transformEnvironment;
+        private readonly VersionedStreamOwner _versionedStreamOwner;     // our instance data stream wrapped
         private static readonly string _featureName = "Microsoft.Metadata.CompressionTransform";
 
         private static readonly VersionPair _currentFeatureVersion = new VersionPair(1, 0);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptedStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptedStream.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
@@ -881,7 +881,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         private long _streamPosition;           // always start at 0 
         
 
-        private CryptoProvider _cryptoProvider;
+        private readonly CryptoProvider _cryptoProvider;
             
         private const int _prefixLengthSize = 8; // 8 byte original stream size prefix  
 
@@ -901,7 +901,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
         // MaxValues below are used in order to ensure that we do not trigger any form of Isolated Storage Backup 
         // This is not a goal here. We are definitely would like to keep  SparseMemoryStream in the cached(in - memory) mode.
-        // In the context of our auto flush logic set at 16K we are pretty safe with those values�
+        // In the context of our auto flush logic set at 16K we are pretty safe with those values…
         private SparseMemoryStream _readCache =  new SparseMemoryStream(Int32.MaxValue, Int64.MaxValue, false); 
         private SparseMemoryStream _writeCache =  new SparseMemoryStream(Int32.MaxValue, Int64.MaxValue, false);
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
@@ -942,7 +942,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
                 set { _useLicense = value; }
             }
 
-            private ContentUser _user;
+            private readonly ContentUser _user;
             private UseLicense _useLicense;
         }
 
@@ -1291,7 +1291,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         //
         // The stream in which the FormatVersion and publish license is stored.
         //
-        private VersionedStreamOwner _publishLicenseStream;
+        private readonly VersionedStreamOwner _publishLicenseStream;
 
         //
         // Uninterpreted bytes from the publish license stream header.
@@ -1301,7 +1301,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         //
         // The storage under which use licenses are stored.
         //
-        private StorageInfo _useLicenseStorage;
+        private readonly StorageInfo _useLicenseStorage;
 
         //
         // All use licenses reside in streams whose names begin with this prefix:

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/StreamWithDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/StreamWithDictionary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description:
@@ -12,8 +12,8 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 {
     internal class StreamWithDictionary : Stream, IDictionary
     {
-        private Stream baseStream;
-        private IDictionary baseDictionary;
+        private readonly Stream baseStream;
+        private readonly IDictionary baseDictionary;
         private bool _disposed;         // keep track of if we are disposed
 
         internal StreamWithDictionary( Stream wrappedStream, IDictionary wrappedDictionary )

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/UserUseLicenseDictionaryLoader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/UserUseLicenseDictionaryLoader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description:
@@ -136,12 +136,12 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         //
         // The object that provides the implementation of the IDictionary methods.
         //
-        private Dictionary<ContentUser, UseLicense> _dict;
+        private readonly Dictionary<ContentUser, UseLicense> _dict;
 
         //
         // Text encoding object used to read or write publish licenses and use licenses.
         //
-        private UTF8Encoding _utf8Encoding = new UTF8Encoding();
+        private readonly UTF8Encoding _utf8Encoding = new UTF8Encoding();
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStream.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description:
@@ -261,7 +261,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         //  Private Fields
         //
         //------------------------------------------------------
-        private VersionedStreamOwner    _versionOwner;
+        private readonly VersionedStreamOwner _versionOwner;
         private Stream                  _stream;            // null indicates Disposed state
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStreamOwner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStreamOwner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description:
@@ -417,7 +417,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         //------------------------------------------------------
         private bool            _writeOccurred;     // did one of our streams get written to?
         private bool            _readOccurred;      // did one of our streams get read from?
-        private FormatVersion   _codeVersion;       // code version
+        private readonly FormatVersion _codeVersion;       // code version
         private FormatVersion   _fileVersion;       // current file version (null if not read or created yet)
         private long            _dataOffset = 0;    // where FormatVersion ends and data begins
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompressEmulationStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompressEmulationStream.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description:
@@ -331,7 +331,7 @@ namespace MS.Internal.IO.Packaging
         private bool    _dirty;             // do we need to recompress?
         protected Stream  _baseStream;      // stream we ultimately decompress from and to in the container
         protected Stream _tempStream;       // temporary storage for the uncompressed stream
-        private IDeflateTransform _transformer;   // does the actual compress/decompress for us
+        private readonly IDeflateTransform _transformer;   // does the actual compress/decompress for us
         #endregion
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/OlePropertyStructs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/OlePropertyStructs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
@@ -557,10 +557,10 @@ namespace MS.Internal.IO.Packaging
             //------------------------------------------------------
 
             private ValidatedPartUri _normalizedPartUri;
-            private string _partUriString;
+            private readonly string _partUriString;
             private string _normalizedPartUriString;
-            private bool   _isNormalized;
-            private bool   _isRelationshipPartUri;
+            private readonly bool   _isNormalized;
+            private readonly bool   _isRelationshipPartUri;
 
             //String Uppercase variants
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/SparseMemoryStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/SparseMemoryStream.cs
@@ -802,7 +802,7 @@ namespace MS.Internal.IO.Packaging
         //
         //------------------------------------------------------
         //we use this class to track total memory consumed by the Memory streams that we are using
-        private TrackingMemoryStreamFactory _trackingMemoryStreamFactory = new TrackingMemoryStreamFactory();
+        private readonly TrackingMemoryStreamFactory _trackingMemoryStreamFactory = new TrackingMemoryStreamFactory();
 
         private string _isolatedStorageStreamFileName;
         private Stream _isolatedStorageStream;
@@ -824,10 +824,10 @@ namespace MS.Internal.IO.Packaging
                                                         // This list is also maintained in offset order
         private MemoryStreamBlock _searchBlock;
 
-        private long _lowWaterMark;
-        private long _highWaterMark;
+        private readonly long _lowWaterMark;
+        private readonly long _highWaterMark;
 
-        private bool _autoCloseSmallBlockGaps;
+        private readonly bool _autoCloseSmallBlockGaps;
     }
 
     internal class MemoryStreamBlock : IComparable<MemoryStreamBlock>
@@ -896,7 +896,7 @@ namespace MS.Internal.IO.Packaging
             }
         }
 
-        private MemoryStream _stream;
+        private readonly MemoryStream _stream;
         private long _offset;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/StorageBasedPackageProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/StorageBasedPackageProperties.cs
@@ -874,13 +874,13 @@ namespace MS.Internal.IO.Packaging
 
         private bool _disposed;
 
-        private int _grfMode;  // Mode in which the compound file was opened.
+        private readonly int _grfMode;  // Mode in which the compound file was opened.
 
         //
         // Interface to the OLE property sets in the compound file representing
         // the RM-protected OPC package.
         //
-        private IPropertySetStorage _pss;
+        private readonly IPropertySetStorage _pss;
         private IPropertyStorage _psSummInfo;
         private IPropertyStorage _psDocSummInfo;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlDigitalSignatureProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlDigitalSignatureProcessor.cs
@@ -1209,10 +1209,10 @@ namespace MS.Internal.IO.Packaging
         //  Private Members
         //
         //------------------------------------------------------
-        private PackagePart _signaturePart;
+        private readonly PackagePart _signaturePart;
         private X509Certificate2                    _certificate;       // non-null if it's embedded
         private bool                                _lookForEmbeddedCert;
-        private PackageDigitalSignatureManager      _manager;
+        private readonly PackageDigitalSignatureManager _manager;
         private PackageDigitalSignature             _signature;         // parsed from part or newly created
         private SignedXml                           _signedXml;         // our format friend
         private String                              _hashAlgorithmName;     // first hash algorithm obtained - considered to be the setting for the entire signature

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ObservableCollectionDefaultValueFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ObservableCollectionDefaultValueFactory.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows;
@@ -106,6 +106,6 @@ namespace MS.Internal
         }
 
 
-        private ObservableCollection<T> _default;
+        private readonly ObservableCollection<T> _default;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/PriorityItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/PriorityItem.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows.Threading
@@ -23,8 +23,8 @@ namespace System.Windows.Threading
         internal PriorityItem<T> PriorityPrev {get{return _priorityPrev;} set{_priorityPrev=value;}}
         internal PriorityItem<T> PriorityNext {get{return _priorityNext;} set{_priorityNext=value;}}
 
-        private T _data;
-        
+        private readonly T _data;
+
         private PriorityItem<T> _sequentialPrev;
         private PriorityItem<T> _sequentialNext;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/PriorityQueue.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/PriorityQueue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows.Threading
@@ -385,8 +385,8 @@ namespace System.Windows.Threading
         }
 
         // Priority chains...
-        private SortedList<int, PriorityChain<T>> _priorityChains; // NOTE: should be Priority
-        private Stack<PriorityChain<T>> _cacheReusableChains;
+        private readonly SortedList<int, PriorityChain<T>> _priorityChains; // NOTE: should be Priority
+        private readonly Stack<PriorityChain<T>> _cacheReusableChains;
         
         // Sequential chain...
         private PriorityItem<T> _head;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/CallbackHandler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/CallbackHandler.cs
@@ -110,9 +110,9 @@ namespace MS.Internal.Security.RightsManagement
         }
 
 
-        private CallbackDelegate _callbackDelegate;
+        private readonly CallbackDelegate _callbackDelegate;
 
-        private AutoResetEvent _resetEvent;
+        private readonly AutoResetEvent _resetEvent;
         private string _callbackData;
         private int _hr;
         private Exception _exception;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/ClientSession.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/ClientSession.cs
@@ -1963,13 +1963,13 @@ namespace MS.Internal.Security.RightsManagement
         private const string _passportActivationRegistryFullKeyName = @"HKEY_LOCAL_MACHINE\Software\Microsoft\MSDRM\ServiceLocation\PassportActivation";
         private const string _passportActivationRegistryKeyName = @"Software\Microsoft\MSDRM\ServiceLocation\PassportActivation";
 
-        private ContentUser _user = null;
+        private readonly ContentUser _user;
         private CallbackHandler _callbackHandler;
 
         private SafeRightsManagementSessionHandle _hSession = null; // if this is zero, we are disposed
 
         // we preserve this so ve can remove certificates in case of temp activation             
-        private UserActivationMode _userActivationMode = UserActivationMode.Permanent;
+        private readonly UserActivationMode _userActivationMode = UserActivationMode.Permanent;
 
         private SafeRightsManagementEnvironmentHandle _envHandle = null;  // if this is null, we are disposed
 
@@ -1979,7 +1979,7 @@ namespace MS.Internal.Security.RightsManagement
 
         // the following 2 arrays are used for parsing and converting between String and Enum; 
         // therefore, the entries in the _rightEnums and the _rightNames must be in the same order. 
-        private static ContentRight[] _rightEnums = {
+        private static readonly ContentRight[] _rightEnums = {
                                         ContentRight.View,
                                         ContentRight.Edit,
                                         ContentRight.Print,
@@ -1995,7 +1995,7 @@ namespace MS.Internal.Security.RightsManagement
                                         ContentRight.Export};
 
         // entries in this array must be in UPPERCASE, as we make such assumption during parsing                                         
-        private static string[] _rightNames = {
+        private static readonly string[] _rightNames = {
                                         "VIEW",
                                         "EDIT",
                                         "PRINT",

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/IssuanceLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/IssuanceLicense.cs
@@ -1037,7 +1037,7 @@ namespace MS.Internal.Security.RightsManagement
         }
 
 
-        private List<SafeRightsManagementPubHandle> _pubHandlesList = new List<SafeRightsManagementPubHandle>(50); // initial capacity 
+        private readonly List<SafeRightsManagementPubHandle> _pubHandlesList = new List<SafeRightsManagementPubHandle>(50); // initial capacity 
         private SafeRightsManagementPubHandle _issuanceLicenseHandle = null; // if this is null, we are disposed
 
         private const string DefaultContentType = "MS-GUID";

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/NativeRightsManagementAPIsStructures.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/NativeRightsManagementAPIsStructures.cs
@@ -78,14 +78,14 @@ namespace MS.Internal.Security.RightsManagement
             }
         }
        
-       private ushort Year =0; 
-       private ushort Month =0; 
-       private ushort DayOfWeek =0; 
-       private ushort Day =0; 
-       private ushort Hour =0; 
-       private ushort Minute =0; 
-       private ushort Second =0; 
-       private ushort Milliseconds =0; 
+       private readonly ushort Year;
+       private readonly ushort Month;
+       private readonly ushort DayOfWeek;
+       private readonly ushort Day;
+       private readonly ushort Hour;
+       private readonly ushort Minute;
+       private readonly ushort Second;
+       private readonly ushort Milliseconds;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/RightNameExpirationInfoPair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/RightNameExpirationInfoPair.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description:
@@ -53,9 +53,9 @@ namespace MS.Internal.Security.RightsManagement
             }
         }
 
-        private string _rightName;
-        private DateTime _validFrom;
-        private DateTime _validUntil;
+        private readonly string _rightName;
+        private readonly DateTime _validFrom;
+        private readonly DateTime _validUntil;
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Threading/ExceptionFilterHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Threading/ExceptionFilterHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description:  Internal class replicating the functionality of the
@@ -48,8 +48,8 @@ namespace MS.Internal.Threading
             return result;
         }
 
-        private InternalRealCallDelegate _internalRealCall;
-        private FilterExceptionDelegate _filterException;
-        private CatchExceptionDelegate _catchException;
+        private readonly InternalRealCallDelegate _internalRealCall;
+        private readonly FilterExceptionDelegate _filterException;
+        private readonly CatchExceptionDelegate _catchException;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/TraceLevelStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/TraceLevelStore.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace MS.Internal
@@ -80,7 +80,7 @@ namespace MS.Internal
         //  Private Fields
         //
 
-        private static Dictionary<Key,PresentationTraceLevel> _dictionary = new Dictionary<Key,PresentationTraceLevel>();
+        private static readonly Dictionary<Key, PresentationTraceLevel> _dictionary = new();
 
         #endregion Private Fields
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakEventTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakEventTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -436,16 +436,16 @@ namespace MS.Internal
         //  Private Fields
         //
 
-        private Hashtable _managerTable = new Hashtable();  // maps manager type -> instance
-        private Hashtable _dataTable = new Hashtable();     // maps EventKey -> data
-        private Hashtable _eventNameTable = new Hashtable(); // maps <Type,name> -> manager
+        private readonly Hashtable _managerTable = new Hashtable();  // maps manager type -> instance
+        private readonly Hashtable _dataTable = new Hashtable();     // maps EventKey -> data
+        private readonly Hashtable _eventNameTable = new Hashtable(); // maps <Type,name> -> manager
 
-        private ReaderWriterLockWrapper     _lock = new ReaderWriterLockWrapper();
+        private readonly ReaderWriterLockWrapper _lock = new ReaderWriterLockWrapper();
         private int                 _cleanupRequests;
         private bool                _cleanupEnabled = true;
-        private CleanupHelper       _cleanupHelper;
+        private readonly CleanupHelper _cleanupHelper;
         private bool                _inPurge;
-        private List<EventKey>      _toRemove = new List<EventKey>();
+        private readonly List<EventKey> _toRemove = new List<EventKey>();
 
 #if WeakEventTelemetry
         const int LOH_Threshold = 85000;    // per LOH docs

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakReferenceKey.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakReferenceKey.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace MS.Internal.Utility
@@ -45,7 +45,7 @@ namespace MS.Internal.Utility
             return _hashCode;
         }
 
-        private WeakReference _item;
-        private int _hashCode;
+        private readonly WeakReference _item;
+        private readonly int _hashCode;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Collections/ObjectModel/WeakReadOnlyCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Collections/ObjectModel/WeakReadOnlyCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
@@ -23,7 +23,7 @@ namespace System.Collections.ObjectModel
     internal class WeakReadOnlyCollection<T>: IList<T>, IList
     {
         //IList<T> list;
-        private IList<WeakReference> list;
+        private readonly IList<WeakReference> list;
         [NonSerialized]
         private Object _syncRoot;
 
@@ -307,7 +307,7 @@ namespace System.Collections.ObjectModel
                 ie.Reset();
             }
 
-            private IEnumerator ie;
+            private readonly IEnumerator ie;
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/DependencyPropertyDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/DependencyPropertyDescriptor.cs
@@ -595,17 +595,17 @@ namespace System.ComponentModel
         #region Private Fields
         
         private PropertyDescriptor _property;
-        private Type _componentType;
-        private DependencyProperty _dp;
-        private bool _isAttached;
-        private PropertyMetadata _metadata;
+        private readonly Type _componentType;
+        private readonly DependencyProperty _dp;
+        private readonly bool _isAttached;
+        private readonly PropertyMetadata _metadata;
 
         // Synchronized by "_cache"
-        private static Dictionary<object, DependencyPropertyDescriptor> _cache = 
+        private static readonly Dictionary<object, DependencyPropertyDescriptor> _cache = 
             new Dictionary<object, DependencyPropertyDescriptor>(
                 ReferenceEqualityComparer.Instance
             );
-        private static Dictionary<object, DependencyPropertyDescriptor> _ignorePropertyTypeCache =
+        private static readonly Dictionary<object, DependencyPropertyDescriptor> _ignorePropertyTypeCache =
             new Dictionary<object, DependencyPropertyDescriptor>(
                 ReferenceEqualityComparer.Instance
             );

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/GroupDescription.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/GroupDescription.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -245,7 +245,7 @@ namespace System.ComponentModel
         //
         //------------------------------------------------------
 
-        private ObservableCollection<object> _explicitGroupNames;
+        private readonly ObservableCollection<object> _explicitGroupNames;
         private SortDescriptionCollection _sort;
         private IComparer _customSort;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/IItemProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/IItemProperties.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Editing functionality for collection views.
@@ -51,8 +51,8 @@ public class ItemPropertyInfo
     /// </summary>
     public object  Descriptor { get { return _descriptor; } }
 
-    private string _name;
-    private Type _type;
-    private object _descriptor;
+    private readonly string _name;
+    private readonly Type _type;
+    private readonly object _descriptor;
 }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyChangedEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Description: Manager for the PropertyChanged event in the "weak event listener"
@@ -612,7 +612,7 @@ namespace System.ComponentModel
         #endregion Private Methods
 
         private ListenerList _proposedAllListenersList;
-        private List<String> _toRemove = new List<String>();
+        private readonly List<String> _toRemove = new List<String>();
         private static readonly string AllListenersKey = "<All Listeners>"; // not a legal property name
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyFilterAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyFilterAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.ComponentModel
@@ -136,7 +136,7 @@ namespace System.ComponentModel
 
         #region Private Fields
         
-        private PropertyFilterOptions _filter;
+        private readonly PropertyFilterOptions _filter;
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/DataSpaceManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/DataSpaceManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -54,7 +54,7 @@ namespace System.IO.Packaging
     /// There is only one data space manager per container instance.  This
     /// points back to "our" reference.
     /// </summary>
-    private StorageRoot _associatedStorage;
+    private readonly StorageRoot _associatedStorage;
 
     /// <summary>
     /// Maps container references to data spaces
@@ -107,7 +107,7 @@ namespace System.IO.Packaging
     /// data in a state where it could not be written out because parts of the
     /// transform stack has already been disposed.
     /// </summary>
-    private ArrayList _transformedStreams;
+    private readonly ArrayList _transformedStreams;
 
     /// <summary>
     /// Table of "well-known" -- that is, "built-in" -- transforms. The keys are
@@ -208,7 +208,7 @@ namespace System.IO.Packaging
         /// </summary>
         internal StorageInfo transformStorage;
 
-        private int _classType;
+        private readonly int _classType;
         private byte[] _extraData;
     }
 
@@ -1705,10 +1705,10 @@ internal interface IDataTransform
 /// </summary>
 internal class TransformInitializationEventArgs : EventArgs
 {
-    private IDataTransform  dataInstance;
-    private string          dataSpaceLabel;
-    private string          streamPath;
-    private string          transformLabel;
+    private readonly IDataTransform  dataInstance;
+    private readonly string          dataSpaceLabel;
+    private readonly string          streamPath;
+    private readonly string          transformLabel;
 
     internal TransformInitializationEventArgs(
         IDataTransform instance,
@@ -1776,8 +1776,8 @@ internal class TransformInitializationEventArgs : EventArgs
 /// </summary>
 internal  class TransformEnvironment
 {
-    private DataSpaceManager transformHost;
-    private string  transformLabel;
+    private readonly DataSpaceManager transformHost;
+    private readonly string  transformLabel;
 
     /// <summary>
     /// This object is only created internally by the data space manager.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageRoot.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageRoot.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
@@ -38,7 +38,7 @@ namespace System.IO.Packaging
     /// <summary>
     /// If we know we are in a read-only mode, we know not to do certain things.
     /// </summary>
-    private bool containerIsReadOnly;
+    private readonly bool containerIsReadOnly;
 
     /// <summary>
     /// When data space manager is being initialized, sometimes it trips

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StreamInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StreamInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
@@ -80,7 +80,7 @@ namespace System.IO.Packaging
         /// <summary>
         /// CompoundFileStreamReference for this StreamInfo object
         /// </summary>
-        private CompoundFileStreamReference _streamReference;
+        private readonly CompoundFileStreamReference _streamReference;
 
         /// <summary>
         /// We need to rememeber the FileAccess that was used for openning 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/VersionPair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/VersionPair.cs
@@ -349,8 +349,8 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
         #region Member Variables
 
-        private Int16 _major;             // Major number
-        private Int16 _minor;             // Minor number
+        private readonly Int16 _major; // Major number
+        private readonly Int16 _minor; // Minor number
 
         #endregion Member Variables
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignature.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignature.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Cryptography.Xml;
@@ -421,8 +421,8 @@ namespace System.IO.Packaging
         //  Private Fields
         //
         //------------------------------------------------------
-        private PackageDigitalSignatureManager                     _manager;
-        private XmlDigitalSignatureProcessor                       _processor;
+        private readonly PackageDigitalSignatureManager _manager;
+        private readonly XmlDigitalSignatureProcessor _processor;
         private CertificatePart                                    _certificatePart;
         private ReadOnlyCollection<Uri>                            _signedParts;
         private ReadOnlyCollection<PackageRelationshipSelector>    _signedRelationshipSelectors;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
@@ -95,8 +95,8 @@ namespace System.IO.Packaging
         //  Private Members
         //
         //------------------------------------------------------
-        private PackageDigitalSignature                 _signature;
-        private VerifyResult                            _result;
+        private readonly PackageDigitalSignature _signature;
+        private readonly VerifyResult _result;
     }
     
     /// <summary>
@@ -897,7 +897,7 @@ namespace System.IO.Packaging
                 return (string.Equals(_id, id, StringComparison.Ordinal));
             }
 
-            private string _id;
+            private readonly string _id;
         }
 
         /// <summary>
@@ -1342,18 +1342,19 @@ namespace System.IO.Packaging
         //
         //------------------------------------------------------
         private CertificateEmbeddingOption      _certificateEmbeddingOption;
-        private Package                         _container;
+        private readonly Package _container;
         private IntPtr                          _parentWindow;
-        private static Uri _defaultOriginPartName = PackUriHelper.CreatePartUri(new Uri("/package/services/digital-signature/origin.psdsor", UriKind.Relative));
         private Uri                             _originPartName = _defaultOriginPartName;
         private PackagePart                     _originPart;
         private String                          _hashAlgorithmString = DefaultHashAlgorithm;
         private String                          _signatureTimeFormat = XmlSignatureProperties.DefaultDateTimeFormat;
         private List<PackageDigitalSignature>   _signatures;
-        private Dictionary<String, String>      _transformDictionary;
+        private readonly Dictionary<String, String> _transformDictionary;
         private bool                            _originSearchConducted;             // don't look more than once for Origin part
         private bool                            _originPartExists;                  // was the part found?
         private ReadOnlyCollection<PackageDigitalSignature> _signatureList;         // lazy-init cached return value for Signatures property
+
+        private static readonly Uri _defaultOriginPartName = PackUriHelper.CreatePartUri(new Uri("/package/services/digital-signature/origin.psdsor", UriKind.Relative));
 
         private static readonly ContentType _originPartContentType = new ContentType("application/vnd.openxmlformats-package.digital-signature-origin");
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/RightsManagementInformation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/RightsManagementInformation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.RightsManagement;
@@ -166,6 +166,6 @@ namespace System.IO.Packaging
             return _rmet.GetEmbeddedUseLicenses();
         }
 
-        private RightsManagementEncryptionTransform _rmet;
+        private readonly RightsManagementEncryptionTransform _rmet;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/CryptoProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/CryptoProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.ObjectModel;
@@ -521,10 +521,10 @@ namespace System.Security.RightsManagement
 
         // if this is Invalid, we are disposed
         private List<SafeRightsManagementHandle> _boundLicenseHandleList;
-        private List<RightNameExpirationInfoPair> _boundRightsInfoList;
+        private readonly List<RightNameExpirationInfoPair> _boundRightsInfoList;
                                                             
         private ReadOnlyCollection<ContentGrant> _boundGrantReadOnlyCollection;
-        private ContentUser _owner;
+        private readonly ContentUser _owner;
 
         private bool _disposed;
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/Exceptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/Exceptions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.Serialization;
@@ -153,7 +153,7 @@ namespace System.Security.RightsManagement
             }
         }
             
-        private RightsManagementFailureCode _failureCode;
+        private readonly RightsManagementFailureCode _failureCode;
         private const string _serializationFailureCodeAttributeName = "FailureCode";
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/Grant.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/Grant.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Security.RightsManagement
@@ -101,9 +101,9 @@ namespace System.Security.RightsManagement
             }
         }
         
-        private ContentUser _user;
-        private ContentRight _right;
-        private DateTime _validFrom;
-        private DateTime _validUntil;
+        private readonly ContentUser _user;
+        private readonly ContentRight _right;
+        private readonly DateTime _validFrom;
+        private readonly DateTime _validUntil;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/LocalizedNameDescriptionPair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/LocalizedNameDescriptionPair.cs
@@ -73,7 +73,7 @@ namespace System.Security.RightsManagement
             return Name.GetHashCode()  ^  Description.GetHashCode();
         }
 
-        private string _name;
-        private string _description; 
+        private readonly string _name;
+        private readonly string _description;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/PublishLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/PublishLicense.cs
@@ -162,10 +162,10 @@ namespace System.Security.RightsManagement
             return secureEnvironment.ClientSession.AcquireUseLicense(_serializedPublishLicense, true);
         }        
 
-        private string _serializedPublishLicense;
-        private string _referralInfoName;
-        private Uri _referralInfoUri;
-        private Guid _contentId;
-        private Uri _useLicenseAcquisitionUriFromPublishLicense = null;
+        private readonly string _serializedPublishLicense;
+        private readonly string _referralInfoName;
+        private readonly Uri _referralInfoUri;
+        private readonly Guid _contentId;
+        private readonly Uri _useLicenseAcquisitionUriFromPublishLicense;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/SecureEnvironment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/SecureEnvironment.cs
@@ -353,8 +353,8 @@ namespace System.Security.RightsManagement
             ObjectDisposedException.ThrowIf(_clientSession == null, typeof(SecureEnvironment));
         }
 
-        private ContentUser _user;
-        private string _applicationManifest;
+        private readonly ContentUser _user;
+        private readonly string _applicationManifest;
         private ClientSession _clientSession;       // if null we are disposed
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UnsignedPublishLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UnsignedPublishLicense.cs
@@ -314,10 +314,11 @@ namespace System.Security.RightsManagement
                 _revocationPoint  = value;
             }
         }
-        
+
+        private readonly ICollection<ContentGrant> _grantCollection;
+
         private Guid _contentId;
         private ContentUser _owner;
-        private ICollection<ContentGrant> _grantCollection;
         private string _referralInfoName;
         private Uri _referralInfoUri;
         private IDictionary <int, LocalizedNameDescriptionPair> _localizedNameDescriptionDictionary = null;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UseLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UseLicense.cs
@@ -140,9 +140,9 @@ namespace System.Security.RightsManagement
         }
 
 
-        private string _serializedUseLicense;
-        private Guid _contentId;
-        private ContentUser _owner = null;
-        private IDictionary <string, string> _applicationSpecificDataDictionary = null;
+        private readonly string _serializedUseLicense;
+        private readonly Guid _contentId;
+        private readonly ContentUser _owner;
+        private readonly IDictionary<string, string> _applicationSpecificDataDictionary;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/User.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/User.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using MS.Internal;
@@ -257,8 +257,9 @@ namespace System.Security.RightsManagement
         private const string AnyoneUserName = "Anyone";
         private static ContentUser _anyoneUser;
 
-        private string _name;
-        private AuthenticationType _authenticationType;
+        private readonly string _name;
+        private readonly AuthenticationType _authenticationType;
+
         private int hashValue;
         private bool hashCalcIsDone;    // flag that indicates the value in hasValue is already calculated and usable
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AttachedPropertyBrowsableForTypeAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AttachedPropertyBrowsableForTypeAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows
@@ -159,7 +159,7 @@ namespace System.Windows
         //
         //------------------------------------------------------
 
-        private Type _targetType;
+        private readonly Type _targetType;
         private DependencyObjectType _dTargetType;
         private bool _dTargetTypeChecked;
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AttachedPropertyBrowsableWhenAttributePresentAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AttachedPropertyBrowsableWhenAttributePresentAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -104,7 +104,7 @@ namespace System.Windows
         //
         //------------------------------------------------------
 
-        private Type _attributeType;
+        private readonly Type _attributeType;
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObjectType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObjectType.cs
@@ -212,7 +212,7 @@ namespace System.Windows
         private DependencyObjectType _baseDType;
 
         // Synchronized: Covered by DispatcherLock
-        private static Dictionary<Type, DependencyObjectType> DTypeFromCLRType = new Dictionary<Type, DependencyObjectType>();
+        private static readonly Dictionary<Type, DependencyObjectType> DTypeFromCLRType = new();
 
         // Synchronized: Covered by DispatcherLock
         private static int DTypeCount = 0;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
@@ -1132,11 +1132,11 @@ namespace System.Windows
         /// <summary> Standard unset value </summary>
         public static readonly object UnsetValue = new NamedObject("DependencyProperty.UnsetValue");
 
-        private string _name;
-        private Type _propertyType;
-        private Type _ownerType;
-        private PropertyMetadata _defaultMetadata;
-        private ValidateValueCallback _validateValueCallback;
+        private readonly string _name;
+        private readonly Type _propertyType;
+        private readonly Type _ownerType;
+        private readonly PropertyMetadata _defaultMetadata;
+        private readonly ValidateValueCallback _validateValueCallback;
         private DependencyPropertyKey _readOnlyKey;
 
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyPropertyChangedEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyPropertyChangedEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows
@@ -330,15 +330,15 @@ namespace System.Windows
 
         #region Data
 
-        private DependencyProperty  _property;
-        private PropertyMetadata    _metadata;
+        private readonly DependencyProperty _property;
+        private readonly PropertyMetadata _metadata;
 
         private PrivateFlags        _flags;
 
         private EffectiveValueEntry _oldEntry;
         private EffectiveValueEntry _newEntry;
-        
-        private OperationType       _operationType;
+
+        private readonly OperationType _operationType;
 
         #endregion Data
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencySource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencySource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows
@@ -40,7 +40,7 @@ namespace System.Windows
             get { return _dp; }
         }
 
-        private DependencyObject _d;
-        private DependencyProperty _dp;
+        private readonly DependencyObject _d;
+        private readonly DependencyProperty _dp;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DesignerSerializationOptionsAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DesignerSerializationOptionsAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -44,7 +44,7 @@ namespace System.Windows.Markup
 
         #region Data
 
-        private DesignerSerializationOptions _designerSerializationOptions;
+        private readonly DesignerSerializationOptions _designerSerializationOptions;
 
         #endregion Data
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/EntryIndex.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/EntryIndex.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /***************************************************************************\
@@ -41,7 +41,7 @@ namespace System.Windows
             get { return _store & 0x7FFFFFFF; }
         }
 
-        private uint _store;
+        private readonly uint _store;
     }   
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/TraversalRequest.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/TraversalRequest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows.Input
@@ -45,7 +45,7 @@ namespace System.Windows.Input
         public FocusNavigationDirection FocusNavigationDirection { get { return _focusNavigationDirection; } }
 
         private bool _wrapped;
-        private FocusNavigationDirection _focusNavigationDirection;
+        private readonly FocusNavigationDirection _focusNavigationDirection;
 }
 
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/LocalValueEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/LocalValueEnumerator.cs
@@ -123,8 +123,8 @@ namespace System.Windows
         }
 
         private int                     _index;
-        private LocalValueEntry[]       _snapshot;
-        private int                     _count;
+        private readonly LocalValueEntry[] _snapshot;
+        private readonly int _count;
     }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Markup/ServiceProviders.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Markup/ServiceProviders.cs
@@ -48,6 +48,6 @@ namespace System.Windows.Markup
             }
         }
 
-        private Dictionary<Type,Object> _objDict = new Dictionary<Type,Object>();
+        private readonly Dictionary<Type, object> _objDict = new();
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/NameScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/NameScope.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /***************************************************************************\
@@ -371,7 +371,7 @@ namespace System.Windows
         #region class Enumerator
         private class Enumerator : IEnumerator<KeyValuePair<string, object>>
         {
-            private IDictionaryEnumerator _enumerator;
+            private readonly IDictionaryEnumerator _enumerator;
             
             public Enumerator(HybridDictionary nameMap)
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/PropertyMetadata.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/PropertyMetadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using MS.Internal;
@@ -513,7 +513,7 @@ namespace System.Windows
             return true;
         }
 
-        private static FreezeValueCallback _defaultFreezeValueCallback = DefaultFreezeValueCallback;
+        private static readonly FreezeValueCallback _defaultFreezeValueCallback = DefaultFreezeValueCallback;
 
         /// <summary>
         ///     Creates a new instance of this property metadata.  This method is used
@@ -744,8 +744,8 @@ namespace System.Windows
         // We use this uncommon field to stash values created by our default value factory
         // in the owner's _localStore.
         private static readonly UncommonField<FrugalMapBase> _defaultValueFactoryCache = new UncommonField<FrugalMapBase>();
-        private static FrugalMapIterationCallback _removalCallback = new FrugalMapIterationCallback(DefaultValueCacheRemovalCallback);
-        private static FrugalMapIterationCallback _promotionCallback = new FrugalMapIterationCallback(DefaultValueCachePromotionCallback);
+        private static readonly FrugalMapIterationCallback _removalCallback = new FrugalMapIterationCallback(DefaultValueCacheRemovalCallback);
+        private static readonly FrugalMapIterationCallback _promotionCallback = new FrugalMapIterationCallback(DefaultValueCachePromotionCallback);
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
@@ -2799,14 +2799,14 @@ namespace System.Windows.Threading
         private const int TIMERID_TIMERS = 2;
         private const int DELTA_BACKGROUND = 1;
 
-        private static List<WeakReference> _dispatchers;
+        private static readonly List<WeakReference> _dispatchers;
         private static WeakReference _possibleDispatcher;
         private static readonly object _globalLock;
 
         [ThreadStatic]
         private static Dispatcher _tlsDispatcher;      // use TLS for ownership only
 
-        private Thread _dispatcherThread;
+        private readonly Thread _dispatcherThread;
 
         private int _frameDepth;
         internal bool _exitAllFrames;       // used from DispatcherFrame
@@ -2822,21 +2822,21 @@ namespace System.Windows.Threading
 
         private MessageOnlyHwndWrapper _window;
 
-        private HwndWrapperHook _hook;
+        private readonly HwndWrapperHook _hook;
 
         private int _postedProcessingType;
-        private static WindowMessage _msgProcessQueue;
+        private static readonly WindowMessage _msgProcessQueue;
 
-        private static ExceptionWrapper _exceptionWrapper;
+        private static readonly ExceptionWrapper _exceptionWrapper;
         private static readonly object ExceptionDataKey = new object();
 
         // Preallocated arguments for exception handling.
         // This helps avoid allocations in the handler code, a potential
         // source of secondary exceptions (i.e. in Out-Of-Memory cases).
-        private DispatcherUnhandledExceptionEventArgs _unhandledExceptionEventArgs;
+        private readonly DispatcherUnhandledExceptionEventArgs _unhandledExceptionEventArgs;
 
         private DispatcherUnhandledExceptionFilterEventHandler _unhandledExceptionFilter;
-        private DispatcherUnhandledExceptionFilterEventArgs _exceptionFilterEventArgs;
+        private readonly DispatcherUnhandledExceptionFilterEventArgs _exceptionFilterEventArgs;
 
         private object _reserved0;
         private object _reserved1;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows.Threading
@@ -26,7 +26,7 @@ namespace System.Windows.Threading
             _dispatcher = dispatcher;
         }
         
-        private Dispatcher _dispatcher;
+        private readonly Dispatcher _dispatcher;
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherFrame.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows.Threading
@@ -84,7 +84,7 @@ namespace System.Windows.Threading
             }
         }
 
-        private bool _exitWhenRequested;
+        private readonly bool _exitWhenRequested;
         private bool _continue;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherHookEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherHookEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Windows.Threading
@@ -41,7 +41,7 @@ namespace System.Windows.Threading
             }
         }
 
-        private DispatcherOperation _operation;
+        private readonly DispatcherOperation _operation;
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherOperation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherOperation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
@@ -602,8 +602,8 @@ namespace System.Windows.Threading
                 _operation.Completed -= new EventHandler(OnCompletedOrAborted);
             }
 
-            private DispatcherOperation _operation;
-            private Timer _waitTimer;
+            private readonly DispatcherOperation _operation;
+            private readonly Timer _waitTimer;
         }
         
         private class DispatcherOperationEvent
@@ -670,9 +670,9 @@ namespace System.Windows.Threading
                 get { return _operation.DispatcherLock; }
             }
             
-            private DispatcherOperation _operation;
-            private TimeSpan _timeout;            
-            private ManualResetEvent _event;
+            private readonly DispatcherOperation _operation;
+            private readonly TimeSpan _timeout;            
+            private readonly ManualResetEvent _event;
             private bool _eventClosed;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherSynchronizationContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherSynchronizationContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
@@ -124,7 +124,7 @@ namespace System.Windows.Threading
 
 
         internal Dispatcher _dispatcher;
-        private DispatcherPriority _priority;
+        private readonly DispatcherPriority _priority;
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -488,9 +488,9 @@ namespace System.Windows
         //  Private Fields
         //
 
-        private WeakEventTable  _table;
+        private readonly WeakEventTable _table;
         private static readonly object StaticSource = new NamedObject("StaticSource");
-        private static MethodInfo s_DeliverEventMethodInfo;
+        private static readonly MethodInfo s_DeliverEventMethodInfo;
 
         #endregion Private Fields
 
@@ -522,8 +522,8 @@ namespace System.Windows
             public Delegate Handler { get { return (_handler != null) ? (Delegate)_handler.Target : null; } }
             public bool HasHandler { get { return _handler != null; } }
 
-            private WeakReference _target;
-            private WeakReference _handler;
+            private readonly WeakReference _target;
+            private readonly WeakReference _handler;
         }
 
         /// <summary>
@@ -871,12 +871,12 @@ namespace System.Windows
                 Interlocked.Decrement(ref _users);
             }
 
-            private FrugalObjectList<Listener> _list;  // list of listeners
+            private readonly FrugalObjectList<Listener> _list;  // list of listeners
             private int _users;     // number of active users
-            private System.Runtime.CompilerServices.ConditionalWeakTable<object, object>
+            private readonly System.Runtime.CompilerServices.ConditionalWeakTable<object, object>
                 _cwt = new System.Runtime.CompilerServices.ConditionalWeakTable<object, object>();
 
-            private static ListenerList s_empty = new ListenerList();
+            private static readonly ListenerList s_empty = new ListenerList();
         }
 
         protected class ListenerList<TEventArgs> : ListenerList

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManagerT.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManagerT.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -118,9 +118,9 @@ namespace System.Windows
 
         #region Private Data
 
-        private Delegate _handler;
-        private string _eventName;
-        private EventInfo _eventInfo;
+        private readonly Delegate _handler;
+        private readonly string _eventName;
+        private readonly EventInfo _eventInfo;
 
         #endregion Private Data
     }


### PR DESCRIPTION
Fixes #10730 

## Description

Fixes occurences of fields that are only written during construction to be `readonly` in `WindowsBase`.

In case they were being initialized to non-default value but are **always** overwritten in the constructor, I have removed such assigment. This is a case which analyzers won't flag and imho there's no better time to do it than when resolving `IDE0044` and changing fields to `readonly`.

## Customer Impact

Increased performance due to the fields being treated as JIT-time constant in case of `static readonly` and better code-gen in `readonly` cases. These changes unlock #10724 since full sweep can only be done after the fields are marked appropriately.

## Regression

No.

## Testing

Local build.

## Risk

Full test pass will be required, even in cases where no manual changes are done.