### PR TITLE
Fixed MenuItem Header alignment wrt to Icons

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/MenuItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/MenuItem.xaml
@@ -58,7 +58,8 @@
 
                 <Grid Margin="10">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" 
+                                          SharedSizeGroup="MenuItemIconColumnGroup"/>
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     <ContentPresenter
@@ -67,7 +68,7 @@
                         Margin="0,0,6,0"
                         VerticalAlignment="Center"
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                        Content="{TemplateBinding Icon}" />
+                        ContentSource="Icon"/>
                     <ContentPresenter
                         x:Name="HeaderPresenter"
                         Grid.Column="1"
@@ -105,7 +106,13 @@
                                 <TranslateTransform />
                             </Border.RenderTransform>
                             <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuItemScrollViewerStyle}">
-                                <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+                                <Grid>
+                                    <ItemsPresenter x:Name="ItemsPresenter"
+                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                    KeyboardNavigation.TabNavigation="Cycle"
+                                    Grid.IsSharedSizeScope="True"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                </Grid>
                             </ScrollViewer>
                             <Border.Effect>
                                 <DropShadowEffect
@@ -169,7 +176,8 @@
             CornerRadius="6">
             <Grid Margin="10">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" 
+                                      SharedSizeGroup="MenuItemIconColumnGroup"/>
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
                 <ContentPresenter
@@ -178,7 +186,7 @@
                     Margin="0,0,6,0"
                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                     VerticalAlignment="Center"
-                    Content="{TemplateBinding Icon}" />
+                    ContentSource="Icon" />
                 <ContentPresenter
                     x:Name="HeaderPresenter"
                     Grid.Column="1"
@@ -222,15 +230,15 @@
             CornerRadius="4">
             <Grid Margin="8,6,8,6">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup"/>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
                 </Grid.ColumnDefinitions>
 
                 <Border
                     x:Name="CheckBoxIconBorder"
-                    Grid.Column="0"
+                    Grid.Column="1"
                     Width="20"
                     Height="20"
                     Margin="0,0,6,0"
@@ -252,11 +260,11 @@
 
                 <ContentPresenter
                     x:Name="Icon"
-                    Grid.Column="1"
+                    Grid.Column="0"
                     Margin="0,0,6,0"
                     VerticalAlignment="Center"
                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                    Content="{TemplateBinding Icon}" />
+                    ContentSource="Icon" />
 
                 <ContentPresenter
                     Grid.Column="2"
@@ -321,7 +329,7 @@
                 CornerRadius="4">
                 <Grid x:Name="MenuItemContent" Margin="8,6,8,6">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup"/>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
@@ -331,7 +339,7 @@
                         Margin="0,0,6,0"
                         VerticalAlignment="Center"
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                        Content="{TemplateBinding Icon}" />
+                        ContentSource="Icon" />
 
                     <ContentPresenter
                         x:Name="HeaderHost"
@@ -377,7 +385,11 @@
                             <TranslateTransform />
                         </Border.RenderTransform>
                         <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuItemScrollViewerStyle}">
-                            <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+                            <ItemsPresenter x:Name="ItemsPresenter"
+                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                    KeyboardNavigation.TabNavigation="Cycle"
+                                    Grid.IsSharedSizeScope="True"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </ScrollViewer>
                         <Border.Effect>
                             <DropShadowEffect

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/MenuItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/MenuItem.xaml
@@ -229,14 +229,14 @@
             <Grid Margin="8,6,8,6">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup"/>
-                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemCheckBoxIconColumnGroup"/>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
                 </Grid.ColumnDefinitions>
 
                 <Border
                     x:Name="CheckBoxIconBorder"
-                    Grid.Column="1"
+                    Grid.Column="0"
                     Width="20"
                     Height="20"
                     Margin="0,0,6,0"
@@ -258,7 +258,7 @@
 
                 <ContentPresenter
                     x:Name="Icon"
-                    Grid.Column="0"
+                    Grid.Column="1"
                     Margin="0,0,6,0"
                     VerticalAlignment="Center"
                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/MenuItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/MenuItem.xaml
@@ -228,8 +228,8 @@
             CornerRadius="4">
             <Grid Margin="8,6,8,6">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup"/>
                     <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemCheckBoxIconColumnGroup"/>
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup"/>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
                 </Grid.ColumnDefinitions>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/MenuItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/MenuItem.xaml
@@ -58,8 +58,7 @@
 
                 <Grid Margin="10">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" 
-                                          SharedSizeGroup="MenuItemIconColumnGroup"/>
+                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     <ContentPresenter
@@ -68,7 +67,7 @@
                         Margin="0,0,6,0"
                         VerticalAlignment="Center"
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                        ContentSource="Icon"/>
+                        Content="{TemplateBinding Icon}"/>
                     <ContentPresenter
                         x:Name="HeaderPresenter"
                         Grid.Column="1"
@@ -176,8 +175,7 @@
             CornerRadius="6">
             <Grid Margin="10">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" 
-                                      SharedSizeGroup="MenuItemIconColumnGroup"/>
+                    <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
                 <ContentPresenter
@@ -186,7 +184,7 @@
                     Margin="0,0,6,0"
                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                     VerticalAlignment="Center"
-                    ContentSource="Icon" />
+                    Content="{TemplateBinding Icon}" />
                 <ContentPresenter
                     x:Name="HeaderPresenter"
                     Grid.Column="1"
@@ -233,7 +231,7 @@
                     <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup"/>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
                 </Grid.ColumnDefinitions>
 
                 <Border
@@ -264,7 +262,7 @@
                     Margin="0,0,6,0"
                     VerticalAlignment="Center"
                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                    ContentSource="Icon" />
+                    Content="{TemplateBinding Icon}" />
 
                 <ContentPresenter
                     Grid.Column="2"
@@ -339,7 +337,7 @@
                         Margin="0,0,6,0"
                         VerticalAlignment="Center"
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                        ContentSource="Icon" />
+                        Content="{TemplateBinding Icon}" />
 
                     <ContentPresenter
                         x:Name="HeaderHost"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -3414,8 +3414,8 @@
     <Border x:Name="Border" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
       <Grid Margin="8,6,8,6">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemCheckBoxIconColumnGroup" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="*" />
           <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
         </Grid.ColumnDefinitions>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -3319,10 +3319,10 @@
         </Grid.RowDefinitions>
         <Grid Margin="10">
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
           <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         </Grid>
         <Popup x:Name="PART_Popup" Grid.Row="1" Grid.Column="0" AllowsTransparency="True" Focusable="False" HorizontalOffset="-12" IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Bottom" PlacementTarget="{Binding ElementName=Border}" PopupAnimation="None" VerticalOffset="1">
@@ -3332,7 +3332,9 @@
                 <TranslateTransform />
               </Border.RenderTransform>
               <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuItemScrollViewerStyle}">
-                <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+                <Grid>
+                  <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle" KeyboardNavigation.TabNavigation="Cycle" Grid.IsSharedSizeScope="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                </Grid>
               </ScrollViewer>
               <Border.Effect>
                 <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
@@ -3380,10 +3382,10 @@
     <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
       <Grid Margin="10">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" ContentSource="Icon" />
         <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Grid>
     </Border>
@@ -3412,15 +3414,15 @@
     <Border x:Name="Border" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
       <Grid Margin="8,6,8,6">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
-          <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
         </Grid.ColumnDefinitions>
-        <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
+        <Border x:Name="CheckBoxIconBorder" Grid.Column="1" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
           <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
-        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
         <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
       </Grid>
@@ -3460,11 +3462,11 @@
       <Border x:Name="Border" Grid.Row="1" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
         <Grid x:Name="MenuItemContent" Margin="8,6,8,6">
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
           <ContentPresenter x:Name="HeaderHost" Grid.Column="1" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" ContentSource="Header" RecognizesAccessKey="True" />
           <Grid Grid.Column="2">
             <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
@@ -3478,7 +3480,7 @@
               <TranslateTransform />
             </Border.RenderTransform>
             <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuItemScrollViewerStyle}">
-              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+              <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle" KeyboardNavigation.TabNavigation="Cycle" Grid.IsSharedSizeScope="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
             </ScrollViewer>
             <Border.Effect>
               <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.5" ShadowDepth="6" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -3319,10 +3319,10 @@
         </Grid.RowDefinitions>
         <Grid Margin="10">
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
+            <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
           <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         </Grid>
         <Popup x:Name="PART_Popup" Grid.Row="1" Grid.Column="0" AllowsTransparency="True" Focusable="False" HorizontalOffset="-12" IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Bottom" PlacementTarget="{Binding ElementName=Border}" PopupAnimation="None" VerticalOffset="1">
@@ -3382,10 +3382,10 @@
     <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
       <Grid Margin="10">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
+          <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" ContentSource="Icon" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
         <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Grid>
     </Border>
@@ -3417,12 +3417,12 @@
           <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
-          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
         </Grid.ColumnDefinitions>
         <Border x:Name="CheckBoxIconBorder" Grid.Column="1" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
           <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
         <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
       </Grid>
@@ -3466,7 +3466,7 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
           <ContentPresenter x:Name="HeaderHost" Grid.Column="1" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" ContentSource="Header" RecognizesAccessKey="True" />
           <Grid Grid.Column="2">
             <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -3415,14 +3415,14 @@
       <Grid Margin="8,6,8,6">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
-          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemCheckBoxIconColumnGroup" />
           <ColumnDefinition Width="*" />
           <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
         </Grid.ColumnDefinitions>
-        <Border x:Name="CheckBoxIconBorder" Grid.Column="1" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
+        <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
           <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
         <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
       </Grid>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -3259,10 +3259,10 @@
         </Grid.RowDefinitions>
         <Grid Margin="10">
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
+            <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
           <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         </Grid>
         <Popup x:Name="PART_Popup" Grid.Row="1" Grid.Column="0" AllowsTransparency="True" Focusable="False" HorizontalOffset="-12" IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Bottom" PlacementTarget="{Binding ElementName=Border}" PopupAnimation="None" VerticalOffset="1">
@@ -3322,10 +3322,10 @@
     <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
       <Grid Margin="10">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
+          <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" ContentSource="Icon" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
         <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Grid>
     </Border>
@@ -3357,12 +3357,12 @@
           <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
-          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
         </Grid.ColumnDefinitions>
         <Border x:Name="CheckBoxIconBorder" Grid.Column="1" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
           <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
         <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
       </Grid>
@@ -3406,7 +3406,7 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
           <ContentPresenter x:Name="HeaderHost" Grid.Column="1" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" ContentSource="Header" RecognizesAccessKey="True" />
           <Grid Grid.Column="2">
             <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -3259,10 +3259,10 @@
         </Grid.RowDefinitions>
         <Grid Margin="10">
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
           <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         </Grid>
         <Popup x:Name="PART_Popup" Grid.Row="1" Grid.Column="0" AllowsTransparency="True" Focusable="False" HorizontalOffset="-12" IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Bottom" PlacementTarget="{Binding ElementName=Border}" PopupAnimation="None" VerticalOffset="1">
@@ -3272,7 +3272,9 @@
                 <TranslateTransform />
               </Border.RenderTransform>
               <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuItemScrollViewerStyle}">
-                <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+                <Grid>
+                  <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle" KeyboardNavigation.TabNavigation="Cycle" Grid.IsSharedSizeScope="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                </Grid>
               </ScrollViewer>
               <Border.Effect>
                 <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
@@ -3320,10 +3322,10 @@
     <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
       <Grid Margin="10">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" ContentSource="Icon" />
         <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Grid>
     </Border>
@@ -3352,15 +3354,15 @@
     <Border x:Name="Border" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
       <Grid Margin="8,6,8,6">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
-          <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
         </Grid.ColumnDefinitions>
-        <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
+        <Border x:Name="CheckBoxIconBorder" Grid.Column="1" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
           <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
-        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
         <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
       </Grid>
@@ -3400,11 +3402,11 @@
       <Border x:Name="Border" Grid.Row="1" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
         <Grid x:Name="MenuItemContent" Margin="8,6,8,6">
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
           <ContentPresenter x:Name="HeaderHost" Grid.Column="1" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" ContentSource="Header" RecognizesAccessKey="True" />
           <Grid Grid.Column="2">
             <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
@@ -3418,7 +3420,7 @@
               <TranslateTransform />
             </Border.RenderTransform>
             <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuItemScrollViewerStyle}">
-              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+              <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle" KeyboardNavigation.TabNavigation="Cycle" Grid.IsSharedSizeScope="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
             </ScrollViewer>
             <Border.Effect>
               <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.5" ShadowDepth="6" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -3354,8 +3354,8 @@
     <Border x:Name="Border" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
       <Grid Margin="8,6,8,6">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemCheckBoxIconColumnGroup" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="*" />
           <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
         </Grid.ColumnDefinitions>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -3355,14 +3355,14 @@
       <Grid Margin="8,6,8,6">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
-          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemCheckBoxIconColumnGroup" />
           <ColumnDefinition Width="*" />
           <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
         </Grid.ColumnDefinitions>
-        <Border x:Name="CheckBoxIconBorder" Grid.Column="1" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
+        <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
           <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
         <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
       </Grid>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -3328,10 +3328,10 @@
         </Grid.RowDefinitions>
         <Grid Margin="10">
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
           <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         </Grid>
         <Popup x:Name="PART_Popup" Grid.Row="1" Grid.Column="0" AllowsTransparency="True" Focusable="False" HorizontalOffset="-12" IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Bottom" PlacementTarget="{Binding ElementName=Border}" PopupAnimation="None" VerticalOffset="1">
@@ -3341,7 +3341,9 @@
                 <TranslateTransform />
               </Border.RenderTransform>
               <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuItemScrollViewerStyle}">
-                <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+                <Grid>
+                  <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle" KeyboardNavigation.TabNavigation="Cycle" Grid.IsSharedSizeScope="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                </Grid>
               </ScrollViewer>
               <Border.Effect>
                 <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
@@ -3389,10 +3391,10 @@
     <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
       <Grid Margin="10">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" ContentSource="Icon" />
         <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Grid>
     </Border>
@@ -3421,15 +3423,15 @@
     <Border x:Name="Border" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
       <Grid Margin="8,6,8,6">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
-          <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
         </Grid.ColumnDefinitions>
-        <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
+        <Border x:Name="CheckBoxIconBorder" Grid.Column="1" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
           <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
-        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
         <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
       </Grid>
@@ -3469,11 +3471,11 @@
       <Border x:Name="Border" Grid.Row="1" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
         <Grid x:Name="MenuItemContent" Margin="8,6,8,6">
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
           <ContentPresenter x:Name="HeaderHost" Grid.Column="1" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" ContentSource="Header" RecognizesAccessKey="True" />
           <Grid Grid.Column="2">
             <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
@@ -3487,7 +3489,7 @@
               <TranslateTransform />
             </Border.RenderTransform>
             <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuItemScrollViewerStyle}">
-              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+              <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle" KeyboardNavigation.TabNavigation="Cycle" Grid.IsSharedSizeScope="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
             </ScrollViewer>
             <Border.Effect>
               <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.5" ShadowDepth="6" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -3424,14 +3424,14 @@
       <Grid Margin="8,6,8,6">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
-          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemCheckBoxIconColumnGroup" />
           <ColumnDefinition Width="*" />
           <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
         </Grid.ColumnDefinitions>
-        <Border x:Name="CheckBoxIconBorder" Grid.Column="1" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
+        <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
           <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
         <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
       </Grid>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -3423,8 +3423,8 @@
     <Border x:Name="Border" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
       <Grid Margin="8,6,8,6">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemCheckBoxIconColumnGroup" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="*" />
           <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
         </Grid.ColumnDefinitions>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -3328,10 +3328,10 @@
         </Grid.RowDefinitions>
         <Grid Margin="10">
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
+            <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
           <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         </Grid>
         <Popup x:Name="PART_Popup" Grid.Row="1" Grid.Column="0" AllowsTransparency="True" Focusable="False" HorizontalOffset="-12" IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Bottom" PlacementTarget="{Binding ElementName=Border}" PopupAnimation="None" VerticalOffset="1">
@@ -3391,10 +3391,10 @@
     <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
       <Grid Margin="10">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
+          <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" ContentSource="Icon" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
         <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Grid>
     </Border>
@@ -3426,12 +3426,12 @@
           <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
-          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
         </Grid.ColumnDefinitions>
         <Border x:Name="CheckBoxIconBorder" Grid.Column="1" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
           <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
         <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
       </Grid>
@@ -3475,7 +3475,7 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" ContentSource="Icon" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
           <ContentPresenter x:Name="HeaderHost" Grid.Column="1" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" ContentSource="Header" RecognizesAccessKey="True" />
           <Grid Grid.Column="2">
             <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />


### PR DESCRIPTION
Fixes #9980

## Description
In the current MenuItem Fluent styles, the Icon column didn't share width among the different MenuItems. Due to this, the Header content presenter gets misaligned.

## Customer Impact
Improves usability and speeds up visual scanning of the UI

## Regression
Technically no, but as compared to Aero2 styles this is a regression in Fluent styles.

## Testing
Local app testing.

## Risk
Minimal
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10735)