### PR TITLE
Fixed ComboBox style and template

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Dark.xaml
@@ -468,17 +468,45 @@
 
     <!--  ComboBox  -->
     <SolidColorBrush x:Key="ComboBoxBackground" Color="{StaticResource ControlFillColorDefault}" />
-    <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="{StaticResource ControlFillColorDefault}" />
     <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundPressed" Color="{StaticResource ControlFillColorTertiary}" />
     <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource ControlFillColorDisabled}" />
     <SolidColorBrush x:Key="ComboBoxForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundPointerOver" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundPressed" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="ComboBoxForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
-    <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="ComboBoxForegroundFocused" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundFocusedPressed" Color="{StaticResource TextFillColorPrimary}" />
+    <LinearGradientBrush x:Key="ComboBoxBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
+        <LinearGradientBrush.GradientStops>
+            <GradientStop Offset="0.33" Color="{StaticResource ControlStrokeColorSecondary}" />
+            <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}" />
+        </LinearGradientBrush.GradientStops>
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="ComboBoxBorderBrushPointerOver" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
+        <LinearGradientBrush.GradientStops>
+            <GradientStop Offset="0.33" Color="{StaticResource ControlStrokeColorSecondary}" />
+            <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}" />
+        </LinearGradientBrush.GradientStops>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="ComboBoxBorderBrushPressed" Color="{StaticResource ControlStrokeColorDefault}" />
     <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource ControlStrokeColorDefault}" />
-    <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemAccentColorLight2}" />
     <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundFocused" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundFocusedPressed" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
     <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SurfaceStrokeColorFlyout}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackgroundPointerPressed" Color="{StaticResource SubtleFillColorTertiary}" />
+    <SolidColorBrush x:Key="ComboBoxFocusedDropDownBackgroundPointerPressed" Color="{StaticResource ControlAltFillColorQuarternary}" />
+    <SolidColorBrush x:Key="ComboBoxEditableDropDownGlyphForeground" Color="{StaticResource TextFillColorSecondary}" />
+
+    <!-- Deprecated ComboBox brushes -->
+        <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemAccentColorLight2}" />
+
+    <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
     <SolidColorBrush x:Key="ComboBoxItemPillFillBrush" Color="{StaticResource SystemAccentColorLight2}" />
     <SolidColorBrush x:Key="ComboBoxItemBackgroundSelected" Color="{StaticResource SubtleFillColorSecondary}" />
     <SolidColorBrush x:Key="ComboBoxItemForeground" Color="{StaticResource TextFillColorPrimary}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
@@ -297,22 +297,40 @@
 
     <!--  ComboBox  -->
     <SolidColorBrush x:Key="ComboBoxBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
-    <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
-    <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
-    <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundPressed" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource SystemColorButtonFaceColor}" />
     <SolidColorBrush x:Key="ComboBoxForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundPointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundPressed" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="ComboBoxForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundFocused" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundFocusedPressed" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundFocused" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundFocusedPressed" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackgroundPointerPressed" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ComboBoxFocusedDropDownBackgroundPointerPressed" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ComboBoxEditableDropDownGlyphForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <!-- Deprecated ComboBox brushes -->
+        <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
+    
     <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
-    <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource SystemColorWindowColor}" />
-    <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
-    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource SystemColorGrayTextColor}" />
-    <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource SystemColorWindowColor}" />
-    <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
     <SolidColorBrush x:Key="ComboBoxItemPillFillBrush" Color="{StaticResource SystemColorHighlightColor}" />
     <SolidColorBrush x:Key="ComboBoxItemBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="ComboBoxItemForeground" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="ComboBoxItemForegroundSelected" Color="{StaticResource SystemColorHighlightColor}" />
-
+    
     <!--  ContentDialog  -->
     <SolidColorBrush
         x:Key="ContentDialogSmokeFill"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Light.xaml
@@ -477,22 +477,57 @@
 
     <!--  ComboBox  -->
     <SolidColorBrush x:Key="ComboBoxBackground" Color="{StaticResource ControlFillColorDefault}" />
-    <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="{StaticResource ControlFillColorDefault}" />
     <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundPressed" Color="{StaticResource ControlFillColorTertiary}" />
     <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource ControlFillColorDisabled}" />
     <SolidColorBrush x:Key="ComboBoxForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundPointerOver" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundPressed" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="ComboBoxForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
-    <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="ComboBoxForegroundFocused" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundFocusedPressed" Color="{StaticResource TextFillColorPrimary}" />
+    <LinearGradientBrush x:Key="ComboBoxBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
+        <LinearGradientBrush.RelativeTransform>
+            <ScaleTransform ScaleY="-1" CenterY="0.5" />
+        </LinearGradientBrush.RelativeTransform>
+        <LinearGradientBrush.GradientStops>
+            <GradientStop Offset="0.33" Color="{StaticResource ControlStrokeColorSecondary}" />
+            <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}" />
+        </LinearGradientBrush.GradientStops>
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="ComboBoxBorderBrushPointerOver" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
+        <LinearGradientBrush.RelativeTransform>
+            <ScaleTransform ScaleY="-1" CenterY="0.5" />
+        </LinearGradientBrush.RelativeTransform>
+        <LinearGradientBrush.GradientStops>
+            <GradientStop Offset="0.33" Color="{StaticResource ControlStrokeColorSecondary}" />
+            <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}" />
+        </LinearGradientBrush.GradientStops>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="ComboBoxBorderBrushPressed" Color="{StaticResource ControlStrokeColorDefault}" />
     <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource ControlStrokeColorDefault}" />
-    <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemAccentColorDark1}" />
-    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundFocused" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundFocusedPressed" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
     <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SurfaceStrokeColorFlyout}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackgroundPointerPressed" Color="{StaticResource SubtleFillColorTertiary}" />
+    <SolidColorBrush x:Key="ComboBoxFocusedDropDownBackgroundPointerPressed" Color="{StaticResource ControlAltFillColorQuarternary}" />
+    <SolidColorBrush x:Key="ComboBoxEditableDropDownGlyphForeground" Color="{StaticResource TextFillColorSecondary}" />
+
+    <!-- Deprecated ComboBox Brushes -->
+        <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemAccentColorDark1}" />
+
+    <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
     <SolidColorBrush x:Key="ComboBoxItemPillFillBrush" Color="{StaticResource SystemAccentColorDark1}" />
     <SolidColorBrush x:Key="ComboBoxItemBackgroundSelected" Color="{StaticResource SubtleFillColorSecondary}" />
     <SolidColorBrush x:Key="ComboBoxItemForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="ComboBoxItemForegroundSelected" Color="{StaticResource TextFillColorPrimary}" />
 
+    
     <!--  ContentDialog  -->
     <SolidColorBrush x:Key="ContentDialogSmokeFill" Color="{StaticResource SmokeFillColorDefault}" />
     <SolidColorBrush x:Key="ContentDialogBackground" Color="{StaticResource SolidBackgroundFillColorBase}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
@@ -3,7 +3,6 @@
     If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
     Copyright (C) Leszek Pomianowski and WPF UI Contributors.
     All Rights Reserved.
-    
     Based on Microsoft XAML for Win UI
     Copyright (c) Microsoft Corporation. All Rights Reserved.
 -->

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
@@ -43,7 +43,6 @@
     <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
     <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
     <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
-    <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
     <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
 
     <system:Double x:Key="ComboBoxMinHeight">24</system:Double>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
@@ -46,7 +46,6 @@
     <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
 
     <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
-    <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
     <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
 
 </ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
@@ -258,7 +258,7 @@
                                       TextElement.FontSize="{TemplateBinding FontSize}"
                                       TextElement.FontWeight="{TemplateBinding FontWeight}"
                                       TextElement.Foreground="{TemplateBinding Foreground}">
-                            <StackPanel IsItemsHost="True"
+                            <ItemsPresenter
                                         KeyboardNavigation.DirectionalNavigation="Contained" />
                         </ScrollViewer>
                     </Grid>
@@ -438,7 +438,7 @@
                                       TextElement.FontSize="{TemplateBinding FontSize}"
                                       TextElement.FontWeight="{TemplateBinding FontWeight}"
                                       TextElement.Foreground="{TemplateBinding Foreground}">
-                            <StackPanel IsItemsHost="True"
+                            <ItemsPresenter
                                         KeyboardNavigation.DirectionalNavigation="Contained" />
                         </ScrollViewer>
                     </Grid>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
@@ -79,7 +79,7 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <!-- Disabling this trigger as this will be handled by the ComboBox style. -->
+                            <!-- Disabling this setter as this will be handled by the ComboBox style. -->
                             <!--<Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />-->
                             <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
                             <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
@@ -14,56 +14,99 @@
     xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
     xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
-    <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
+    <!-- Deprecated .NET 9 Keys -->
+        <Thickness x:Key="ComboBoxAccentBorderThemeThickness">0,0,0,2</Thickness>
+        <Thickness x:Key="ComboBoxChevronMargin">8,0,10,0</Thickness>
+        <!-- Redefined in .NET 10 -->
+            <!-- <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
+            <system:Double x:Key="ComboBoxChevronSize">11</system:Double> -->
+
+    <Thickness x:Key="ComboBoxPadding">12,5,0,7</Thickness>
+    <Thickness x:Key="ComboBoxEditableTextPadding">11,5,38,6</Thickness>
     <Thickness x:Key="ComboBoxBorderThemeThickness">1,1,1,1</Thickness>
-    <Thickness x:Key="ComboBoxAccentBorderThemeThickness">0,0,0,2</Thickness>
-    <Thickness x:Key="ComboBoxChevronMargin">8,0,10,0</Thickness>
-    <Thickness x:Key="ComboBoxItemMargin">3,2,3,0</Thickness>
-    <Thickness x:Key="ComboBoxItemContentMargin">10,8,8,8</Thickness>
-    <system:Double x:Key="ComboBoxChevronSize">11.0</system:Double>
+    <system:Double x:Key="ComboBoxChevronSize">10</system:Double>
     <system:Double x:Key="ComboBoxPopupMinHeight">32.0</system:Double>
     <system:String x:Key="ComboBoxChevronDownGlyph">&#xE70D;</system:String>    
+    <CornerRadius x:Key="ComboBoxDropDownButtonBackgroundCornerRadius">4</CornerRadius>
+
+    <Thickness x:Key="ComboBoxItemMargin">3,2,3,0</Thickness>
+    <Thickness x:Key="ComboBoxItemContentMargin">10,8,8,8</Thickness>
 
     <Style x:Key="DefaultComboBoxTextBoxStyle" TargetType="{x:Type TextBox}">
-        <!--  Focus by parent element  -->
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-        <!--  Focus by parent element  -->
-        <!--  Universal WPF UI ContextMenu  -->
         <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
-        <!--  Universal WPF UI ContextMenu  -->
-        <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
-        <Setter Property="CaretBrush" Value="{DynamicResource ComboBoxForeground}" />
-        <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Visibility" Value="Hidden" />
+        <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+        <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThickness}" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Top" />
         <Setter Property="Cursor" Value="IBeam" />
-        <Setter Property="Margin" Value="0" />
-        <Setter Property="Padding" Value="0" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+        <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
+        <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
+        <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="AllowDrop" Value="True"/>
+        <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
         <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}"/>
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="{x:Type TextBox}">
-                    <Decorator
-                        x:Name="PART_ContentHost"
-                        Margin="{TemplateBinding Padding}"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"
-                        TextElement.Foreground="{TemplateBinding Foreground}" />
+                <ControlTemplate TargetType="{x:Type TextBoxBase}">
+                    <Grid>
+                        <Border
+                            x:Name="ContentBorder"
+                            MinWidth="{TemplateBinding MinWidth}"
+                            MinHeight="{TemplateBinding MinHeight}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding Border.CornerRadius}" />
+
+                        <ScrollViewer
+                            x:Name="PART_ContentHost"
+                            Margin="{TemplateBinding BorderThickness}"
+                            CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
+                            HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                            IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                            IsTabStop="{TemplateBinding ScrollViewer.IsTabStop}"
+                            Padding="{TemplateBinding Padding}"
+                            TextElement.Foreground="{TemplateBinding Foreground}"
+                            VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <!-- Disabling this trigger as this will be handled by the ComboBox style. -->
+                            <!--<Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />-->
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
+                            <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
+                        </Trigger>
+                        <Trigger Property="IsFocused" Value="True">
+                            <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThicknessFocused}" />
+                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
+                            <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundDisabled}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushDisabled}" />
+                            <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundDisabled}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
     <Style x:Key="DefaultComboBoxToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-        <!--  Focus by parent element  -->
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-        <!--  Focus by parent element  -->
         <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />
-        <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="Border.CornerRadius" Value="0" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
@@ -143,14 +186,381 @@
         </Setter>
     </Style>
 
+    <ControlTemplate x:Key="DefaultComboBoxTemplate" TargetType="{x:Type ComboBox}">
+        <Grid x:Name="LayoutGrid">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="38" />
+            </Grid.ColumnDefinitions>
+
+            <Border x:Name="ContentBorder"
+                    Grid.ColumnSpan="2"
+                    Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="{TemplateBinding Border.CornerRadius}" />
+
+            <ContentPresenter Name="PART_ContentPresenter"
+                              Content="{TemplateBinding SelectionBoxItem}"
+                              ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                              ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                              ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
+                              Margin="{TemplateBinding Padding}"
+                              TextElement.Foreground="{TemplateBinding Foreground}"
+                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                              IsHitTestVisible="False" />
+
+            <ToggleButton x:Name="ToggleButton"
+                          Grid.ColumnSpan="2"
+                          Focusable="False"
+                          IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                          Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
+
+            <TextBlock x:Name="ChevronIcon"
+                       Grid.Column="1"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       IsHitTestVisible="False"
+                       RenderTransformOrigin="0.5,0.5"
+                       FontFamily="{DynamicResource SymbolThemeFontFamily}"
+                       FontSize="{StaticResource ComboBoxChevronSize}"
+                       Text="{StaticResource ComboBoxChevronDownGlyph}">
+                <TextBlock.RenderTransform>
+                    <RotateTransform Angle="0" />
+                </TextBlock.RenderTransform>
+            </TextBlock>
+            
+            <Popup x:Name="PART_Popup"
+                   MinWidth="{TemplateBinding ActualWidth}"
+                   AllowsTransparency="True"
+                   Focusable="False"
+                   IsOpen="{TemplateBinding IsDropDownOpen}"
+                   Placement="{TemplateBinding Popup.Placement}"
+                   PopupAnimation="{TemplateBinding Popup.PopupAnimation}"
+                   VerticalOffset="1">
+                <Border x:Name="DropDownBorder"
+                        Padding="0,4,0,6"
+                        Background="{DynamicResource ComboBoxDropDownBackground}"
+                        BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
+                        BorderThickness="1.5"
+                        CornerRadius="{DynamicResource PopupCornerRadius}"
+                        SnapsToDevicePixels="True">
+                    <Border.RenderTransform>
+                        <TranslateTransform />
+                    </Border.RenderTransform>
+                    <Grid>
+                        <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                                      SnapsToDevicePixels="True"
+                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                      TextElement.FontSize="{TemplateBinding FontSize}"
+                                      TextElement.FontWeight="{TemplateBinding FontWeight}"
+                                      TextElement.Foreground="{TemplateBinding Foreground}">
+                            <StackPanel IsItemsHost="True"
+                                        KeyboardNavigation.DirectionalNavigation="Contained" />
+                        </ScrollViewer>
+                    </Grid>
+                    <Border.Effect>
+                        <DropShadowEffect BlurRadius="20"
+                                          Direction="270"
+                                          Opacity="0.25"
+                                          ShadowDepth="6" />
+                    </Border.Effect>
+                </Border>
+            </Popup>
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsDropDownOpen" Value="True">
+                <Trigger.EnterActions>
+                    <BeginStoryboard>
+                        <Storyboard>
+                            <DoubleAnimation
+                                Storyboard.TargetName="ChevronIcon"
+                                Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)"
+                                From="0"
+                                To="180"
+                                Duration="00:00:00.167" />
+                            <DoubleAnimation
+                                Storyboard.TargetName="DropDownBorder"
+                                Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)"
+                                From="-90"
+                                To="0"
+                                Duration="00:00:00.167">
+                                <DoubleAnimation.EasingFunction>
+                                    <CircleEase EasingMode="EaseOut" />
+                                </DoubleAnimation.EasingFunction>
+                            </DoubleAnimation>
+                        </Storyboard>
+                    </BeginStoryboard>
+                </Trigger.EnterActions>
+                <Trigger.ExitActions>
+                    <BeginStoryboard>
+                        <Storyboard>
+                            <DoubleAnimation
+                                Storyboard.TargetName="ChevronIcon"
+                                Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)"
+                                From="180"
+                                To="0"
+                                Duration="00:00:00.167" />
+                        </Storyboard>
+                    </BeginStoryboard>
+                </Trigger.ExitActions>
+            </Trigger>
+
+            <Trigger Property="HasItems" Value="False">
+                <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
+            </Trigger>
+
+            <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
+                <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
+            </Trigger>
+
+            <Trigger Property="IsGrouping" Value="True">
+                <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+            </Trigger>
+
+            <!--PointerOver state-->
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+                <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}" />
+                <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPointerOver}" />
+            </Trigger>
+
+            <!--Pressed state-->
+            <Trigger SourceName="ToggleButton" Property="IsPressed" Value="True">
+                <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPressed}" />
+                <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPressed}" />
+                <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPressed}" />                
+            </Trigger>
+
+            <!--Focused state-->
+            <Trigger Property="IsFocused" Value="True">
+                <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocused}" />
+                <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocused}" />
+            </Trigger>
+
+            <!--FocusedPressed state-->
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsFocused" Value="True" />
+                    <Condition SourceName="ToggleButton" Property="IsPressed" Value="True" />
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocusedPressed}" />
+                <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocusedPressed}" />
+            </MultiTrigger>
+
+            <!--Disabled state-->
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+                <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
+                <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+                <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="EditableComboBoxTemplate" TargetType="{x:Type ComboBox}">
+        <Grid x:Name="LayoutGrid">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="38" />
+            </Grid.ColumnDefinitions>
+
+            <Border x:Name="ContentBorder"
+                    Grid.ColumnSpan="2"
+                    Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="{TemplateBinding Border.CornerRadius}" />
+
+            <TextBox x:Name="PART_EditableTextBox"
+                     Grid.ColumnSpan="2"
+                     Padding="11,5,38,6"
+                     Foreground="{TemplateBinding Foreground}"
+                     FontSize="{TemplateBinding FontSize}"
+                     IsReadOnly="{TemplateBinding IsReadOnly}"
+                     Style="{StaticResource DefaultComboBoxTextBoxStyle}"
+                     AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" />
+
+            <Border x:Name="DropDownOverlay"
+                    Grid.Column="1"
+                    Margin="4"
+                    Width="30"
+                    Background="Transparent"
+                    CornerRadius="{StaticResource ComboBoxDropDownButtonBackgroundCornerRadius}" />
+            
+            <ToggleButton x:Name="ToggleButton"
+                          Grid.Column="1"
+                          Margin="4"
+                          Focusable="False"
+                          IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                          Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
+
+            <TextBlock x:Name="ChevronIcon"
+                       Grid.Column="1"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       IsHitTestVisible="False"
+                       RenderTransformOrigin="0.5,0.5"
+                       FontFamily="{DynamicResource SymbolThemeFontFamily}"
+                       FontSize="{StaticResource ComboBoxChevronSize}"
+                       Text="{StaticResource ComboBoxChevronDownGlyph}">
+                <TextBlock.RenderTransform>
+                    <RotateTransform Angle="0" />
+                </TextBlock.RenderTransform>
+            </TextBlock>
+
+            <Popup x:Name="PART_Popup"
+                   Focusable="False"
+                   AllowsTransparency="True"
+                   MinWidth="{TemplateBinding ActualWidth}"
+                   IsOpen="{TemplateBinding IsDropDownOpen}"
+                   Placement="{TemplateBinding Popup.Placement}"
+                   PopupAnimation="{TemplateBinding Popup.PopupAnimation}"
+                   VerticalOffset="1">
+                <Border x:Name="DropDownBorder"
+                        Padding="0,4,0,6"
+                        BorderThickness="1.5"
+                        Background="{DynamicResource ComboBoxDropDownBackground}"
+                        BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
+                        CornerRadius="{DynamicResource PopupCornerRadius}"
+                        SnapsToDevicePixels="True">
+                    <Border.RenderTransform>
+                        <TranslateTransform />
+                    </Border.RenderTransform>
+                    <Grid>
+                        <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                                      SnapsToDevicePixels="True"
+                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                      TextElement.FontSize="{TemplateBinding FontSize}"
+                                      TextElement.FontWeight="{TemplateBinding FontWeight}"
+                                      TextElement.Foreground="{TemplateBinding Foreground}">
+                            <StackPanel IsItemsHost="True"
+                                        KeyboardNavigation.DirectionalNavigation="Contained" />
+                        </ScrollViewer>
+                    </Grid>
+                    <Border.Effect>
+                        <DropShadowEffect BlurRadius="20"
+                                          Direction="270"
+                                          Opacity="0.25"
+                                          ShadowDepth="6" />
+                    </Border.Effect>
+                </Border>
+            </Popup>
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsDropDownOpen" Value="True">
+                <Trigger.EnterActions>
+                    <BeginStoryboard>
+                        <Storyboard>
+                            <DoubleAnimation
+                                Storyboard.TargetName="ChevronIcon"
+                                Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)"
+                                From="0"
+                                To="180"
+                                Duration="00:00:00.167" />
+                            <DoubleAnimation
+                                Storyboard.TargetName="DropDownBorder"
+                                Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)"
+                                From="-90"
+                                To="0"
+                                Duration="00:00:00.167">
+                                <DoubleAnimation.EasingFunction>
+                                    <CircleEase EasingMode="EaseOut" />
+                                </DoubleAnimation.EasingFunction>
+                            </DoubleAnimation>
+                        </Storyboard>
+                    </BeginStoryboard>
+                </Trigger.EnterActions>
+                <Trigger.ExitActions>
+                    <BeginStoryboard>
+                        <Storyboard>
+                            <DoubleAnimation
+                                Storyboard.TargetName="ChevronIcon"
+                                Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)"
+                                From="180"
+                                To="0"
+                                Duration="00:00:00.167" />
+                        </Storyboard>
+                    </BeginStoryboard>
+                </Trigger.ExitActions>
+            </Trigger>
+
+            <Trigger Property="HasItems" Value="False">
+                <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
+            </Trigger>
+
+            <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
+                <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
+            </Trigger>
+
+            <Trigger Property="IsGrouping" Value="True">
+                <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+            </Trigger>
+
+            <!-- PointerOver state-->
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+                <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}" />
+                <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPointerOver}" />
+            </Trigger>
+
+            <!-- Focused / TextBoxFocused -->
+            <Trigger Property="IsFocused" Value="True">
+                <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocused}" />
+                <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+            </Trigger>
+
+            <!--TextBoxOverlayPointerOver state-->
+            <Trigger SourceName="ToggleButton" Property="IsMouseOver" Value="True">
+                <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerOver}" />
+            </Trigger>
+
+            <!--TextBoxOverlayPressed-->
+            <Trigger SourceName="ToggleButton" Property="IsPressed" Value="True">
+                <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerPressed}" />
+            </Trigger>
+
+            <!--TextBoxFocusedOverlayPointerOver state-->
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsFocused" Value="True" />
+                    <Condition SourceName="ToggleButton" Property="IsMouseOver" Value="True" />
+                </MultiTrigger.Conditions>
+                <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerOver}" />
+                <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+            </MultiTrigger>
+
+            <!-- FocusedPressed state / TextBoxFocusedOverlayPressed state -->
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsFocused" Value="True" />
+                    <Condition SourceName="ToggleButton" Property="IsPressed" Value="True" />
+                </MultiTrigger.Conditions>
+                <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+                <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocusedPressed}" />
+                <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxFocusedDropDownBackgroundPointerPressed}" />
+            </MultiTrigger>
+
+            <!--Disabled state-->
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+                <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
+                <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+                <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+ 
     <Style x:Key="DefaultComboBoxStyle" TargetType="{x:Type ComboBox}">
-        <!--  Universal WPF UI focus  -->
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-        <!--  Universal WPF UI ContextMenu  -->
         <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
         <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
         <Setter Property="Background" Value="{DynamicResource ComboBoxBackground}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
         <Setter Property="BorderThickness" Value="{StaticResource ComboBoxBorderThemeThickness}" />
         <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
@@ -165,225 +575,15 @@
         <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Popup.PopupAnimation" Value="None" />
-        <!--  WPF doesn't like centering, the animation is ugly and the mouse button sometimes clicks right away.  -->
         <Setter Property="Popup.Placement" Value="Bottom" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ComboBox}">
-                    <Grid>
-                        <Border
-                            x:Name="ContentBorder"
-                            Grid.Row="0"
-                            MinWidth="{TemplateBinding MinWidth}"
-                            MinHeight="{TemplateBinding MinHeight}"
-                            Padding="0"
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Stretch"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{TemplateBinding Border.CornerRadius}">
-                            <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                <!--
-                                    Funky grid - because:
-                                    Chevron is over Presenter, ToggleButton is over Chevron, TextBox is over ToggleButton.
-                                    But, TextBox is not over Chevron, so ToggleButton still works.
-                                -->
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                                        <ContentPresenter
-                                            Name="PART_ContentPresenter"
-                                            HorizontalAlignment="Stretch"
-                                            VerticalAlignment="Stretch"
-                                            Content="{TemplateBinding SelectionBoxItem}"
-                                            ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
-                                            ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                            ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                            IsHitTestVisible="False"
-                                            TextElement.Foreground="{TemplateBinding Foreground}" />
-                                    </Grid>
-                                    <Grid Grid.Column="1" Margin="{StaticResource ComboBoxChevronMargin}">
-                                        <TextBlock
-                                            x:Name="ChevronIcon"
-                                            Margin="0"
-                                            VerticalAlignment="Center"
-                                            FontSize="{StaticResource ComboBoxChevronSize}"
-                                            Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}"
-                                            RenderTransformOrigin="0.5, 0.5"
-                                            FontFamily="{DynamicResource SymbolThemeFontFamily}"
-                                            Text ="{StaticResource ComboBoxChevronDownGlyph}">
-                                            <TextBlock.RenderTransform>
-                                                <RotateTransform Angle="0" />
-                                            </TextBlock.RenderTransform>
-                                        </TextBlock>
-                                    </Grid>
-                                    <Grid
-                                        Grid.Column="0"
-                                        Grid.ColumnSpan="2"
-                                        Margin="0">
-                                        <ToggleButton
-                                            Name="ToggleButton"
-                                            HorizontalAlignment="Stretch"
-                                            VerticalAlignment="Stretch"
-                                            ClickMode="Press"
-                                            Focusable="False"
-                                            Foreground="{TemplateBinding Foreground}"
-                                            IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                            Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
-                                    </Grid>
-                                    <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                                        <TextBox
-                                            x:Name="PART_EditableTextBox"
-                                            HorizontalAlignment="Stretch"
-                                            VerticalAlignment="Stretch"
-                                            FontSize="{TemplateBinding FontSize}"
-                                            Foreground="{TemplateBinding Foreground}"
-                                            IsReadOnly="{TemplateBinding IsReadOnly}"
-                                            Style="{StaticResource DefaultComboBoxTextBoxStyle}"
-                                            AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" />
-                                    </Grid>
-                                </Grid>
-                                <Popup
-                                    x:Name="PART_Popup"
-                                    MinWidth="{TemplateBinding ActualWidth}"
-                                    VerticalAlignment="Center"
-                                    AllowsTransparency="True"
-                                    Focusable="False"
-                                    IsOpen="{TemplateBinding IsDropDownOpen}"
-                                    Placement="{TemplateBinding Popup.Placement}"
-                                    PopupAnimation="{TemplateBinding Popup.PopupAnimation}"
-                                    VerticalOffset="1">
-                                    <Border
-                                        x:Name="DropDownBorder"
-                                        Padding="0,4,0,6"
-                                        Background="{DynamicResource ComboBoxDropDownBackground}"
-                                        BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
-                                        BorderThickness="1.5"
-                                        CornerRadius="{DynamicResource PopupCornerRadius}"
-                                        SnapsToDevicePixels="True">
-                                        <!--Will revist this code while doing performance evaluation for dynamic resources.-->
-                                        <Border.RenderTransform>
-                                            <TranslateTransform />
-                                        </Border.RenderTransform>
-                                        <Grid>
-                                            <ScrollViewer
-                                                MaxHeight="{TemplateBinding MaxDropDownHeight}"
-                                                Margin="0"
-                                                HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                                SnapsToDevicePixels="True"
-                                                TextElement.FontSize="{TemplateBinding FontSize}"
-                                                TextElement.FontWeight="{TemplateBinding FontWeight}"
-                                                TextElement.Foreground="{TemplateBinding Foreground}"
-                                                VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                                                <ItemsPresenter
-                                                    KeyboardNavigation.DirectionalNavigation="Contained"
-                                                    TextElement.FontSize="{TemplateBinding FontSize}" />
-                                            </ScrollViewer>
-                                        </Grid>
-                                        <Border.Effect>
-                                            <DropShadowEffect
-                                                BlurRadius="20"
-                                                Direction="270"
-                                                Opacity="0.25"
-                                                ShadowDepth="6"/>
-                                        </Border.Effect>
-                                    </Border>
-                                </Popup>
-                            </Grid>
-                        </Border>
-                        <Border
-                            x:Name="AccentBorder"
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Stretch"
-                            BorderBrush="{DynamicResource ComboBoxBorderBrushFocused}"
-                            BorderThickness="{StaticResource ComboBoxAccentBorderThemeThickness}"
-                            CornerRadius="{TemplateBinding Border.CornerRadius}"
-                            Visibility="Collapsed" />
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsDropDownOpen" Value="True">
-                            <Trigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation
-                                            Storyboard.TargetName="ChevronIcon"
-                                            Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)"
-                                            From="0"
-                                            To="180"
-                                            Duration="00:00:00.167" />
-                                        <DoubleAnimation
-                                            Storyboard.TargetName="DropDownBorder"
-                                            Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)"
-                                            From="-90"
-                                            To="0"
-                                            Duration="00:00:00.167">
-                                            <DoubleAnimation.EasingFunction>
-                                                <CircleEase EasingMode="EaseOut" />
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </Trigger.EnterActions>
-                            <Trigger.ExitActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation
-                                            Storyboard.TargetName="ChevronIcon"
-                                            Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)"
-                                            From="180"
-                                            To="0"
-                                            Duration="00:00:00.167" />
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </Trigger.ExitActions>
-                        </Trigger>
-                        <Trigger Property="HasItems" Value="False">
-                            <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
-                        </Trigger>
-                        <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
-                            <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
-                        </Trigger>
-                        <Trigger Property="IsGrouping" Value="True">
-                            <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
-                        </Trigger>
-                        <Trigger Property="IsEditable" Value="True">
-                            <Setter Property="IsTabStop" Value="False" />
-                            <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />
-                            <Setter TargetName="PART_ContentPresenter" Property="Visibility" Value="Hidden" />
-                        </Trigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsEnabled" Value="True" />
-                                <Condition Property="IsKeyboardFocusWithin" Value="True" />
-                                <Condition Property="IsEditable" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundFocused}" />
-                            <Setter TargetName="AccentBorder" Property="Visibility" Value="Visible" />
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsEnabled" Value="True" />
-                                <Condition Property="IsMouseOver" Value="True" />
-                                <Condition Property="IsKeyboardFocusWithin" Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
-                        </MultiTrigger>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
-                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
-                            <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="Template" Value="{StaticResource DefaultComboBoxTemplate}"/>
+        <Style.Triggers>
+            <Trigger Property="IsEditable" Value="True">
+                <Setter Property="Template" Value="{StaticResource EditableComboBoxTemplate}" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style BasedOn="{StaticResource DefaultComboBoxItemStyle}" TargetType="{x:Type ComboBoxItem}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
@@ -38,7 +38,7 @@
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
         <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
-        <Setter Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThickness}" />
+        <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -85,7 +85,7 @@
                             <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
                         </Trigger>
                         <Trigger Property="IsFocused" Value="True">
-                            <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThicknessFocused}" />
+                            <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
                             <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
                             <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
                             <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -77,6 +77,7 @@
   <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
+  <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
   <!--

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -77,8 +77,7 @@
   <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
-  <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
-  <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
+  <!-- <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness> -->
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
@@ -469,17 +468,43 @@
   <!--  TODO  -->
   <!--  ComboBox  -->
   <SolidColorBrush x:Key="ComboBoxBackground" Color="{StaticResource ControlFillColorDefault}" />
-  <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="{StaticResource ControlFillColorDefault}" />
   <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+  <SolidColorBrush x:Key="ComboBoxBackgroundPressed" Color="{StaticResource ControlFillColorTertiary}" />
   <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource ControlFillColorDisabled}" />
   <SolidColorBrush x:Key="ComboBoxForeground" Color="{StaticResource TextFillColorPrimary}" />
+  <SolidColorBrush x:Key="ComboBoxForegroundPointerOver" Color="{StaticResource TextFillColorPrimary}" />
+  <SolidColorBrush x:Key="ComboBoxForegroundPressed" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="ComboBoxForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
-  <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+  <SolidColorBrush x:Key="ComboBoxForegroundFocused" Color="{StaticResource TextFillColorPrimary}" />
+  <SolidColorBrush x:Key="ComboBoxForegroundFocusedPressed" Color="{StaticResource TextFillColorPrimary}" />
+  <LinearGradientBrush x:Key="ComboBoxBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
+    <LinearGradientBrush.GradientStops>
+      <GradientStop Offset="0.33" Color="{StaticResource ControlStrokeColorSecondary}" />
+      <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}" />
+    </LinearGradientBrush.GradientStops>
+  </LinearGradientBrush>
+  <LinearGradientBrush x:Key="ComboBoxBorderBrushPointerOver" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
+    <LinearGradientBrush.GradientStops>
+      <GradientStop Offset="0.33" Color="{StaticResource ControlStrokeColorSecondary}" />
+      <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}" />
+    </LinearGradientBrush.GradientStops>
+  </LinearGradientBrush>
+  <SolidColorBrush x:Key="ComboBoxBorderBrushPressed" Color="{StaticResource ControlStrokeColorDefault}" />
   <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource ControlStrokeColorDefault}" />
-  <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemAccentColorLight2}" />
   <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource TextFillColorSecondary}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundFocused" Color="{StaticResource TextFillColorSecondary}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundFocusedPressed" Color="{StaticResource TextFillColorSecondary}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownForeground" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
   <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SurfaceStrokeColorFlyout}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownBackgroundPointerPressed" Color="{StaticResource SubtleFillColorTertiary}" />
+  <SolidColorBrush x:Key="ComboBoxFocusedDropDownBackgroundPointerPressed" Color="{StaticResource ControlAltFillColorQuarternary}" />
+  <SolidColorBrush x:Key="ComboBoxEditableDropDownGlyphForeground" Color="{StaticResource TextFillColorSecondary}" />
+  <!-- Deprecated ComboBox brushes -->
+  <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemAccentColorLight2}" />
+  <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
   <SolidColorBrush x:Key="ComboBoxItemPillFillBrush" Color="{StaticResource SystemAccentColorLight2}" />
   <SolidColorBrush x:Key="ComboBoxItemBackgroundSelected" Color="{StaticResource SubtleFillColorSecondary}" />
   <SolidColorBrush x:Key="ComboBoxItemForeground" Color="{StaticResource TextFillColorPrimary}" />
@@ -1399,49 +1424,78 @@
   <DataTemplate DataType="{x:Type CollectionViewGroup}">
     <ContentPresenter Content="{Binding Path=Name}" ContentStringFormat="{TemplateBinding ContentStringFormat}" />
   </DataTemplate>
-  <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
-  <Thickness x:Key="ComboBoxBorderThemeThickness">1,1,1,1</Thickness>
+  <!-- Deprecated .NET 9 Keys -->
   <Thickness x:Key="ComboBoxAccentBorderThemeThickness">0,0,0,2</Thickness>
   <Thickness x:Key="ComboBoxChevronMargin">8,0,10,0</Thickness>
-  <Thickness x:Key="ComboBoxItemMargin">3,2,3,0</Thickness>
-  <Thickness x:Key="ComboBoxItemContentMargin">10,8,8,8</Thickness>
-  <system:Double x:Key="ComboBoxChevronSize">11.0</system:Double>
+  <!-- Redefined in .NET 10 -->
+  <!-- <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
+            <system:Double x:Key="ComboBoxChevronSize">11</system:Double> -->
+  <Thickness x:Key="ComboBoxPadding">12,5,0,7</Thickness>
+  <Thickness x:Key="ComboBoxEditableTextPadding">11,5,38,6</Thickness>
+  <Thickness x:Key="ComboBoxBorderThemeThickness">1,1,1,1</Thickness>
+  <system:Double x:Key="ComboBoxChevronSize">10</system:Double>
   <system:Double x:Key="ComboBoxPopupMinHeight">32.0</system:Double>
   <system:String x:Key="ComboBoxChevronDownGlyph"></system:String>
+  <CornerRadius x:Key="ComboBoxDropDownButtonBackgroundCornerRadius">4</CornerRadius>
+  <Thickness x:Key="ComboBoxItemMargin">3,2,3,0</Thickness>
+  <Thickness x:Key="ComboBoxItemContentMargin">10,8,8,8</Thickness>
   <Style x:Key="DefaultComboBoxTextBoxStyle" TargetType="{x:Type TextBox}">
-    <!--  Focus by parent element  -->
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-    <!--  Focus by parent element  -->
-    <!--  Universal WPF UI ContextMenu  -->
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
-    <!--  Universal WPF UI ContextMenu  -->
-    <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
-    <Setter Property="CaretBrush" Value="{DynamicResource ComboBoxForeground}" />
-    <Setter Property="Background" Value="Transparent" />
-    <Setter Property="Visibility" Value="Hidden" />
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThickness}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="Margin" Value="0" />
-    <Setter Property="Padding" Value="0" />
-    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
+    <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="AllowDrop" Value="True" />
+    <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
+    <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="{x:Type TextBox}">
-          <Decorator x:Name="PART_ContentHost" Margin="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" TextElement.Foreground="{TemplateBinding Foreground}" />
+        <ControlTemplate TargetType="{x:Type TextBoxBase}">
+          <Grid>
+            <Border x:Name="ContentBorder" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+            <ScrollViewer x:Name="PART_ContentHost" Margin="{TemplateBinding BorderThickness}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}" IsTabStop="{TemplateBinding ScrollViewer.IsTabStop}" Padding="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <!-- Disabling this trigger as this will be handled by the ComboBox style. -->
+              <!--<Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />-->
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsFocused" Value="True">
+              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThicknessFocused}" />
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundDisabled}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushDisabled}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
   </Style>
   <Style x:Key="DefaultComboBoxToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-    <!--  Focus by parent element  -->
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-    <!--  Focus by parent element  -->
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="Transparent" />
-    <Setter Property="BorderThickness" Value="0" />
-    <Setter Property="Border.CornerRadius" Value="0" />
-    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
@@ -1491,14 +1545,217 @@
       </Setter.Value>
     </Setter>
   </Style>
+  <ControlTemplate x:Key="DefaultComboBoxTemplate" TargetType="{x:Type ComboBox}">
+    <Grid x:Name="LayoutGrid">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="38" />
+      </Grid.ColumnDefinitions>
+      <Border x:Name="ContentBorder" Grid.ColumnSpan="2" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+      <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" Margin="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" IsHitTestVisible="False" />
+      <ToggleButton x:Name="ToggleButton" Grid.ColumnSpan="2" Focusable="False" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
+      <TextBlock x:Name="ChevronIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False" RenderTransformOrigin="0.5,0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{StaticResource ComboBoxChevronSize}" Text="{StaticResource ComboBoxChevronDownGlyph}">
+        <TextBlock.RenderTransform>
+          <RotateTransform Angle="0" />
+        </TextBlock.RenderTransform>
+      </TextBlock>
+      <Popup x:Name="PART_Popup" MinWidth="{TemplateBinding ActualWidth}" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
+        <Border x:Name="DropDownBorder" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
+          <Border.RenderTransform>
+            <TranslateTransform />
+          </Border.RenderTransform>
+          <Grid>
+            <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
+              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+            </ScrollViewer>
+          </Grid>
+          <Border.Effect>
+            <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
+          </Border.Effect>
+        </Border>
+      </Popup>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsDropDownOpen" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
+              <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
+                <DoubleAnimation.EasingFunction>
+                  <CircleEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+              </DoubleAnimation>
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+      <Trigger Property="HasItems" Value="False">
+        <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
+      </Trigger>
+      <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
+        <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
+      </Trigger>
+      <Trigger Property="IsGrouping" Value="True">
+        <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+      </Trigger>
+      <!--PointerOver state-->
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}" />
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPointerOver}" />
+      </Trigger>
+      <!--Pressed state-->
+      <Trigger SourceName="ToggleButton" Property="IsPressed" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPressed}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPressed}" />
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPressed}" />
+      </Trigger>
+      <!--Focused state-->
+      <Trigger Property="IsFocused" Value="True">
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocused}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocused}" />
+      </Trigger>
+      <!--FocusedPressed state-->
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="IsFocused" Value="True" />
+          <Condition SourceName="ToggleButton" Property="IsPressed" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocusedPressed}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocusedPressed}" />
+      </MultiTrigger>
+      <!--Disabled state-->
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <ControlTemplate x:Key="EditableComboBoxTemplate" TargetType="{x:Type ComboBox}">
+    <Grid x:Name="LayoutGrid">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="38" />
+      </Grid.ColumnDefinitions>
+      <Border x:Name="ContentBorder" Grid.ColumnSpan="2" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+      <TextBox x:Name="PART_EditableTextBox" Grid.ColumnSpan="2" Padding="11,5,38,6" Foreground="{TemplateBinding Foreground}" FontSize="{TemplateBinding FontSize}" IsReadOnly="{TemplateBinding IsReadOnly}" Style="{StaticResource DefaultComboBoxTextBoxStyle}" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" />
+      <Border x:Name="DropDownOverlay" Grid.Column="1" Margin="4" Width="30" Background="Transparent" CornerRadius="{StaticResource ComboBoxDropDownButtonBackgroundCornerRadius}" />
+      <ToggleButton x:Name="ToggleButton" Grid.Column="1" Margin="4" Focusable="False" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
+      <TextBlock x:Name="ChevronIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False" RenderTransformOrigin="0.5,0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{StaticResource ComboBoxChevronSize}" Text="{StaticResource ComboBoxChevronDownGlyph}">
+        <TextBlock.RenderTransform>
+          <RotateTransform Angle="0" />
+        </TextBlock.RenderTransform>
+      </TextBlock>
+      <Popup x:Name="PART_Popup" Focusable="False" AllowsTransparency="True" MinWidth="{TemplateBinding ActualWidth}" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
+        <Border x:Name="DropDownBorder" Padding="0,4,0,6" BorderThickness="1.5" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
+          <Border.RenderTransform>
+            <TranslateTransform />
+          </Border.RenderTransform>
+          <Grid>
+            <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
+              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+            </ScrollViewer>
+          </Grid>
+          <Border.Effect>
+            <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
+          </Border.Effect>
+        </Border>
+      </Popup>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsDropDownOpen" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
+              <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
+                <DoubleAnimation.EasingFunction>
+                  <CircleEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+              </DoubleAnimation>
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+      <Trigger Property="HasItems" Value="False">
+        <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
+      </Trigger>
+      <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
+        <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
+      </Trigger>
+      <Trigger Property="IsGrouping" Value="True">
+        <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+      </Trigger>
+      <!-- PointerOver state-->
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}" />
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPointerOver}" />
+      </Trigger>
+      <!-- Focused / TextBoxFocused -->
+      <Trigger Property="IsFocused" Value="True">
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocused}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+      </Trigger>
+      <!--TextBoxOverlayPointerOver state-->
+      <Trigger SourceName="ToggleButton" Property="IsMouseOver" Value="True">
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerOver}" />
+      </Trigger>
+      <!--TextBoxOverlayPressed-->
+      <Trigger SourceName="ToggleButton" Property="IsPressed" Value="True">
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerPressed}" />
+      </Trigger>
+      <!--TextBoxFocusedOverlayPointerOver state-->
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="IsFocused" Value="True" />
+          <Condition SourceName="ToggleButton" Property="IsMouseOver" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerOver}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+      </MultiTrigger>
+      <!-- FocusedPressed state / TextBoxFocusedOverlayPressed state -->
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="IsFocused" Value="True" />
+          <Condition SourceName="ToggleButton" Property="IsPressed" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocusedPressed}" />
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxFocusedDropDownBackgroundPointerPressed}" />
+      </MultiTrigger>
+      <!--Disabled state-->
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
   <Style x:Key="DefaultComboBoxStyle" TargetType="{x:Type ComboBox}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI ContextMenu  -->
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
     <Setter Property="Background" Value="{DynamicResource ComboBoxBackground}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
     <Setter Property="BorderThickness" Value="{StaticResource ComboBoxBorderThemeThickness}" />
     <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
@@ -1513,125 +1770,15 @@
     <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="Popup.PopupAnimation" Value="None" />
-    <!--  WPF doesn't like centering, the animation is ugly and the mouse button sometimes clicks right away.  -->
     <Setter Property="Popup.Placement" Value="Bottom" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
-    <Setter Property="Template">
-      <Setter.Value>
-        <ControlTemplate TargetType="{x:Type ComboBox}">
-          <Grid>
-            <Border x:Name="ContentBorder" Grid.Row="0" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
-              <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                <!--
-                                    Funky grid - because:
-                                    Chevron is over Presenter, ToggleButton is over Chevron, TextBox is over ToggleButton.
-                                    But, TextBox is not over Chevron, so ToggleButton still works.
-                                -->
-                <Grid>
-                  <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                  </Grid.ColumnDefinitions>
-                  <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                    <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
-                  </Grid>
-                  <Grid Grid.Column="1" Margin="{StaticResource ComboBoxChevronMargin}">
-                    <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ComboBoxChevronDownGlyph}">
-                      <TextBlock.RenderTransform>
-                        <RotateTransform Angle="0" />
-                      </TextBlock.RenderTransform>
-                    </TextBlock>
-                  </Grid>
-                  <Grid Grid.Column="0" Grid.ColumnSpan="2" Margin="0">
-                    <ToggleButton Name="ToggleButton" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ClickMode="Press" Focusable="False" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
-                  </Grid>
-                  <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                    <TextBox x:Name="PART_EditableTextBox" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" IsReadOnly="{TemplateBinding IsReadOnly}" Style="{StaticResource DefaultComboBoxTextBoxStyle}" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" />
-                  </Grid>
-                </Grid>
-                <Popup x:Name="PART_Popup" MinWidth="{TemplateBinding ActualWidth}" VerticalAlignment="Center" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
-                  <Border x:Name="DropDownBorder" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
-                    <!--Will revist this code while doing performance evaluation for dynamic resources.-->
-                    <Border.RenderTransform>
-                      <TranslateTransform />
-                    </Border.RenderTransform>
-                    <Grid>
-                      <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" Margin="0" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" SnapsToDevicePixels="True" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                        <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" TextElement.FontSize="{TemplateBinding FontSize}" />
-                      </ScrollViewer>
-                    </Grid>
-                    <Border.Effect>
-                      <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
-                    </Border.Effect>
-                  </Border>
-                </Popup>
-              </Grid>
-            </Border>
-            <Border x:Name="AccentBorder" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderBrush="{DynamicResource ComboBoxBorderBrushFocused}" BorderThickness="{StaticResource ComboBoxAccentBorderThemeThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" Visibility="Collapsed" />
-          </Grid>
-          <ControlTemplate.Triggers>
-            <Trigger Property="IsDropDownOpen" Value="True">
-              <Trigger.EnterActions>
-                <BeginStoryboard>
-                  <Storyboard>
-                    <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
-                    <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
-                      <DoubleAnimation.EasingFunction>
-                        <CircleEase EasingMode="EaseOut" />
-                      </DoubleAnimation.EasingFunction>
-                    </DoubleAnimation>
-                  </Storyboard>
-                </BeginStoryboard>
-              </Trigger.EnterActions>
-              <Trigger.ExitActions>
-                <BeginStoryboard>
-                  <Storyboard>
-                    <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
-                  </Storyboard>
-                </BeginStoryboard>
-              </Trigger.ExitActions>
-            </Trigger>
-            <Trigger Property="HasItems" Value="False">
-              <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
-            </Trigger>
-            <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
-              <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
-            </Trigger>
-            <Trigger Property="IsGrouping" Value="True">
-              <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
-            </Trigger>
-            <Trigger Property="IsEditable" Value="True">
-              <Setter Property="IsTabStop" Value="False" />
-              <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />
-              <Setter TargetName="PART_ContentPresenter" Property="Visibility" Value="Hidden" />
-            </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="True" />
-                <Condition Property="IsKeyboardFocusWithin" Value="True" />
-                <Condition Property="IsEditable" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundFocused}" />
-              <Setter TargetName="AccentBorder" Property="Visibility" Value="Visible" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="True" />
-                <Condition Property="IsMouseOver" Value="True" />
-                <Condition Property="IsKeyboardFocusWithin" Value="False" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
-            </MultiTrigger>
-            <Trigger Property="IsEnabled" Value="False">
-              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
-              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
-              <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
-            </Trigger>
-          </ControlTemplate.Triggers>
-        </ControlTemplate>
-      </Setter.Value>
-    </Setter>
+    <Setter Property="Template" Value="{StaticResource DefaultComboBoxTemplate}" />
+    <Style.Triggers>
+      <Trigger Property="IsEditable" Value="True">
+        <Setter Property="Template" Value="{StaticResource EditableComboBoxTemplate}" />
+      </Trigger>
+    </Style.Triggers>
   </Style>
   <Style BasedOn="{StaticResource DefaultComboBoxItemStyle}" TargetType="{x:Type ComboBoxItem}" />
   <Style BasedOn="{StaticResource DefaultComboBoxStyle}" TargetType="{x:Type ComboBox}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -1444,7 +1444,7 @@
     <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
     <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
-    <Setter Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThickness}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -1474,7 +1474,7 @@
               <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
             </Trigger>
             <Trigger Property="IsFocused" Value="True">
-              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThicknessFocused}" />
+              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
               <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
               <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
               <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -1565,7 +1565,7 @@
           </Border.RenderTransform>
           <Grid>
             <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
-              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+              <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
             </ScrollViewer>
           </Grid>
           <Border.Effect>
@@ -1662,7 +1662,7 @@
           </Border.RenderTransform>
           <Grid>
             <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
-              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+              <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
             </ScrollViewer>
           </Grid>
           <Border.Effect>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -79,7 +79,6 @@
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
   <!-- <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness> -->
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
-  <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
   <!--
         Microsoft UI XAML
@@ -1469,7 +1468,7 @@
           </Grid>
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-              <!-- Disabling this trigger as this will be handled by the ComboBox style. -->
+              <!-- Disabling this setter as this will be handled by the ComboBox style. -->
               <!--<Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />-->
               <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
               <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -77,7 +77,6 @@
   <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
-  <!-- <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness> -->
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
   <!--

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -1347,7 +1347,7 @@
     <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
     <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
-    <Setter Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThickness}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -1377,7 +1377,7 @@
               <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
             </Trigger>
             <Trigger Property="IsFocused" Value="True">
-              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThicknessFocused}" />
+              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
               <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
               <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
               <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -79,7 +79,6 @@
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
   <!-- <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness> -->
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
-  <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
   <!--
         Microsoft UI XAML
@@ -1372,7 +1371,7 @@
           </Grid>
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-              <!-- Disabling this trigger as this will be handled by the ComboBox style. -->
+              <!-- Disabling this setter as this will be handled by the ComboBox style. -->
               <!--<Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />-->
               <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
               <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -77,6 +77,7 @@
   <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
+  <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
   <!--

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -77,7 +77,6 @@
   <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
-  <!-- <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness> -->
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
   <!--

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -1468,7 +1468,7 @@
           </Border.RenderTransform>
           <Grid>
             <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
-              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+              <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
             </ScrollViewer>
           </Grid>
           <Border.Effect>
@@ -1565,7 +1565,7 @@
           </Border.RenderTransform>
           <Grid>
             <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
-              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+              <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
             </ScrollViewer>
           </Grid>
           <Border.Effect>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -77,8 +77,7 @@
   <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
-  <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
-  <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
+  <!-- <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness> -->
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
@@ -326,17 +325,33 @@
   <!--  TODO  -->
   <!--  ComboBox  -->
   <SolidColorBrush x:Key="ComboBoxBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
-  <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
-  <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
-  <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+  <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+  <SolidColorBrush x:Key="ComboBoxBackgroundPressed" Color="{StaticResource SystemColorButtonFaceColor}" />
+  <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource SystemColorButtonFaceColor}" />
   <SolidColorBrush x:Key="ComboBoxForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+  <SolidColorBrush x:Key="ComboBoxForegroundPointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+  <SolidColorBrush x:Key="ComboBoxForegroundPressed" Color="{StaticResource SystemColorButtonTextColor}" />
   <SolidColorBrush x:Key="ComboBoxForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
-  <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
-  <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource SystemColorWindowColor}" />
+  <SolidColorBrush x:Key="ComboBoxForegroundFocused" Color="{StaticResource SystemColorButtonTextColor}" />
+  <SolidColorBrush x:Key="ComboBoxForegroundFocusedPressed" Color="{StaticResource SystemColorButtonTextColor}" />
+  <SolidColorBrush x:Key="ComboBoxBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+  <SolidColorBrush x:Key="ComboBoxBorderBrushPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+  <SolidColorBrush x:Key="ComboBoxBorderBrushPressed" Color="{StaticResource SystemColorHighlightColor}" />
+  <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundFocused" Color="{StaticResource SystemColorButtonTextColor}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundFocusedPressed" Color="{StaticResource SystemColorButtonTextColor}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownBackgroundPointerPressed" Color="{StaticResource SystemColorButtonFaceColor}" />
+  <SolidColorBrush x:Key="ComboBoxFocusedDropDownBackgroundPointerPressed" Color="{StaticResource SystemColorButtonFaceColor}" />
+  <SolidColorBrush x:Key="ComboBoxEditableDropDownGlyphForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+  <!-- Deprecated ComboBox brushes -->
   <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
-  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource SystemColorGrayTextColor}" />
-  <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource SystemColorWindowColor}" />
-  <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+  <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
   <SolidColorBrush x:Key="ComboBoxItemPillFillBrush" Color="{StaticResource SystemColorHighlightColor}" />
   <SolidColorBrush x:Key="ComboBoxItemBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
   <SolidColorBrush x:Key="ComboBoxItemForeground" Color="{StaticResource SystemColorButtonTextColor}" />
@@ -1312,49 +1327,78 @@
   <DataTemplate DataType="{x:Type CollectionViewGroup}">
     <ContentPresenter Content="{Binding Path=Name}" ContentStringFormat="{TemplateBinding ContentStringFormat}" />
   </DataTemplate>
-  <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
-  <Thickness x:Key="ComboBoxBorderThemeThickness">1,1,1,1</Thickness>
+  <!-- Deprecated .NET 9 Keys -->
   <Thickness x:Key="ComboBoxAccentBorderThemeThickness">0,0,0,2</Thickness>
   <Thickness x:Key="ComboBoxChevronMargin">8,0,10,0</Thickness>
-  <Thickness x:Key="ComboBoxItemMargin">3,2,3,0</Thickness>
-  <Thickness x:Key="ComboBoxItemContentMargin">10,8,8,8</Thickness>
-  <system:Double x:Key="ComboBoxChevronSize">11.0</system:Double>
+  <!-- Redefined in .NET 10 -->
+  <!-- <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
+            <system:Double x:Key="ComboBoxChevronSize">11</system:Double> -->
+  <Thickness x:Key="ComboBoxPadding">12,5,0,7</Thickness>
+  <Thickness x:Key="ComboBoxEditableTextPadding">11,5,38,6</Thickness>
+  <Thickness x:Key="ComboBoxBorderThemeThickness">1,1,1,1</Thickness>
+  <system:Double x:Key="ComboBoxChevronSize">10</system:Double>
   <system:Double x:Key="ComboBoxPopupMinHeight">32.0</system:Double>
   <system:String x:Key="ComboBoxChevronDownGlyph"></system:String>
+  <CornerRadius x:Key="ComboBoxDropDownButtonBackgroundCornerRadius">4</CornerRadius>
+  <Thickness x:Key="ComboBoxItemMargin">3,2,3,0</Thickness>
+  <Thickness x:Key="ComboBoxItemContentMargin">10,8,8,8</Thickness>
   <Style x:Key="DefaultComboBoxTextBoxStyle" TargetType="{x:Type TextBox}">
-    <!--  Focus by parent element  -->
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-    <!--  Focus by parent element  -->
-    <!--  Universal WPF UI ContextMenu  -->
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
-    <!--  Universal WPF UI ContextMenu  -->
-    <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
-    <Setter Property="CaretBrush" Value="{DynamicResource ComboBoxForeground}" />
-    <Setter Property="Background" Value="Transparent" />
-    <Setter Property="Visibility" Value="Hidden" />
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThickness}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="Margin" Value="0" />
-    <Setter Property="Padding" Value="0" />
-    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
+    <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="AllowDrop" Value="True" />
+    <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
+    <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="{x:Type TextBox}">
-          <Decorator x:Name="PART_ContentHost" Margin="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" TextElement.Foreground="{TemplateBinding Foreground}" />
+        <ControlTemplate TargetType="{x:Type TextBoxBase}">
+          <Grid>
+            <Border x:Name="ContentBorder" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+            <ScrollViewer x:Name="PART_ContentHost" Margin="{TemplateBinding BorderThickness}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}" IsTabStop="{TemplateBinding ScrollViewer.IsTabStop}" Padding="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <!-- Disabling this trigger as this will be handled by the ComboBox style. -->
+              <!--<Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />-->
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsFocused" Value="True">
+              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThicknessFocused}" />
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundDisabled}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushDisabled}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
   </Style>
   <Style x:Key="DefaultComboBoxToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-    <!--  Focus by parent element  -->
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-    <!--  Focus by parent element  -->
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="Transparent" />
-    <Setter Property="BorderThickness" Value="0" />
-    <Setter Property="Border.CornerRadius" Value="0" />
-    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
@@ -1404,14 +1448,217 @@
       </Setter.Value>
     </Setter>
   </Style>
+  <ControlTemplate x:Key="DefaultComboBoxTemplate" TargetType="{x:Type ComboBox}">
+    <Grid x:Name="LayoutGrid">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="38" />
+      </Grid.ColumnDefinitions>
+      <Border x:Name="ContentBorder" Grid.ColumnSpan="2" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+      <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" Margin="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" IsHitTestVisible="False" />
+      <ToggleButton x:Name="ToggleButton" Grid.ColumnSpan="2" Focusable="False" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
+      <TextBlock x:Name="ChevronIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False" RenderTransformOrigin="0.5,0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{StaticResource ComboBoxChevronSize}" Text="{StaticResource ComboBoxChevronDownGlyph}">
+        <TextBlock.RenderTransform>
+          <RotateTransform Angle="0" />
+        </TextBlock.RenderTransform>
+      </TextBlock>
+      <Popup x:Name="PART_Popup" MinWidth="{TemplateBinding ActualWidth}" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
+        <Border x:Name="DropDownBorder" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
+          <Border.RenderTransform>
+            <TranslateTransform />
+          </Border.RenderTransform>
+          <Grid>
+            <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
+              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+            </ScrollViewer>
+          </Grid>
+          <Border.Effect>
+            <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
+          </Border.Effect>
+        </Border>
+      </Popup>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsDropDownOpen" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
+              <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
+                <DoubleAnimation.EasingFunction>
+                  <CircleEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+              </DoubleAnimation>
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+      <Trigger Property="HasItems" Value="False">
+        <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
+      </Trigger>
+      <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
+        <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
+      </Trigger>
+      <Trigger Property="IsGrouping" Value="True">
+        <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+      </Trigger>
+      <!--PointerOver state-->
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}" />
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPointerOver}" />
+      </Trigger>
+      <!--Pressed state-->
+      <Trigger SourceName="ToggleButton" Property="IsPressed" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPressed}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPressed}" />
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPressed}" />
+      </Trigger>
+      <!--Focused state-->
+      <Trigger Property="IsFocused" Value="True">
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocused}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocused}" />
+      </Trigger>
+      <!--FocusedPressed state-->
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="IsFocused" Value="True" />
+          <Condition SourceName="ToggleButton" Property="IsPressed" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocusedPressed}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocusedPressed}" />
+      </MultiTrigger>
+      <!--Disabled state-->
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <ControlTemplate x:Key="EditableComboBoxTemplate" TargetType="{x:Type ComboBox}">
+    <Grid x:Name="LayoutGrid">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="38" />
+      </Grid.ColumnDefinitions>
+      <Border x:Name="ContentBorder" Grid.ColumnSpan="2" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+      <TextBox x:Name="PART_EditableTextBox" Grid.ColumnSpan="2" Padding="11,5,38,6" Foreground="{TemplateBinding Foreground}" FontSize="{TemplateBinding FontSize}" IsReadOnly="{TemplateBinding IsReadOnly}" Style="{StaticResource DefaultComboBoxTextBoxStyle}" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" />
+      <Border x:Name="DropDownOverlay" Grid.Column="1" Margin="4" Width="30" Background="Transparent" CornerRadius="{StaticResource ComboBoxDropDownButtonBackgroundCornerRadius}" />
+      <ToggleButton x:Name="ToggleButton" Grid.Column="1" Margin="4" Focusable="False" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
+      <TextBlock x:Name="ChevronIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False" RenderTransformOrigin="0.5,0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{StaticResource ComboBoxChevronSize}" Text="{StaticResource ComboBoxChevronDownGlyph}">
+        <TextBlock.RenderTransform>
+          <RotateTransform Angle="0" />
+        </TextBlock.RenderTransform>
+      </TextBlock>
+      <Popup x:Name="PART_Popup" Focusable="False" AllowsTransparency="True" MinWidth="{TemplateBinding ActualWidth}" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
+        <Border x:Name="DropDownBorder" Padding="0,4,0,6" BorderThickness="1.5" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
+          <Border.RenderTransform>
+            <TranslateTransform />
+          </Border.RenderTransform>
+          <Grid>
+            <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
+              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+            </ScrollViewer>
+          </Grid>
+          <Border.Effect>
+            <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
+          </Border.Effect>
+        </Border>
+      </Popup>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsDropDownOpen" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
+              <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
+                <DoubleAnimation.EasingFunction>
+                  <CircleEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+              </DoubleAnimation>
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+      <Trigger Property="HasItems" Value="False">
+        <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
+      </Trigger>
+      <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
+        <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
+      </Trigger>
+      <Trigger Property="IsGrouping" Value="True">
+        <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+      </Trigger>
+      <!-- PointerOver state-->
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}" />
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPointerOver}" />
+      </Trigger>
+      <!-- Focused / TextBoxFocused -->
+      <Trigger Property="IsFocused" Value="True">
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocused}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+      </Trigger>
+      <!--TextBoxOverlayPointerOver state-->
+      <Trigger SourceName="ToggleButton" Property="IsMouseOver" Value="True">
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerOver}" />
+      </Trigger>
+      <!--TextBoxOverlayPressed-->
+      <Trigger SourceName="ToggleButton" Property="IsPressed" Value="True">
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerPressed}" />
+      </Trigger>
+      <!--TextBoxFocusedOverlayPointerOver state-->
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="IsFocused" Value="True" />
+          <Condition SourceName="ToggleButton" Property="IsMouseOver" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerOver}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+      </MultiTrigger>
+      <!-- FocusedPressed state / TextBoxFocusedOverlayPressed state -->
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="IsFocused" Value="True" />
+          <Condition SourceName="ToggleButton" Property="IsPressed" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocusedPressed}" />
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxFocusedDropDownBackgroundPointerPressed}" />
+      </MultiTrigger>
+      <!--Disabled state-->
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
   <Style x:Key="DefaultComboBoxStyle" TargetType="{x:Type ComboBox}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI ContextMenu  -->
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
     <Setter Property="Background" Value="{DynamicResource ComboBoxBackground}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
     <Setter Property="BorderThickness" Value="{StaticResource ComboBoxBorderThemeThickness}" />
     <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
@@ -1426,125 +1673,15 @@
     <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="Popup.PopupAnimation" Value="None" />
-    <!--  WPF doesn't like centering, the animation is ugly and the mouse button sometimes clicks right away.  -->
     <Setter Property="Popup.Placement" Value="Bottom" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
-    <Setter Property="Template">
-      <Setter.Value>
-        <ControlTemplate TargetType="{x:Type ComboBox}">
-          <Grid>
-            <Border x:Name="ContentBorder" Grid.Row="0" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
-              <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                <!--
-                                    Funky grid - because:
-                                    Chevron is over Presenter, ToggleButton is over Chevron, TextBox is over ToggleButton.
-                                    But, TextBox is not over Chevron, so ToggleButton still works.
-                                -->
-                <Grid>
-                  <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                  </Grid.ColumnDefinitions>
-                  <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                    <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
-                  </Grid>
-                  <Grid Grid.Column="1" Margin="{StaticResource ComboBoxChevronMargin}">
-                    <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ComboBoxChevronDownGlyph}">
-                      <TextBlock.RenderTransform>
-                        <RotateTransform Angle="0" />
-                      </TextBlock.RenderTransform>
-                    </TextBlock>
-                  </Grid>
-                  <Grid Grid.Column="0" Grid.ColumnSpan="2" Margin="0">
-                    <ToggleButton Name="ToggleButton" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ClickMode="Press" Focusable="False" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
-                  </Grid>
-                  <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                    <TextBox x:Name="PART_EditableTextBox" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" IsReadOnly="{TemplateBinding IsReadOnly}" Style="{StaticResource DefaultComboBoxTextBoxStyle}" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" />
-                  </Grid>
-                </Grid>
-                <Popup x:Name="PART_Popup" MinWidth="{TemplateBinding ActualWidth}" VerticalAlignment="Center" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
-                  <Border x:Name="DropDownBorder" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
-                    <!--Will revist this code while doing performance evaluation for dynamic resources.-->
-                    <Border.RenderTransform>
-                      <TranslateTransform />
-                    </Border.RenderTransform>
-                    <Grid>
-                      <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" Margin="0" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" SnapsToDevicePixels="True" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                        <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" TextElement.FontSize="{TemplateBinding FontSize}" />
-                      </ScrollViewer>
-                    </Grid>
-                    <Border.Effect>
-                      <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
-                    </Border.Effect>
-                  </Border>
-                </Popup>
-              </Grid>
-            </Border>
-            <Border x:Name="AccentBorder" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderBrush="{DynamicResource ComboBoxBorderBrushFocused}" BorderThickness="{StaticResource ComboBoxAccentBorderThemeThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" Visibility="Collapsed" />
-          </Grid>
-          <ControlTemplate.Triggers>
-            <Trigger Property="IsDropDownOpen" Value="True">
-              <Trigger.EnterActions>
-                <BeginStoryboard>
-                  <Storyboard>
-                    <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
-                    <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
-                      <DoubleAnimation.EasingFunction>
-                        <CircleEase EasingMode="EaseOut" />
-                      </DoubleAnimation.EasingFunction>
-                    </DoubleAnimation>
-                  </Storyboard>
-                </BeginStoryboard>
-              </Trigger.EnterActions>
-              <Trigger.ExitActions>
-                <BeginStoryboard>
-                  <Storyboard>
-                    <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
-                  </Storyboard>
-                </BeginStoryboard>
-              </Trigger.ExitActions>
-            </Trigger>
-            <Trigger Property="HasItems" Value="False">
-              <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
-            </Trigger>
-            <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
-              <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
-            </Trigger>
-            <Trigger Property="IsGrouping" Value="True">
-              <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
-            </Trigger>
-            <Trigger Property="IsEditable" Value="True">
-              <Setter Property="IsTabStop" Value="False" />
-              <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />
-              <Setter TargetName="PART_ContentPresenter" Property="Visibility" Value="Hidden" />
-            </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="True" />
-                <Condition Property="IsKeyboardFocusWithin" Value="True" />
-                <Condition Property="IsEditable" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundFocused}" />
-              <Setter TargetName="AccentBorder" Property="Visibility" Value="Visible" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="True" />
-                <Condition Property="IsMouseOver" Value="True" />
-                <Condition Property="IsKeyboardFocusWithin" Value="False" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
-            </MultiTrigger>
-            <Trigger Property="IsEnabled" Value="False">
-              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
-              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
-              <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
-            </Trigger>
-          </ControlTemplate.Triggers>
-        </ControlTemplate>
-      </Setter.Value>
-    </Setter>
+    <Setter Property="Template" Value="{StaticResource DefaultComboBoxTemplate}" />
+    <Style.Triggers>
+      <Trigger Property="IsEditable" Value="True">
+        <Setter Property="Template" Value="{StaticResource EditableComboBoxTemplate}" />
+      </Trigger>
+    </Style.Triggers>
   </Style>
   <Style BasedOn="{StaticResource DefaultComboBoxItemStyle}" TargetType="{x:Type ComboBoxItem}" />
   <Style BasedOn="{StaticResource DefaultComboBoxStyle}" TargetType="{x:Type ComboBox}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -77,6 +77,7 @@
   <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
+  <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
   <!--

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -77,7 +77,6 @@
   <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
-  <!-- <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness> -->
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
   <!--

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -79,7 +79,6 @@
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
   <!-- <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness> -->
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
-  <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
   <!--
         Microsoft UI XAML
@@ -1484,7 +1483,7 @@
           </Grid>
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-              <!-- Disabling this trigger as this will be handled by the ComboBox style. -->
+              <!-- Disabling this setter as this will be handled by the ComboBox style. -->
               <!--<Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />-->
               <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
               <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -1580,7 +1580,7 @@
           </Border.RenderTransform>
           <Grid>
             <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
-              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+              <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
             </ScrollViewer>
           </Grid>
           <Border.Effect>
@@ -1677,7 +1677,7 @@
           </Border.RenderTransform>
           <Grid>
             <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
-              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+              <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
             </ScrollViewer>
           </Grid>
           <Border.Effect>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -1459,7 +1459,7 @@
     <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
     <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
-    <Setter Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThickness}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -1489,7 +1489,7 @@
               <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
             </Trigger>
             <Trigger Property="IsFocused" Value="True">
-              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThicknessFocused}" />
+              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
               <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
               <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
               <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -77,8 +77,7 @@
   <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
-  <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
-  <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
+  <!-- <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness> -->
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
@@ -478,17 +477,49 @@
   <!--  TODO  -->
   <!--  ComboBox  -->
   <SolidColorBrush x:Key="ComboBoxBackground" Color="{StaticResource ControlFillColorDefault}" />
-  <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="{StaticResource ControlFillColorDefault}" />
   <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+  <SolidColorBrush x:Key="ComboBoxBackgroundPressed" Color="{StaticResource ControlFillColorTertiary}" />
   <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource ControlFillColorDisabled}" />
   <SolidColorBrush x:Key="ComboBoxForeground" Color="{StaticResource TextFillColorPrimary}" />
+  <SolidColorBrush x:Key="ComboBoxForegroundPointerOver" Color="{StaticResource TextFillColorPrimary}" />
+  <SolidColorBrush x:Key="ComboBoxForegroundPressed" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="ComboBoxForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
-  <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+  <SolidColorBrush x:Key="ComboBoxForegroundFocused" Color="{StaticResource TextFillColorPrimary}" />
+  <SolidColorBrush x:Key="ComboBoxForegroundFocusedPressed" Color="{StaticResource TextFillColorPrimary}" />
+  <LinearGradientBrush x:Key="ComboBoxBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
+    <LinearGradientBrush.RelativeTransform>
+      <ScaleTransform ScaleY="-1" CenterY="0.5" />
+    </LinearGradientBrush.RelativeTransform>
+    <LinearGradientBrush.GradientStops>
+      <GradientStop Offset="0.33" Color="{StaticResource ControlStrokeColorSecondary}" />
+      <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}" />
+    </LinearGradientBrush.GradientStops>
+  </LinearGradientBrush>
+  <LinearGradientBrush x:Key="ComboBoxBorderBrushPointerOver" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
+    <LinearGradientBrush.RelativeTransform>
+      <ScaleTransform ScaleY="-1" CenterY="0.5" />
+    </LinearGradientBrush.RelativeTransform>
+    <LinearGradientBrush.GradientStops>
+      <GradientStop Offset="0.33" Color="{StaticResource ControlStrokeColorSecondary}" />
+      <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}" />
+    </LinearGradientBrush.GradientStops>
+  </LinearGradientBrush>
+  <SolidColorBrush x:Key="ComboBoxBorderBrushPressed" Color="{StaticResource ControlStrokeColorDefault}" />
   <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource ControlStrokeColorDefault}" />
-  <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemAccentColorDark1}" />
-  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource TextFillColorPrimary}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource TextFillColorSecondary}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundFocused" Color="{StaticResource TextFillColorSecondary}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundFocusedPressed" Color="{StaticResource TextFillColorSecondary}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownGlyphForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownForeground" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
   <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SurfaceStrokeColorFlyout}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownBackgroundPointerPressed" Color="{StaticResource SubtleFillColorTertiary}" />
+  <SolidColorBrush x:Key="ComboBoxFocusedDropDownBackgroundPointerPressed" Color="{StaticResource ControlAltFillColorQuarternary}" />
+  <SolidColorBrush x:Key="ComboBoxEditableDropDownGlyphForeground" Color="{StaticResource TextFillColorSecondary}" />
+  <!-- Deprecated ComboBox Brushes -->
+  <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemAccentColorDark1}" />
+  <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
   <SolidColorBrush x:Key="ComboBoxItemPillFillBrush" Color="{StaticResource SystemAccentColorDark1}" />
   <SolidColorBrush x:Key="ComboBoxItemBackgroundSelected" Color="{StaticResource SubtleFillColorSecondary}" />
   <SolidColorBrush x:Key="ComboBoxItemForeground" Color="{StaticResource TextFillColorPrimary}" />
@@ -1408,49 +1439,78 @@
   <DataTemplate DataType="{x:Type CollectionViewGroup}">
     <ContentPresenter Content="{Binding Path=Name}" ContentStringFormat="{TemplateBinding ContentStringFormat}" />
   </DataTemplate>
-  <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
-  <Thickness x:Key="ComboBoxBorderThemeThickness">1,1,1,1</Thickness>
+  <!-- Deprecated .NET 9 Keys -->
   <Thickness x:Key="ComboBoxAccentBorderThemeThickness">0,0,0,2</Thickness>
   <Thickness x:Key="ComboBoxChevronMargin">8,0,10,0</Thickness>
-  <Thickness x:Key="ComboBoxItemMargin">3,2,3,0</Thickness>
-  <Thickness x:Key="ComboBoxItemContentMargin">10,8,8,8</Thickness>
-  <system:Double x:Key="ComboBoxChevronSize">11.0</system:Double>
+  <!-- Redefined in .NET 10 -->
+  <!-- <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
+            <system:Double x:Key="ComboBoxChevronSize">11</system:Double> -->
+  <Thickness x:Key="ComboBoxPadding">12,5,0,7</Thickness>
+  <Thickness x:Key="ComboBoxEditableTextPadding">11,5,38,6</Thickness>
+  <Thickness x:Key="ComboBoxBorderThemeThickness">1,1,1,1</Thickness>
+  <system:Double x:Key="ComboBoxChevronSize">10</system:Double>
   <system:Double x:Key="ComboBoxPopupMinHeight">32.0</system:Double>
   <system:String x:Key="ComboBoxChevronDownGlyph"></system:String>
+  <CornerRadius x:Key="ComboBoxDropDownButtonBackgroundCornerRadius">4</CornerRadius>
+  <Thickness x:Key="ComboBoxItemMargin">3,2,3,0</Thickness>
+  <Thickness x:Key="ComboBoxItemContentMargin">10,8,8,8</Thickness>
   <Style x:Key="DefaultComboBoxTextBoxStyle" TargetType="{x:Type TextBox}">
-    <!--  Focus by parent element  -->
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-    <!--  Focus by parent element  -->
-    <!--  Universal WPF UI ContextMenu  -->
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
-    <!--  Universal WPF UI ContextMenu  -->
-    <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
-    <Setter Property="CaretBrush" Value="{DynamicResource ComboBoxForeground}" />
-    <Setter Property="Background" Value="Transparent" />
-    <Setter Property="Visibility" Value="Hidden" />
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThickness}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="Margin" Value="0" />
-    <Setter Property="Padding" Value="0" />
-    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
+    <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="AllowDrop" Value="True" />
+    <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
+    <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="{x:Type TextBox}">
-          <Decorator x:Name="PART_ContentHost" Margin="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" TextElement.Foreground="{TemplateBinding Foreground}" />
+        <ControlTemplate TargetType="{x:Type TextBoxBase}">
+          <Grid>
+            <Border x:Name="ContentBorder" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+            <ScrollViewer x:Name="PART_ContentHost" Margin="{TemplateBinding BorderThickness}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}" IsTabStop="{TemplateBinding ScrollViewer.IsTabStop}" Padding="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <!-- Disabling this trigger as this will be handled by the ComboBox style. -->
+              <!--<Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />-->
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsFocused" Value="True">
+              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{StaticResource TextControlBorderThemeThicknessFocused}" />
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundDisabled}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushDisabled}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
   </Style>
   <Style x:Key="DefaultComboBoxToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-    <!--  Focus by parent element  -->
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-    <!--  Focus by parent element  -->
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="Transparent" />
-    <Setter Property="BorderThickness" Value="0" />
-    <Setter Property="Border.CornerRadius" Value="0" />
-    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
@@ -1500,14 +1560,217 @@
       </Setter.Value>
     </Setter>
   </Style>
+  <ControlTemplate x:Key="DefaultComboBoxTemplate" TargetType="{x:Type ComboBox}">
+    <Grid x:Name="LayoutGrid">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="38" />
+      </Grid.ColumnDefinitions>
+      <Border x:Name="ContentBorder" Grid.ColumnSpan="2" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+      <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" Margin="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" IsHitTestVisible="False" />
+      <ToggleButton x:Name="ToggleButton" Grid.ColumnSpan="2" Focusable="False" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
+      <TextBlock x:Name="ChevronIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False" RenderTransformOrigin="0.5,0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{StaticResource ComboBoxChevronSize}" Text="{StaticResource ComboBoxChevronDownGlyph}">
+        <TextBlock.RenderTransform>
+          <RotateTransform Angle="0" />
+        </TextBlock.RenderTransform>
+      </TextBlock>
+      <Popup x:Name="PART_Popup" MinWidth="{TemplateBinding ActualWidth}" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
+        <Border x:Name="DropDownBorder" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
+          <Border.RenderTransform>
+            <TranslateTransform />
+          </Border.RenderTransform>
+          <Grid>
+            <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
+              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+            </ScrollViewer>
+          </Grid>
+          <Border.Effect>
+            <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
+          </Border.Effect>
+        </Border>
+      </Popup>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsDropDownOpen" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
+              <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
+                <DoubleAnimation.EasingFunction>
+                  <CircleEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+              </DoubleAnimation>
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+      <Trigger Property="HasItems" Value="False">
+        <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
+      </Trigger>
+      <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
+        <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
+      </Trigger>
+      <Trigger Property="IsGrouping" Value="True">
+        <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+      </Trigger>
+      <!--PointerOver state-->
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}" />
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPointerOver}" />
+      </Trigger>
+      <!--Pressed state-->
+      <Trigger SourceName="ToggleButton" Property="IsPressed" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPressed}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPressed}" />
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPressed}" />
+      </Trigger>
+      <!--Focused state-->
+      <Trigger Property="IsFocused" Value="True">
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocused}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocused}" />
+      </Trigger>
+      <!--FocusedPressed state-->
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="IsFocused" Value="True" />
+          <Condition SourceName="ToggleButton" Property="IsPressed" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocusedPressed}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocusedPressed}" />
+      </MultiTrigger>
+      <!--Disabled state-->
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <ControlTemplate x:Key="EditableComboBoxTemplate" TargetType="{x:Type ComboBox}">
+    <Grid x:Name="LayoutGrid">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="38" />
+      </Grid.ColumnDefinitions>
+      <Border x:Name="ContentBorder" Grid.ColumnSpan="2" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+      <TextBox x:Name="PART_EditableTextBox" Grid.ColumnSpan="2" Padding="11,5,38,6" Foreground="{TemplateBinding Foreground}" FontSize="{TemplateBinding FontSize}" IsReadOnly="{TemplateBinding IsReadOnly}" Style="{StaticResource DefaultComboBoxTextBoxStyle}" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" />
+      <Border x:Name="DropDownOverlay" Grid.Column="1" Margin="4" Width="30" Background="Transparent" CornerRadius="{StaticResource ComboBoxDropDownButtonBackgroundCornerRadius}" />
+      <ToggleButton x:Name="ToggleButton" Grid.Column="1" Margin="4" Focusable="False" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
+      <TextBlock x:Name="ChevronIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False" RenderTransformOrigin="0.5,0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{StaticResource ComboBoxChevronSize}" Text="{StaticResource ComboBoxChevronDownGlyph}">
+        <TextBlock.RenderTransform>
+          <RotateTransform Angle="0" />
+        </TextBlock.RenderTransform>
+      </TextBlock>
+      <Popup x:Name="PART_Popup" Focusable="False" AllowsTransparency="True" MinWidth="{TemplateBinding ActualWidth}" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
+        <Border x:Name="DropDownBorder" Padding="0,4,0,6" BorderThickness="1.5" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
+          <Border.RenderTransform>
+            <TranslateTransform />
+          </Border.RenderTransform>
+          <Grid>
+            <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
+              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+            </ScrollViewer>
+          </Grid>
+          <Border.Effect>
+            <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
+          </Border.Effect>
+        </Border>
+      </Popup>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsDropDownOpen" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
+              <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
+                <DoubleAnimation.EasingFunction>
+                  <CircleEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+              </DoubleAnimation>
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+      <Trigger Property="HasItems" Value="False">
+        <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
+      </Trigger>
+      <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
+        <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
+      </Trigger>
+      <Trigger Property="IsGrouping" Value="True">
+        <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+      </Trigger>
+      <!-- PointerOver state-->
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}" />
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPointerOver}" />
+      </Trigger>
+      <!-- Focused / TextBoxFocused -->
+      <Trigger Property="IsFocused" Value="True">
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocused}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+      </Trigger>
+      <!--TextBoxOverlayPointerOver state-->
+      <Trigger SourceName="ToggleButton" Property="IsMouseOver" Value="True">
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerOver}" />
+      </Trigger>
+      <!--TextBoxOverlayPressed-->
+      <Trigger SourceName="ToggleButton" Property="IsPressed" Value="True">
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerPressed}" />
+      </Trigger>
+      <!--TextBoxFocusedOverlayPointerOver state-->
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="IsFocused" Value="True" />
+          <Condition SourceName="ToggleButton" Property="IsMouseOver" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerOver}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+      </MultiTrigger>
+      <!-- FocusedPressed state / TextBoxFocusedOverlayPressed state -->
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="IsFocused" Value="True" />
+          <Condition SourceName="ToggleButton" Property="IsPressed" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocusedPressed}" />
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxFocusedDropDownBackgroundPointerPressed}" />
+      </MultiTrigger>
+      <!--Disabled state-->
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
   <Style x:Key="DefaultComboBoxStyle" TargetType="{x:Type ComboBox}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI ContextMenu  -->
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
     <Setter Property="Background" Value="{DynamicResource ComboBoxBackground}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
     <Setter Property="BorderThickness" Value="{StaticResource ComboBoxBorderThemeThickness}" />
     <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
@@ -1522,125 +1785,15 @@
     <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="Popup.PopupAnimation" Value="None" />
-    <!--  WPF doesn't like centering, the animation is ugly and the mouse button sometimes clicks right away.  -->
     <Setter Property="Popup.Placement" Value="Bottom" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
-    <Setter Property="Template">
-      <Setter.Value>
-        <ControlTemplate TargetType="{x:Type ComboBox}">
-          <Grid>
-            <Border x:Name="ContentBorder" Grid.Row="0" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
-              <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                <!--
-                                    Funky grid - because:
-                                    Chevron is over Presenter, ToggleButton is over Chevron, TextBox is over ToggleButton.
-                                    But, TextBox is not over Chevron, so ToggleButton still works.
-                                -->
-                <Grid>
-                  <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                  </Grid.ColumnDefinitions>
-                  <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                    <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
-                  </Grid>
-                  <Grid Grid.Column="1" Margin="{StaticResource ComboBoxChevronMargin}">
-                    <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ComboBoxChevronDownGlyph}">
-                      <TextBlock.RenderTransform>
-                        <RotateTransform Angle="0" />
-                      </TextBlock.RenderTransform>
-                    </TextBlock>
-                  </Grid>
-                  <Grid Grid.Column="0" Grid.ColumnSpan="2" Margin="0">
-                    <ToggleButton Name="ToggleButton" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ClickMode="Press" Focusable="False" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
-                  </Grid>
-                  <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                    <TextBox x:Name="PART_EditableTextBox" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" IsReadOnly="{TemplateBinding IsReadOnly}" Style="{StaticResource DefaultComboBoxTextBoxStyle}" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" />
-                  </Grid>
-                </Grid>
-                <Popup x:Name="PART_Popup" MinWidth="{TemplateBinding ActualWidth}" VerticalAlignment="Center" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
-                  <Border x:Name="DropDownBorder" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
-                    <!--Will revist this code while doing performance evaluation for dynamic resources.-->
-                    <Border.RenderTransform>
-                      <TranslateTransform />
-                    </Border.RenderTransform>
-                    <Grid>
-                      <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" Margin="0" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" SnapsToDevicePixels="True" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                        <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" TextElement.FontSize="{TemplateBinding FontSize}" />
-                      </ScrollViewer>
-                    </Grid>
-                    <Border.Effect>
-                      <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
-                    </Border.Effect>
-                  </Border>
-                </Popup>
-              </Grid>
-            </Border>
-            <Border x:Name="AccentBorder" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderBrush="{DynamicResource ComboBoxBorderBrushFocused}" BorderThickness="{StaticResource ComboBoxAccentBorderThemeThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" Visibility="Collapsed" />
-          </Grid>
-          <ControlTemplate.Triggers>
-            <Trigger Property="IsDropDownOpen" Value="True">
-              <Trigger.EnterActions>
-                <BeginStoryboard>
-                  <Storyboard>
-                    <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
-                    <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
-                      <DoubleAnimation.EasingFunction>
-                        <CircleEase EasingMode="EaseOut" />
-                      </DoubleAnimation.EasingFunction>
-                    </DoubleAnimation>
-                  </Storyboard>
-                </BeginStoryboard>
-              </Trigger.EnterActions>
-              <Trigger.ExitActions>
-                <BeginStoryboard>
-                  <Storyboard>
-                    <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
-                  </Storyboard>
-                </BeginStoryboard>
-              </Trigger.ExitActions>
-            </Trigger>
-            <Trigger Property="HasItems" Value="False">
-              <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
-            </Trigger>
-            <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
-              <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
-            </Trigger>
-            <Trigger Property="IsGrouping" Value="True">
-              <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
-            </Trigger>
-            <Trigger Property="IsEditable" Value="True">
-              <Setter Property="IsTabStop" Value="False" />
-              <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />
-              <Setter TargetName="PART_ContentPresenter" Property="Visibility" Value="Hidden" />
-            </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="True" />
-                <Condition Property="IsKeyboardFocusWithin" Value="True" />
-                <Condition Property="IsEditable" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundFocused}" />
-              <Setter TargetName="AccentBorder" Property="Visibility" Value="Visible" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="True" />
-                <Condition Property="IsMouseOver" Value="True" />
-                <Condition Property="IsKeyboardFocusWithin" Value="False" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
-            </MultiTrigger>
-            <Trigger Property="IsEnabled" Value="False">
-              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
-              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
-              <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
-            </Trigger>
-          </ControlTemplate.Triggers>
-        </ControlTemplate>
-      </Setter.Value>
-    </Setter>
+    <Setter Property="Template" Value="{StaticResource DefaultComboBoxTemplate}" />
+    <Style.Triggers>
+      <Trigger Property="IsEditable" Value="True">
+        <Setter Property="Template" Value="{StaticResource EditableComboBoxTemplate}" />
+      </Trigger>
+    </Style.Triggers>
   </Style>
   <Style BasedOn="{StaticResource DefaultComboBoxItemStyle}" TargetType="{x:Type ComboBoxItem}" />
   <Style BasedOn="{StaticResource DefaultComboBoxStyle}" TargetType="{x:Type ComboBox}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
@@ -792,7 +792,7 @@
           </Border.RenderTransform>
           <Grid>
             <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
-              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+              <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
             </ScrollViewer>
           </Grid>
           <Border.Effect>
@@ -889,7 +889,7 @@
           </Border.RenderTransform>
           <Grid>
             <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
-              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+              <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
             </ScrollViewer>
           </Grid>
           <Border.Effect>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
@@ -77,10 +77,8 @@
   <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
-  <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
   <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
-  <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
   <Thickness x:Key="ButtonPadding">11,5,11,6</Thickness>
   <Thickness x:Key="ButtonBorderThemeThickness">1</Thickness>
@@ -652,49 +650,78 @@
   <DataTemplate DataType="{x:Type CollectionViewGroup}">
     <ContentPresenter Content="{Binding Path=Name}" ContentStringFormat="{TemplateBinding ContentStringFormat}" />
   </DataTemplate>
-  <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
-  <Thickness x:Key="ComboBoxBorderThemeThickness">1,1,1,1</Thickness>
+  <!-- Deprecated .NET 9 Keys -->
   <Thickness x:Key="ComboBoxAccentBorderThemeThickness">0,0,0,2</Thickness>
   <Thickness x:Key="ComboBoxChevronMargin">8,0,10,0</Thickness>
-  <Thickness x:Key="ComboBoxItemMargin">3,2,3,0</Thickness>
-  <Thickness x:Key="ComboBoxItemContentMargin">10,8,8,8</Thickness>
-  <system:Double x:Key="ComboBoxChevronSize">11.0</system:Double>
+  <!-- Redefined in .NET 10 -->
+  <!-- <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
+            <system:Double x:Key="ComboBoxChevronSize">11</system:Double> -->
+  <Thickness x:Key="ComboBoxPadding">12,5,0,7</Thickness>
+  <Thickness x:Key="ComboBoxEditableTextPadding">11,5,38,6</Thickness>
+  <Thickness x:Key="ComboBoxBorderThemeThickness">1,1,1,1</Thickness>
+  <system:Double x:Key="ComboBoxChevronSize">10</system:Double>
   <system:Double x:Key="ComboBoxPopupMinHeight">32.0</system:Double>
   <system:String x:Key="ComboBoxChevronDownGlyph"></system:String>
+  <CornerRadius x:Key="ComboBoxDropDownButtonBackgroundCornerRadius">4</CornerRadius>
+  <Thickness x:Key="ComboBoxItemMargin">3,2,3,0</Thickness>
+  <Thickness x:Key="ComboBoxItemContentMargin">10,8,8,8</Thickness>
   <Style x:Key="DefaultComboBoxTextBoxStyle" TargetType="{x:Type TextBox}">
-    <!--  Focus by parent element  -->
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-    <!--  Focus by parent element  -->
-    <!--  Universal WPF UI ContextMenu  -->
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
-    <!--  Universal WPF UI ContextMenu  -->
-    <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
-    <Setter Property="CaretBrush" Value="{DynamicResource ComboBoxForeground}" />
-    <Setter Property="Background" Value="Transparent" />
-    <Setter Property="Visibility" Value="Hidden" />
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="Margin" Value="0" />
-    <Setter Property="Padding" Value="0" />
-    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
+    <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="AllowDrop" Value="True" />
+    <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
+    <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="{x:Type TextBox}">
-          <Decorator x:Name="PART_ContentHost" Margin="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" TextElement.Foreground="{TemplateBinding Foreground}" />
+        <ControlTemplate TargetType="{x:Type TextBoxBase}">
+          <Grid>
+            <Border x:Name="ContentBorder" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+            <ScrollViewer x:Name="PART_ContentHost" Margin="{TemplateBinding BorderThickness}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}" IsTabStop="{TemplateBinding ScrollViewer.IsTabStop}" Padding="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <!-- Disabling this setter as this will be handled by the ComboBox style. -->
+              <!--<Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />-->
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsFocused" Value="True">
+              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundDisabled}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushDisabled}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
   </Style>
   <Style x:Key="DefaultComboBoxToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-    <!--  Focus by parent element  -->
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-    <!--  Focus by parent element  -->
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="Transparent" />
-    <Setter Property="BorderThickness" Value="0" />
-    <Setter Property="Border.CornerRadius" Value="0" />
-    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
@@ -744,14 +771,217 @@
       </Setter.Value>
     </Setter>
   </Style>
+  <ControlTemplate x:Key="DefaultComboBoxTemplate" TargetType="{x:Type ComboBox}">
+    <Grid x:Name="LayoutGrid">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="38" />
+      </Grid.ColumnDefinitions>
+      <Border x:Name="ContentBorder" Grid.ColumnSpan="2" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+      <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" Margin="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" IsHitTestVisible="False" />
+      <ToggleButton x:Name="ToggleButton" Grid.ColumnSpan="2" Focusable="False" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
+      <TextBlock x:Name="ChevronIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False" RenderTransformOrigin="0.5,0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{StaticResource ComboBoxChevronSize}" Text="{StaticResource ComboBoxChevronDownGlyph}">
+        <TextBlock.RenderTransform>
+          <RotateTransform Angle="0" />
+        </TextBlock.RenderTransform>
+      </TextBlock>
+      <Popup x:Name="PART_Popup" MinWidth="{TemplateBinding ActualWidth}" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
+        <Border x:Name="DropDownBorder" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
+          <Border.RenderTransform>
+            <TranslateTransform />
+          </Border.RenderTransform>
+          <Grid>
+            <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
+              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+            </ScrollViewer>
+          </Grid>
+          <Border.Effect>
+            <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
+          </Border.Effect>
+        </Border>
+      </Popup>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsDropDownOpen" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
+              <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
+                <DoubleAnimation.EasingFunction>
+                  <CircleEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+              </DoubleAnimation>
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+      <Trigger Property="HasItems" Value="False">
+        <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
+      </Trigger>
+      <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
+        <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
+      </Trigger>
+      <Trigger Property="IsGrouping" Value="True">
+        <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+      </Trigger>
+      <!--PointerOver state-->
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}" />
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPointerOver}" />
+      </Trigger>
+      <!--Pressed state-->
+      <Trigger SourceName="ToggleButton" Property="IsPressed" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPressed}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPressed}" />
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPressed}" />
+      </Trigger>
+      <!--Focused state-->
+      <Trigger Property="IsFocused" Value="True">
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocused}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocused}" />
+      </Trigger>
+      <!--FocusedPressed state-->
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="IsFocused" Value="True" />
+          <Condition SourceName="ToggleButton" Property="IsPressed" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocusedPressed}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocusedPressed}" />
+      </MultiTrigger>
+      <!--Disabled state-->
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
+        <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <ControlTemplate x:Key="EditableComboBoxTemplate" TargetType="{x:Type ComboBox}">
+    <Grid x:Name="LayoutGrid">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="38" />
+      </Grid.ColumnDefinitions>
+      <Border x:Name="ContentBorder" Grid.ColumnSpan="2" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+      <TextBox x:Name="PART_EditableTextBox" Grid.ColumnSpan="2" Padding="11,5,38,6" Foreground="{TemplateBinding Foreground}" FontSize="{TemplateBinding FontSize}" IsReadOnly="{TemplateBinding IsReadOnly}" Style="{StaticResource DefaultComboBoxTextBoxStyle}" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" />
+      <Border x:Name="DropDownOverlay" Grid.Column="1" Margin="4" Width="30" Background="Transparent" CornerRadius="{StaticResource ComboBoxDropDownButtonBackgroundCornerRadius}" />
+      <ToggleButton x:Name="ToggleButton" Grid.Column="1" Margin="4" Focusable="False" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
+      <TextBlock x:Name="ChevronIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False" RenderTransformOrigin="0.5,0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{StaticResource ComboBoxChevronSize}" Text="{StaticResource ComboBoxChevronDownGlyph}">
+        <TextBlock.RenderTransform>
+          <RotateTransform Angle="0" />
+        </TextBlock.RenderTransform>
+      </TextBlock>
+      <Popup x:Name="PART_Popup" Focusable="False" AllowsTransparency="True" MinWidth="{TemplateBinding ActualWidth}" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
+        <Border x:Name="DropDownBorder" Padding="0,4,0,6" BorderThickness="1.5" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
+          <Border.RenderTransform>
+            <TranslateTransform />
+          </Border.RenderTransform>
+          <Grid>
+            <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" SnapsToDevicePixels="True" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}">
+              <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+            </ScrollViewer>
+          </Grid>
+          <Border.Effect>
+            <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
+          </Border.Effect>
+        </Border>
+      </Popup>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsDropDownOpen" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
+              <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
+                <DoubleAnimation.EasingFunction>
+                  <CircleEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+              </DoubleAnimation>
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+      <Trigger Property="HasItems" Value="False">
+        <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
+      </Trigger>
+      <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
+        <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
+      </Trigger>
+      <Trigger Property="IsGrouping" Value="True">
+        <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+      </Trigger>
+      <!-- PointerOver state-->
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}" />
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundPointerOver}" />
+      </Trigger>
+      <!-- Focused / TextBoxFocused -->
+      <Trigger Property="IsFocused" Value="True">
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocused}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+      </Trigger>
+      <!--TextBoxOverlayPointerOver state-->
+      <Trigger SourceName="ToggleButton" Property="IsMouseOver" Value="True">
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerOver}" />
+      </Trigger>
+      <!--TextBoxOverlayPressed-->
+      <Trigger SourceName="ToggleButton" Property="IsPressed" Value="True">
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerPressed}" />
+      </Trigger>
+      <!--TextBoxFocusedOverlayPointerOver state-->
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="IsFocused" Value="True" />
+          <Condition SourceName="ToggleButton" Property="IsMouseOver" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerOver}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+      </MultiTrigger>
+      <!-- FocusedPressed state / TextBoxFocusedOverlayPressed state -->
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="IsFocused" Value="True" />
+          <Condition SourceName="ToggleButton" Property="IsPressed" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxEditableDropDownGlyphForeground}" />
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundFocusedPressed}" />
+        <Setter TargetName="DropDownOverlay" Property="Background" Value="{DynamicResource ComboBoxFocusedDropDownBackgroundPointerPressed}" />
+      </MultiTrigger>
+      <!--Disabled state-->
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
+        <Setter TargetName="PART_EditableTextBox" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+        <Setter TargetName="ChevronIcon" Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
   <Style x:Key="DefaultComboBoxStyle" TargetType="{x:Type ComboBox}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI ContextMenu  -->
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
     <Setter Property="Background" Value="{DynamicResource ComboBoxBackground}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
     <Setter Property="BorderThickness" Value="{StaticResource ComboBoxBorderThemeThickness}" />
     <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
@@ -766,125 +996,15 @@
     <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="Popup.PopupAnimation" Value="None" />
-    <!--  WPF doesn't like centering, the animation is ugly and the mouse button sometimes clicks right away.  -->
     <Setter Property="Popup.Placement" Value="Bottom" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
-    <Setter Property="Template">
-      <Setter.Value>
-        <ControlTemplate TargetType="{x:Type ComboBox}">
-          <Grid>
-            <Border x:Name="ContentBorder" Grid.Row="0" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
-              <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                <!--
-                                    Funky grid - because:
-                                    Chevron is over Presenter, ToggleButton is over Chevron, TextBox is over ToggleButton.
-                                    But, TextBox is not over Chevron, so ToggleButton still works.
-                                -->
-                <Grid>
-                  <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                  </Grid.ColumnDefinitions>
-                  <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                    <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
-                  </Grid>
-                  <Grid Grid.Column="1" Margin="{StaticResource ComboBoxChevronMargin}">
-                    <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ComboBoxChevronDownGlyph}">
-                      <TextBlock.RenderTransform>
-                        <RotateTransform Angle="0" />
-                      </TextBlock.RenderTransform>
-                    </TextBlock>
-                  </Grid>
-                  <Grid Grid.Column="0" Grid.ColumnSpan="2" Margin="0">
-                    <ToggleButton Name="ToggleButton" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ClickMode="Press" Focusable="False" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
-                  </Grid>
-                  <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                    <TextBox x:Name="PART_EditableTextBox" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" IsReadOnly="{TemplateBinding IsReadOnly}" Style="{StaticResource DefaultComboBoxTextBoxStyle}" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" />
-                  </Grid>
-                </Grid>
-                <Popup x:Name="PART_Popup" MinWidth="{TemplateBinding ActualWidth}" VerticalAlignment="Center" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
-                  <Border x:Name="DropDownBorder" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
-                    <!--Will revist this code while doing performance evaluation for dynamic resources.-->
-                    <Border.RenderTransform>
-                      <TranslateTransform />
-                    </Border.RenderTransform>
-                    <Grid>
-                      <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" Margin="0" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" SnapsToDevicePixels="True" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                        <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" TextElement.FontSize="{TemplateBinding FontSize}" />
-                      </ScrollViewer>
-                    </Grid>
-                    <Border.Effect>
-                      <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
-                    </Border.Effect>
-                  </Border>
-                </Popup>
-              </Grid>
-            </Border>
-            <Border x:Name="AccentBorder" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderBrush="{DynamicResource ComboBoxBorderBrushFocused}" BorderThickness="{StaticResource ComboBoxAccentBorderThemeThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" Visibility="Collapsed" />
-          </Grid>
-          <ControlTemplate.Triggers>
-            <Trigger Property="IsDropDownOpen" Value="True">
-              <Trigger.EnterActions>
-                <BeginStoryboard>
-                  <Storyboard>
-                    <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
-                    <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
-                      <DoubleAnimation.EasingFunction>
-                        <CircleEase EasingMode="EaseOut" />
-                      </DoubleAnimation.EasingFunction>
-                    </DoubleAnimation>
-                  </Storyboard>
-                </BeginStoryboard>
-              </Trigger.EnterActions>
-              <Trigger.ExitActions>
-                <BeginStoryboard>
-                  <Storyboard>
-                    <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
-                  </Storyboard>
-                </BeginStoryboard>
-              </Trigger.ExitActions>
-            </Trigger>
-            <Trigger Property="HasItems" Value="False">
-              <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
-            </Trigger>
-            <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
-              <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
-            </Trigger>
-            <Trigger Property="IsGrouping" Value="True">
-              <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
-            </Trigger>
-            <Trigger Property="IsEditable" Value="True">
-              <Setter Property="IsTabStop" Value="False" />
-              <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />
-              <Setter TargetName="PART_ContentPresenter" Property="Visibility" Value="Hidden" />
-            </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="True" />
-                <Condition Property="IsKeyboardFocusWithin" Value="True" />
-                <Condition Property="IsEditable" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundFocused}" />
-              <Setter TargetName="AccentBorder" Property="Visibility" Value="Visible" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="True" />
-                <Condition Property="IsMouseOver" Value="True" />
-                <Condition Property="IsKeyboardFocusWithin" Value="False" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
-            </MultiTrigger>
-            <Trigger Property="IsEnabled" Value="False">
-              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
-              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
-              <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
-            </Trigger>
-          </ControlTemplate.Triggers>
-        </ControlTemplate>
-      </Setter.Value>
-    </Setter>
+    <Setter Property="Template" Value="{StaticResource DefaultComboBoxTemplate}" />
+    <Style.Triggers>
+      <Trigger Property="IsEditable" Value="True">
+        <Setter Property="Template" Value="{StaticResource EditableComboBoxTemplate}" />
+      </Trigger>
+    </Style.Triggers>
   </Style>
   <Style BasedOn="{StaticResource DefaultComboBoxItemStyle}" TargetType="{x:Type ComboBoxItem}" />
   <Style BasedOn="{StaticResource DefaultComboBoxStyle}" TargetType="{x:Type ComboBox}" />


### PR DESCRIPTION
Fixes #10470 , #10656 

## Description
In this PR I have restyled the ComboBox style and template to make it more similar to WinUI's style, however the styles are slightly different to make it easier in WPF. Here are the list of few major changes in the PR : 
1. Split the control template for ComboBox in two parts : one for normal ComboBox and other for EditableComboBox.
3. Fixed the layout in each of the ComboBox template and matched the height and other parameters to WinUI.
4. Added missing control template triggers to get the correct behavior for different states of controls.
5. Added the correct TextBox style Editable ComboBox and fixed the dropdown button styling.
6. Added the correct resources for ComboBox styles.

### Bug Fixes covered in this PR : 
- Fixes the chevron icon positioning when ComboBox has custom height. 
- Chevron button highlight in PointerOver state in Editable combo box mode. 
- Fixes the default height of ComboBox control to 32 px. 
- Fixes margins and padding for different sub components of ComboBox. 
- Fixes the text selection brush color in ComboBox. 
- Fixes triggers for different states of ComboBox. 
- Fixes the behavior of ComboBox when it is pressed ( for editable ComboBox ) 

This is not an exhaustive list.

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Correct style for developers.

## Regression
No.

## Testing
Local app testing.

## Risk
Minimal.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10818)