### PR TITLE
Fixes TreeViewItem chevron arrow orientation when FlowDirection is RightToLeft

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TreeViewItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TreeViewItem.xaml
@@ -14,6 +14,7 @@
     <system:Double x:Key="TreeViewItemChevronSize">10</system:Double>
     <system:Double x:Key="TreeViewItemFontSize">14</system:Double>
     <system:String x:Key="TreeViewChevronRightGlyph">&#xE76C;</system:String>
+    <system:String x:Key="TreeViewChevronLeftGlyph">&#xE76B;</system:String>
 
     <Style x:Key="ExpandCollapseToggleButtonStyle" TargetType="{x:Type ToggleButton}">
         <!--  Universal WPF UI focus  -->
@@ -43,6 +44,9 @@
                             Text="{StaticResource TreeViewChevronRightGlyph}" />
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="FlowDirection" Value="RightToLeft">
+                            <Setter TargetName="ChevronIcon" Property="Text" Value="{StaticResource TreeViewChevronLeftGlyph}" />
+                        </Trigger>
                         <Trigger Property="IsChecked" Value="True">
                             <Trigger.EnterActions>
                                 <BeginStoryboard>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -5230,6 +5230,7 @@
   <system:Double x:Key="TreeViewItemChevronSize">10</system:Double>
   <system:Double x:Key="TreeViewItemFontSize">14</system:Double>
   <system:String x:Key="TreeViewChevronRightGlyph"></system:String>
+  <system:String x:Key="TreeViewChevronLeftGlyph"></system:String>
   <Style x:Key="ExpandCollapseToggleButtonStyle" TargetType="{x:Type ToggleButton}">
     <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
@@ -5247,6 +5248,9 @@
             <TextBlock x:Name="ChevronIcon" VerticalAlignment="Center" FontSize="{StaticResource TreeViewItemChevronSize}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource TreeViewChevronRightGlyph}" />
           </Grid>
           <ControlTemplate.Triggers>
+            <Trigger Property="FlowDirection" Value="RightToLeft">
+              <Setter TargetName="ChevronIcon" Property="Text" Value="{StaticResource TreeViewChevronLeftGlyph}" />
+            </Trigger>
             <Trigger Property="IsChecked" Value="True">
               <Trigger.EnterActions>
                 <BeginStoryboard>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -5170,6 +5170,7 @@
   <system:Double x:Key="TreeViewItemChevronSize">10</system:Double>
   <system:Double x:Key="TreeViewItemFontSize">14</system:Double>
   <system:String x:Key="TreeViewChevronRightGlyph"></system:String>
+  <system:String x:Key="TreeViewChevronLeftGlyph"></system:String>
   <Style x:Key="ExpandCollapseToggleButtonStyle" TargetType="{x:Type ToggleButton}">
     <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
@@ -5187,6 +5188,9 @@
             <TextBlock x:Name="ChevronIcon" VerticalAlignment="Center" FontSize="{StaticResource TreeViewItemChevronSize}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource TreeViewChevronRightGlyph}" />
           </Grid>
           <ControlTemplate.Triggers>
+            <Trigger Property="FlowDirection" Value="RightToLeft">
+              <Setter TargetName="ChevronIcon" Property="Text" Value="{StaticResource TreeViewChevronLeftGlyph}" />
+            </Trigger>
             <Trigger Property="IsChecked" Value="True">
               <Trigger.EnterActions>
                 <BeginStoryboard>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -5239,6 +5239,7 @@
   <system:Double x:Key="TreeViewItemChevronSize">10</system:Double>
   <system:Double x:Key="TreeViewItemFontSize">14</system:Double>
   <system:String x:Key="TreeViewChevronRightGlyph"></system:String>
+  <system:String x:Key="TreeViewChevronLeftGlyph"></system:String>
   <Style x:Key="ExpandCollapseToggleButtonStyle" TargetType="{x:Type ToggleButton}">
     <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
@@ -5256,6 +5257,9 @@
             <TextBlock x:Name="ChevronIcon" VerticalAlignment="Center" FontSize="{StaticResource TreeViewItemChevronSize}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource TreeViewChevronRightGlyph}" />
           </Grid>
           <ControlTemplate.Triggers>
+            <Trigger Property="FlowDirection" Value="RightToLeft">
+              <Setter TargetName="ChevronIcon" Property="Text" Value="{StaticResource TreeViewChevronLeftGlyph}" />
+            </Trigger>
             <Trigger Property="IsChecked" Value="True">
               <Trigger.EnterActions>
                 <BeginStoryboard>


### PR DESCRIPTION
Fixes #10209 

## Description
In Fluent styles, we use icon fonts to render the arrow / chevron in TreeViewItem instead of Path ( as in Aero2 ). When FlowDirection is set RightToLeft, the arrow defined in Path was reversed, but in case of TextBlock, this does not happen with characters. So, in order to fix this I use a trigger which uses the left chevron for the icon. 

## Customer Impact
Developers will correct behavior for TreeViewItem when using Fluent theme and RightToLeft FlowDirection.

## Regression
No

## Testing
Local app testing.

## Risk
Minimal

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10744)