### PR TITLE
Add Resource Dictionary Tests

### DIFF
--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/GlobalUsings.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/GlobalUsings.cs
@@ -5,3 +5,7 @@ global using Xunit;
 
 global using System.Collections.Generic;
 global using System.Globalization;
+
+#pragma warning disable IDE0005 // Using directive is unnecessary.
+global using FluentAssertions;
+#pragma warning restore IDE0005 // Using directive is unnecessary.

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/PresentationFramework.Tests.csproj
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/PresentationFramework.Tests.csproj
@@ -10,6 +10,8 @@
     <NoWarn>$(NoWarn)</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework Condition="!$(TargetFramework.Contains('windows'))">$(TargetFramework)-windows</TargetFramework>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+    <GenerateProgramFile>true</GenerateProgramFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +23,7 @@
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
     <ProjectReference Include="$(WpfSourceDir)System.Xaml\System.Xaml.csproj" />
     <ProjectReference Include="$(WpfSourceDir)Extensions\PresentationFramework-SystemDrawing\PresentationFramework-SystemDrawing.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)UIAutomation\UIAutomationTypes\UIAutomationTypes.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,6 +39,15 @@
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" />
     <PackageReference Include="$(SystemDrawingCommonPackage)" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="System.Private.Windows.Core.TestUtilities" Version="$(SystemPrivateWindowsCoreTestUtilitiesVersion)" />
+    <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="System\Windows\Resources\SampleResourceDictionary.xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Include="System\Windows\Resources\SampleResourceDictionary.xaml" Generator="MSBuild:Compile" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/System/Windows/ResourceDictionaryTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/System/Windows/ResourceDictionaryTests.cs
@@ -1,0 +1,162 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+namespace System.Windows;
+
+public class ResourceDictionaryTests
+{
+    private readonly ResourceDictionary _dictionary;
+    private string SampleDictionaryPath => "/PresentationFramework.Tests;component/System/Windows/Resources/SampleResourceDictionary.xaml";
+
+    public ResourceDictionaryTests()
+    {
+        _dictionary = (ResourceDictionary)Application.LoadComponent(new Uri(SampleDictionaryPath, UriKind.Relative));
+    }
+
+    [Fact]
+    public void Dictionary_ShouldContainStaticResource()
+    {
+        _dictionary.Contains("StaticBrush").Should().BeTrue();
+        _dictionary["StaticBrush"].Should().BeOfType<SolidColorBrush>();
+    }
+
+    [Fact]
+    public void Dictionary_ShouldContainDynamicResource()
+    {
+        _dictionary.Contains("DynamicBrush").Should().BeTrue();
+        _dictionary["DynamicBrush"].Should().BeAssignableTo<Brush>();
+    }
+
+    [Fact]
+    public void Dictionary_ShouldContainGradientBrush()
+    {
+        _dictionary.Contains("GradientBackground").Should().BeTrue();
+        _dictionary["GradientBackground"].Should().BeOfType<LinearGradientBrush>();
+    }
+
+    [Fact]
+    public void Dictionary_ShouldContainStyleForButton()
+    {
+        _dictionary.Contains("PrimaryButtonStyle").Should().BeTrue();
+
+        var style = _dictionary["PrimaryButtonStyle"] as Style;
+
+        style.Should().NotBeNull();
+
+        style!.TargetType.Should().Be(typeof(Button));
+        style.Setters.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Dictionary_StyleShouldContainTrigger()
+    {
+        var style = _dictionary["PrimaryButtonStyle"] as Style;
+
+        style.Should().NotBeNull();
+
+#pragma warning disable IDE0002 // Name should be simplified
+        style!.Triggers.Should().NotBeNull();
+        style.Triggers.OfType<Trigger>().Should().ContainSingle(t =>
+            t.Property == Button.IsMouseOverProperty &&
+            t.Value.Equals(true));
+#pragma warning restore IDE0002 // Name should be simplified
+    }
+
+    [Fact]
+    public void Dictionary_ShouldContainDataTemplate()
+    {
+        _dictionary.Contains("ItemTemplate").Should().BeTrue();
+        _dictionary["ItemTemplate"].Should().BeOfType<DataTemplate>();
+    }
+
+    [Fact]
+    public void Dictionary_ShouldContainControlTemplate()
+    {
+        _dictionary.Contains("CustomControlTemplate").Should().BeTrue();
+        _dictionary["CustomControlTemplate"].Should().BeOfType<ControlTemplate>();
+    }
+
+    [Fact]
+    public void Dictionary_ShouldContainStyleWithBasedOn()
+    {
+        var baseStyle = _dictionary["BaseTextBlockStyle"] as Style;
+        var derivedStyle = _dictionary["DerivedTextBlockStyle"] as Style;
+
+        baseStyle.Should().NotBeNull();
+        derivedStyle.Should().NotBeNull();
+        derivedStyle!.BasedOn.Should().Be(baseStyle);
+    }
+
+    [Fact]
+    public void Dictionary_StyleShouldHaveMultiTrigger()
+    {
+        var style = _dictionary["MultiTriggerStyle"] as Style;
+
+        style.Should().NotBeNull();
+        style!.Triggers.OfType<MultiTrigger>().Should().Contain(mt =>
+            mt.Conditions.Count == 2);
+    }
+
+    [WpfFact]
+    public void DynamicResource_ShouldResolve_FromLocalResourceDictionary()
+    {
+        var key = "DynamicBrush";
+
+        var brush = new SolidColorBrush(Colors.Green);
+        var textBlock = new TextBlock();
+
+        textBlock.Resources[key] = brush;
+        textBlock.SetResourceReference(TextBlock.ForegroundProperty, key);
+
+        textBlock.Foreground.Should().BeSameAs(brush);
+    }
+
+    [WpfFact]
+    public void DynamicResource_ShouldUpdate_WhenLocalResourceChanges()
+    {
+        var key = "DynamicBrush";
+        var initialBrush = new SolidColorBrush(Colors.Green);
+        var updatedBrush = new SolidColorBrush(Colors.Red);
+
+        var textBlock = new TextBlock();
+        textBlock.Resources[key] = initialBrush;
+        textBlock.SetResourceReference(TextBlock.ForegroundProperty, key);
+
+        textBlock.Foreground.Should().BeSameAs(initialBrush);
+
+        // Update local resource
+        textBlock.Resources[key] = updatedBrush;
+
+        // Force UI changes
+        textBlock.Dispatcher.Invoke(() => { }, DispatcherPriority.Background);
+
+        textBlock.Foreground.Should().BeSameAs(updatedBrush);
+    }
+
+    [WpfFact]
+    public void DynamicResource_ShouldRemainLastValue_WhenLocalResourceRemoved()
+    {
+        var key = "DynamicBrush";
+        var initialBrush = new SolidColorBrush(Colors.Green);
+
+        var textBlock = new TextBlock();
+        textBlock.SetResourceReference(TextBlock.ForegroundProperty, key);
+
+        textBlock.Resources[key] = initialBrush;
+        textBlock.Foreground.Should().BeSameAs(initialBrush);
+
+        // Remove the key from resources
+        textBlock.Resources.Remove(key);
+
+        // Force UI Changes
+        textBlock.Dispatcher.Invoke(() => { }, DispatcherPriority.Background);
+
+        // The default foreground color of textBlock (as in aero2)
+        textBlock.Foreground.Should().BeSameAs(Brushes.Black);
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/System/Windows/Resources/SampleResourceDictionary.xaml
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/System/Windows/Resources/SampleResourceDictionary.xaml
@@ -1,0 +1,69 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <SolidColorBrush x:Key="StaticBrush" Color="Blue"/>
+
+    <SolidColorBrush x:Key="DynamicBrush" Color="Red"/>
+
+    <LinearGradientBrush x:Key="GradientBackground" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="LightBlue" Offset="0"/>
+        <GradientStop Color="DarkBlue" Offset="1"/>
+    </LinearGradientBrush>
+
+    <Style x:Key="BaseTextBlockStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="Foreground" Value="Gray"/>
+    </Style>
+
+    <Style x:Key="DerivedTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
+        <Setter Property="FontWeight" Value="Bold"/>
+    </Style>
+
+    <Style x:Key="PrimaryButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource StaticBrush}"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="DarkBlue"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="MultiTriggerStyle" TargetType="ToggleButton">
+        <Setter Property="Background" Value="LightGray"/>
+        <Style.Triggers>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsMouseOver" Value="True"/>
+                    <Condition Property="IsChecked" Value="True"/>
+                </MultiTrigger.Conditions>
+                <Setter Property="Background" Value="Green"/>
+            </MultiTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="DataTriggerStyle" TargetType="TextBox">
+        <Setter Property="Background" Value="White"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding IsReadOnly}" Value="True">
+                <Setter Property="Background" Value="LightGray"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <ControlTemplate x:Key="CustomControlTemplate" TargetType="Button">
+        <Border x:Name="Root" Background="{TemplateBinding Background}" BorderBrush="Black" BorderThickness="1">
+            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter TargetName="Root" Property="Background" Value="Gray"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <DataTemplate x:Key="ItemTemplate">
+        <TextBlock Text="{Binding Name}" Style="{StaticResource DerivedTextBlockStyle}"/>
+    </DataTemplate>
+</ResourceDictionary>


### PR DESCRIPTION
## Description
The following changes adds some unit tests around `ResourceDictionary` and some more `DynamicResource` based tests that ensures obvious functionalities are not breaking. Again, the change here is to validate, to an elementary extent, the changes of the PR #10532 

## Regression
_None_
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Build pass, the unit tests are green here
<!-- What kind of testing has been done with the fix. -->

## Risk
Low
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10753)