### PR TITLE
Replace arch-specific package properties with arch neutral ones

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -8,8 +8,8 @@
   <!-- Pre-download vcxproj dependencies as vcxprojs in this repo don't support NuGet package download. -->
   <ItemGroup>
     <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(MicrosoftNETCoreAppRefVersion)]" Condition="'$(MicrosoftNETCoreAppRefVersion)' != ''" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.$(_RuntimeIdentifier)" Version="[$(MicrosoftNETCoreAppRuntimewinx64Version)]" Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''" />
-    <PackageDownload Include="Microsoft.NETCore.App.Host.$(_RuntimeIdentifier)" Version="[$(MicrosoftNETCoreAppRuntimewinx64Version)]" Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.$(_RuntimeIdentifier)" Version="[$(MicrosoftNETCoreAppRefVersion)]" Condition="'$(MicrosoftNETCoreAppRefVersion)' != ''" />
+    <PackageDownload Include="Microsoft.NETCore.App.Host.$(_RuntimeIdentifier)" Version="[$(MicrosoftNETCoreAppRefVersion)]" Condition="'$(MicrosoftNETCoreAppRefVersion)' != ''" />
   </ItemGroup>
 
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -38,14 +38,6 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>85778473549347b3e4bad3ea009e9438df7b11bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="10.0.0-preview.5.25260.104">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>85778473549347b3e4bad3ea009e9438df7b11bb</Sha>
-    </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.10.0" Version="10.0.0-preview.5.25260.104">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>85778473549347b3e4bad3ea009e9438df7b11bb</Sha>
-    </Dependency>
     <Dependency Name="System.CodeDom" Version="10.0.0-preview.5.25260.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>85778473549347b3e4bad3ea009e9438df7b11bb</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,9 +31,7 @@
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/runtime -->
   <PropertyGroup>
-    <VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>10.0.0-preview.5.25260.104</VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>
     <MicrosoftNETCoreAppRefVersion>10.0.0-preview.5.25260.104</MicrosoftNETCoreAppRefVersion>
-    <MicrosoftNETCoreAppRuntimewinx64Version>10.0.0-preview.5.25260.104</MicrosoftNETCoreAppRuntimewinx64Version>
     <MicrosoftNETCorePlatformsVersion>10.0.0-preview.5.25260.104</MicrosoftNETCorePlatformsVersion>
     <SystemCodeDomPackageVersion>10.0.0-preview.5.25260.104</SystemCodeDomPackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>10.0.0-preview.5.25260.104</SystemConfigurationConfigurationManagerPackageVersion>

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -22,23 +22,23 @@
   <!-- The below logic intentionally doesn't consider multiple .NETCoreApp TFMs as that isn't necessary at this point. -->
   <PropertyGroup>
     <UseOOBNETCoreAppTargetingPack Condition="'$(UseOOBNETCoreAppTargetingPack)' == '' and '$(MicrosoftNETCoreAppRefVersion)' != ''">true</UseOOBNETCoreAppTargetingPack>
-    <UseOOBNETCoreAppRuntimePack Condition="'$(UseOOBNETCoreAppRuntimePack)' == '' and '$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''">true</UseOOBNETCoreAppRuntimePack>
-    <UseOOBNETCoreAppAppHostPack Condition="'$(UseOOBNETCoreAppAppHostPack)' == '' and '$(MicrosoftNETCoreAppRuntimewinx64Version)' != ''">true</UseOOBNETCoreAppAppHostPack>
+    <UseOOBNETCoreAppRuntimePack Condition="'$(UseOOBNETCoreAppRuntimePack)' == '' and '$(MicrosoftNETCoreAppRefVersion)' != ''">true</UseOOBNETCoreAppRuntimePack>
+    <UseOOBNETCoreAppAppHostPack Condition="'$(UseOOBNETCoreAppAppHostPack)' == '' and '$(MicrosoftNETCoreAppRefVersion)' != ''">true</UseOOBNETCoreAppAppHostPack>
   </PropertyGroup>
 
   <ItemGroup>
     <KnownFrameworkReference Update="Microsoft.NETCore.App">
       <TargetingPackVersion Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true'">$(MicrosoftNETCoreAppRefVersion)</TargetingPackVersion>
-      <DefaultRuntimeFrameworkVersion Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true'">$(MicrosoftNETCoreAppRuntimewinx64Version)</DefaultRuntimeFrameworkVersion>
-      <LatestRuntimeFrameworkVersion Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true'">$(MicrosoftNETCoreAppRuntimewinx64Version)</LatestRuntimeFrameworkVersion>
+      <DefaultRuntimeFrameworkVersion Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true'">$(MicrosoftNETCoreAppRefVersion)</DefaultRuntimeFrameworkVersion>
+      <LatestRuntimeFrameworkVersion Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true'">$(MicrosoftNETCoreAppRefVersion)</LatestRuntimeFrameworkVersion>
     </KnownFrameworkReference>
 
     <KnownRuntimePack Update="Microsoft.NETCore.App"
-                      LatestRuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimewinx64Version)"
+                      LatestRuntimeFrameworkVersion="$(MicrosoftNETCoreAppRefVersion)"
                       Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true'" />
 
     <KnownAppHostPack Update="Microsoft.NETCore.App"
-                      AppHostPackVersion="$(MicrosoftNETCoreAppRuntimewinx64Version)"
+                      AppHostPackVersion="$(MicrosoftNETCoreAppRefVersion)"
                       Condition="'$(UseOOBNETCoreAppAppHostPack)' == 'true'" />
   </ItemGroup>
 
@@ -59,15 +59,15 @@
           AfterTargets="ResolveFrameworkReferences">
     <ItemGroup>
       <Error Text="'MicrosoftNETCoreAppRefVersion' is not set. Please set it to the version of the targeting pack you want to use." Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(MicrosoftNETCoreAppRefVersion)' == ''" />
-      <Error Text="'MicrosoftNETCoreAppRuntimewinx64Version' is not set. Please set it to the version of the runtime pack you want to use." Condition="('$(UseOOBNETCoreAppRuntimePack)' == 'true' or '$(UseOOBNETCoreAppAppHostPack)' == 'true') and '$(MicrosoftNETCoreAppRuntimewinx64Version)' == ''" />
+      <Error Text="'MicrosoftNETCoreAppRefVersion' is not set. Please set it to the version of the runtime pack you want to use." Condition="('$(UseOOBNETCoreAppRuntimePack)' == 'true' or '$(UseOOBNETCoreAppAppHostPack)' == 'true') and '$(MicrosoftNETCoreAppRefVersion)' == ''" />
 
       <ResolvedTargetingPack Path="$(NuGetPackageRoot)microsoft.netcore.app.ref\$(MicrosoftNETCoreAppRefVersion)"
                              NuGetPackageVersion="$(MicrosoftNETCoreAppRefVersion)"
                              PackageDirectory="$(NuGetPackageRoot)microsoft.netcore.app.ref\$(MicrosoftNETCoreAppRefVersion)"
                              Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(EnableTargetingPackDownload)' == 'false' and '%(ResolvedTargetingPack.RuntimeFrameworkName)' == 'Microsoft.NETCore.App'" />
 
-      <ResolvedRuntimePack PackageDirectory="$(NuGetPackageRoot)microsoft.netcore.app.runtime.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRuntimewinx64Version)"
-                           NuGetPackageVersion="$(MicrosoftNETCoreAppRuntimewinx64Version)"
+      <ResolvedRuntimePack PackageDirectory="$(NuGetPackageRoot)microsoft.netcore.app.runtime.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRefVersion)"
+                           NuGetPackageVersion="$(MicrosoftNETCoreAppRefVersion)"
                            Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(EnableRuntimePackDownload)' == 'false' and '%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App'" />
     </ItemGroup>
 
@@ -80,15 +80,15 @@
         <TargetingPackPath Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(EnableTargetingPackDownload)' == 'false'">$(NuGetPackageRoot)microsoft.netcore.app.ref\$(MicrosoftNETCoreAppRefVersion)</TargetingPackPath>
         <TargetingPackVersion Condition="'$(UseOOBNETCoreAppTargetingPack)' == 'true' and '$(EnableTargetingPackDownload)' == 'false'">$(MicrosoftNETCoreAppRefVersion)</TargetingPackVersion>
         <RuntimePackPath Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(EnableRuntimePackDownload)' == 'false'">$(_ResolvedRuntimePackPath)</RuntimePackPath>
-        <RuntimePackVersion Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(EnableRuntimePackDownload)' == 'false'">$(MicrosoftNETCoreAppRuntimewinx64Version)</RuntimePackVersion>
+        <RuntimePackVersion Condition="'$(UseOOBNETCoreAppRuntimePack)' == 'true' and '$(EnableRuntimePackDownload)' == 'false'">$(MicrosoftNETCoreAppRefVersion)</RuntimePackVersion>
       </ResolvedFrameworkReference>
 
-      <ResolvedAppHostPack Path="$(NuGetPackageRoot)microsoft.netcore.app.host.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRuntimewinx64Version)\%(ResolvedAppHostPack.PathInPackage)"
-                           PackageDirectory="$(NuGetPackageRoot)microsoft.netcore.app.host.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRuntimewinx64Version)"
+      <ResolvedAppHostPack Path="$(NuGetPackageRoot)microsoft.netcore.app.host.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRefVersion)\%(ResolvedAppHostPack.PathInPackage)"
+                           PackageDirectory="$(NuGetPackageRoot)microsoft.netcore.app.host.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRefVersion)"
                            Condition="'$(UseOOBNETCoreAppAppHostPack)' == 'true' and '$(EnableAppHostPackDownload)' == 'false'" />
 
-      <ResolvedIjwHostPack Path="$(NuGetPackageRoot)microsoft.netcore.app.host.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRuntimewinx64Version)\%(ResolvedIjwHostPack.PathInPackage)"
-                           PackageDirectory="$(NuGetPackageRoot)microsoft.netcore.app.host.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRuntimewinx64Version)"
+      <ResolvedIjwHostPack Path="$(NuGetPackageRoot)microsoft.netcore.app.host.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRefVersion)\%(ResolvedIjwHostPack.PathInPackage)"
+                           PackageDirectory="$(NuGetPackageRoot)microsoft.netcore.app.host.%(RuntimeIdentifier)\$(MicrosoftNETCoreAppRefVersion)"
                            Condition="'$(UseOOBNETCoreAppAppHostPack)' == 'true' and '$(EnableAppHostPackDownload)' == 'false'" />
     </ItemGroup>
 

--- a/global.json
+++ b/global.json
@@ -3,10 +3,10 @@
     "dotnet": "10.0.100-preview.3.25201.16",
     "runtimes": {
       "dotnet/x64": [
-        "$(VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion)"
+        "$(MicrosoftNETCorePlatformsVersion)"
       ],
       "dotnet/x86": [
-        "$(VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion)"
+        "$(MicrosoftNETCorePlatformsVersion)"
       ]
     },
     "vs": {


### PR DESCRIPTION
This avoids need for a workaround in VMR builds and reduces friction for stable builds. When building non-win-x64 verticals, we end up having to set the x64 runtime pack and x64 VS redist pack properties (stable and non-stable properties) based on other values in the VMR orchestrator. Instead, use MicrosoftNEtCoreAppRef as the stable version property, and MicrosoftNETCOrePlatforms as the non-stable one.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10844)