### PR TITLE
Ignore Dynamic Resource Opt out Preferences

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
@@ -31,7 +31,7 @@ namespace System
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.KeyboardNavigationFromHyperlinkInItemsControlIsNotRelativeToFocusedElementSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.ItemAutomationPeerKeepsItsItemAliveSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableFluentThemeWindowBackdropSwitchName, false);
-            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableDynamicResourceOptimizationSwitchName, true);
+            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableDynamicResourceOptimizationSwitchName, false);
 
 #pragma warning restore CS0436 // Type conflicts with imported type
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceExpression.cs
@@ -275,18 +275,11 @@ namespace System.Windows
                         WriteInternalState(InternalState.IsListeningForInflated, false);
                     }
                 }
-
-                if (FrameworkAppContextSwitches.DisableDynamicResourceOptimization)
-                {
-                    deferredResourceReference.RemoveFromDictionary();
-                }
-                else
-                {
-                    // This will inflate the deferred reference, causing it
-                    // to be removed from the list.  The list may also be
-                    // purged of dead references.
-                    deferredResourceReference.GetValue(BaseValueSourceInternal.Unknown);
-                }
+                
+                // This will inflate the deferred reference, causing it
+                // to be removed from the list.  The list may also be
+                // purged of dead references.
+                deferredResourceReference.GetValue(BaseValueSourceInternal.Unknown);
             }
 
             StopListeningForFreezableChanges(resource);


### PR DESCRIPTION
## Description
The changes here are intended to disregard developers' preferences regarding the `DisableDynamicResourceOptimization` switch. Regardless of the value set for this app context switch, the goal is to execute the code path that includes the recent optimizations introduced in #10532. This is because the optimizations will be part of the preview release, and our aim is to gather as many hits as possible.

cc:/ @batzen 

## Regression
_None_
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
<!-- What kind of testing has been done with the fix. -->

## Risk
By enforcing the execution of the optimized code path, we might encounter unforeseen issues that could have been mitigated using the switch. However, collecting such issues is beneficial to refine the optimizations before the final release, if needed. 
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10794)