### PR TITLE
 [StyleCleanUp] Fix MilCodeGen empty lines

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/TextDecorationCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/TextDecorationCollection.cs
@@ -18,7 +18,6 @@ namespace System.Windows
     /// <summary>
     /// A collection of TextDecoration objects.
     /// </summary>
-
     public sealed partial class TextDecorationCollection : Animatable, IList, IList<TextDecoration>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/TimelineCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/TimelineCollection.cs
@@ -17,7 +17,6 @@ namespace System.Windows.Media.Animation
     /// <summary>
     /// A collection of Timeline objects.
     /// </summary>
-
     public sealed partial class TimelineCollection : Animatable, IList, IList<Timeline>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectCollection.cs
@@ -20,7 +20,6 @@ namespace System.Windows.Media.Effects
     /// <summary>
     /// A collection of BitmapEffect objects.
     /// </summary>
-
     public sealed partial class BitmapEffectCollection : Animatable, IList, IList<BitmapEffect>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Brush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Brush.cs
@@ -24,7 +24,6 @@ using System.Windows.Media.Converters;
 
 namespace System.Windows.Media
 {
-
     [TypeConverter(typeof(BrushConverter))]
     [ValueSerializer(typeof(BrushValueSerializer))] // Used by MarkupWriter
     public abstract partial class Brush : Animatable, IFormattable, DUCE.IResource

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/CacheMode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/CacheMode.cs
@@ -24,7 +24,6 @@ using System.Windows.Media.Converters;
 
 namespace System.Windows.Media
 {
-
     [TypeConverter(typeof(CacheModeConverter))]
     [ValueSerializer(typeof(CacheModeValueSerializer))] // Used by MarkupWriter
     public abstract partial class CacheMode : Animatable, DUCE.IResource

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingCollection.cs
@@ -27,7 +27,6 @@ namespace System.Windows.Media
     /// <summary>
     /// A collection of Drawing objects.
     /// </summary>
-
     public sealed partial class DrawingCollection : Animatable, IList, IList<Drawing>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeneralTransformCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeneralTransformCollection.cs
@@ -27,7 +27,6 @@ namespace System.Windows.Media
     /// <summary>
     /// A collection of GeneralTransform objects.
     /// </summary>
-
     public sealed partial class GeneralTransformCollection : Animatable, IList, IList<GeneralTransform>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Geometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Geometry.cs
@@ -24,7 +24,6 @@ using System.Windows.Media.Converters;
 
 namespace System.Windows.Media
 {
-
     [TypeConverter(typeof(GeometryConverter))]
     [ValueSerializer(typeof(GeometryValueSerializer))] // Used by MarkupWriter
     public abstract partial class Geometry : Animatable, IFormattable, DUCE.IResource

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryCollection.cs
@@ -27,7 +27,6 @@ namespace System.Windows.Media
     /// <summary>
     /// A collection of Geometry objects.
     /// </summary>
-
     public sealed partial class GeometryCollection : Animatable, IList, IList<Geometry>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GradientStopCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GradientStopCollection.cs
@@ -27,7 +27,6 @@ namespace System.Windows.Media
     /// <summary>
     /// A collection of GradientStop objects.
     /// </summary>
-
     public sealed partial class GradientStopCollection : Animatable, IFormattable, IList, IList<GradientStop>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathSegmentCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathSegmentCollection.cs
@@ -27,7 +27,6 @@ namespace System.Windows.Media
     /// <summary>
     /// A collection of PathSegment objects.
     /// </summary>
-
     public sealed partial class PathSegmentCollection : Animatable, IList, IList<PathSegment>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TextEffectCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TextEffectCollection.cs
@@ -27,7 +27,6 @@ namespace System.Windows.Media
     /// <summary>
     /// A collection of TextEffect objects.
     /// </summary>
-
     public sealed partial class TextEffectCollection : Animatable, IList, IList<TextEffect>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Transform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Transform.cs
@@ -24,7 +24,6 @@ using System.Windows.Media.Converters;
 
 namespace System.Windows.Media
 {
-
     [TypeConverter(typeof(TransformConverter))]
     [ValueSerializer(typeof(TransformValueSerializer))] // Used by MarkupWriter
     public abstract partial class Transform : GeneralTransform, DUCE.IResource

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformCollection.cs
@@ -27,7 +27,6 @@ namespace System.Windows.Media
     /// <summary>
     /// A collection of Transform objects.
     /// </summary>
-
     public sealed partial class TransformCollection : Animatable, IList, IList<Transform>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeneralTransform3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeneralTransform3DCollection.cs
@@ -25,7 +25,6 @@ namespace System.Windows.Media.Media3D
     /// <summary>
     /// A collection of GeneralTransform3D objects.
     /// </summary>
-
     public sealed partial class GeneralTransform3DCollection : Animatable, IList, IList<GeneralTransform3D>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MaterialCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MaterialCollection.cs
@@ -25,7 +25,6 @@ namespace System.Windows.Media.Media3D
     /// <summary>
     /// A collection of Material objects.
     /// </summary>
-
     public sealed partial class MaterialCollection : Animatable, IList, IList<Material>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Matrix3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Matrix3D.cs
@@ -22,7 +22,6 @@ using System.Windows.Media.Composition;
 
 namespace System.Windows.Media.Media3D
 {
-
     [Serializable]
     [TypeConverter(typeof(Matrix3DConverter))]
     [ValueSerializer(typeof(Matrix3DValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3DCollection.cs
@@ -25,7 +25,6 @@ namespace System.Windows.Media.Media3D
     /// <summary>
     /// A collection of Model3D objects.
     /// </summary>
-
     public sealed partial class Model3DCollection : Animatable, IList, IList<Model3D>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3D.cs
@@ -22,7 +22,6 @@ using System.Windows.Media.Composition;
 
 namespace System.Windows.Media.Media3D
 {
-
     [Serializable]
     [TypeConverter(typeof(Point3DConverter))]
     [ValueSerializer(typeof(Point3DValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point4D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point4D.cs
@@ -22,7 +22,6 @@ using System.Windows.Media.Composition;
 
 namespace System.Windows.Media.Media3D
 {
-
     [Serializable]
     [TypeConverter(typeof(Point4DConverter))]
     [ValueSerializer(typeof(Point4DValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Quaternion.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Quaternion.cs
@@ -22,7 +22,6 @@ using System.Windows.Media.Composition;
 
 namespace System.Windows.Media.Media3D
 {
-
     [Serializable]
     [TypeConverter(typeof(QuaternionConverter))]
     [ValueSerializer(typeof(QuaternionValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Rect3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Rect3D.cs
@@ -22,7 +22,6 @@ using System.Windows.Media.Composition;
 
 namespace System.Windows.Media.Media3D
 {
-
     [Serializable]
     [TypeConverter(typeof(Rect3DConverter))]
     [ValueSerializer(typeof(Rect3DValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Size3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Size3D.cs
@@ -22,7 +22,6 @@ using System.Windows.Media.Composition;
 
 namespace System.Windows.Media.Media3D
 {
-
     [Serializable]
     [TypeConverter(typeof(Size3DConverter))]
     [ValueSerializer(typeof(Size3DValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Transform3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Transform3DCollection.cs
@@ -25,7 +25,6 @@ namespace System.Windows.Media.Media3D
     /// <summary>
     /// A collection of Transform3D objects.
     /// </summary>
-
     public sealed partial class Transform3DCollection : Animatable, IList, IList<Transform3D>
     {
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3D.cs
@@ -22,7 +22,6 @@ using System.Windows.Media.Composition;
 
 namespace System.Windows.Media.Media3D
 {
-
     [Serializable]
     [TypeConverter(typeof(Vector3DConverter))]
     [ValueSerializer(typeof(Vector3DValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Int32Rect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Int32Rect.cs
@@ -16,7 +16,6 @@ using System.Windows.Converters;
 
 namespace System.Windows
 {
-
     [Serializable]
     [TypeConverter(typeof(Int32RectConverter))]
     [ValueSerializer(typeof(Int32RectValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Point.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Point.cs
@@ -16,7 +16,6 @@ using System.Windows.Converters;
 
 namespace System.Windows
 {
-
     [Serializable]
     [TypeConverter(typeof(PointConverter))]
     [ValueSerializer(typeof(PointValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Rect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Rect.cs
@@ -16,7 +16,6 @@ using System.Windows.Converters;
 
 namespace System.Windows
 {
-
     [Serializable]
     [TypeConverter(typeof(RectConverter))]
     [ValueSerializer(typeof(RectValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Size.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Size.cs
@@ -16,7 +16,6 @@ using System.Windows.Converters;
 
 namespace System.Windows
 {
-
     [Serializable]
     [TypeConverter(typeof(SizeConverter))]
     [ValueSerializer(typeof(SizeValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Vector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Generated/Vector.cs
@@ -16,7 +16,6 @@ using System.Windows.Converters;
 
 namespace System.Windows
 {
-
     [Serializable]
     [TypeConverter(typeof(VectorConverter))]
     [ValueSerializer(typeof(VectorValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Generated/Matrix.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Generated/Matrix.cs
@@ -16,7 +16,6 @@ using System.Windows.Media.Converters;
 
 namespace System.Windows.Media
 {
-
     [Serializable]
     [TypeConverter(typeof(MatrixConverter))]
     [ValueSerializer(typeof(MatrixValueSerializer))] // Used by MarkupWriter

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/ManagedResource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/generators/ManagedResource.cs
@@ -159,13 +159,35 @@ namespace MS.Internal.MilCodeGen.Generators
                                 );
                     }
 
-                    csFile.WriteBlock(
+                    csFile.Write(
                         [[inline]]
 
                             namespace [[resource.ManagedNamespace]]
                             {
-                                [[Helpers.CollectionHelper.WriteCollectionSummary(resource)]]
-                                [[attributes]]
+                        [[/inline]]
+                    );
+
+                    string collectionSummary = Helpers.CollectionHelper.WriteCollectionSummary(resource);
+                    if (!string.IsNullOrEmpty(collectionSummary))
+                    {
+                        csFile.Write(
+                            [[inline]]
+                                    [[collectionSummary]]
+                            [[/inline]]
+                            );
+                    }
+
+                    if (!string.IsNullOrEmpty(attributes))
+                    {
+                        csFile.Write(
+                            [[inline]]
+                                    [[attributes]]
+                            [[/inline]]
+                            );
+                    }
+
+                    csFile.WriteBlock(
+                        [[inline]]
                                 [[WriteClassDeclaration(resource.Name, !resource.IsValueType, modifiers, extends)]]
                                 {
                                     [[Helpers.ManagedStyle.WriteSection("Public Methods")]]


### PR DESCRIPTION
## Description
Fixes empty lines added by MilCodeGen.

This PR also syncs MilCodeGen with the empty line changes from dotnet/wpf#10021.

## Customer Impact
None, whitespace changes only.

## Regression
No.

## Testing
Local build + ran MilCodeGen.

## Risk
None, whitespace changes only.