### PR TITLE
Fix DataObject SetData methods inaccordance to previous implementation

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -225,19 +225,30 @@ public sealed unsafe partial class DataObject :
     /// <summary>
     ///  Stores the specified data and its associated format in this instance.
     /// </summary>
-    public void SetData(string format, object? data) => _innerData.SetData(format, data);
+    public void SetData(string format, object? data)
+    {
+        ArgumentNullException.ThrowIfNull(data, nameof(data));
+        _innerData.SetData(format, data);
+    }
 
     /// <summary>
     ///  Stores the specified data and its associated class type in this instance.
     /// </summary>
-    public void SetData(Type format, object? data) => _innerData.SetData(format, data);
+    public void SetData(Type format, object? data)
+    {
+        ArgumentNullException.ThrowIfNull(data, nameof(data));
+        _innerData.SetData(format, data);
+    }
 
     /// <summary>
     ///  Stores the specified data and its associated format in this instance, using the automatic conversion parameter
     ///  to specify whether the data can be converted to another format.
     /// </summary>
-    public void SetData(string format, object? data, bool autoConvert) =>
+    public void SetData(string format, object? data, bool autoConvert)
+    {
+        ArgumentNullException.ThrowIfNull(data, nameof(data));
         _innerData.SetData(format, autoConvert, data);
+    }
 
     // WinForms and WPF have these defined in a different order.
     void IDataObjectInternal.SetData(string format, bool autoConvert, object? data) => SetData(format, data, autoConvert);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -227,7 +227,8 @@ public sealed unsafe partial class DataObject :
     /// </summary>
     public void SetData(string format, object? data)
     {
-        ArgumentNullException.ThrowIfNull(data, nameof(data));
+        ArgumentNullException.ThrowIfNull(data);
+
         _innerData.SetData(format, data);
     }
 
@@ -236,7 +237,8 @@ public sealed unsafe partial class DataObject :
     /// </summary>
     public void SetData(Type format, object? data)
     {
-        ArgumentNullException.ThrowIfNull(data, nameof(data));
+        ArgumentNullException.ThrowIfNull(data);
+
         _innerData.SetData(format, data);
     }
 
@@ -246,7 +248,8 @@ public sealed unsafe partial class DataObject :
     /// </summary>
     public void SetData(string format, object? data, bool autoConvert)
     {
-        ArgumentNullException.ThrowIfNull(data, nameof(data));
+        ArgumentNullException.ThrowIfNull(data);
+        
         _innerData.SetData(format, autoConvert, data);
     }
 


### PR DESCRIPTION
## Description
These changes are in accordance to the original API contract of certain `SetData` methods in `DataObject` class. The original behaviour was altered a bit in form of exceptions not being thrown as part of the shared clipboard code for winforms and wpf as in the PR #10544. These changes brings back the expected behaviour that respects WPFs original implementation.
 <!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Avoids breaking changes in subsequent preview release of .NET 10.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass, unit testing and verified the same with sample applications.
<!-- What kind of testing has been done with the fix. -->

## Risk
Low
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10732)