### PR TITLE
Swap `Dictionary<K, V>` with `HashSet<XamlMember>`, avoid double lookup

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
@@ -129,14 +129,12 @@ namespace System.Xaml
             {
                 if (objectNode.Members is null)
                 {
-                    objectNode.Members = new XamlPropertySet();
+                    objectNode.Members = new HashSet<XamlMember>() { property };
                 }
-                else if (objectNode.Members.Contains(property))
+                else if (!objectNode.Members.Add(property))
                 {
                     throw new InvalidOperationException(SR.Format(SR.XamlMarkupExtensionWriterDuplicateMember, property.Name));
                 }
-
-                objectNode.Members.Add(property);
             }
         }
 
@@ -188,7 +186,7 @@ namespace System.Xaml
                 set;
             }
 
-            public XamlPropertySet Members
+            public HashSet<XamlMember> Members
             {
                 get;
                 set;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
@@ -495,27 +495,23 @@ namespace System.Xaml
             {
                 // Find the top most object frame.
                 Frame objectFrame = namespaceScopes.Peek();
-                if (objectFrame.AllocatingNodeType != XamlNodeType.StartObject &&
-                    objectFrame.AllocatingNodeType != XamlNodeType.GetObject)
+                if (objectFrame.AllocatingNodeType is not XamlNodeType.StartObject and not XamlNodeType.GetObject)
                 {
                     Frame temp = namespaceScopes.Pop();
                     objectFrame = namespaceScopes.Peek();
                     namespaceScopes.Push(temp);
                 }
 
-                Debug.Assert(objectFrame.AllocatingNodeType == XamlNodeType.StartObject ||
-                             objectFrame.AllocatingNodeType == XamlNodeType.GetObject);
+                Debug.Assert(objectFrame.AllocatingNodeType is XamlNodeType.StartObject or XamlNodeType.GetObject);
 
                 if (objectFrame.Members is null)
                 {
-                    objectFrame.Members = new XamlPropertySet();
+                    objectFrame.Members = new HashSet<XamlMember>() { property };
                 }
-                else if (objectFrame.Members.Contains(property))
+                else if (!objectFrame.Members.Add(property))
                 {
                     throw new XamlXmlWriterException(SR.Format(SR.XamlXmlWriterDuplicateMember, property.Name));
                 }
-
-                objectFrame.Members.Add(property);
             }
         }
 
@@ -690,7 +686,7 @@ namespace System.Xaml
                 set;
             }
 
-            public XamlPropertySet Members
+            public HashSet<XamlMember> Members
             {
                 get;
                 set;
@@ -2179,23 +2175,6 @@ namespace System.Xaml
 
                 CurrentDepth = 0;
             }
-        }
-    }
-
-    // need to implement our own Set class to alleviate ties to System.Core.dll
-    // HashSet<T> lives in System.Core.dll
-    internal class XamlPropertySet
-    {
-        private Dictionary<XamlMember, bool> dictionary = new Dictionary<XamlMember, bool>();
-
-        public bool Contains(XamlMember member)
-        {
-            return dictionary.ContainsKey(member);
-        }
-
-        public void Add(XamlMember member)
-        {
-            dictionary.Add(member, true);
         }
     }
 }


### PR DESCRIPTION
## Description

Replaces `XamlPropertySet` which is just a wrapped `Dictionary<XamlMember, bool>` with `HashSet<XamlMember>` for improved performance and decreased allocations. The conditions under which this was written do no longer apply.

Also avoids double lookup on each addition.

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build.

## Risk

Low.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10750)