### PR TITLE
Add DataObject SetData tests

### DIFF
--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/DataObjectTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/DataObjectTests.cs
@@ -67,4 +67,227 @@ public class DataObjectTests
         Action action = () => data.SetData((string)null!, "Some Data");
         action.Should().Throw<ArgumentNullException>().Where(e => e.ParamName == "format");
     }
+
+    [WpfFact]
+    public void SetData_MultipleTypes_GetReturnsExpected()
+    {
+        int intData = 20;
+        string stringData = "test string";
+
+        DataObject data = new();
+
+        data.SetData(intData);
+        data.SetData(stringData);
+        data.GetData(intData.GetType().FullName!).Should().Be(intData);
+        data.GetData(stringData.GetType().FullName!).Should().Be(stringData);
+    }
+
+    [WpfFact]
+    public void SetData_SameTypeTwice_OverwritesData()
+    {
+        string data1 = "data 1";
+        string data2 = "data 2";
+
+        DataObject data = new();
+
+        data.SetData(data1);
+        data.SetData(data2);
+        data.GetData(data1.GetType().FullName!).Should().Be(data2);
+    }
+
+    [WpfFact]
+    public void SetData_StringObject_Invoke_GetReturnsExpected()
+    {
+        string key = "key";
+        string testData = "test data";
+
+        DataObject data = new();
+
+        data.SetData(key, testData);
+        data.GetData(key).Should().Be(testData);
+    }
+
+    [WpfFact]
+    public void SetData_StringObject_NullData_ThrowsArgumentNullException()
+    {
+        string key = "key";
+        string? testData = null;
+
+        DataObject data = new();
+
+        Action act = () => data.SetData(key, testData);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [WpfFact]
+    public void SetData_StringObject_EmptyStringKey_ThrowsArgumentException()
+    {
+        string testData = "test data";
+
+        DataObject data = new();
+
+        Action act = () => data.SetData(string.Empty, testData);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [WpfFact]
+    public void SetData_StringObject_SameKeyTwice_OverwritesData()
+    {
+        string key = "key";
+        string data1 = "data1";
+        string data2 = "data2";
+
+        DataObject data = new();
+
+        data.SetData(key, data1);
+        data.SetData(key, data2);
+
+        data.GetData(key).Should().Be(data2);
+    }
+
+    [WpfFact]
+    public void SetData_StringObject_DifferentKeys_DataIsStoredSeparately()
+    {
+        string key1 = "key1";
+        string key2 = "key2";
+        string data1 = "data1";
+        string data2 = "data2";
+
+        DataObject data = new();
+
+        data.SetData(key1, data1);
+        data.SetData(key2, data2);
+        data.GetData(key1).Should().Be(data1);
+        data.GetData(key2).Should().Be(data2);
+    }
+
+    [WpfFact]
+    public void SetData_TypeObject_Invoke_GetReturnsExpected()
+    {
+        Type stringKey = typeof(string);
+        Type intKey = typeof(int);
+        Type boolKey = typeof(bool);
+        string stringTestData = "string test data";
+        string intTestData = "int test data";
+        string boolTestData = "bool test data";
+
+        DataObject data = new();
+
+        data.SetData(stringKey, stringTestData);
+        data.SetData(intKey, intTestData);
+        data.SetData(boolKey, boolTestData);
+
+        data.GetData(stringKey.FullName!).Should().Be(stringTestData);
+        data.GetData(intKey.FullName!).Should().Be(intTestData);
+        data.GetData(boolKey.FullName!).Should().Be(boolTestData);
+    }
+
+    [WpfFact]
+    public void SetData_TypeObject_NullTypeKey_ThrowsArgumentNullException()
+    {
+        Type? key = null;
+        string testData = "test data";
+
+        DataObject data = new();
+
+        Action act = () => data.SetData(key!, testData);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [WpfFact]
+    public void SetData_TypeObject_NullData_ThrowsArgumentNullException()
+    {
+        Type key = typeof(string);
+
+        DataObject data = new();
+
+        Action act = () => data.SetData(key, null);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [WpfFact]
+    public void GetData_NonExistentKey_ReturnsNull()
+    {
+        Type key = typeof(string);
+
+        DataObject data = new();
+
+        data.GetData(key.FullName!).Should().BeNull();
+    }
+
+    [WpfFact]
+    public void SetData_TypeObject_SameKeyTwice_OverwritesData()
+    {
+        Type key = typeof(string);
+        string data1 = "data1";
+        string data2 = "data2";
+
+        DataObject data = new();
+
+        data.SetData(key, data1);
+        data.SetData(key, data2);
+
+        data.GetData(key.FullName!).Should().Be(data2);
+    }
+
+    [WpfFact]
+    public void SetData_TypeObject_DifferentKeys_DataIsStoredSeparately()
+    {
+        Type key1 = typeof(string);
+        Type key2 = typeof(int);
+        string data1 = "data1";
+        string data2 = "data2";
+
+        DataObject data = new();
+
+        data.SetData(key1, data1);
+        data.SetData(key2, data2);
+        data.GetData(key1.FullName!).Should().Be(data1);
+        data.GetData(key2.FullName!).Should().Be(data2);
+    }
+
+    [WpfFact]
+    public void SetData_StringObjectBool_Invoke_GetReturnsExpected()
+    {
+        string key = "key";
+        string testData = "test data";
+
+        DataObject data = new();
+
+        data.SetData(key, testData, true);
+        data.GetData(key).Should().Be(testData);
+    }
+
+    [WpfFact]
+    public void SetData_StringObjectBool_NullData_ThrowsArgumentNullException()
+    {
+        string key = "key";
+
+        DataObject data = new();
+
+        Action act = () => data.SetData(key, null, true);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [WpfFact]
+    public void SetData_StringObjectBool_NullKey_ThrowsArgumentNullException()
+    {
+        string testData = "test data";
+
+        DataObject data = new();
+
+        Action act = () => data.SetData((string)null!, testData, true);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [WpfFact]
+    public void SetData_StringObjectBool_EmptyKey_ThrowsArgumentException()
+    {
+        string testData = "test data";
+
+        DataObject data = new();
+
+        Action act = () => data.SetData(string.Empty, testData, true);
+        act.Should().Throw<ArgumentException>();
+    }
 }


### PR DESCRIPTION
## Description
The changes here aims at adding tests around `SetData` method of DataObject class. This is to validate that the contracts are not breached and avoid minor bugs after the merger of #10544. The changes also references to a task item mentioned in https://github.com/dotnet/wpf/issues/10736.

The following tests are added in the following changes
**Around [SetData(Object)](https://learn.microsoft.com/en-us/dotnet/api/system.windows.dataobject.setdata?view=windowsdesktop-9.0#system-windows-dataobject-setdata(system-object))**
- Different types returns expected values.
- Same type, returns later value.

**Around [SetData(String, Object)](https://learn.microsoft.com/en-us/dotnet/api/system.windows.dataobject.setdata?view=windowsdesktop-9.0#system-windows-dataobject-setdata(system-string-system-object))**
- Base Init test
- ArgumentNullException while using Null data
- ArgumentException while using empty string
- Same key added twice, returns latest addition
- Different keys can have data separately

**Around [SetData(Type, Object)](https://learn.microsoft.com/en-us/dotnet/api/system.windows.dataobject.setdata?view=windowsdesktop-9.0#system-windows-dataobject-setdata(system-type-system-object))**
- Base Init test
- ArgumentNullException while using Null key
- ArgumentNullException while using Null data
- Same type added twice, returns latest data
- Different types can have data separately

**Around [SetData(String, Data, Boolean)](https://learn.microsoft.com/en-us/dotnet/api/system.windows.dataobject.setdata?view=windowsdesktop-9.0#system-windows-dataobject-setdata(system-string-system-object-system-boolean))**
- Base Init test
- ArgumentNullException while using Null key
- ArgumentNullException while using Null data
- ArgumentException while using empty string

## Regression
_None_
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Build pass, the tests are all green
<!-- What kind of testing has been done with the fix. -->

## Risk
Low
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

cc: @JeremyKuhne 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10754)