### PR TITLE
Fixes chevron arrow direction for Expander when FlowDirection is set to RightToLeft

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Expander.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Expander.xaml
@@ -177,6 +177,9 @@
             </Grid>
         </Grid>
         <ControlTemplate.Triggers>
+            <Trigger Property="FlowDirection" Value="RightToLeft">
+                <Setter TargetName="ControlChevronIcon" Property="Text" Value="{StaticResource ExpanderChevronRightGlyph}" />
+            </Trigger>
             <Trigger Property="IsChecked" Value="True">
                 <Trigger.EnterActions>
                     <BeginStoryboard>
@@ -237,6 +240,9 @@
             </Grid>
         </Grid>
         <ControlTemplate.Triggers>
+            <Trigger Property="FlowDirection" Value="RightToLeft">
+                <Setter TargetName="ControlChevronIcon" Property="Text" Value="{StaticResource ExpanderChevronLeftGlyph}" />
+            </Trigger>
             <Trigger Property="IsChecked" Value="True">
                 <Trigger.EnterActions>
                     <BeginStoryboard>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -2599,6 +2599,9 @@
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
+      <Trigger Property="FlowDirection" Value="RightToLeft">
+        <Setter TargetName="ControlChevronIcon" Property="Text" Value="{StaticResource ExpanderChevronRightGlyph}" />
+      </Trigger>
       <Trigger Property="IsChecked" Value="True">
         <Trigger.EnterActions>
           <BeginStoryboard>
@@ -2632,6 +2635,9 @@
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
+      <Trigger Property="FlowDirection" Value="RightToLeft">
+        <Setter TargetName="ControlChevronIcon" Property="Text" Value="{StaticResource ExpanderChevronLeftGlyph}" />
+      </Trigger>
       <Trigger Property="IsChecked" Value="True">
         <Trigger.EnterActions>
           <BeginStoryboard>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -2512,6 +2512,9 @@
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
+      <Trigger Property="FlowDirection" Value="RightToLeft">
+        <Setter TargetName="ControlChevronIcon" Property="Text" Value="{StaticResource ExpanderChevronRightGlyph}" />
+      </Trigger>
       <Trigger Property="IsChecked" Value="True">
         <Trigger.EnterActions>
           <BeginStoryboard>
@@ -2545,6 +2548,9 @@
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
+      <Trigger Property="FlowDirection" Value="RightToLeft">
+        <Setter TargetName="ControlChevronIcon" Property="Text" Value="{StaticResource ExpanderChevronLeftGlyph}" />
+      </Trigger>
       <Trigger Property="IsChecked" Value="True">
         <Trigger.EnterActions>
           <BeginStoryboard>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -2608,6 +2608,9 @@
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
+      <Trigger Property="FlowDirection" Value="RightToLeft">
+        <Setter TargetName="ControlChevronIcon" Property="Text" Value="{StaticResource ExpanderChevronRightGlyph}" />
+      </Trigger>
       <Trigger Property="IsChecked" Value="True">
         <Trigger.EnterActions>
           <BeginStoryboard>
@@ -2641,6 +2644,9 @@
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
+      <Trigger Property="FlowDirection" Value="RightToLeft">
+        <Setter TargetName="ControlChevronIcon" Property="Text" Value="{StaticResource ExpanderChevronLeftGlyph}" />
+      </Trigger>
       <Trigger Property="IsChecked" Value="True">
         <Trigger.EnterActions>
           <BeginStoryboard>


### PR DESCRIPTION

## Description

Fixes chevron arrow direction for Expander when FlowDirection is set to RightToLeft
## Customer Impact

Customers will see the wrong direction of chevron arrow when FlowDirection is set to RightToLeft.
## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

local build pass, tested with sample apps
## Risk

Low