### PR TITLE
Common Fluent.xaml for System ThemeMode

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/Generator/ThemeGenerator.Fluent.ps1
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/Generator/ThemeGenerator.Fluent.ps1
@@ -13,11 +13,6 @@ foreach($themeColor in $themeColors)
     if($themeColor -eq "System") {
         $outFilePath = Join-Path $fluentThemeDir "Themes\Fluent.xaml"
     }
-    else
-    {
-        $outFilePath = Join-Path $fluentThemeDir "Themes\Fluent.$themeColor.xaml"
-        $themeColorFilePath = Join-Path $resouceFilesDir "Theme\$themeColor.xaml"
-    }
    
     [xml]$combinedXaml = '<ResourceDictionary 
                             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/Generator/ThemeGenerator.Fluent.ps1
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/Generator/ThemeGenerator.Fluent.ps1
@@ -1,4 +1,4 @@
-$themeColors=@("Light", "Dark", "HC");
+$themeColors=@("Light", "Dark", "HC", "System");
 
 $currentDir = Get-Location
 $fluentThemeDir = Join-Path $currentDir "..\PresentationFramework.Fluent\"
@@ -10,6 +10,14 @@ foreach($themeColor in $themeColors)
 {
     $outFilePath = Join-Path $fluentThemeDir "Themes\Fluent.$themeColor.xaml"
     $themeColorFilePath = Join-Path $resouceFilesDir "Theme\$themeColor.xaml"
+    if($themeColor -eq "System") {
+        $outFilePath = Join-Path $fluentThemeDir "Themes\Fluent.xaml"
+    }
+    else
+    {
+        $outFilePath = Join-Path $fluentThemeDir "Themes\Fluent.$themeColor.xaml"
+        $themeColorFilePath = Join-Path $resouceFilesDir "Theme\$themeColor.xaml"
+    }
    
     [xml]$combinedXaml = '<ResourceDictionary 
                             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
@@ -33,8 +41,10 @@ foreach($themeColor in $themeColors)
         $combinedXaml.ResourceDictionary.InnerXml += $currentXaml.ResourceDictionary.InnerXml
     }
     
-    [xml]$themeColorXaml = Get-Content $themeColorFilePath -Encoding UTF8
-    $combinedXaml.ResourceDictionary.InnerXml += $themeColorXaml.ResourceDictionary.InnerXml
+    if($themeColor -ne "System") {
+        [xml]$themeColorXaml = Get-Content $themeColorFilePath -Encoding UTF8
+        $combinedXaml.ResourceDictionary.InnerXml += $themeColorXaml.ResourceDictionary.InnerXml
+    }
     
     foreach ($file in Get-ChildItem $styleFilesDir -Filter "*.xaml") {
         [xml]$currentXaml = Get-Content $file.FullName -Encoding UTF8

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
@@ -4,62 +4,4840 @@
     Copyright (C) Leszek Pomianowski and WPF UI Contributors.
     All Rights Reserved.
 -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Resources/DefaultContextMenu.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Resources/DefaultFocusVisualStyle.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Resources/Fonts.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Resources/StaticColors.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Resources/Variables.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Button.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Calendar.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/CheckBox.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/CollectionViewGroup.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ComboBox.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ContentControl.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ContextMenu.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/DataGrid.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/DatePicker.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/DocumentViewer.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Expander.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Frame.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/GridSplitter.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/GroupBox.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/GroupItem.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/HeaderedContentControl.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Hyperlink.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ItemsControl.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Label.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ListBox.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ListBoxItem.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ListView.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ListViewItem.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Menu.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/MenuItem.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/NavigationWindow.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Page.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/PasswordBox.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ProgressBar.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/RadioButton.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/RepeatButton.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ResizeGrip.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/RichTextBox.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ScrollBar.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ScrollViewer.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Separator.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Slider.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/StatusBar.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/StatusBarItem.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/TabControl.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/TextBlock.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/TextBox.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Thumb.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ToggleButton.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ToolBar.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ToolTip.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/TreeView.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/TreeViewItem.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/UserControl.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Window.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" xmlns:fluentcontrols="clr-namespace:Fluent.Controls" xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI" xmlns:theme="clr-namespace:Microsoft.Windows.Themes" xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework" xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
+  <!-- #region DefaultContextmenu -->
+    <ContextMenu x:Key="DefaultControlContextMenu">
+        <MenuItem Command="ApplicationCommands.Copy" />
+        <MenuItem Command="ApplicationCommands.Cut" />
+        <MenuItem Command="ApplicationCommands.Paste" />
+    </ContextMenu>
+  <!-- #endregion -->
+  <!-- #region DefaultFocusVisualStyle -->
+    <Style x:Key="DefaultControlFocusVisualStyle">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle
+                        RadiusX="4"
+                        RadiusY="4"
+                        Margin = "-3"
+                        SnapsToDevicePixels="True"
+                        Stroke="{DynamicResource KeyboardFocusBorderColorBrush}"
+                        StrokeThickness="2" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="DefaultCollectionFocusVisualStyle">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle
+                        RadiusX="4"
+                        RadiusY="4"
+                        SnapsToDevicePixels="True"
+                        Stroke="{DynamicResource KeyboardFocusBorderColorBrush}"
+                        StrokeThickness="2" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="{x:Static SystemParameters.FocusVisualStyleKey}" BasedOn="{StaticResource DefaultControlFocusVisualStyle}" />
+  <!-- #endregion -->
+  <!-- #region Fonts -->
+  <FontFamily x:Key="SymbolThemeFontFamily">Segoe Fluent Icons, Segoe MDL2 Assets</FontFamily>
+  <!-- #endregion -->
+  <!-- #region StaticColors -->
+    <Color x:Key="TextFillColorLightPrimary">#FFFFFF</Color>
+    <Color x:Key="TextFillColorLightSecondary">#C5FFFFFF</Color>
+    <Color x:Key="TextFillColorLightTertiary">#87FFFFFF</Color>
+    <Color x:Key="TextFillColorLightDisabled">#5DFFFFFF</Color>
+    <Color x:Key="TextFillColorLightInverse">#E4000000</Color>
+
+    <SolidColorBrush x:Key="TextFillColorLightPrimaryBrush" Color="{StaticResource TextFillColorLightPrimary}" />
+    <SolidColorBrush x:Key="TextFillColorLightSecondaryBrush" Color="{StaticResource TextFillColorLightSecondary}" />
+    <SolidColorBrush x:Key="TextFillColorLightTertiaryBrush" Color="{StaticResource TextFillColorLightTertiary}" />
+    <SolidColorBrush x:Key="TextFillColorLightDisabledBrush" Color="{StaticResource TextFillColorLightDisabled}" />
+    <SolidColorBrush x:Key="TextFillColorLightInverseBrush" Color="{StaticResource TextFillColorLightInverse}" />
+
+    <Color x:Key="TextFillColorDarkPrimary">#E4000000</Color>
+    <Color x:Key="TextFillColorDarkSecondary">#BE000000</Color>
+    <Color x:Key="TextFillColorDarkTertiary">#A2000000</Color>
+    <Color x:Key="TextFillColorDarkDisabled">#5C000000</Color>
+    <Color x:Key="TextFillColorDarkInverse">#FFFFFF</Color>
+
+    <SolidColorBrush x:Key="TextFillColorDarkPrimaryBrush" Color="{StaticResource TextFillColorDarkPrimary}" />
+    <SolidColorBrush x:Key="TextFillColorDarkSecondaryBrush" Color="{StaticResource TextFillColorDarkSecondary}" />
+    <SolidColorBrush x:Key="TextFillColorDarkTertiaryBrush" Color="{StaticResource TextFillColorDarkTertiary}" />
+    <SolidColorBrush x:Key="TextFillColorDarkDisabledBrush" Color="{StaticResource TextFillColorDarkDisabled}" />
+    <SolidColorBrush x:Key="TextFillColorDarkInverseBrush" Color="{StaticResource TextFillColorDarkInverse}" />
+
+    <Color x:Key="ApplicationBackgroundColorLight">#FFFAFAFA</Color>
+    <SolidColorBrush x:Key="ApplicationBackgroundColorLightBrush" Color="{StaticResource ApplicationBackgroundColorLight}" />
+
+    <Color x:Key="ApplicationBackgroundColorDark">#FF202020</Color>
+    <SolidColorBrush x:Key="ApplicationBackgroundColorDarkBrush" Color="{StaticResource ApplicationBackgroundColorDark}" />
+
+    <Color x:Key="ControlStrongFillColorLight">#B3FFFFFF</Color>
+    <SolidColorBrush x:Key="ControlStrongFillColorLightBrush" Color="{StaticResource ControlStrongFillColorLight}" />
+
+    <Color x:Key="ControlStrongFillColorDark">#72000000</Color>
+    <SolidColorBrush x:Key="ControlStrongFillColorDarkBrush" Color="{StaticResource ControlStrongFillColorDark}" />
+
+  <!-- #endregion -->
+  <!-- #region Variables -->
+  <system:Double x:Key="DefaultIconFontSize">16</system:Double>
+
+    <system:Double x:Key="ControlContentThemeFontSize">14</system:Double>
+    <CornerRadius x:Key="ControlCornerRadius">4,4,4,4</CornerRadius>
+    <CornerRadius x:Key="OverlayCornerRadius">8,8,8,8</CornerRadius>
+    <CornerRadius x:Key="PopupCornerRadius">8,8,8,8</CornerRadius>
+
+    <!--
+    <system:String x:Key="ControlFastOutSlowInKeySpline">0,0,0,1</system:String>
+    <Duration x:Key="ControlNormalAnimationDuration">00:00:00.250</Duration>
+    <Duration x:Key="ControlFastAnimationDuration">00:00:00.167</Duration>
+    <Duration x:Key="ControlFastAnimationAfterDuration">00:00:00.168</Duration>
+    <Duration x:Key="ControlFasterAnimationDuration">00:00:00.083</Duration>
+    -->
+
+    <Thickness x:Key="TextControlBorderThemeThickness">1</Thickness>
+    <Thickness x:Key="TextControlThemePadding">10,5,6,6</Thickness>
+
+    <!-- Moved to Light, Dark and HC resource files -->
+    <!-- <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness> -->
+
+    <system:Double x:Key="ContentControlFontSize">14</system:Double>
+    <system:Double x:Key="TextControlThemeMinHeight">24</system:Double>
+    <system:Double x:Key="TextControlThemeMinWidth">0</system:Double>
+    <system:Double x:Key="TreeViewItemMultiSelectCheckBoxMinHeight">24</system:Double>
+    <system:Double x:Key="TreeViewItemPresenterMargin">0</system:Double>
+    <system:Double x:Key="TreeViewItemPresenterPadding">0</system:Double>
+
+    <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
+    <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
+    <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
+    <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
+
+    <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
+    <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
+    <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
+  <!-- #endregion -->
+  <!-- #region Controls -->
+  <Thickness x:Key="ButtonPadding">11,5,11,6</Thickness>
+  <Thickness x:Key="ButtonBorderThemeThickness">1</Thickness>
+  <Thickness x:Key="ButtonIconMargin">0,0,8,0</Thickness>
+  <Style x:Key="DefaultButtonStyle" TargetType="{x:Type ButtonBase}">
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+    <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource ButtonBorderThemeThickness}" />
+    <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ButtonBase}">
+          <Border x:Name="ContentBorder" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Padding="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <ContentPresenter x:Name="ContentPresenter" RecognizesAccessKey="True" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" TextElement.Foreground="{TemplateBinding Foreground}" />
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPressed}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="AccentButtonStyle" TargetType="{x:Type Button}">
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+    <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource AccentButtonForeground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource ButtonBorderThemeThickness}" />
+    <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Button}">
+          <Border x:Name="ContentBorder" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Padding="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <ContentPresenter x:Name="ContentPresenter" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" TextElement.Foreground="{TemplateBinding Foreground}" />
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource AccentButtonBackgroundPointerOver}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushPointerOver}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource AccentButtonForegroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource AccentButtonBackgroundPressed}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushPressed}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource AccentButtonForegroundPressed}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource AccentButtonBackgroundDisabled}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushDisabled}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource AccentButtonForegroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultButtonStyle}" TargetType="{x:Type ButtonBase}" />
+  <Style BasedOn="{StaticResource DefaultButtonStyle}" TargetType="{x:Type Button}" />
+  <!--  HINT: Day button style  -->
+  <Style x:Key="DefaultCalendarDayButtonStyle" TargetType="CalendarDayButton">
+    <Setter Property="MinWidth" Value="40" />
+    <Setter Property="MinHeight" Value="40" />
+    <Setter Property="MaxWidth" Value="60" />
+    <Setter Property="MaxHeight" Value="60" />
+    <Setter Property="Margin" Value="1" />
+    <Setter Property="FontSize" Value="14" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="CalendarDayButton">
+          <Grid>
+            <Rectangle x:Name="TodayBackground" Fill="{DynamicResource CalendarViewTodayBackground}" Opacity="0" RadiusX="99" RadiusY="99" />
+            <Rectangle x:Name="SelectedBackground" Opacity="0" RadiusX="99" RadiusY="99" Stroke="{DynamicResource CalendarViewSelectedBorderBrush}" StrokeThickness="1" />
+            <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" />
+            <Rectangle x:Name="HighlightBackground" Fill="{DynamicResource CalendarViewItemBackgroundPointerOver}" Opacity="0" RadiusX="99" RadiusY="99" />
+            <ContentPresenter x:Name="NormalText" Margin="5,1,5,1" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" TextBlock.Foreground="{DynamicResource CalendarViewForeground}" />
+            <Rectangle x:Name="DayButtonFocusVisual" IsHitTestVisible="false" RadiusX="1" RadiusY="1" Visibility="Collapsed">
+              <Rectangle.Stroke>
+                <SolidColorBrush Color="Transparent" />
+              </Rectangle.Stroke>
+            </Rectangle>
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup Name="CommonStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition GeneratedDuration="0:0:0.1" />
+                </VisualStateGroup.Transitions>
+                <VisualState Name="Normal" />
+                <VisualState Name="MouseOver">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="HighlightBackground" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                  </Storyboard>
+                </VisualState>
+                <VisualState Name="Pressed">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="HighlightBackground" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                  </Storyboard>
+                </VisualState>
+                <VisualState Name="Disabled">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="HighlightBackground" Storyboard.TargetProperty="Opacity" To="0" Duration="0" />
+                    <DoubleAnimation Storyboard.TargetName="NormalText" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup Name="SelectionStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition GeneratedDuration="0" />
+                </VisualStateGroup.Transitions>
+                <VisualState Name="Unselected" />
+                <VisualState Name="Selected">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="SelectedBackground" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup Name="CalendarButtonFocusStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition GeneratedDuration="0" />
+                </VisualStateGroup.Transitions>
+                <VisualState Name="CalendarButtonFocused">
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DayButtonFocusVisual" Storyboard.TargetProperty="Visibility" Duration="0">
+                      <DiscreteObjectKeyFrame KeyTime="0">
+                        <DiscreteObjectKeyFrame.Value>
+                          <Visibility>Visible</Visibility>
+                        </DiscreteObjectKeyFrame.Value>
+                      </DiscreteObjectKeyFrame>
+                    </ObjectAnimationUsingKeyFrames>
+                  </Storyboard>
+                </VisualState>
+                <VisualState Name="CalendarButtonUnfocused">
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DayButtonFocusVisual" Storyboard.TargetProperty="Visibility" Duration="0">
+                      <DiscreteObjectKeyFrame KeyTime="0">
+                        <DiscreteObjectKeyFrame.Value>
+                          <Visibility>Collapsed</Visibility>
+                        </DiscreteObjectKeyFrame.Value>
+                      </DiscreteObjectKeyFrame>
+                    </ObjectAnimationUsingKeyFrames>
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup Name="ActiveStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition GeneratedDuration="0" />
+                </VisualStateGroup.Transitions>
+                <VisualState Name="Active" />
+              </VisualStateGroup>
+              <VisualStateGroup Name="DayStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition GeneratedDuration="0" />
+                </VisualStateGroup.Transitions>
+                <VisualState Name="RegularDay" />
+                <VisualState Name="Today">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="TodayBackground" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalText" Storyboard.TargetProperty="(TextBlock.Foreground)">
+                      <ObjectAnimationUsingKeyFrames.KeyFrames>
+                        <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{DynamicResource CalendarViewTodayForeground}" />
+                      </ObjectAnimationUsingKeyFrames.KeyFrames>
+                    </ObjectAnimationUsingKeyFrames>
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup Name="BlackoutDayStates" />
+            </VisualStateManager.VisualStateGroups>
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DefaultCalendarButtonStyle" TargetType="CalendarButton">
+    <Setter Property="MinWidth" Value="40" />
+    <Setter Property="MinHeight" Value="40" />
+    <Setter Property="MaxWidth" Value="70" />
+    <Setter Property="MaxHeight" Value="70" />
+    <Setter Property="Margin" Value="1" />
+    <Setter Property="FontSize" Value="14" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="CalendarButton">
+          <Grid>
+            <Rectangle x:Name="SelectedBackground" Fill="{DynamicResource CalendarViewSelectedBackground}" Opacity="0" RadiusX="99" RadiusY="99" />
+            <Rectangle x:Name="Background" Fill="{DynamicResource CalendarViewItemBackgroundPointerOver}" Opacity="0" RadiusX="99" RadiusY="99" />
+            <ContentPresenter x:Name="NormalText" Margin="1,0,1,1" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" TextBlock.Foreground="{DynamicResource CalendarViewForeground}" />
+            <Rectangle x:Name="CalendarButtonFocusVisual" IsHitTestVisible="false" RadiusX="99" RadiusY="99" Stroke="{DynamicResource CalendarViewForeground}" Visibility="Collapsed" />
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup Name="CommonStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition GeneratedDuration="0:0:0.1" />
+                </VisualStateGroup.Transitions>
+                <VisualState Name="Normal" />
+                <VisualState Name="MouseOver">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="Background" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                  </Storyboard>
+                </VisualState>
+                <VisualState Name="Pressed">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="Background" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup Name="SelectionStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition GeneratedDuration="0" />
+                </VisualStateGroup.Transitions>
+                <VisualState Name="Unselected" />
+                <VisualState Name="Selected">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="SelectedBackground" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalText" Storyboard.TargetProperty="(TextBlock.Foreground)">
+                      <ObjectAnimationUsingKeyFrames.KeyFrames>
+                        <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{DynamicResource CalendarViewTodayForeground}" />
+                      </ObjectAnimationUsingKeyFrames.KeyFrames>
+                    </ObjectAnimationUsingKeyFrames>
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup Name="ActiveStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition GeneratedDuration="0" />
+                </VisualStateGroup.Transitions>
+                <VisualState Name="Active" />
+              </VisualStateGroup>
+              <VisualStateGroup Name="CalendarButtonFocusStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition GeneratedDuration="0" />
+                </VisualStateGroup.Transitions>
+                <VisualState Name="CalendarButtonFocused">
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CalendarButtonFocusVisual" Storyboard.TargetProperty="Visibility" Duration="0">
+                      <DiscreteObjectKeyFrame KeyTime="0">
+                        <DiscreteObjectKeyFrame.Value>
+                          <Visibility>Visible</Visibility>
+                        </DiscreteObjectKeyFrame.Value>
+                      </DiscreteObjectKeyFrame>
+                    </ObjectAnimationUsingKeyFrames>
+                  </Storyboard>
+                </VisualState>
+                <VisualState Name="CalendarButtonUnfocused" />
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DefaultCalendarItemStyle" TargetType="{x:Type CalendarItem}">
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type CalendarItem}">
+          <Grid x:Name="PART_Root">
+            <Grid KeyboardNavigation.TabNavigation="Local">
+              <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+              </Grid.RowDefinitions>
+              <!--  HINT: Header with title and navigation buttons  -->
+              <Grid Grid.Row="0" KeyboardNavigation.TabIndex="0">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="Auto" />
+                  <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Button x:Name="PART_HeaderButton" Grid.Column="0" Margin="7,6,3,7" Padding="8,7,8,8" HorizontalAlignment="Left" VerticalAlignment="Stretch" Background="Transparent" BorderBrush="Transparent" Focusable="True" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource CalendarViewForeground}" />
+                <Button x:Name="PART_PreviousButton" Grid.Column="1" Width="26" Height="26" Margin="7,6,7,7" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="Transparent" BorderBrush="Transparent" Focusable="True" AutomationProperties.Name="Previous" Foreground="{DynamicResource CalendarViewButtonForeground}">
+                  <Button.Content>
+                    <TextBlock FontSize="8" FontFamily="{DynamicResource SymbolThemeFontFamily}"></TextBlock>
+                  </Button.Content>
+                </Button>
+                <Button x:Name="PART_NextButton" Grid.Column="2" Width="26" Height="26" Margin="7,6,7,7" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="Transparent" BorderBrush="Transparent" Focusable="True" AutomationProperties.Name="Next" Foreground="{DynamicResource CalendarViewButtonForeground}">
+                  <Button.Content>
+                    <TextBlock FontSize="8" FontFamily="{DynamicResource SymbolThemeFontFamily}"></TextBlock>
+                  </Button.Content>
+                </Button>
+              </Grid>
+              <Border Grid.Row="1" Height="0.5" Background="{DynamicResource CalendarViewBorderBrush}" />
+              <!--  HINT: Day picker  -->
+              <Grid x:Name="PART_MonthView" Grid.Row="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" KeyboardNavigation.TabNavigation="Once" KeyboardNavigation.TabIndex="1" Visibility="Visible">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                  <RowDefinition Height="*" />
+                  <RowDefinition Height="*" />
+                  <RowDefinition Height="*" />
+                  <RowDefinition Height="*" />
+                  <RowDefinition Height="*" />
+                  <RowDefinition Height="*" />
+                  <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+              </Grid>
+              <Grid x:Name="PART_YearView" Grid.Row="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Visibility="Hidden" KeyboardNavigation.TabNavigation="Once" KeyboardNavigation.TabIndex="1">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                  <RowDefinition Height="*" />
+                  <RowDefinition Height="*" />
+                  <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+              </Grid>
+              <Rectangle x:Name="PART_DisabledVisual" Grid.Row="0" Grid.RowSpan="2" Opacity="0" RadiusX="2" RadiusY="2" Stretch="Fill" Stroke="Transparent" StrokeThickness="0" Visibility="Collapsed" KeyboardNavigation.TabNavigation="Once" KeyboardNavigation.TabIndex="1">
+                <Rectangle.Fill>
+                  <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+                </Rectangle.Fill>
+              </Rectangle>
+            </Grid>
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="PART_DisabledVisual" Property="Visibility" Value="Visible" />
+            </Trigger>
+            <DataTrigger Binding="{Binding DisplayMode, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}}" Value="Year">
+              <Setter TargetName="PART_MonthView" Property="Visibility" Value="Hidden" />
+              <Setter TargetName="PART_YearView" Property="Visibility" Value="Visible" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding DisplayMode, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}}" Value="Decade">
+              <Setter TargetName="PART_MonthView" Property="Visibility" Value="Hidden" />
+              <Setter TargetName="PART_YearView" Property="Visibility" Value="Visible" />
+            </DataTrigger>
+          </ControlTemplate.Triggers>
+          <ControlTemplate.Resources>
+            <DataTemplate x:Key="{x:Static CalendarItem.DayTitleTemplateResourceKey}">
+              <TextBlock Margin="1" Padding="12" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource CalendarViewForeground}" Text="{Binding}" />
+            </DataTemplate>
+          </ControlTemplate.Resources>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <!--  https://developer.microsoft.com/en-us/fluentui#/controls/web/datepicker  -->
+  <Style x:Key="DefaultCalendarStyle" TargetType="{x:Type Calendar}">
+    <Setter Property="CalendarButtonStyle" Value="{StaticResource DefaultCalendarButtonStyle}" />
+    <Setter Property="CalendarDayButtonStyle" Value="{StaticResource DefaultCalendarDayButtonStyle}" />
+    <Setter Property="CalendarItemStyle" Value="{StaticResource DefaultCalendarItemStyle}" />
+    <Setter Property="Foreground" Value="{DynamicResource CalendarViewForeground}" />
+    <Setter Property="Background" Value="{DynamicResource CalendarViewBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource CalendarViewBorderBrush}" />
+    <Setter Property="HorizontalAlignment" Value="Center" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Calendar}">
+          <Border x:Name="PART_Root" Margin="0" Padding="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="4">
+            <CalendarItem x:Name="PART_CalendarItem" Margin="0" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="Transparent" BorderBrush="Transparent" BorderThickness="0" Style="{TemplateBinding CalendarItemStyle}" />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultCalendarStyle}" TargetType="{x:Type Calendar}" />
+  <Color x:Key="FallbackColor">#FFFF0000</Color>
+  <Thickness x:Key="CheckBoxBorderThickness">1</Thickness>
+  <Thickness x:Key="CheckBoxPadding">8,5,0,0</Thickness>
+  <sys:Double x:Key="CheckBoxIconSize">14</sys:Double>
+  <sys:Double x:Key="CheckBoxSize">20</sys:Double>
+  <sys:String x:Key="CheckBoxCheckedGlyph"></sys:String>
+  <sys:String x:Key="CheckBoxIndeterminateGlyph"></sys:String>
+  <sys:Double x:Key="CheckBoxHeight">32</sys:Double>
+  <sys:Double x:Key="CheckBoxMinWidth">120</sys:Double>
+  <Style x:Key="DefaultCheckBoxStyle" TargetType="{x:Type CheckBox}">
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+    <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUnchecked}" />
+    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUnchecked}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUnchecked}" />
+    <Setter Property="BorderThickness" Value="{StaticResource CheckBoxBorderThickness}" />
+    <Setter Property="Padding" Value="{StaticResource CheckBoxPadding}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
+    <Setter Property="Focusable" Value="True" />
+    <Setter Property="MinWidth" Value="{StaticResource CheckBoxMinWidth}" />
+    <Setter Property="MinHeight" Value="{StaticResource CheckBoxHeight}" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type CheckBox}">
+          <Border x:Name="RootBorder" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <Grid x:Name="RootGrid">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+              </Grid.ColumnDefinitions>
+              <Border x:Name="ControlBorderIconPresenter" Width="{StaticResource CheckBoxSize}" Height="{StaticResource CheckBoxSize}" VerticalAlignment="Center" Background="{DynamicResource CheckBoxCheckBackgroundFillUnchecked}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+                <Border x:Name="StrokeBorder" BorderBrush="{DynamicResource CheckBoxCheckBackgroundStrokeUnchecked}" BorderThickness="{StaticResource CheckBoxBorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+                  <Grid>
+                    <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource CheckBoxIconSize}" FontWeight="Bold" Foreground="{DynamicResource CheckBoxCheckGlyphForeground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" Visibility="Collapsed" Text="{StaticResource CheckBoxCheckedGlyph}" />
+                  </Grid>
+                </Border>
+              </Border>
+              <ContentPresenter x:Name="ContentPresenter" Grid.Column="1" Margin="{TemplateBinding Padding}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" RecognizesAccessKey="True" />
+            </Grid>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="Content" Value="{x:Null}">
+              <Setter TargetName="ContentPresenter" Property="Margin" Value="0" />
+              <Setter Property="MinWidth" Value="30" />
+            </Trigger>
+            <Trigger Property="Content" Value="">
+              <Setter TargetName="ContentPresenter" Property="Margin" Value="0" />
+              <Setter Property="MinWidth" Value="30" />
+            </Trigger>
+            <!--Indeterminate Normal-->
+            <Trigger Property="IsChecked" Value="{x:Null}">
+              <Setter TargetName="ControlIcon" Property="Text" Value="{StaticResource CheckBoxIndeterminateGlyph}" />
+              <Setter TargetName="ControlIcon" Property="Visibility" Value="Visible" />
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminate}" />
+              <Setter TargetName="StrokeBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminate}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminate}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminate}" />
+            </Trigger>
+            <!--Checked Normal-->
+            <Trigger Property="IsChecked" Value="True">
+              <Setter TargetName="ControlIcon" Property="Visibility" Value="Visible" />
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillChecked}" />
+              <Setter TargetName="StrokeBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeChecked}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushChecked}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource CheckBoxBackgroundChecked}" />
+            </Trigger>
+            <!--Unchecked PointerOver-->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="False" />
+                <Condition Property="IsPressed" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedPointerOver}" />
+              <Setter TargetName="StrokeBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedPointerOver}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUncheckedPointerOver}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource CheckBoxBackgroundUncheckedPointerOver}" />
+            </MultiTrigger>
+            <!--Unchecked Pressed-->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="False" />
+                <Condition Property="IsPressed" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedPressed}" />
+              <Setter TargetName="StrokeBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedPressed}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUncheckedPressed}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource CheckBoxBackgroundUncheckedPressed}" />
+            </MultiTrigger>
+            <!--Indeterminate PointerOver-->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="{x:Null}" />
+                <Condition Property="IsPressed" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminatePointerOver}" />
+              <Setter TargetName="StrokeBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminatePointerOver}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminatePointerOver}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminatePointerOver}" />
+            </MultiTrigger>
+            <!--Indeterminate Pressed-->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="{x:Null}" />
+                <Condition Property="IsPressed" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminatePressed}" />
+              <Setter TargetName="StrokeBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminatePressed}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminatePressed}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminatePressed}" />
+              <Setter TargetName="ControlIcon" Property="Foreground" Value="{DynamicResource CheckBoxCheckGlyphForegroundPressed}" />
+            </MultiTrigger>
+            <!--Checked PointerOver-->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="True" />
+                <Condition Property="IsPressed" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillCheckedPointerOver}" />
+              <Setter TargetName="StrokeBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeCheckedPointerOver}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushCheckedPointerOver}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource CheckBoxBackgroundCheckedPointerOver}" />
+            </MultiTrigger>
+            <!--Checked Pressed-->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="True" />
+                <Condition Property="IsPressed" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillCheckedPressed}" />
+              <Setter TargetName="StrokeBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeCheckedPressed}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushCheckedPressed}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource CheckBoxBackgroundCheckedPressed}" />
+              <Setter TargetName="ControlIcon" Property="Foreground" Value="{DynamicResource CheckBoxCheckGlyphForegroundPressed}" />
+            </MultiTrigger>
+            <!--Disabled-->
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedDisabled}" />
+              <Setter TargetName="StrokeBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedDisabled}" />
+              <Setter TargetName="ControlIcon" Property="Foreground" Value="{DynamicResource CheckBoxForegroundUncheckedDisabled}" />
+              <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUncheckedPressed}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource CheckBoxBackgroundUncheckedPressed}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultCheckBoxStyle}" TargetType="{x:Type CheckBox}" />
+  <DataTemplate DataType="{x:Type CollectionViewGroup}">
+    <ContentPresenter Content="{Binding Path=Name}" ContentStringFormat="{TemplateBinding ContentStringFormat}" />
+  </DataTemplate>
+  <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
+  <Thickness x:Key="ComboBoxBorderThemeThickness">1,1,1,1</Thickness>
+  <Thickness x:Key="ComboBoxAccentBorderThemeThickness">0,0,0,2</Thickness>
+  <Thickness x:Key="ComboBoxChevronMargin">8,0,10,0</Thickness>
+  <Thickness x:Key="ComboBoxItemMargin">3,2,3,0</Thickness>
+  <Thickness x:Key="ComboBoxItemContentMargin">10,8,8,8</Thickness>
+  <system:Double x:Key="ComboBoxChevronSize">11.0</system:Double>
+  <system:Double x:Key="ComboBoxPopupMinHeight">32.0</system:Double>
+  <system:String x:Key="ComboBoxChevronDownGlyph"></system:String>
+  <Style x:Key="DefaultComboBoxTextBoxStyle" TargetType="{x:Type TextBox}">
+    <!--  Focus by parent element  -->
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <!--  Focus by parent element  -->
+    <!--  Universal WPF UI ContextMenu  -->
+    <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
+    <!--  Universal WPF UI ContextMenu  -->
+    <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource ComboBoxForeground}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Visibility" Value="Hidden" />
+    <Setter Property="Cursor" Value="IBeam" />
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type TextBox}">
+          <Decorator x:Name="PART_ContentHost" Margin="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" TextElement.Foreground="{TemplateBinding Foreground}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DefaultComboBoxToggleButtonStyle" TargetType="{x:Type ToggleButton}">
+    <!--  Focus by parent element  -->
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <!--  Focus by parent element  -->
+    <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="Border.CornerRadius" Value="0" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ToggleButton}">
+          <Border x:Name="ContentBorder" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <ContentPresenter x:Name="PART_ContentHost" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DefaultComboBoxItemStyle" TargetType="{x:Type ComboBoxItem}">
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Margin" Value="{StaticResource ComboBoxItemMargin}" />
+    <Setter Property="Padding" Value="{StaticResource ComboBoxItemContentMargin}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ComboBoxItem}">
+          <Grid>
+            <Border Name="ContentBorder" Margin="{TemplateBinding Margin}" Padding="0" VerticalAlignment="Stretch" CornerRadius="{TemplateBinding Border.CornerRadius}" SnapsToDevicePixels="True">
+              <Grid>
+                <ContentPresenter x:Name="PART_ContentPresenter" Margin="{TemplateBinding Padding}" VerticalAlignment="Center" />
+                <Rectangle x:Name="ActiveRectangle" Width="3" Height="16" Margin="0" HorizontalAlignment="Left" VerticalAlignment="Center" Fill="{DynamicResource ComboBoxItemPillFillBrush}" RadiusX="2" RadiusY="2" Visibility="Collapsed" />
+              </Grid>
+            </Border>
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxItemBackgroundSelected}" />
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+              <Setter TargetName="ActiveRectangle" Property="Visibility" Value="Visible" />
+              <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxItemForegroundSelected}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DefaultComboBoxStyle" TargetType="{x:Type ComboBox}">
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+    <!--  Universal WPF UI ContextMenu  -->
+    <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
+    <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
+    <Setter Property="Background" Value="{DynamicResource ComboBoxBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource ComboBoxBorderThemeThickness}" />
+    <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
+    <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="Popup.PopupAnimation" Value="None" />
+    <!--  WPF doesn't like centering, the animation is ugly and the mouse button sometimes clicks right away.  -->
+    <Setter Property="Popup.Placement" Value="Bottom" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ComboBox}">
+          <Grid>
+            <Border x:Name="ContentBorder" Grid.Row="0" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+              <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                <!--
+                                    Funky grid - because:
+                                    Chevron is over Presenter, ToggleButton is over Chevron, TextBox is over ToggleButton.
+                                    But, TextBox is not over Chevron, so ToggleButton still works.
+                                -->
+                <Grid>
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                  </Grid.ColumnDefinitions>
+                  <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
+                  </Grid>
+                  <Grid Grid.Column="1" Margin="{StaticResource ComboBoxChevronMargin}">
+                    <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ComboBoxChevronDownGlyph}">
+                      <TextBlock.RenderTransform>
+                        <RotateTransform Angle="0" />
+                      </TextBlock.RenderTransform>
+                    </TextBlock>
+                  </Grid>
+                  <Grid Grid.Column="0" Grid.ColumnSpan="2" Margin="0">
+                    <ToggleButton Name="ToggleButton" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ClickMode="Press" Focusable="False" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource DefaultComboBoxToggleButtonStyle}" />
+                  </Grid>
+                  <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
+                    <TextBox x:Name="PART_EditableTextBox" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" IsReadOnly="{TemplateBinding IsReadOnly}" Style="{StaticResource DefaultComboBoxTextBoxStyle}" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" />
+                  </Grid>
+                </Grid>
+                <Popup x:Name="PART_Popup" MinWidth="{TemplateBinding ActualWidth}" VerticalAlignment="Center" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
+                  <Border x:Name="DropDownBorder" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
+                    <!--Will revist this code while doing performance evaluation for dynamic resources.-->
+                    <Border.RenderTransform>
+                      <TranslateTransform />
+                    </Border.RenderTransform>
+                    <Grid>
+                      <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}" Margin="0" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" SnapsToDevicePixels="True" TextElement.FontSize="{TemplateBinding FontSize}" TextElement.FontWeight="{TemplateBinding FontWeight}" TextElement.Foreground="{TemplateBinding Foreground}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                        <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" TextElement.FontSize="{TemplateBinding FontSize}" />
+                      </ScrollViewer>
+                    </Grid>
+                    <Border.Effect>
+                      <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
+                    </Border.Effect>
+                  </Border>
+                </Popup>
+              </Grid>
+            </Border>
+            <Border x:Name="AccentBorder" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderBrush="{DynamicResource ComboBoxBorderBrushFocused}" BorderThickness="{StaticResource ComboBoxAccentBorderThemeThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" Visibility="Collapsed" />
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsDropDownOpen" Value="True">
+              <Trigger.EnterActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="0" To="180" Duration="00:00:00.167" />
+                    <DoubleAnimation Storyboard.TargetName="DropDownBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
+                      <DoubleAnimation.EasingFunction>
+                        <CircleEase EasingMode="EaseOut" />
+                      </DoubleAnimation.EasingFunction>
+                    </DoubleAnimation>
+                  </Storyboard>
+                </BeginStoryboard>
+              </Trigger.EnterActions>
+              <Trigger.ExitActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="ChevronIcon" Storyboard.TargetProperty="(TextBlock.RenderTransform).(RotateTransform.Angle)" From="180" To="0" Duration="00:00:00.167" />
+                  </Storyboard>
+                </BeginStoryboard>
+              </Trigger.ExitActions>
+            </Trigger>
+            <Trigger Property="HasItems" Value="False">
+              <Setter TargetName="DropDownBorder" Property="MinHeight" Value="{StaticResource ComboBoxPopupMinHeight}" />
+            </Trigger>
+            <Trigger SourceName="PART_Popup" Property="Popup.AllowsTransparency" Value="False">
+              <Setter TargetName="DropDownBorder" Property="CornerRadius" Value="0" />
+            </Trigger>
+            <Trigger Property="IsGrouping" Value="True">
+              <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+            </Trigger>
+            <Trigger Property="IsEditable" Value="True">
+              <Setter Property="IsTabStop" Value="False" />
+              <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />
+              <Setter TargetName="PART_ContentPresenter" Property="Visibility" Value="Hidden" />
+            </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsEnabled" Value="True" />
+                <Condition Property="IsKeyboardFocusWithin" Value="True" />
+                <Condition Property="IsEditable" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundFocused}" />
+              <Setter TargetName="AccentBorder" Property="Visibility" Value="Visible" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsEnabled" Value="True" />
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsKeyboardFocusWithin" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+            </MultiTrigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
+              <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultComboBoxItemStyle}" TargetType="{x:Type ComboBoxItem}" />
+  <Style BasedOn="{StaticResource DefaultComboBoxStyle}" TargetType="{x:Type ComboBox}" />
+  <Style x:Key="{x:Type ContentControl}" TargetType="{x:Type ContentControl}">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ContentControl}">
+          <ContentPresenter />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Thickness x:Key="ContextMenuBorderThickness">1</Thickness>
+  <Style x:Key="DefaultContextMenuStyle" TargetType="{x:Type ContextMenu}">
+    <Setter Property="TextElement.Foreground" Value="{DynamicResource ContextMenuForeground}" />
+    <Setter Property="Foreground" Value="{DynamicResource ContextMenuForeground}" />
+    <Setter Property="Background" Value="{DynamicResource ContextMenuBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ContextMenuBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource ContextMenuBorderThickness}" />
+    <Setter Property="MinWidth" Value="140" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="HasDropShadow" Value="False" />
+    <Setter Property="Grid.IsSharedSizeScope" Value="True" />
+    <Setter Property="Popup.PopupAnimation" Value="None" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ContextMenu}">
+          <Border x:Name="Border" Padding="0,3,0,3" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="8">
+            <Border.RenderTransform>
+              <TranslateTransform />
+            </Border.RenderTransform>
+            <ScrollViewer CanContentScroll="True" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+              <StackPanel ClipToBounds="True" IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" Orientation="Vertical" />
+            </ScrollViewer>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsOpen" Value="True">
+              <Trigger.EnterActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="Border" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
+                      <DoubleAnimation.EasingFunction>
+                        <CircleEase EasingMode="EaseOut" />
+                      </DoubleAnimation.EasingFunction>
+                    </DoubleAnimation>
+                  </Storyboard>
+                </BeginStoryboard>
+              </Trigger.EnterActions>
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultContextMenuStyle}" TargetType="{x:Type ContextMenu}" />
+  <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+  <system:Double x:Key="DefaultDataGridFontSize">14</system:Double>
+  <Color x:Key="DisabledControlLightColor">#FFE8EDF9</Color>
+  <Color x:Key="DisabledControlDarkColor">#FFC5CBF9</Color>
+  <Color x:Key="DisabledForegroundColor">#FF888888</Color>
+  <Color x:Key="ControlLightColor">White</Color>
+  <Color x:Key="ControlMediumColor">#FF7381F9</Color>
+  <Color x:Key="ControlDarkColor">#FF211AA9</Color>
+  <Color x:Key="ControlMouseOverColor">#FF3843C4</Color>
+  <Color x:Key="ControlPressedColor">#FF211AA9</Color>
+  <Color x:Key="GlyphColor">#FF444444</Color>
+  <system:String x:Key="DataGridCheckBoxCheckedGlyph"></system:String>
+  <system:String x:Key="DataGridCheckBoxIndeterminateGlyph"></system:String>
+  <LinearGradientBrush x:Key="MenuPopupBrush" StartPoint="0.5,0" EndPoint="0.5,1">
+    <GradientStop Offset="0" Color="{DynamicResource ControlLightColor}" />
+    <GradientStop Offset="0.5" Color="{DynamicResource ControlMediumColor}" />
+    <GradientStop Offset="1" Color="{DynamicResource ControlLightColor}" />
+  </LinearGradientBrush>
+  <LinearGradientBrush x:Key="ProgressBarIndicatorAnimatedFill" StartPoint="0,0" EndPoint="1,0">
+    <LinearGradientBrush.GradientStops>
+      <GradientStopCollection>
+        <GradientStop Offset="0" Color="#000000FF" />
+        <GradientStop Offset="0.4" Color="#600000FF" />
+        <GradientStop Offset="0.6" Color="#600000FF" />
+        <GradientStop Offset="1" Color="#000000FF" />
+      </GradientStopCollection>
+    </LinearGradientBrush.GradientStops>
+  </LinearGradientBrush>
+  <!--  END REMOVE COLORS  -->
+  <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Button}">
+          <Grid>
+            <Rectangle x:Name="Border" Fill="Transparent" SnapsToDevicePixels="True" Stroke="Transparent" />
+            <Polygon x:Name="Arrow" Margin="8,8,3,3" HorizontalAlignment="Right" VerticalAlignment="Bottom" Opacity="0.15" Points="0,10 10,10 10,0" Stretch="Uniform">
+              <Polygon.Fill>
+                <SolidColorBrush Color="{DynamicResource GlyphColor}" />
+              </Polygon.Fill>
+            </Polygon>
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="CommonStates">
+                <VisualState x:Name="Normal" />
+                <VisualState x:Name="MouseOver">
+                  <Storyboard>
+                    <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border" Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)">
+                      <EasingColorKeyFrame KeyTime="0" Value="{StaticResource ControlMouseOverColor}" />
+                    </ColorAnimationUsingKeyFrames>
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="Pressed">
+                  <!--
+                                    <Storyboard>
+                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border" Storyboard.TargetProperty="(Shape.Fill).                       (GradientBrush.GradientStops)[1].(GradientStop.Color)">
+                                            <EasingColorKeyFrame KeyTime="0" Value="{StaticResource ControlPressedColor}" />
+                                        </ColorAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                    -->
+                </VisualState>
+                <VisualState x:Name="Disabled">
+                  <!--
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Collapsed}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                    -->
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DataGridCellFocusVisual">
+    <Setter Property="Control.Template">
+      <Setter.Value>
+        <ControlTemplate>
+          <Border>
+            <Rectangle Margin="2" StrokeThickness="1" Stroke="{DynamicResource DataGridRowSelectedForegroundThemeBrush}" SnapsToDevicePixels="true" />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <!--  Style and template for the DataGridCell.  -->
+  <Style x:Key="DefaultDataGridCellStyle" TargetType="{x:Type DataGridCell}">
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Stretch" />
+    <Setter Property="MinHeight" Value="32" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="FocusVisualStyle" Value="{StaticResource DataGridCellFocusVisual}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type DataGridCell}">
+          <Border x:Name="Border" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" Background="Transparent" BorderBrush="Transparent" SnapsToDevicePixels="True">
+            <ContentPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="FocusStates">
+                <VisualState x:Name="Unfocused" />
+                <VisualState x:Name="Focused" />
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="CurrentStates">
+                <VisualState x:Name="Regular" />
+                <VisualState x:Name="Current">
+                  <!--
+                                    <Storyboard>
+                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border" Storyboard.TargetProperty="(Border.BorderBrush).(SolidColorBrush.Color)">
+                                            <EasingColorKeyFrame KeyTime="0" Value="Red" />
+                                        </ColorAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                    -->
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsSelected" Value="True">
+              <Setter TargetName="Border" Property="Background" Value="{DynamicResource DataGridRowSelectedBackgroundThemeBrush}" />
+              <Setter Property="Foreground" Value="{DynamicResource DataGridRowSelectedForegroundThemeBrush}" />
+            </Trigger>
+            <Trigger Property="IsFocused" Value="True">
+              <Setter TargetName="Border" Property="BorderThickness" Value="1" />
+              <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource {x:Static DataGrid.FocusBorderBrushKey}}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <!--  Style and template for the DataGridRow.  -->
+  <Style x:Key="DefaultDataGridRowStyle" TargetType="{x:Type DataGridRow}">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Validation.ErrorTemplate" Value="{x:Null}" />
+    <Setter Property="ValidationErrorTemplate">
+      <Setter.Value>
+        <ControlTemplate>
+          <TextBlock Margin="2,0,0,0" VerticalAlignment="Center" Foreground="{DynamicResource SystemFillColorCriticalBrush}" Text="!" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type DataGridRow}">
+          <Border x:Name="DGR_Border" Background="Transparent" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" SnapsToDevicePixels="True">
+            <SelectiveScrollingGrid>
+              <SelectiveScrollingGrid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+              </SelectiveScrollingGrid.ColumnDefinitions>
+              <SelectiveScrollingGrid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+              </SelectiveScrollingGrid.RowDefinitions>
+              <DataGridCellsPresenter Grid.Column="1" ItemsPanel="{TemplateBinding ItemsPanel}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+              <DataGridDetailsPresenter Grid.Row="1" Grid.Column="1" SelectiveScrollingGrid.SelectiveScrollingOrientation="{Binding AreRowDetailsFrozen, ConverterParameter={x:Static SelectiveScrollingOrientation.Vertical}, Converter={x:Static DataGrid.RowDetailsScrollingConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" Visibility="{TemplateBinding DetailsVisibility}" />
+              <DataGridRowHeader Grid.Row="0" Grid.RowSpan="2" Grid.Column="0" SelectiveScrollingGrid.SelectiveScrollingOrientation="Vertical" Visibility="{Binding HeadersVisibility, ConverterParameter={x:Static DataGridHeadersVisibility.Row}, Converter={x:Static DataGrid.HeadersVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
+            </SelectiveScrollingGrid>
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <!--  Style and template for the resize control on the DataGridRowHeader.  -->
+  <Style x:Key="RowHeaderGripperStyle" TargetType="{x:Type Thumb}">
+    <Setter Property="Height" Value="8" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Cursor" Value="SizeNS" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Thumb}">
+          <Border Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <!--  Style and template for the DataGridRowHeader.  -->
+  <Style x:Key="DefaultDataGridRowHeaderStyle" TargetType="{x:Type DataGridRowHeader}">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type DataGridRowHeader}">
+          <Grid>
+            <Border x:Name="rowHeaderBorder" Width="10" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0,0,1,0">
+              <StackPanel Orientation="Horizontal">
+                <ContentPresenter VerticalAlignment="Center" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <Control SnapsToDevicePixels="False" Template="{Binding ValidationErrorTemplate, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}" Visibility="{Binding (Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}" />
+              </StackPanel>
+            </Border>
+            <Thumb x:Name="PART_TopHeaderGripper" VerticalAlignment="Top" Style="{StaticResource RowHeaderGripperStyle}" />
+            <Thumb x:Name="PART_BottomHeaderGripper" VerticalAlignment="Bottom" Style="{StaticResource RowHeaderGripperStyle}" />
+            <VisualStateManager.VisualStateGroups>
+              <!--
+                                This example does not specify an appearance for every
+                                state.  You can add storyboard to the states that are listed
+                                to change the appearance of the DataGridRowHeader when it is
+                                in a specific state.
+                            -->
+              <VisualStateGroup x:Name="CommonStates">
+                <VisualState x:Name="Normal" />
+                <VisualState x:Name="Normal_CurrentRow" />
+                <VisualState x:Name="Unfocused_EditingRow" />
+                <VisualState x:Name="Normal_EditingRow" />
+                <VisualState x:Name="MouseOver">
+                  <!--
+                                    <Storyboard>
+                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="rowHeaderBorder" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)">
+                                            <EasingColorKeyFrame KeyTime="0" Value="{StaticResource ControlMouseOverColor}" />
+                                        </ColorAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                    -->
+                </VisualState>
+                <VisualState x:Name="MouseOver_CurrentRow" />
+                <VisualState x:Name="MouseOver_Unfocused_EditingRow" />
+                <VisualState x:Name="MouseOver_EditingRow" />
+                <VisualState x:Name="MouseOver_Unfocused_Selected" />
+                <VisualState x:Name="MouseOver_Selected" />
+                <VisualState x:Name="MouseOver_Unfocused_CurrentRow_Selected" />
+                <VisualState x:Name="MouseOver_CurrentRow_Selected" />
+                <VisualState x:Name="Unfocused_Selected" />
+                <VisualState x:Name="Unfocused_CurrentRow_Selected" />
+                <VisualState x:Name="Normal_CurrentRow_Selected" />
+                <VisualState x:Name="Normal_Selected" />
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <!--  Style and template for the resize control on the DataGridColumnHeader.  -->
+  <Style x:Key="ColumnHeaderGripperStyle" TargetType="{x:Type Thumb}">
+    <Setter Property="Width" Value="8" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Cursor" Value="SizeWE" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Thumb}">
+          <Border Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <!--  Style and template for the DataGridColumnHeader.  -->
+  <Style x:Key="DefaultDataGridColumnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="Padding" Value="12,0,0,0" />
+    <Setter Property="MinHeight" Value="32" />
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="SeparatorBrush" Value="{DynamicResource ControlFillColorDefault}" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
+          <Grid>
+            <Border x:Name="columnHeaderBorder" Padding="3,0,3,0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0,0,1,1">
+              <ContentPresenter RecognizesAccessKey="True" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+            </Border>
+            <Thumb x:Name="PART_LeftHeaderGripper" HorizontalAlignment="Left" Style="{StaticResource ColumnHeaderGripperStyle}" />
+            <Thumb x:Name="PART_RightHeaderGripper" HorizontalAlignment="Right" Style="{StaticResource ColumnHeaderGripperStyle}" />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <!--  Style and template for the DataGridColumnHeadersPresenter.  -->
+  <Style x:Key="DefaultDataGridColumnHeadersPresenterStyle" TargetType="{x:Type DataGridColumnHeadersPresenter}">
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type DataGridColumnHeadersPresenter}">
+          <Grid>
+            <DataGridColumnHeader x:Name="PART_FillerColumnHeader" IsHitTestVisible="False" SeparatorVisibility="Collapsed" />
+            <ItemsPresenter />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DefaultDataGridCellsPresenterStyle" TargetType="{x:Type DataGridCellsPresenter}">
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type DataGridColumnHeadersPresenter}">
+          <Grid>
+            <DataGridColumnHeader x:Name="PART_FillerColumnHeader" IsHitTestVisible="False" SeparatorVisibility="Collapsed" />
+            <ItemsPresenter />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DefaultDragIndicatorStyleStyle" TargetType="{x:Type Control}">
+    <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <!--  DataGridColumnFloatingHeader  is  internal  -->
+        <ControlTemplate TargetType="Control">
+          <Grid Background="{TemplateBinding Background}">
+            <Grid Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" MinWidth="32" />
+              </Grid.ColumnDefinitions>
+              <!-- <ContentPresenter Content="{TemplateBinding Content}" /> -->
+              <TextBlock x:Name="SortIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12" Opacity="0" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="" />
+            </Grid>
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="SortStates">
+                <VisualState x:Name="Unsorted" />
+                <VisualState x:Name="SortAscending">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="SortIcon" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="SortDescending">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="SortIcon" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="TextBoxStyle" TargetType="TextBox">
+    <Setter Property="Margin" Value="3" />
+    <Setter Property="MinWidth" Value="30" />
+    <Setter Property="Height" Value="20" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="Background" Value="Yellow" />
+    <Style.Triggers>
+      <Trigger Property="IsReadOnly" Value="True">
+        <Setter Property="Background" Value="LightGray" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+  <!--  Style and template for the DataGrid.  -->
+  <Style x:Key="DefaultDataGridStyle" TargetType="{x:Type DataGrid}">
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="Background">
+      <Setter.Value>
+        <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+      </Setter.Value>
+    </Setter>
+    <Setter Property="RowBackground" Value="Transparent" />
+    <Setter Property="Foreground">
+      <Setter.Value>
+        <SolidColorBrush Color="{DynamicResource TextFillColorPrimary}" />
+      </Setter.Value>
+    </Setter>
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="RowDetailsVisibilityMode" Value="VisibleWhenSelected" />
+    <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
+    <Setter Property="ScrollViewer.PanningMode" Value="Both" />
+    <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="RowStyle" Value="{StaticResource DefaultDataGridRowStyle}" />
+    <Setter Property="RowHeaderStyle" Value="{StaticResource DefaultDataGridRowHeaderStyle}" />
+    <Setter Property="CellStyle" Value="{StaticResource DefaultDataGridCellStyle}" />
+    <Setter Property="ColumnHeaderStyle" Value="{StaticResource DefaultDataGridColumnHeaderStyle}" />
+    <Setter Property="DragIndicatorStyle" Value="{StaticResource DefaultDragIndicatorStyleStyle}" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type DataGrid}">
+          <Border x:Name="border" Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" SnapsToDevicePixels="True">
+            <ScrollViewer x:Name="DG_ScrollViewer" Focusable="False">
+              <ScrollViewer.Template>
+                <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                  <Grid>
+                    <Grid.ColumnDefinitions>
+                      <ColumnDefinition Width="Auto" />
+                      <ColumnDefinition Width="*" />
+                      <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                      <RowDefinition Height="Auto" />
+                      <RowDefinition Height="*" />
+                      <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Button Width="{Binding CellsPanelHorizontalOffset, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" Command="{x:Static DataGrid.SelectAllCommand}" Focusable="false" Style="{DynamicResource {ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle,                                                                                           TypeInTargetAssembly={x:Type DataGrid}}}" Visibility="{Binding HeadersVisibility, ConverterParameter={x:Static DataGridHeadersVisibility.All}, Converter={x:Static DataGrid.HeadersVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
+                    <DataGridColumnHeadersPresenter x:Name="PART_ColumnHeadersPresenter" Grid.Row="0" Grid.Column="1" Visibility="{Binding HeadersVisibility, ConverterParameter={x:Static DataGridHeadersVisibility.Column}, Converter={x:Static DataGrid.HeadersVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
+                    <ScrollContentPresenter x:Name="PART_ScrollContentPresenter" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" CanContentScroll="{TemplateBinding CanContentScroll}" />
+                    <ScrollBar x:Name="PART_VerticalScrollBar" Grid.Row="1" Grid.Column="2" Maximum="{TemplateBinding ScrollableHeight}" Orientation="Vertical" ViewportSize="{TemplateBinding ViewportHeight}" Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}" Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                    <Grid Grid.Row="2" Grid.Column="1">
+                      <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="{Binding NonFrozenColumnsViewportHorizontalOffset, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
+                        <ColumnDefinition Width="*" />
+                      </Grid.ColumnDefinitions>
+                      <ScrollBar x:Name="PART_HorizontalScrollBar" Grid.Column="1" Maximum="{TemplateBinding ScrollableWidth}" Orientation="Horizontal" ViewportSize="{TemplateBinding ViewportWidth}" Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}" Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                    </Grid>
+                  </Grid>
+                </ControlTemplate>
+              </ScrollViewer.Template>
+              <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+            </ScrollViewer>
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="CommonStates">
+                <VisualState x:Name="Disabled">
+                  <Storyboard>
+                    <ColorAnimationUsingKeyFrames Storyboard.TargetName="border" Storyboard.TargetProperty="(Panel.Background).                       (SolidColorBrush.Color)">
+                      <EasingColorKeyFrame KeyTime="0" Value="{DynamicResource ControlLightColor}" />
+                    </ColorAnimationUsingKeyFrames>
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="Normal" />
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Style.Triggers>
+      <Trigger Property="IsGrouping" Value="True">
+        <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+  <fluentcontrols:FallbackBrushConverter x:Key="FallbackBrushConverter" />
+  <!-- <Color x:Key="FallbackColor">#FFFF0000</Color> -->
+  <Thickness x:Key="DataGridCheckBoxPadding">11,5,11,6</Thickness>
+  <Thickness x:Key="DataGridCheckBoxBorderThemeThickness">1</Thickness>
+  <Thickness x:Key="DataGridCheckBoxContentMargin">8,0,0,0</Thickness>
+  <system:Double x:Key="DataGridCheckBoxIconSize">14</system:Double>
+  <system:Double x:Key="DataGridCheckBoxHeight">22</system:Double>
+  <system:Double x:Key="DataGridCheckBoxWidth">22</system:Double>
+  <Style x:Key="DataGridCheckBoxElementDefaultStyle" TargetType="{x:Type CheckBox}">
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground">
+      <Setter.Value>
+        <SolidColorBrush Color="{DynamicResource TextFillColorPrimary}" />
+      </Setter.Value>
+    </Setter>
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource DataGridCheckBoxBorderThemeThickness}" />
+    <Setter Property="Padding" Value="{StaticResource DataGridCheckBoxPadding}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="HorizontalAlignment" Value="Center" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
+    <Setter Property="Focusable" Value="True" />
+    <Setter Property="MinWidth" Value="120" />
+    <Setter Property="MinHeight" Value="32" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type CheckBox}">
+          <BulletDecorator HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" Background="Transparent">
+            <BulletDecorator.Bullet>
+              <Border x:Name="ControlBorderIconPresenter" Width="{StaticResource DataGridCheckBoxHeight}" Height="{StaticResource DataGridCheckBoxWidth}" HorizontalAlignment="Left" VerticalAlignment="Center" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+                <Grid>
+                  <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource DataGridCheckBoxIconSize}" FontWeight="Bold" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource DataGridCheckBoxCheckedGlyph}" Visibility="Collapsed">
+                    <TextBlock.Foreground>
+                      <SolidColorBrush Color="{DynamicResource TextOnAccentFillColorPrimary}" />
+                    </TextBlock.Foreground>
+                  </TextBlock>
+                </Grid>
+              </Border>
+            </BulletDecorator.Bullet>
+            <ContentPresenter x:Name="ContentPresenter" Margin="{StaticResource DataGridCheckBoxContentMargin}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" RecognizesAccessKey="True" />
+          </BulletDecorator>
+          <ControlTemplate.Triggers>
+            <Trigger Property="Content" Value="{x:Null}">
+              <Setter TargetName="ContentPresenter" Property="Margin" Value="0" />
+            </Trigger>
+            <Trigger Property="Content" Value="">
+              <Setter TargetName="ContentPresenter" Property="Margin" Value="0" />
+            </Trigger>
+            <Trigger Property="IsChecked" Value="{x:Null}">
+              <Setter TargetName="ControlIcon" Property="Text" Value="{StaticResource DataGridCheckBoxIndeterminateGlyph}" />
+              <Setter TargetName="ControlIcon" Property="Visibility" Value="Visible" />
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background">
+                <Setter.Value>
+                  <SolidColorBrush Opacity="1.0" Color="{DynamicResource SystemAccentColorSecondary}" />
+                </Setter.Value>
+              </Setter>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+              <Setter TargetName="ControlIcon" Property="Visibility" Value="Visible" />
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background">
+                <Setter.Value>
+                  <SolidColorBrush Opacity="1.0" Color="{DynamicResource SystemAccentColorSecondary}" />
+                </Setter.Value>
+              </Setter>
+            </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background" Value="{DynamicResource ControlFillColorSecondaryBrush}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="{x:Null}" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background">
+                <Setter.Value>
+                  <SolidColorBrush Opacity="0.8" Color="{DynamicResource SystemAccentColorSecondary}" />
+                </Setter.Value>
+              </Setter>
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background">
+                <Setter.Value>
+                  <SolidColorBrush Opacity="0.8" Color="{DynamicResource SystemAccentColorSecondary}" />
+                </Setter.Value>
+              </Setter>
+            </MultiTrigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ControlBorderIconPresenter" Property="Background" Value="{DynamicResource ControlFillColorDisabledBrush}" />
+              <Setter TargetName="ControlBorderIconPresenter" Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefaultBrush}" />
+              <Setter TargetName="ControlIcon" Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
+              <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DataGridCheckBoxEditingElementDefaultStyle" BasedOn="{StaticResource DataGridCheckBoxElementDefaultStyle}" TargetType="{x:Type CheckBox}">
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+  </Style>
+  <Style BasedOn="{StaticResource DefaultDataGridColumnHeadersPresenterStyle}" TargetType="{x:Type DataGridColumnHeadersPresenter}" />
+  <Style BasedOn="{StaticResource DefaultDataGridStyle}" TargetType="{x:Type DataGrid}" />
+  <!-- .NET 9 Keys -->
+  <Thickness x:Key="DatePickerBorderThemeThickness">1,1,1,0</Thickness>
+  <Thickness x:Key="DatePickerAccentBorderThemeThickness">0,0,0,1</Thickness>
+  <Thickness x:Key="DatePickerLeftIconMargin">10,8,0,0</Thickness>
+  <Thickness x:Key="DatePickerRightIconMargin">0,8,10,0</Thickness>
+  <Thickness x:Key="DatePickerCalendarButtonPadding">0,0,0,0</Thickness>
+  <sys:Double x:Key="DatePickerCalendarButtonHeight">24</sys:Double>
+  <sys:String x:Key="CalendarGlyph"></sys:String>
+  <!-- .NET 9 keys redefined in .NET 10 -->
+  <!-- <Thickness x:Key="DatePickerCalendarButtonMargin">0,5,4,0</Thickness> -->
+  <!-- <sys:Double x:Key="DatePickerCalendarButtonIconSize">14</sys:Double> -->
+  <!-- .NET 10 Keys -->
+  <Thickness x:Key="DatePickerCalendarButtonMargin">0,4,4,4</Thickness>
+  <Thickness x:Key="DatePickerBorderThickness">1</Thickness>
+  <sys:Double x:Key="DatePickerCalendarButtonIconSize">12</sys:Double>
+  <sys:String x:Key="DatePickerCalendarGlyph"></sys:String>
+  <Style x:Key="DefaultDatePickerTextBoxStyle" TargetType="{x:Type DatePickerTextBox}">
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="AutomationProperties.Name" Value="{Binding Path=(AutomationProperties.Name), Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource DatePickerTextBoxCaretBrush}" />
+    <Setter Property="Cursor" Value="IBeam" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type DatePickerTextBox}">
+          <Border x:Name="RootBorder" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}">
+            <Border.Resources>
+              <Style x:Key="DatePickerScrollViewerStyle" TargetType="ScrollViewer">
+                <Setter Property="OverridesDefaultStyle" Value="True" />
+                <Setter Property="Template">
+                  <Setter.Value>
+                    <ControlTemplate TargetType="ScrollViewer">
+                      <ScrollContentPresenter />
+                    </ControlTemplate>
+                  </Setter.Value>
+                </Setter>
+              </Style>
+            </Border.Resources>
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup Name="WatermarkStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition GeneratedDuration="0" />
+                </VisualStateGroup.Transitions>
+                <VisualState Name="Unwatermarked" />
+                <VisualState Name="Watermarked">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="PART_Watermark" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <Grid x:Name="RootGrid" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+              <ContentControl x:Name="PART_Watermark" Opacity="0" Focusable="False" IsHitTestVisible="False" />
+              <ScrollViewer x:Name="PART_ContentHost" Style="{StaticResource DatePickerScrollViewerStyle}" Padding="0" HorizontalScrollBarVisibility="Hidden" />
+            </Grid>
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DatePickerCalendarStyle" BasedOn="{StaticResource DefaultCalendarStyle}" TargetType="{x:Type Calendar}">
+    <Setter Property="Background" Value="{DynamicResource DatePickerPopupBackground}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
+    <Setter Property="Margin" Value="10" />
+    <Setter Property="Effect">
+      <Setter.Value>
+        <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DefaultDatePickerStyle" TargetType="{x:Type DatePicker}">
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
+    <Setter Property="CalendarStyle" Value="{DynamicResource DatePickerCalendarStyle}" />
+    <Setter Property="Foreground" Value="{DynamicResource DatePickerForeground}" />
+    <Setter Property="Background" Value="{DynamicResource DatePickerBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource DatePickerBorderThickness}" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Stretch" />
+    <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="IsTodayHighlighted" Value="True" />
+    <Setter Property="SelectedDateFormat" Value="Short" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type DatePicker}">
+          <Grid>
+            <Grid.Resources>
+              <Style x:Key="CalendarButtonStyle" TargetType="Button">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+                <Setter Property="Width" Value="{Binding ActualHeight, RelativeSource={RelativeSource Self}}" />
+                <Setter Property="OverridesDefaultStyle" Value="True" />
+                <Setter Property="Template">
+                  <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                      <Border x:Name="ButtonLayoutBorder" Margin="{DynamicResource DatePickerCalendarButtonMargin}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+                        <ContentPresenter x:Name="GlyphElement" TextElement.Foreground="{TemplateBinding Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                      </Border>
+                      <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                          <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}" />
+                          <Setter Property="BorderBrush" Value="{DynamicResource SubtleFillColorSecondaryBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                          <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
+                          <Setter Property="BorderBrush" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
+                        </Trigger>
+                      </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                  </Setter.Value>
+                </Setter>
+              </Style>
+            </Grid.Resources>
+            <Grid.RowDefinitions>
+              <RowDefinition Height="*" />
+              <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid x:Name="PART_Root">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+              </Grid.ColumnDefinitions>
+              <Border x:Name="BorderElement" Grid.ColumnSpan="2" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}" MinHeight="32">
+              </Border>
+              <DatePickerTextBox x:Name="PART_TextBox" Padding="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+              <Button x:Name="PART_Button" Grid.Column="1" VerticalAlignment="Stretch" Style="{StaticResource CalendarButtonStyle}" Focusable="False" MinWidth="30">
+                <TextBlock FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{DynamicResource DatePickerCalendarButtonIconSize}" Text="{StaticResource DatePickerCalendarGlyph}" HorizontalAlignment="Center" VerticalAlignment="Center" />
+              </Button>
+            </Grid>
+            <Popup x:Name="PART_Popup" VerticalAlignment="Top" AllowsTransparency="True" Placement="Bottom" PlacementTarget="{Binding ElementName=PART_Root}" StaysOpen="False">
+            </Popup>
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="BorderElement" Property="Background" Value="{DynamicResource DatePickerBackgroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsKeyboardFocusWithin" Value="True">
+              <Setter TargetName="BorderElement" Property="Background" Value="{DynamicResource DatePickerBackgroundFocused}" />
+              <Setter TargetName="BorderElement" Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderFocusedBrush}" />
+              <Setter TargetName="BorderElement" Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="BorderElement" Property="Background" Value="{DynamicResource ControlFillColorDisabledBrush}" />
+              <Setter TargetName="BorderElement" Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefaultBrush}" />
+              <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultDatePickerTextBoxStyle}" TargetType="{x:Type DatePickerTextBox}" />
+  <Style BasedOn="{StaticResource DefaultDatePickerStyle}" TargetType="{x:Type DatePicker}" />
+  <Style x:Key="{x:Type FlowDocument}" TargetType="{x:Type FlowDocument}">
+    <Setter Property="TextAlignment" Value="Justify" />
+    <Setter Property="FontFamily" Value="Georgia" />
+    <Setter Property="FontSize" Value="16.0" />
+  </Style>
+  <Style x:Key="{x:Type TextBlock}" TargetType="{x:Type TextBlock}">
+    <Setter Property="TextWrapping" Value="NoWrap" />
+    <Setter Property="TextTrimming" Value="None" />
+  </Style>
+  <Style x:Key="{x:Type Bold}" TargetType="{x:Type Bold}">
+    <Setter Property="FontWeight" Value="Bold" />
+  </Style>
+  <Style x:Key="{x:Type Italic}" TargetType="{x:Type Italic}">
+    <Setter Property="FontStyle" Value="Italic" />
+  </Style>
+  <Style x:Key="{x:Type Underline}" TargetType="{x:Type Underline}">
+    <Setter Property="TextDecorations" Value="Underline" />
+  </Style>
+  <Style x:Key="{x:Type Paragraph}" TargetType="{x:Type Paragraph}">
+    <Setter Property="Margin" Value="Auto" />
+  </Style>
+  <Style x:Key="{x:Type List}" TargetType="{x:Type List}">
+    <Setter Property="Margin" Value="Auto" />
+    <Setter Property="Padding" Value="Auto" />
+  </Style>
+  <Style x:Key="{x:Type Floater}" TargetType="{x:Type Floater}">
+    <Setter Property="HorizontalAlignment" Value="Right" />
+  </Style>
+  <DataTemplate DataType="{x:Type FlowDocument}">
+    <FlowDocumentReader Document="{Binding}" />
+  </DataTemplate>
+  <DataTemplate DataType="{x:Type FixedDocument}">
+    <DocumentViewer Document="{Binding}" />
+  </DataTemplate>
+  <DataTemplate DataType="{x:Type FixedDocumentSequence}">
+    <DocumentViewer Document="{Binding}" />
+  </DataTemplate>
+  <Style x:Key="{x:Type DocumentViewer}" BasedOn="{x:Null}" TargetType="{x:Type DocumentViewer}">
+    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
+    <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="ContextMenu" Value="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources}, ResourceId=PUIDocumentViewerContextMenu}}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type DocumentViewer}">
+          <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
+            <Grid Background="{TemplateBinding Background}" KeyboardNavigation.TabNavigation="Local">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+              </Grid.ColumnDefinitions>
+              <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+              </Grid.RowDefinitions>
+              <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources}, ResourceId=PUIDocumentViewerToolBarStyleKey}}" Grid.Row="0" Grid.Column="0" Focusable="{TemplateBinding Focusable}" TabIndex="0" />
+              <ScrollViewer Grid.Row="1" Grid.Column="0" CanContentScroll="True" HorizontalScrollBarVisibility="Auto" x:Name="PART_ContentHost" Focusable="{TemplateBinding Focusable}" IsTabStop="True" TabIndex="1" />
+              <DockPanel Grid.Row="1">
+                <FrameworkElement DockPanel.Dock="Right" Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" />
+                <Rectangle Visibility="Visible" VerticalAlignment="top" Height="10">
+                  <Rectangle.Fill>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                      <GradientBrush.GradientStops>
+                        <GradientStopCollection>
+                          <GradientStop Color="#66000000" Offset="0" />
+                          <GradientStop Color="Transparent" Offset="1" />
+                        </GradientStopCollection>
+                      </GradientBrush.GradientStops>
+                    </LinearGradientBrush>
+                  </Rectangle.Fill>
+                </Rectangle>
+              </DockPanel>
+              <ContentControl Grid.Row="2" Grid.Column="0" TabIndex="2" Focusable="{TemplateBinding Focusable}" x:Name="PART_FindToolBarHost" />
+            </Grid>
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="{ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=DocumentGridPageContainerWithBorder}" TargetType="ContentControl" BasedOn="{x:Null}">
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ContentControl}">
+          <Grid>
+            <Grid.RowDefinitions>
+              <RowDefinition Height="5" />
+              <RowDefinition Height="*" />
+              <RowDefinition Height="5" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="5" />
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="5" />
+            </Grid.ColumnDefinitions>
+            <Border Background="White" BorderBrush="Black" BorderThickness="1" Grid.RowSpan="2" Grid.ColumnSpan="2">
+              <ContentPresenter />
+            </Border>
+            <Rectangle Fill="Black" Opacity="0.35" Grid.Column="2" Grid.Row="1" />
+            <Rectangle Fill="Black" Opacity="0.35" Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="2" />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Thickness x:Key="ExpanderPadding">11,11,11,11</Thickness>
+  <Thickness x:Key="ExpanderBorderThemeThickness">1</Thickness>
+  <system:Double x:Key="ExpanderChevronSize">12.0</system:Double>
+  <fluentcontrols:AnimationFactorToValueConverter x:Key="AnimationFactorToValueConverter" />
+  <system:String x:Key="ExpanderChevronUpGlyph"></system:String>
+  <system:String x:Key="ExpanderChevronDownGlyph"></system:String>
+  <system:String x:Key="ExpanderChevronLeftGlyph"></system:String>
+  <system:String x:Key="ExpanderChevronRightGlyph"></system:String>
+  <ControlTemplate x:Key="DefaultExpanderToggleButtonDownStyle" TargetType="{x:Type ToggleButton}">
+    <Grid Margin="{TemplateBinding Padding}" Background="Transparent">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+      </Grid.ColumnDefinitions>
+      <ContentPresenter x:Name="ContentPresenter" Grid.Column="0" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" TextElement.FontSize="{TemplateBinding FontSize}" />
+      <Grid x:Name="ChevronGrid" Grid.Column="1" Margin="0" VerticalAlignment="Center" Background="Transparent" RenderTransformOrigin="0.5, 0.5">
+        <Grid.RenderTransform>
+          <RotateTransform Angle="0" />
+        </Grid.RenderTransform>
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronDownGlyph}" />
+      </Grid>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsChecked" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronGrid" Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)" To="180" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronGrid" Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)" To="0" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <ControlTemplate x:Key="DefaultExpanderToggleButtonUpStyle" TargetType="{x:Type ToggleButton}">
+    <Grid Margin="{TemplateBinding Padding}" Background="Transparent">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+      </Grid.ColumnDefinitions>
+      <ContentPresenter x:Name="ContentPresenter" Grid.Column="0" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" TextElement.FontSize="{TemplateBinding FontSize}" />
+      <Grid x:Name="ChevronGrid" Grid.Column="1" Margin="0" VerticalAlignment="Center" Background="Transparent" RenderTransformOrigin="0.5, 0.5">
+        <Grid.RenderTransform>
+          <RotateTransform Angle="0" />
+        </Grid.RenderTransform>
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronUpGlyph}" />
+      </Grid>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsChecked" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronGrid" Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)" To="180" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronGrid" Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)" To="0" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <ControlTemplate x:Key="DefaultExpanderToggleButtonLeftStyle" TargetType="{x:Type ToggleButton}">
+    <Grid Margin="{TemplateBinding Padding}" Background="Transparent">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="*" />
+        <RowDefinition Height="Auto" />
+      </Grid.RowDefinitions>
+      <ContentPresenter x:Name="ContentPresenter" Grid.Row="0" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" TextElement.FontSize="{TemplateBinding FontSize}" />
+      <Grid x:Name="ChevronGrid" Grid.Row="1" Margin="0" VerticalAlignment="Center" Background="Transparent" RenderTransformOrigin="0.5, 0.5">
+        <Grid.RenderTransform>
+          <RotateTransform Angle="0" />
+        </Grid.RenderTransform>
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronLeftGlyph}" />
+      </Grid>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="FlowDirection" Value="RightToLeft">
+        <Setter TargetName="ControlChevronIcon" Property="Text" Value="{StaticResource ExpanderChevronRightGlyph}" />
+      </Trigger>
+      <Trigger Property="IsChecked" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronGrid" Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)" To="180" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronGrid" Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)" To="0" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <ControlTemplate x:Key="DefaultExpanderToggleButtonRightStyle" TargetType="{x:Type ToggleButton}">
+    <Grid Margin="{TemplateBinding Padding}" Background="Transparent">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="*" />
+        <RowDefinition Height="Auto" />
+      </Grid.RowDefinitions>
+      <ContentPresenter x:Name="ContentPresenter" Grid.Row="0" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" TextElement.FontSize="{TemplateBinding FontSize}" />
+      <Grid x:Name="ChevronGrid" Grid.Row="1" Margin="0" VerticalAlignment="Center" Background="Transparent" RenderTransformOrigin="0.5, 0.5">
+        <Grid.RenderTransform>
+          <RotateTransform Angle="0" />
+        </Grid.RenderTransform>
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronRightGlyph}" />
+      </Grid>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="FlowDirection" Value="RightToLeft">
+        <Setter TargetName="ControlChevronIcon" Property="Text" Value="{StaticResource ExpanderChevronLeftGlyph}" />
+      </Trigger>
+      <Trigger Property="IsChecked" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronGrid" Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)" To="180" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="ChevronGrid" Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)" To="0" Duration="00:00:00.167" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <Style x:Key="DefaultExpanderStyle" TargetType="{x:Type Expander}">
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+    <Setter Property="Background" Value="{DynamicResource ExpanderHeaderBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource ExpanderHeaderForeground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ExpanderHeaderBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource ExpanderBorderThemeThickness}" />
+    <Setter Property="Padding" Value="{StaticResource ExpanderPadding}" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="IsExpanded" Value="False" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Expander}">
+          <DockPanel>
+            <Border x:Name="ToggleButtonBorder" DockPanel.Dock="Top" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+              <ToggleButton x:Name="HeaderSite" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" Margin="0" Padding="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" FontFamily="{TemplateBinding FontFamily}" FontSize="{TemplateBinding FontSize}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontWeight="{TemplateBinding FontWeight}" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}" IsEnabled="{TemplateBinding IsEnabled}" OverridesDefaultStyle="True" Template="{StaticResource DefaultExpanderToggleButtonDownStyle}" FocusVisualStyle="{DynamicResource DefaultControlFocusVisualStyle}" />
+            </Border>
+            <Grid x:Name="ContentPresenterGrid" DockPanel.Dock="Bottom" ClipToBounds="True">
+              <!-- Dummy border to store Animation factor for expander -->
+              <Border x:Name="AnimationFactorBorder" Width="0" Visibility="Collapsed" />
+              <Border x:Name="ContentPresenterBorder" Background="{DynamicResource ExpanderContentBackground}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,0,1,1" CornerRadius="0,0,4,4" Visibility="Collapsed">
+                <ContentPresenter x:Name="ContentPresenter" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" />
+                <Border.Resources>
+                  <TranslateTransform x:Key="HeightAnimationNegative">
+                    <TranslateTransform.Y>
+                      <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="negative">
+                        <Binding ElementName="ContentPresenterBorder" Path="ActualHeight" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
+                      </MultiBinding>
+                    </TranslateTransform.Y>
+                  </TranslateTransform>
+                  <TranslateTransform x:Key="WidthAnimationNegative">
+                    <TranslateTransform.X>
+                      <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="negative">
+                        <Binding ElementName="ContentPresenterBorder" Path="ActualWidth" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
+                      </MultiBinding>
+                    </TranslateTransform.X>
+                  </TranslateTransform>
+                  <TranslateTransform x:Key="HeightAnimationPositive">
+                    <TranslateTransform.Y>
+                      <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="positive">
+                        <Binding ElementName="ContentPresenterBorder" Path="ActualHeight" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
+                      </MultiBinding>
+                    </TranslateTransform.Y>
+                  </TranslateTransform>
+                  <TranslateTransform x:Key="WidthAnimationPositive">
+                    <TranslateTransform.X>
+                      <MultiBinding Converter="{StaticResource AnimationFactorToValueConverter}" ConverterParameter="positive">
+                        <Binding ElementName="ContentPresenterBorder" Path="ActualWidth" />
+                        <Binding ElementName="AnimationFactorBorder" Path="Width" />
+                      </MultiBinding>
+                    </TranslateTransform.X>
+                  </TranslateTransform>
+                </Border.Resources>
+              </Border>
+            </Grid>
+          </DockPanel>
+          <ControlTemplate.Triggers>
+            <!-- Down Expansion Animations -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsExpanded" Value="True" />
+                <Condition Property="ExpandDirection" Value="Down" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ContentPresenterBorder" Property="Visibility" Value="Visible" />
+              <MultiTrigger.EnterActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+                    </ObjectAnimationUsingKeyFrames>
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
+                      <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
+                    </DoubleAnimationUsingKeyFrames>
+                  </Storyboard>
+                </BeginStoryboard>
+              </MultiTrigger.EnterActions>
+              <MultiTrigger.ExitActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+                      <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
+                    </ObjectAnimationUsingKeyFrames>
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
+                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
+                    </DoubleAnimationUsingKeyFrames>
+                  </Storyboard>
+                </BeginStoryboard>
+              </MultiTrigger.ExitActions>
+            </MultiTrigger>
+            <!-- Up Expansion Animations -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsExpanded" Value="True" />
+                <Condition Property="ExpandDirection" Value="Up" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ToggleButtonBorder" Property="CornerRadius" Value="0,0,4,4" />
+              <Setter TargetName="ContentPresenterBorder" Property="BorderThickness" Value="1,1,1,0" />
+              <Setter TargetName="ContentPresenterBorder" Property="CornerRadius" Value="4,4,0,0" />
+              <Setter TargetName="ContentPresenterBorder" Property="Visibility" Value="Visible" />
+              <MultiTrigger.EnterActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+                    </ObjectAnimationUsingKeyFrames>
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
+                      <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
+                    </DoubleAnimationUsingKeyFrames>
+                  </Storyboard>
+                </BeginStoryboard>
+              </MultiTrigger.EnterActions>
+              <MultiTrigger.ExitActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+                      <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
+                    </ObjectAnimationUsingKeyFrames>
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
+                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
+                    </DoubleAnimationUsingKeyFrames>
+                  </Storyboard>
+                </BeginStoryboard>
+              </MultiTrigger.ExitActions>
+            </MultiTrigger>
+            <!-- Left Expansion Animations -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsExpanded" Value="True" />
+                <Condition Property="ExpandDirection" Value="Left" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ToggleButtonBorder" Property="CornerRadius" Value="0,4,4,0" />
+              <Setter TargetName="ContentPresenterBorder" Property="BorderThickness" Value="1,1,0,1" />
+              <Setter TargetName="ContentPresenterBorder" Property="CornerRadius" Value="4,0,0,4" />
+              <Setter TargetName="ContentPresenterBorder" Property="Visibility" Value="Visible" />
+              <MultiTrigger.EnterActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+                    </ObjectAnimationUsingKeyFrames>
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
+                      <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
+                    </DoubleAnimationUsingKeyFrames>
+                  </Storyboard>
+                </BeginStoryboard>
+              </MultiTrigger.EnterActions>
+              <MultiTrigger.ExitActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+                      <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
+                    </ObjectAnimationUsingKeyFrames>
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
+                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
+                    </DoubleAnimationUsingKeyFrames>
+                  </Storyboard>
+                </BeginStoryboard>
+              </MultiTrigger.ExitActions>
+            </MultiTrigger>
+            <!-- Right Expansion Animations -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsExpanded" Value="True" />
+                <Condition Property="ExpandDirection" Value="Right" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ToggleButtonBorder" Property="CornerRadius" Value="4,0,0,4" />
+              <Setter TargetName="ContentPresenterBorder" Property="BorderThickness" Value="0,1,1,1" />
+              <Setter TargetName="ContentPresenterBorder" Property="CornerRadius" Value="0,4,4,0" />
+              <Setter TargetName="ContentPresenterBorder" Property="Visibility" Value="Visible" />
+              <MultiTrigger.EnterActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+                    </ObjectAnimationUsingKeyFrames>
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="1.0" />
+                      <SplineDoubleKeyFrame KeySpline="0.0, 0.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="0.0" />
+                    </DoubleAnimationUsingKeyFrames>
+                  </Storyboard>
+                </BeginStoryboard>
+              </MultiTrigger.EnterActions>
+              <MultiTrigger.ExitActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterBorder" Storyboard.TargetProperty="(Border.Visibility)">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+                      <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="{x:Static Visibility.Collapsed}" />
+                    </ObjectAnimationUsingKeyFrames>
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="AnimationFactorBorder" Storyboard.TargetProperty="Width">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="0.0" />
+                      <SplineDoubleKeyFrame KeySpline="1.0, 1.0, 0.0, 1.0" KeyTime="0:0:0.333" Value="1.0" />
+                    </DoubleAnimationUsingKeyFrames>
+                  </Storyboard>
+                </BeginStoryboard>
+              </MultiTrigger.ExitActions>
+            </MultiTrigger>
+            <Trigger Property="ExpandDirection" Value="Right">
+              <Setter Property="DockPanel.Dock" Value="Right" TargetName="ContentPresenterGrid" />
+              <Setter Property="DockPanel.Dock" Value="Left" TargetName="ToggleButtonBorder" />
+              <Setter Property="Template" Value="{StaticResource DefaultExpanderToggleButtonRightStyle}" TargetName="HeaderSite" />
+              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimationNegative}" TargetName="ContentPresenterBorder" />
+            </Trigger>
+            <Trigger Property="ExpandDirection" Value="Up">
+              <Setter Property="DockPanel.Dock" Value="Top" TargetName="ContentPresenterGrid" />
+              <Setter Property="DockPanel.Dock" Value="Bottom" TargetName="ToggleButtonBorder" />
+              <Setter Property="Template" Value="{StaticResource DefaultExpanderToggleButtonUpStyle}" TargetName="HeaderSite" />
+              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimationPositive}" TargetName="ContentPresenterBorder" />
+            </Trigger>
+            <Trigger Property="ExpandDirection" Value="Down">
+              <Setter Property="RenderTransform" Value="{DynamicResource HeightAnimationNegative}" TargetName="ContentPresenterBorder" />
+            </Trigger>
+            <Trigger Property="ExpandDirection" Value="Left">
+              <Setter Property="DockPanel.Dock" Value="Left" TargetName="ContentPresenterGrid" />
+              <Setter Property="DockPanel.Dock" Value="Right" TargetName="ToggleButtonBorder" />
+              <Setter Property="Template" Value="{StaticResource DefaultExpanderToggleButtonLeftStyle}" TargetName="HeaderSite" />
+              <Setter Property="RenderTransform" Value="{DynamicResource WidthAnimationPositive}" TargetName="ContentPresenterBorder" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ExpanderHeaderDisabledForeground}" />
+              <Setter TargetName="HeaderSite" Property="Foreground" Value="{DynamicResource ExpanderHeaderDisabledForeground}" />
+              <Setter TargetName="HeaderSite" Property="BorderBrush" Value="{DynamicResource ExpanderHeaderDisabledBorderBrush}" />
+            </Trigger>
+            <Trigger SourceName="HeaderSite" Property="IsMouseOver" Value="True">
+              <Setter TargetName="HeaderSite" Property="BorderBrush" Value="{DynamicResource ExpanderHeaderBorderPointerOverBrush}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultExpanderStyle}" TargetType="{x:Type Expander}" />
+  <JournalEntryUnifiedViewConverter x:Key="JournalEntryUnifiedViewConverter" />
+  <Thickness x:Key="FrameMenuItemBorderThickness">1</Thickness>
+  <Thickness x:Key="FramePadding">0</Thickness>
+  <system:String x:Key="FrameMenuItemChevronDownGlyph"></system:String>
+  <system:String x:Key="FrameMenuItemArrowLeftGlyph"></system:String>
+  <system:String x:Key="FrameMenuItemArrowRightGlyph"></system:String>
+  <system:String x:Key="FrameMenuiItemCurrentGlyph"></system:String>
+  <Style x:Key="FrameNavigationButtonJournalEntryStyle" TargetType="{x:Type MenuItem}">
+    <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
+    <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
+    <Setter Property="Background" Value="{DynamicResource FrameMenuItemBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource FrameMenuItemBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource FrameMenuItemBorderThickness}" />
+    <Setter Property="Focusable" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Header" Value="{Binding Path=(JournalEntry.Name)}" />
+    <Setter Property="Command" Value="NavigationCommands.NavigateJournal" />
+    <Setter Property="CommandTarget" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type Menu}}, Path=TemplatedParent}" />
+    <Setter Property="CommandParameter" Value="{Binding RelativeSource={RelativeSource Self}}" />
+    <Setter Property="JournalEntryUnifiedViewConverter.JournalEntryPosition" Value="{Binding (JournalEntryUnifiedViewConverter.JournalEntryPosition)}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type MenuItem}">
+          <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}">
+            <Grid Margin="8">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+              </Grid.ColumnDefinitions>
+              <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,8,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
+              <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
+            </Grid>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+              <Setter TargetName="Border" Property="Background" Value="{DynamicResource FrameMenuItemBackgroundSelected}" />
+            </Trigger>
+            <Trigger Property="Header" Value="{x:Null}">
+              <Setter TargetName="Icon" Property="Margin" Value="0" />
+              <Setter TargetName="HeaderPresenter" Property="Visibility" Value="Collapsed" />
+            </Trigger>
+            <Trigger Property="JournalEntryUnifiedViewConverter.JournalEntryPosition" Value="Current">
+              <Setter TargetName="Icon" Property="Content">
+                <Setter.Value>
+                  <TextBlock Text="{StaticResource FrameMenuiItemCurrentGlyph}" FontFamily="{DynamicResource SymbolThemeFontFamily}" />
+                </Setter.Value>
+              </Setter>
+            </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="MenuItem.IsHighlighted" Value="True" />
+                <Condition Property="JournalEntryUnifiedViewConverter.JournalEntryPosition" Value="Forward" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Icon" Property="Content">
+                <Setter.Value>
+                  <TextBlock Text="{StaticResource FrameMenuItemArrowRightGlyph}" FontFamily="{DynamicResource SymbolThemeFontFamily}" />
+                </Setter.Value>
+              </Setter>
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="MenuItem.IsHighlighted" Value="True" />
+                <Condition Property="JournalEntryUnifiedViewConverter.JournalEntryPosition" Value="Back" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Icon" Property="Content">
+                <Setter.Value>
+                  <TextBlock Text="{StaticResource FrameMenuItemArrowLeftGlyph}" FontFamily="{DynamicResource SymbolThemeFontFamily}" />
+                </Setter.Value>
+              </Setter>
+            </MultiTrigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="Icon" Property="TextElement.Foreground" Value="{DynamicResource FrameMenuItemForegroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <ControlTemplate x:Key="FrameTemplateKey" TargetType="{x:Type Frame}">
+    <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+      <DockPanel>
+        <Menu Name="NavMenu" VerticalAlignment="Center" DockPanel.Dock="Top">
+          <MenuItem Background="Transparent" BorderBrush="Transparent" Command="NavigationCommands.BrowseBack" FontFamily="{DynamicResource SymbolThemeFontFamily}" Header="{StaticResource FrameMenuItemArrowLeftGlyph}" />
+          <MenuItem Background="Transparent" BorderBrush="Transparent" Command="NavigationCommands.BrowseForward" FontFamily="{DynamicResource SymbolThemeFontFamily}" Header="{StaticResource FrameMenuItemArrowRightGlyph}" />
+          <Separator />
+          <MenuItem x:Name="Arrow" SnapsToDevicePixels="False" HorizontalAlignment="Right" VerticalAlignment="Center" ItemContainerStyle="{StaticResource FrameNavigationButtonJournalEntryStyle}" IsSubmenuOpen="{Binding Path=(MenuItem.IsSubmenuOpen),Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}">
+            <MenuItem.Icon>
+              <TextBlock FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource FrameMenuItemChevronDownGlyph}" />
+            </MenuItem.Icon>
+            <MenuItem.ItemsSource>
+              <MultiBinding Converter="{StaticResource JournalEntryUnifiedViewConverter}">
+                <MultiBinding.Bindings>
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="BackStack" />
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ForwardStack" />
+                </MultiBinding.Bindings>
+              </MultiBinding>
+            </MenuItem.ItemsSource>
+          </MenuItem>
+        </Menu>
+        <ContentPresenter Name="PART_FrameCP" ClipToBounds="True" />
+      </DockPanel>
+    </Border>
+    <ControlTemplate.Triggers>
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="CanGoForward" Value="False" />
+          <Condition Property="CanGoBack" Value="False" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="NavMenu" Property="IsEnabled" Value="False" />
+      </MultiTrigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <Style x:Key="DefaultFrameStyle" TargetType="{x:Type Frame}">
+    <Setter Property="Foreground" Value="{DynamicResource FrameForeground}" />
+    <Setter Property="Background" Value="{DynamicResource FrameBackground}" />
+    <Setter Property="Padding" Value="{DynamicResource FramePadding}" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Frame}">
+          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}">
+            <ContentPresenter x:Name="PART_FrameCP" />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Style.Triggers>
+      <Trigger Property="NavigationUIVisibility" Value="Visible">
+        <Setter Property="Template" Value="{StaticResource FrameTemplateKey}" />
+      </Trigger>
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="JournalOwnership" Value="OwnsJournal" />
+          <Condition Property="NavigationUIVisibility" Value="Automatic" />
+        </MultiTrigger.Conditions>
+        <Setter Property="Template" Value="{StaticResource FrameTemplateKey}" />
+      </MultiTrigger>
+    </Style.Triggers>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultFrameStyle}" TargetType="{x:Type Frame}" />
+  <system:Double x:Key="GridsplitterThumbHeight">24</system:Double>
+  <system:Double x:Key="GridsplitterThumbWidth">4</system:Double>
+  <system:Double x:Key="GridsplitterThumbRadius">2</system:Double>
+  <system:Double x:Key="GridsplitterMinHeight">8</system:Double>
+  <system:Double x:Key="GridsplitterMinWidth">8</system:Double>
+  <Thickness x:Key="GridsplitterPadding">4</Thickness>
+  <Style x:Key="DefaultGridSplitterStyle" TargetType="{x:Type GridSplitter}">
+    <Setter Property="IsTabStop" Value="True" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="MinHeight" Value="{DynamicResource GridsplitterMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource GridsplitterMinHeight}" />
+    <Setter Property="Padding" Value="{DynamicResource GridsplitterPadding}" />
+    <Setter Property="Foreground" Value="{DynamicResource GridsplitterForeground}" />
+    <Setter Property="Background" Value="{DynamicResource GridsplitterBackground}" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type GridSplitter}">
+          <Border x:Name="RootGrid" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
+            <Rectangle x:Name="PART_Thumb" Width="{DynamicResource GridsplitterThumbWidth}" Height="{DynamicResource GridsplitterThumbHeight}" Margin="{TemplateBinding Padding}" Fill="{TemplateBinding Foreground}" RadiusX="{StaticResource GridsplitterThumbRadius}" RadiusY="{StaticResource GridsplitterThumbRadius}" />
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="True">
+              <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundPressed}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource GridsplitterBackgroundDisabled}" />
+              <Setter TargetName="PART_Thumb" Property="Opacity" Value="0.45" />
+            </Trigger>
+            <Trigger Property="Cursor" Value="SizeNS">
+              <Setter TargetName="PART_Thumb" Property="Width" Value="{DynamicResource GridsplitterThumbHeight}" />
+              <Setter TargetName="PART_Thumb" Property="Height" Value="{DynamicResource GridsplitterThumbWidth}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultGridSplitterStyle}" TargetType="{x:Type GridSplitter}" />
+  <Thickness x:Key="GroupBoxPadding">0,0,0,16</Thickness>
+  <system:Double x:Key="GroupBoxHeaderFontSize">20</system:Double>
+  <Thickness x:Key="GroupBoxHeaderMargin">0,4,0,12</Thickness>
+  <Thickness x:Key="GroupBoxBorderThickness">0</Thickness>
+  <Style x:Key="DefaultGroupBoxStyle" TargetType="{x:Type GroupBox}">
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="BorderThickness" Value="{DynamicResource GroupBoxBorderThickness}" />
+    <Setter Property="Background" Value="{DynamicResource GroupBoxBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource GroupBoxBorderBrush}" />
+    <Setter Property="Padding" Value="{DynamicResource GroupBoxPadding}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type GroupBox}">
+          <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
+            <Grid>
+              <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+              </Grid.RowDefinitions>
+              <ContentPresenter Grid.Row="0" TextElement.FontSize="{DynamicResource GroupBoxHeaderFontSize}" Margin="{DynamicResource GroupBoxHeaderMargin}" ContentSource="Header" TextElement.Foreground="{DynamicResource GroupBoxHeaderForeground}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+              <ContentPresenter Grid.Row="1" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+            </Grid>
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultGroupBoxStyle}" TargetType="{x:Type GroupBox}" />
+  <Style x:Key="{x:Type GroupItem}" TargetType="{x:Type GroupItem}">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type GroupItem}">
+          <StackPanel>
+            <ContentPresenter x:Name="PART_Header" />
+            <ItemsPresenter x:Name="ItemsPresenter" Margin="5,0,0,0" />
+          </StackPanel>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="{x:Type HeaderedContentControl}" TargetType="{x:Type HeaderedContentControl}">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type HeaderedContentControl}">
+          <StackPanel>
+            <ContentPresenter ContentSource="Header" />
+            <ContentPresenter />
+          </StackPanel>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DefaultHyperlinkStyle" TargetType="Hyperlink">
+    <Setter Property="Foreground" Value="{DynamicResource HyperlinkForeground}" />
+    <Setter Property="TextDecorations" Value="Underline" />
+    <Style.Triggers>
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter Property="Foreground" Value="{DynamicResource HyperlinkForegroundPointerOver}" />
+        <Setter Property="TextDecorations" Value="None" />
+      </Trigger>
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter Property="Foreground" Value="{DynamicResource HyperlinkForegroundDisabled}" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+  <Style TargetType="Hyperlink" BasedOn="{StaticResource DefaultHyperlinkStyle}" />
+  <Style x:Key="DefaultItemsControlStyle" TargetType="{x:Type ItemsControl}">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ItemsControl}">
+          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
+            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultItemsControlStyle}" TargetType="{x:Type ItemsControl}" />
+  <Style x:Key="DefaultLabelStyle" TargetType="{x:Type Label}">
+    <Setter Property="Padding" Value="0,0,0,4" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="Foreground" Value="{DynamicResource LabelForeground}" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+  </Style>
+  <Style BasedOn="{StaticResource DefaultLabelStyle}" TargetType="{x:Type Label}" />
+  <Style x:Key="DefaultListBoxStyle" TargetType="{x:Type ListBox}">
+    <Setter Property="Background" Value="{DynamicResource ListBoxBackground}" />
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="VirtualizingPanel.IsVirtualizing" Value="True" />
+    <Setter Property="VirtualizingPanel.VirtualizationMode" Value="Standard" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="ItemsPanel">
+      <Setter.Value>
+        <ItemsPanelTemplate>
+          <VirtualizingStackPanel IsVirtualizing="{TemplateBinding VirtualizingPanel.IsVirtualizing}" VirtualizationMode="{TemplateBinding VirtualizingPanel.VirtualizationMode}" />
+        </ItemsPanelTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ListBox}">
+          <Border Name="Bd" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+            <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+              <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+            </ScrollViewer>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsGrouping" Value="True">
+              <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultListBoxStyle}" TargetType="{x:Type ListBox}" />
+  <Thickness x:Key="ListBoxItemPadding">12</Thickness>
+  <Thickness x:Key="ListBoxItemMargin">0</Thickness>
+  <Style x:Key="DefaultListBoxItemStyle" TargetType="{x:Type ListBoxItem}">
+    <Setter Property="Foreground" Value="{DynamicResource ListBoxItemForeground}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
+    <Setter Property="Margin" Value="{DynamicResource ListBoxItemMargin}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Padding" Value="{DynamicResource ListBoxItemPadding}" />
+    <Setter Property="Border.CornerRadius" Value="0" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ListBoxItem}">
+          <Border x:Name="Border" Margin="0" Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsSelected" Value="True">
+              <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListBoxItemSelectedBackgroundThemeBrush}" />
+              <Setter Property="Foreground" Value="{DynamicResource ListBoxItemSelectedForegroundThemeBrush}" />
+            </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsSelected" Value="False" />
+                <Condition Property="IsMouseOver" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListBoxItemUnselectedBackgroundPointerOverThemeBrush}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsSelected" Value="True" />
+                <Condition Property="IsMouseOver" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListBoxItemSelectedBackgroundPointerOverThemeBrush}" />
+            </MultiTrigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultListBoxItemStyle}" TargetType="{x:Type ListBoxItem}" />
+  <Style x:Key="DefaultListViewStyle" TargetType="{x:Type ListView}">
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="Background" Value="{DynamicResource ListViewBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ListViewBorderBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="VirtualizingPanel.IsVirtualizing" Value="True" />
+    <Setter Property="VirtualizingPanel.VirtualizationMode" Value="Standard" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="ItemsPanel">
+      <Setter.Value>
+        <ItemsPanelTemplate>
+          <VirtualizingStackPanel IsVirtualizing="{TemplateBinding VirtualizingPanel.IsVirtualizing}" VirtualizationMode="{TemplateBinding VirtualizingPanel.VirtualizationMode}" />
+        </ItemsPanelTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ListView}">
+          <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}">
+            <Grid>
+              <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+              </ScrollViewer>
+              <Rectangle x:Name="PART_DisabledVisual" Opacity="0" RadiusX="2" RadiusY="2" Stretch="Fill" Stroke="Transparent" StrokeThickness="0" Visibility="Collapsed">
+                <Rectangle.Fill>
+                  <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+                </Rectangle.Fill>
+              </Rectangle>
+            </Grid>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsGrouping" Value="True">
+              <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="PART_DisabledVisual" Property="Visibility" Value="Visible" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultListViewStyle}" TargetType="{x:Type ListView}" />
+  <system:Double x:Key="ListViewItemMinHeight">40</system:Double>
+  <system:Double x:Key="ListViewItemMinWidth">88</system:Double>
+  <Thickness x:Key="ListViewItemPadding">16,0,12,0</Thickness>
+  <Thickness x:Key="ListViewItemMargin">0,0,0,2</Thickness>
+  <Style x:Key="DefaultListViewItemStyle" TargetType="{x:Type ListViewItem}">
+    <Setter Property="Foreground" Value="{DynamicResource ListViewItemForeground}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="MinHeight" Value="{StaticResource ListViewItemMinHeight}" />
+    <Setter Property="MinWidth" Value="{StaticResource ListViewItemMinWidth}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Margin" Value="{DynamicResource ListViewItemMargin}" />
+    <Setter Property="Padding" Value="{DynamicResource ListViewItemPadding}" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ListBoxItem}">
+          <Border x:Name="Border" Margin="0" Padding="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <Grid>
+              <ContentPresenter Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+              <Rectangle x:Name="ActiveRectangle" Width="3" Height="18" Margin="0" HorizontalAlignment="Left" VerticalAlignment="Center" Fill="{DynamicResource ListViewItemPillFillBrush}" RadiusX="2" RadiusY="2" Visibility="Collapsed" />
+            </Grid>
+          </Border>
+          <ControlTemplate.Triggers>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsEnabled" Value="True" />
+                <Condition Property="IsMouseOver" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
+            </MultiTrigger>
+            <Trigger Property="IsSelected" Value="True">
+              <Setter TargetName="ActiveRectangle" Property="Visibility" Value="Visible" />
+              <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultListViewItemStyle}" TargetType="{x:Type ListViewItem}" />
+  <Style x:Key="DefaultMenuStyle" TargetType="{x:Type Menu}">
+    <Setter Property="Background" Value="{DynamicResource MenuBarBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource MenuBarForeground}" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Menu}">
+          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}">
+            <ItemsPresenter ClipToBounds="True" />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="{x:Type Menu}" BasedOn="{StaticResource DefaultMenuStyle}" TargetType="{x:Type Menu}" />
+  <system:String x:Key="MenuItemChevronRightGlyph"></system:String>
+  <system:String x:Key="MenuItemCheckedGlyph"></system:String>
+  <Style x:Key="MenuItemScrollViewerStyle" BasedOn="{StaticResource {x:Type ScrollViewer}}" TargetType="{x:Type ScrollViewer}">
+    <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
+    <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
+  </Style>
+  <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}" TargetType="{x:Type Separator}">
+    <Setter Property="BorderBrush" Value="{DynamicResource MenuBarItemBorderBrush}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Margin" Value="0,1,0,1" />
+    <Setter Property="BorderThickness" Value="1,1,0,0" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Separator}">
+          <Border Width="{TemplateBinding Width}" Margin="{TemplateBinding Margin}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <!--  TopLevelHeader  -->
+  <ControlTemplate x:Key="{x:Static MenuItem.TopLevelHeaderTemplateKey}" TargetType="{x:Type MenuItem}">
+    <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
+      <Grid>
+        <Grid.RowDefinitions>
+          <RowDefinition Height="*" />
+          <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid Margin="10">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+          </Grid.ColumnDefinitions>
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
+        </Grid>
+        <Popup x:Name="PART_Popup" Grid.Row="1" Grid.Column="0" AllowsTransparency="True" Focusable="False" HorizontalOffset="-12" IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Bottom" PlacementTarget="{Binding ElementName=Border}" PopupAnimation="None" VerticalOffset="1">
+          <Grid>
+            <Border x:Name="SubmenuBorder" Margin="12,0,12,18" Padding="0,3,0,3" Background="{DynamicResource FlyoutBackground}" BorderBrush="{DynamicResource FlyoutBorderBrush}" BorderThickness="1" CornerRadius="8" SnapsToDevicePixels="True">
+              <Border.RenderTransform>
+                <TranslateTransform />
+              </Border.RenderTransform>
+              <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuItemScrollViewerStyle}">
+                <Grid>
+                  <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle" KeyboardNavigation.TabNavigation="Cycle" Grid.IsSharedSizeScope="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                </Grid>
+              </ScrollViewer>
+              <Border.Effect>
+                <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.25" ShadowDepth="6" />
+              </Border.Effect>
+            </Border>
+          </Grid>
+        </Popup>
+      </Grid>
+    </Border>
+    <ControlTemplate.Triggers>
+      <Trigger Property="Icon" Value="{x:Null}">
+        <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <Trigger Property="Header" Value="{x:Null}">
+        <Setter TargetName="Icon" Property="Margin" Value="0" />
+        <Setter TargetName="HeaderPresenter" Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <Trigger Property="IsHighlighted" Value="True">
+        <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuBarItemBackgroundSelected}" />
+      </Trigger>
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter Property="Foreground">
+          <Setter.Value>
+            <SolidColorBrush Color="{DynamicResource TextFillColorDisabled}" />
+          </Setter.Value>
+        </Setter>
+      </Trigger>
+      <Trigger Property="IsSubmenuOpen" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="SubmenuBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
+                <DoubleAnimation.EasingFunction>
+                  <CircleEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+              </DoubleAnimation>
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <!--  TopLevelItem  -->
+  <ControlTemplate x:Key="{x:Static MenuItem.TopLevelItemTemplateKey}" TargetType="{x:Type MenuItem}">
+    <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
+      <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
+      </Grid>
+    </Border>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsHighlighted" Value="True">
+        <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuBarItemBackgroundSelected}" />
+      </Trigger>
+      <Trigger Property="Icon" Value="{x:Null}">
+        <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <Trigger Property="Header" Value="{x:Null}">
+        <Setter TargetName="Icon" Property="Margin" Value="0" />
+        <Setter TargetName="HeaderPresenter" Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter Property="Foreground">
+          <Setter.Value>
+            <SolidColorBrush Color="{DynamicResource TextFillColorDisabled}" />
+          </Setter.Value>
+        </Setter>
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <!--  SubmenuItem  -->
+  <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}" TargetType="{x:Type MenuItem}">
+    <Border x:Name="Border" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
+      <Grid Margin="8,6,8,6">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemCheckBoxIconColumnGroup" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
+        </Grid.ColumnDefinitions>
+        <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
+          <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
+        </Border>
+        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+        <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
+        <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
+      </Grid>
+    </Border>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsHighlighted" Value="True">
+        <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuBarItemBackgroundSelected}" />
+      </Trigger>
+      <Trigger Property="Icon" Value="{x:Null}">
+        <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <Trigger Property="IsCheckable" Value="True">
+        <Setter TargetName="CheckBoxIconBorder" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsChecked" Value="True">
+        <Setter TargetName="CheckBoxIcon" Property="Text" Value="{StaticResource MenuItemCheckedGlyph}" />
+      </Trigger>
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter Property="Foreground">
+          <Setter.Value>
+            <SolidColorBrush Color="{DynamicResource TextFillColorDisabled}" />
+          </Setter.Value>
+        </Setter>
+      </Trigger>
+      <Trigger Property="InputGestureText" Value="">
+        <Setter TargetName="InputGestureText" Property="Visibility" Value="Collapsed" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <!--  SubItem with Subitems  -->
+  <ControlTemplate x:Key="{x:Static MenuItem.SubmenuHeaderTemplateKey}" TargetType="{x:Type MenuItem}">
+    <Grid>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="*" />
+        <RowDefinition Height="Auto" />
+      </Grid.RowDefinitions>
+      <Border x:Name="Border" Grid.Row="1" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
+        <Grid x:Name="MenuItemContent" Margin="8,6,8,6">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+          </Grid.ColumnDefinitions>
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="HeaderHost" Grid.Column="1" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" ContentSource="Header" RecognizesAccessKey="True" />
+          <Grid Grid.Column="2">
+            <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
+          </Grid>
+        </Grid>
+      </Border>
+      <Popup x:Name="PART_Popup" Grid.Row="1" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" PlacementTarget="{Binding ElementName=MenuItemContent}" PopupAnimation="None" VerticalOffset="-20">
+        <Grid>
+          <Border x:Name="SubmenuBorder" Margin="12,10,12,18" Padding="0,3,0,3" Background="{DynamicResource FlyoutBackground}" BorderBrush="{DynamicResource FlyoutBorderBrush}" BorderThickness="1" CornerRadius="8" SnapsToDevicePixels="True">
+            <Border.RenderTransform>
+              <TranslateTransform />
+            </Border.RenderTransform>
+            <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuItemScrollViewerStyle}">
+              <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle" KeyboardNavigation.TabNavigation="Cycle" Grid.IsSharedSizeScope="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+            </ScrollViewer>
+            <Border.Effect>
+              <DropShadowEffect BlurRadius="20" Direction="270" Opacity="0.5" ShadowDepth="6" />
+            </Border.Effect>
+          </Border>
+        </Grid>
+      </Popup>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="Icon" Value="{x:Null}">
+        <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
+        <Setter TargetName="Icon" Property="Margin" Value="0" />
+      </Trigger>
+      <Trigger Property="IsHighlighted" Value="true">
+        <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuBarItemBackgroundSelected}" />
+      </Trigger>
+      <!--<Trigger SourceName="Popup" Property="AllowsTransparency" Value="True">
+                <Setter TargetName="SubmenuBorder" Property="CornerRadius" Value="4" />
+                <Setter TargetName="SubmenuBorder" Property="Padding" Value="0,3,0,3" />
+            </Trigger>-->
+      <Trigger Property="IsEnabled" Value="false">
+        <Setter Property="Foreground">
+          <Setter.Value>
+            <SolidColorBrush Color="{DynamicResource TextFillColorDisabled}" />
+          </Setter.Value>
+        </Setter>
+        <Setter TargetName="Chevron" Property="Foreground">
+          <Setter.Value>
+            <SolidColorBrush Color="{DynamicResource TextFillColorDisabled}" />
+          </Setter.Value>
+        </Setter>
+      </Trigger>
+      <Trigger Property="IsSubmenuOpen" Value="True">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="SubmenuBorder" Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)" From="-90" To="0" Duration="00:00:00.167">
+                <DoubleAnimation.EasingFunction>
+                  <CircleEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+              </DoubleAnimation>
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <Style x:Key="DefaultMenuItemStyle" TargetType="{x:Type MenuItem}">
+    <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
+    <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Focusable" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Style.Triggers>
+      <Trigger Property="Role" Value="TopLevelHeader">
+        <Setter Property="Template" Value="{StaticResource {x:Static MenuItem.TopLevelHeaderTemplateKey}}" />
+        <Setter Property="Grid.IsSharedSizeScope" Value="True" />
+      </Trigger>
+      <Trigger Property="Role" Value="TopLevelItem">
+        <Setter Property="Template" Value="{StaticResource {x:Static MenuItem.TopLevelItemTemplateKey}}" />
+      </Trigger>
+      <Trigger Property="Role" Value="SubmenuHeader">
+        <Setter Property="Template" Value="{StaticResource {x:Static MenuItem.SubmenuHeaderTemplateKey}}" />
+      </Trigger>
+      <Trigger Property="Role" Value="SubmenuItem">
+        <Setter Property="Template" Value="{StaticResource {x:Static MenuItem.SubmenuItemTemplateKey}}" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultMenuItemStyle}" TargetType="{x:Type MenuItem}" />
+  <system:String x:Key="NavigationWindowMenuItemChevronDownGlyph"></system:String>
+  <system:String x:Key="NavigationWindowMenuItemArrowLeftGlyph"></system:String>
+  <system:String x:Key="NavigationWindowMenuItemArrowRightGlyph"></system:String>
+  <ControlTemplate x:Key="NavigationWindowTemplateKey" TargetType="{x:Type NavigationWindow}">
+    <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+      <DockPanel>
+        <Menu Name="NavMenu" VerticalAlignment="Center" DockPanel.Dock="Top">
+          <MenuItem Background="Transparent" BorderBrush="Transparent" Command="NavigationCommands.BrowseBack" FontFamily="{DynamicResource SymbolThemeFontFamily}" Header="{StaticResource NavigationWindowMenuItemArrowLeftGlyph}" />
+          <MenuItem Background="Transparent" BorderBrush="Transparent" Command="NavigationCommands.BrowseForward" FontFamily="{DynamicResource SymbolThemeFontFamily}" Header="{StaticResource NavigationWindowMenuItemArrowRightGlyph}" />
+          <Separator />
+          <MenuItem x:Name="Arrow" SnapsToDevicePixels="False" HorizontalAlignment="Right" VerticalAlignment="Center" ItemContainerStyle="{StaticResource FrameNavigationButtonJournalEntryStyle}" IsSubmenuOpen="{Binding Path=(MenuItem.IsSubmenuOpen),Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}">
+            <MenuItem.Icon>
+              <TextBlock FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource NavigationWindowMenuItemChevronDownGlyph}" />
+            </MenuItem.Icon>
+            <MenuItem.ItemsSource>
+              <MultiBinding Converter="{StaticResource JournalEntryUnifiedViewConverter}">
+                <MultiBinding.Bindings>
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(NavigationWindow.BackStack)" />
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(NavigationWindow.ForwardStack)" />
+                </MultiBinding.Bindings>
+              </MultiBinding>
+            </MenuItem.ItemsSource>
+          </MenuItem>
+        </Menu>
+        <Grid>
+          <AdornerDecorator>
+            <ContentPresenter Name="PART_NavWinCP" ClipToBounds="True" />
+          </AdornerDecorator>
+          <ResizeGrip x:Name="WindowResizeGrip" HorizontalAlignment="Right" VerticalAlignment="Bottom" Visibility="Collapsed" IsTabStop="False" />
+        </Grid>
+      </DockPanel>
+    </Border>
+    <ControlTemplate.Triggers>
+      <Trigger Property="ShowsNavigationUI" Value="False">
+        <Setter TargetName="NavMenu" Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="Window.ResizeMode" Value="CanResizeWithGrip" />
+          <Condition Property="Window.WindowState" Value="Normal" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="WindowResizeGrip" Property="Visibility" Value="Visible" />
+      </MultiTrigger>
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="NavigationWindow.CanGoForward" Value="False" />
+          <Condition Property="NavigationWindow.CanGoBack" Value="False" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="NavMenu" Property="IsEnabled" Value="False" />
+      </MultiTrigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <Style x:Key="DefaultNavigationWindowStyle" TargetType="{x:Type NavigationWindow}">
+    <Setter Property="Foreground" Value="{DynamicResource NavigationWindowForeground}" />
+    <Setter Property="Background" Value="{DynamicResource NavigationWindowBackground}" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template" Value="{StaticResource NavigationWindowTemplateKey}" />
+  </Style>
+  <Style BasedOn="{StaticResource DefaultNavigationWindowStyle}" TargetType="{x:Type NavigationWindow}" />
+  <Style x:Key="DefaultPageStyle" TargetType="{x:Type Page}">
+    <Setter Property="Foreground" Value="{DynamicResource PageForeground}" />
+    <Setter Property="Background" Value="{DynamicResource PageBackground}" />
+    <!--  The Display option casues a large aliasing effect  -->
+    <!-- <Setter Property="TextOptions.TextFormattingMode" Value="Ideal" /> -->
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Page}">
+          <Border Background="{TemplateBinding Background}" CornerRadius="8">
+            <ContentPresenter Content="{TemplateBinding ContentControl.Content}" TextElement.Foreground="{TemplateBinding Foreground}" />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultPageStyle}" TargetType="{x:Type Page}" />
+  <!-- Deprecated PasswordBox Resources ( Used in .NET 9 ) -->
+  <Thickness x:Key="PasswordBoxAccentBorderThemeThickness">0,0,0,1</Thickness>
+  <Thickness x:Key="PasswordBoxLeftIconMargin">10,8,0,0</Thickness>
+  <Thickness x:Key="PasswordBoxRightIconMargin">0,8,10,0</Thickness>
+  <Thickness x:Key="PasswordBoxButtonMargin">0,5,4,0</Thickness>
+  <Thickness x:Key="PasswordBoxButtonPadding">0,0,0,0</Thickness>
+  <sys:Double x:Key="PasswordBoxButtonHeight">24</sys:Double>
+  <sys:Double x:Key="PasswordBoxButtonIconSize">14</sys:Double>
+  <!-- These rsources are redefined in .NET 10 -->
+  <!-- <Thickness x:Key="PasswordBoxBorderThemeThickness">1,1,1,1</Thickness> -->
+  <Thickness x:Key="PasswordBoxBorderThemeThickness">1</Thickness>
+  <!-- Instead of PasswordBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
+            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
+  <sys:Double x:Key="PasswordBoxThemeMinHeight">32</sys:Double>
+  <ContextMenu x:Key="DefaultPasswordBoxContextMenu">
+    <MenuItem Command="ApplicationCommands.Paste" />
+  </ContextMenu>
+  <Style x:Key="DefaultPasswordBoxStyle" TargetType="{x:Type PasswordBox}">
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="ContextMenu" Value="{DynamicResource DefaultPasswordBoxContextMenu}" />
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource PasswordBoxBorderThemeThickness}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="Cursor" Value="IBeam" />
+    <Setter Property="MinHeight" Value="{DynamicResource PasswordBoxThemeMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
+    <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="AllowDrop" Value="True" />
+    <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
+    <Setter Property="PasswordChar" Value="●" />
+    <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type PasswordBox}">
+          <Grid>
+            <Border x:Name="ContentBorder" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+            <ScrollViewer x:Name="PART_ContentHost" Margin="{TemplateBinding BorderThickness}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}" IsTabStop="{TemplateBinding ScrollViewer.IsTabStop}" Padding="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsFocused" Value="True">
+              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundDisabled}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushDisabled}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultPasswordBoxStyle}" TargetType="{x:Type PasswordBox}" />
+  <Style TargetType="{x:Type ProgressBar}">
+    <Setter Property="Foreground" Value="{DynamicResource ProgressBarForeground}" />
+    <Setter Property="Background" Value="{DynamicResource ProgressBarBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ProgressBarBorderBrush}" />
+    <Setter Property="Height" Value="4" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ProgressBar}">
+          <Grid x:Name="TemplateRoot">
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="CommonStates">
+                <VisualState x:Name="Determinate" />
+                <VisualState x:Name="Indeterminate">
+                  <Storyboard RepeatBehavior="Forever">
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)" Storyboard.TargetName="Animation">
+                      <EasingDoubleKeyFrame KeyTime="0" Value="0.25" />
+                      <EasingDoubleKeyFrame KeyTime="0:0:0.45" Value="0.25" />
+                      <EasingDoubleKeyFrame KeyTime="0:0:0.9" Value="0.25" />
+                    </DoubleAnimationUsingKeyFrames>
+                    <PointAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransformOrigin)" Storyboard.TargetName="Animation">
+                      <EasingPointKeyFrame KeyTime="0" Value="-0.5,0.5" />
+                      <EasingPointKeyFrame KeyTime="0:0:0.45" Value="0.5,0.5" />
+                      <EasingPointKeyFrame KeyTime="0:0:0.9" Value="1.5,0.5" />
+                    </PointAnimationUsingKeyFrames>
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <Border x:Name="TrackBorder" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" Margin="1,1,1,1" />
+            <Rectangle x:Name="PART_Track" />
+            <Grid x:Name="PART_Indicator" Margin="1,1,1,1" Background="{TemplateBinding BorderBrush}" HorizontalAlignment="Left">
+              <Rectangle x:Name="Indicator" Fill="{TemplateBinding Foreground}" RadiusX="6" RadiusY="6" />
+              <Rectangle x:Name="Animation" RenderTransformOrigin="0.5,0.5" Fill="{TemplateBinding Foreground}" RadiusX="6" RadiusY="6">
+                <Rectangle.RenderTransform>
+                  <TransformGroup>
+                    <ScaleTransform />
+                    <SkewTransform />
+                    <RotateTransform />
+                    <TranslateTransform />
+                  </TransformGroup>
+                </Rectangle.RenderTransform>
+              </Rectangle>
+            </Grid>
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="Orientation" Value="Vertical">
+              <Setter Property="LayoutTransform" TargetName="TemplateRoot">
+                <Setter.Value>
+                  <RotateTransform Angle="-90" />
+                </Setter.Value>
+              </Setter>
+            </Trigger>
+            <Trigger Property="IsIndeterminate" Value="True">
+              <Setter Property="Visibility" TargetName="Indicator" Value="Collapsed" />
+              <Setter Property="BorderBrush" Value="{DynamicResource ProgressBarIndeterminateBorderBrush}" />
+              <Setter Property="Background" Value="{DynamicResource ProgressBarIndeterminateBackground}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <system:Double x:Key="RadioButtonCheckGlyphSize">12</system:Double>
+  <system:Double x:Key="RadioButtonOuterEllipseSize">20</system:Double>
+  <!--
+    <system:Double x:Key="RadioButtonCheckGlyphPointerOverSize">14</system:Double>
+    <system:Double x:Key="RadioButtonCheckGlyphPressedOverSize">10</system:Double>-->
+  <system:Double x:Key="RadioButtonStrokeThickness">1</system:Double>
+  <Thickness x:Key="RadioButtonPadding">8,6,0,0</Thickness>
+  <Style x:Key="DefaultRadioButtonStyle" TargetType="{x:Type RadioButton}">
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource RadioButtonForeground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />
+    <Setter Property="Border.CornerRadius" Value="4" />
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="Padding" Value="{StaticResource RadioButtonPadding}" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="MinWidth" Value="120" />
+    <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
+    <Setter Property="Focusable" Value="True" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type RadioButton}">
+          <Border x:Name="RootBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="CommonStates">
+                <VisualState x:Name="Normal">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleX)" To="1" Duration="0:0:0.25" />
+                    <DoubleAnimation Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleY)" To="1" Duration="0:0:0.25" />
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="MouseOver">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleX)" To="1.167" Duration="0:0:0.25" />
+                    <DoubleAnimation Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleY)" To="1.167" Duration="0:0:0.25" />
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="Pressed">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleX)" To="0.86" Duration="0:0:0.25" />
+                    <DoubleAnimation Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleY)" To="0.86" Duration="0:0:0.25" />
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <Grid x:Name="RootGrid">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="20" />
+                <ColumnDefinition Width="*" />
+              </Grid.ColumnDefinitions>
+              <Grid Height="32" VerticalAlignment="Top">
+                <Ellipse x:Name="OuterEllipse" Width="20" Height="20" Fill="{DynamicResource RadioButtonOuterEllipseFill}" Stroke="{DynamicResource RadioButtonOuterEllipseStroke}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
+                <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
+                <Ellipse x:Name="CheckOuterEllipse" Width="20" Height="20" Fill="{DynamicResource RadioButtonOuterEllipseCheckedFill}" Opacity="0" Stroke="{DynamicResource RadioButtonOuterEllipseCheckedStroke}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
+                <Ellipse x:Name="CheckGlyph" Width="{StaticResource RadioButtonCheckGlyphSize}" Height="{StaticResource RadioButtonCheckGlyphSize}" Fill="{DynamicResource RadioButtonCheckGlyphFill}" RenderTransformOrigin="0.5, 0.5" Opacity="0" Stroke="{DynamicResource CircleElevationBorderBrush}" UseLayoutRounding="False">
+                  <Ellipse.RenderTransform>
+                    <ScaleTransform />
+                  </Ellipse.RenderTransform>
+                </Ellipse>
+                <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
+                <Border x:Name="PressedCheckGlyph" Width="4" Height="4" Background="{DynamicResource RadioButtonCheckGlyphFill}" BorderBrush="{DynamicResource CircleElevationBorderBrush}" CornerRadius="6" Opacity="0" UseLayoutRounding="False" />
+              </Grid>
+              <ContentPresenter x:Name="ContentPresenter" Grid.Column="1" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" TextElement.Foreground="{TemplateBinding Foreground}" />
+            </Grid>
+          </Border>
+          <ControlTemplate.Triggers>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsPressed" Value="True" />
+                <Condition Property="IsChecked" Value="False" />
+                <Condition Property="IsEnabled" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="CheckGlyph" Property="Opacity" Value="1.0" />
+              <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPressed}" />
+              <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePressed}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPressed}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPressed}" />
+            </MultiTrigger>
+            <Trigger Property="IsChecked" Value="True">
+              <Setter TargetName="CheckGlyph" Property="Opacity" Value="1.0" />
+              <Setter TargetName="OuterEllipse" Property="Opacity" Value="0.0" />
+              <Setter TargetName="CheckOuterEllipse" Property="Opacity" Value="1.0" />
+            </Trigger>
+            <Trigger Property="FlowDirection" Value="RightToLeft">
+              <Setter Property="HorizontalAlignment" Value="Right" />
+            </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="False" />
+                <Condition Property="IsEnabled" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPointerOver}" />
+              <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePointerOver}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPointerOver}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPointerOver}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="True" />
+                <Condition Property="IsEnabled" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPointerOver}" />
+              <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePointerOver}" />
+              <Setter TargetName="CheckOuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPointerOver}" />
+              <!--<Setter TargetName="CheckGlyph" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokePointerOver}" />-->
+              <Setter TargetName="PressedCheckGlyph" Property="Background" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokePointerOver}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPointerOver}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPointerOver}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsPressed" Value="True" />
+                <Condition Property="IsChecked" Value="True" />
+                <Condition Property="IsEnabled" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPressed}" />
+              <Setter TargetName="CheckOuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPressed}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPressed}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPressed}" />
+              <Setter TargetName="PressedCheckGlyph" Property="Background" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedStrokePressed}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsChecked" Value="False" />
+                <Condition Property="IsEnabled" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter Property="Foreground" Value="{DynamicResource RadioButtonForegroundDisabled}" />
+              <Setter Property="Background" Value="{DynamicResource RadioButtonBackgroundDisabled}" />
+              <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillDisabled}" />
+              <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokeDisabled}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsChecked" Value="True" />
+                <Condition Property="IsEnabled" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter Property="Foreground" Value="{DynamicResource RadioButtonForegroundDisabled}" />
+              <Setter Property="Background" Value="{DynamicResource RadioButtonBackgroundDisabled}" />
+              <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillDisabled}" />
+              <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokeDisabled}" />
+              <Setter TargetName="CheckOuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokeDisabled}" />
+              <Setter TargetName="CheckOuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseCheckedFillDisabled}" />
+            </MultiTrigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultRadioButtonStyle}" TargetType="{x:Type RadioButton}" />
+  <Thickness x:Key="RepeatButtonPadding">11,5,11,6</Thickness>
+  <Thickness x:Key="RepeatButtonBorderThemeThickness">1</Thickness>
+  <Thickness x:Key="RepeatButtonIconMargin">0,0,8,0</Thickness>
+  <Style x:Key="DefaultRepeatButtonStyle" TargetType="{x:Type RepeatButton}">
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="Background" Value="{DynamicResource RepeatButtonBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForeground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource RepeatButtonBorderThemeThickness}" />
+    <Setter Property="Padding" Value="{StaticResource RepeatButtonPadding}" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type RepeatButton}">
+          <Border x:Name="ContentBorder" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Padding="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <ContentPresenter x:Name="ContentPresenter" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" TextElement.Foreground="{TemplateBinding Foreground}" TextElement.FontSize="{TemplateBinding FontSize}" />
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter Property="Background" Value="{DynamicResource RepeatButtonBackgroundDisabled}" />
+              <Setter Property="BorderBrush" Value="{DynamicResource RepeatButtonBorderBrushDisabled}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource RepeatButtonForegroundDisabled}" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter Property="Background" Value="{DynamicResource RepeatButtonBackgroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+              <Setter Property="Background" Value="{DynamicResource RepeatButtonBackgroundPressed}" />
+              <Setter Property="BorderBrush" Value="{DynamicResource RepeatButtonBorderBrushPressed}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource RepeatButtonForegroundPressed}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultRepeatButtonStyle}" TargetType="{x:Type RepeatButton}" />
+  <sys:Double x:Key="ResizeGripMinHeight" xmlns:sys="clr-namespace:System;assembly=System.Runtime">12</sys:Double>
+  <sys:Double x:Key="ResizeGripMinWidth" xmlns:sys="clr-namespace:System;assembly=System.Runtime">12</sys:Double>
+  <sys:Double x:Key="ResizeGripIconSize" xmlns:sys="clr-namespace:System;assembly=System.Runtime">8.0</sys:Double>
+  <sys:String x:Key="ResizeGripIconGlyph" xmlns:sys="clr-namespace:System;assembly=System.Runtime"></sys:String>
+  <Style x:Key="DefaultResizeGripStyle" TargetType="{x:Type ResizeGrip}">
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="MinWidth" Value="{DynamicResource ResizeGripMinWidth}" />
+    <Setter Property="MinHeight" Value="{DynamicResource ResizeGripMinHeight}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ResizeGrip">
+          <Grid SnapsToDevicePixels="True" Background="{TemplateBinding Background}">
+            <TextBlock FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ResizeGripIconGlyph}" FontSize="{DynamicResource ResizeGripIconSize}" Foreground="{DynamicResource ResizeGripForeground}" />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultResizeGripStyle}" TargetType="{x:Type ResizeGrip}" />
+  <!-- Deprecated RichTextBox Resources ( Used in .NET 9 ) -->
+  <Thickness x:Key="RichTextBoxAccentBorderThemeThickness">0,0,0,1</Thickness>
+  <!-- Instead of RichTextBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
+            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
+  <system:Double x:Key="RichTextBoxThemeMinHeight">32</system:Double>
+  <Style x:Key="DefaultRichTextBoxStyle" TargetType="{x:Type RichTextBox}">
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="Cursor" Value="IBeam" />
+    <Setter Property="MinHeight" Value="{DynamicResource RichTextBoxThemeMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
+    <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="AllowDrop" Value="True" />
+    <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
+    <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type RichTextBox}">
+          <Grid>
+            <Border x:Name="ContentBorder" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+            <ScrollViewer x:Name="PART_ContentHost" Margin="{TemplateBinding BorderThickness}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}" IsTabStop="{TemplateBinding ScrollViewer.IsTabStop}" Padding="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsFocused" Value="True">
+              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundDisabled}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushDisabled}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultRichTextBoxStyle}" TargetType="{x:Type RichTextBox}" />
+  <Duration x:Key="ScrollAnimationDuration">0:0:0.16</Duration>
+  <Duration x:Key="ButtonHoverAnimationDuration">0:0:0.16</Duration>
+  <sys:Double x:Key="LineButtonHeight">12</sys:Double>
+  <sys:Double x:Key="LineButtonWidth">12</sys:Double>
+  <sys:Double x:Key="ScrollBarButtonArrowIconFontSize">8</sys:Double>
+  <system:String x:Key="ScrollBarCaretUpGlyph"></system:String>
+  <system:String x:Key="ScrollBarCaretDownGlyph"></system:String>
+  <system:String x:Key="ScrollBarCaretLeftGlyph"></system:String>
+  <system:String x:Key="ScrollBarCaretRightGlyph"></system:String>
+  <Style x:Key="ScrollBarLineButtonStyle" TargetType="{x:Type RepeatButton}">
+    <Setter Property="Foreground" Value="{DynamicResource ScrollBarButtonArrowForeground}" />
+    <Setter Property="Width" Value="{StaticResource LineButtonWidth}" />
+    <Setter Property="Height" Value="{StaticResource LineButtonHeight}" />
+    <Setter Property="FontSize" Value="{StaticResource ScrollBarButtonArrowIconFontSize}" />
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type RepeatButton}">
+          <Border x:Name="Border" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" Margin="{TemplateBinding Margin}" Background="{DynamicResource ScrollBarButtonBackground}" CornerRadius="6">
+            <TextBlock Margin="0,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Trigger.EnterActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="Border" Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Opacity)" From="0.0" To="1.0" Duration="{StaticResource ButtonHoverAnimationDuration}" />
+                  </Storyboard>
+                </BeginStoryboard>
+              </Trigger.EnterActions>
+              <Trigger.ExitActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="Border" Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Opacity)" From="1.0" To="0.0" Duration="{StaticResource ButtonHoverAnimationDuration}" />
+                  </Storyboard>
+                </BeginStoryboard>
+              </Trigger.ExitActions>
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="ScrollBarPageButtonStyle" TargetType="{x:Type RepeatButton}">
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="true" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type RepeatButton}">
+          <Border Background="Transparent" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="ScrollBarThumbStyle" TargetType="{x:Type Thumb}">
+    <Setter Property="Background" Value="{DynamicResource ScrollBarThumbFill}" />
+    <Setter Property="Border.CornerRadius" Value="4" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Thumb}">
+          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <ControlTemplate x:Key="VerticalScrollBarTemplate" TargetType="{x:Type ScrollBar}">
+    <Grid>
+      <Grid.RowDefinitions>
+        <RowDefinition MaxHeight="14" />
+        <RowDefinition Height="0.00001*" />
+        <RowDefinition MaxHeight="14" />
+      </Grid.RowDefinitions>
+      <Border x:Name="PART_Border" Grid.RowSpan="3" Width="12" HorizontalAlignment="Center" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6" Opacity="0" />
+      <RepeatButton x:Name="PART_ButtonScrollUp" Grid.Row="0" HorizontalContentAlignment="Left" Command="ScrollBar.LineUpCommand" Content="{StaticResource ScrollBarCaretUpGlyph}" Opacity="0" AutomationProperties.Name="Scroll Up" Style="{StaticResource ScrollBarLineButtonStyle}" />
+      <Track x:Name="PART_Track" Grid.Row="1" Width="4" IsDirectionReversed="True">
+        <Track.DecreaseRepeatButton>
+          <RepeatButton Command="ScrollBar.PageUpCommand" Style="{StaticResource ScrollBarPageButtonStyle}" />
+        </Track.DecreaseRepeatButton>
+        <Track.Thumb>
+          <!--
+                        TODO: Need to add a custom Thumb with a corner radius that will increase when OnMouseOver is triggered.
+                    -->
+          <Thumb Margin="0" Padding="0" Style="{StaticResource ScrollBarThumbStyle}" />
+        </Track.Thumb>
+        <Track.IncreaseRepeatButton>
+          <RepeatButton Command="ScrollBar.PageDownCommand" Style="{StaticResource ScrollBarPageButtonStyle}" />
+        </Track.IncreaseRepeatButton>
+      </Track>
+      <RepeatButton x:Name="PART_ButtonScrollDown" Grid.Row="2" HorizontalContentAlignment="Left" Command="ScrollBar.LineDownCommand" Content="{StaticResource ScrollBarCaretDownGlyph}" Opacity="0" AutomationProperties.Name="Scroll Down" Style="{StaticResource ScrollBarLineButtonStyle}" />
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFillPointerOver}" />
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="4" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollUp" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollDown" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="8" To="4" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollUp" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollDown" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <ControlTemplate x:Key="HorizontalScrollBarTemplate" TargetType="{x:Type ScrollBar}">
+    <Grid>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition MaxWidth="18" />
+        <ColumnDefinition Width="0.00001*" />
+        <ColumnDefinition MaxWidth="18" />
+      </Grid.ColumnDefinitions>
+      <Border x:Name="PART_Border" Grid.ColumnSpan="3" Height="12" VerticalAlignment="Center" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6" Opacity="0" />
+      <RepeatButton x:Name="PART_ButtonScrollLeft" Grid.Column="0" VerticalAlignment="Center" Command="ScrollBar.LineLeftCommand" Content="{StaticResource ScrollBarCaretLeftGlyph}" Opacity="0" AutomationProperties.Name="Scroll Left" Style="{StaticResource ScrollBarLineButtonStyle}" />
+      <Track x:Name="PART_Track" Grid.Column="1" Height="4" VerticalAlignment="Center" IsDirectionReversed="False">
+        <Track.DecreaseRepeatButton>
+          <RepeatButton Command="ScrollBar.PageLeftCommand" Style="{StaticResource ScrollBarPageButtonStyle}" />
+        </Track.DecreaseRepeatButton>
+        <Track.Thumb>
+          <Thumb Margin="0" Padding="0" Style="{StaticResource ScrollBarThumbStyle}" />
+        </Track.Thumb>
+        <Track.IncreaseRepeatButton>
+          <RepeatButton Command="ScrollBar.PageRightCommand" Style="{StaticResource ScrollBarPageButtonStyle}" />
+        </Track.IncreaseRepeatButton>
+      </Track>
+      <RepeatButton x:Name="PART_ButtonScrollRight" Grid.Column="2" VerticalAlignment="Center" Command="ScrollBar.LineRightCommand" Content="{StaticResource ScrollBarCaretRightGlyph}" Opacity="0" AutomationProperties.Name="Scroll Right" Style="{StaticResource ScrollBarLineButtonStyle}" />
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFillPointerOver}" />
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="4" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollLeft" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollRight" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="8" To="4" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollLeft" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollRight" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <Style x:Key="DefaultScrollBarStyle" TargetType="{x:Type ScrollBar}">
+    <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFill}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ScrollBarTrackStroke}" />
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Style.Triggers>
+      <Trigger Property="Orientation" Value="Horizontal">
+        <Setter Property="Width" Value="Auto" />
+        <Setter Property="Height" Value="12" />
+        <Setter Property="Template" Value="{StaticResource HorizontalScrollBarTemplate}" />
+      </Trigger>
+      <Trigger Property="Orientation" Value="Vertical">
+        <Setter Property="Width" Value="12" />
+        <Setter Property="Height" Value="Auto" />
+        <Setter Property="Template" Value="{StaticResource VerticalScrollBarTemplate}" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultScrollBarStyle}" TargetType="{x:Type ScrollBar}" />
+  <Style x:Key="DefaultScrollViewerStyle" TargetType="{x:Type ScrollViewer}">
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ScrollViewer}">
+          <Grid>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+              <RowDefinition Height="*" />
+              <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid Grid.Row="0" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="{TemplateBinding Padding}">
+              <ScrollContentPresenter x:Name="PART_ScrollContentPresenter" CanContentScroll="{TemplateBinding CanContentScroll}" />
+            </Grid>
+            <ScrollBar x:Name="PART_VerticalScrollBar" Grid.Row="0" Grid.Column="1" Maximum="{TemplateBinding ScrollableHeight}" ViewportSize="{TemplateBinding ViewportHeight}" Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}" Value="{TemplateBinding VerticalOffset}" />
+            <ScrollBar x:Name="PART_HorizontalScrollBar" Grid.Row="1" Grid.Column="0" Maximum="{TemplateBinding ScrollableWidth}" Orientation="Horizontal" ViewportSize="{TemplateBinding ViewportWidth}" Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}" Value="{TemplateBinding HorizontalOffset}" />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultScrollViewerStyle}" TargetType="{x:Type ScrollViewer}" />
+  <Style x:Key="DefaultSeparatorStyle" TargetType="{x:Type Separator}">
+    <Setter Property="BorderBrush" Value="{DynamicResource SeparatorBorderBrush}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="BorderThickness" Value="1,1,0,0" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Separator}">
+          <Border Width="{TemplateBinding Width}" Margin="{TemplateBinding Margin}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultSeparatorStyle}" TargetType="{x:Type Separator}" />
+  <Style x:Key="SliderButtonStyle" TargetType="{x:Type RepeatButton}">
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type RepeatButton}">
+          <Border Background="Transparent" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="SliderThumbStyle" TargetType="{x:Type Thumb}">
+    <Setter Property="Height" Value="20" />
+    <Setter Property="Width" Value="20" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="Background" Value="{DynamicResource SliderThumbBackground}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Thumb}">
+          <Border Background="{DynamicResource SliderOuterThumbBackground}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Margin="-2" CornerRadius="16">
+            <Ellipse x:Name="SliderInnerThumb" RenderTransformOrigin="0.5, 0.5" Width="12" Height="12" Fill="{TemplateBinding Background}">
+              <Ellipse.RenderTransform>
+                <ScaleTransform />
+              </Ellipse.RenderTransform>
+            </Ellipse>
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="CommonStates">
+                <VisualState x:Name="Normal">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="SliderInnerThumb" Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleX)" To="0.86" Duration="0:0:0.1" />
+                    <DoubleAnimation Storyboard.TargetName="SliderInnerThumb" Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleY)" To="0.86" Duration="0:0:0.1" />
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="MouseOver">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="SliderInnerThumb" Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleX)" To="1.167" Duration="0:0:0.1" />
+                    <DoubleAnimation Storyboard.TargetName="SliderInnerThumb" Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleY)" To="1.167" Duration="0:0:0.1" />
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="Pressed">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="SliderInnerThumb" Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleX)" To="0.71" Duration="0:0:0.1" />
+                    <DoubleAnimation Storyboard.TargetName="SliderInnerThumb" Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleY)" To="0.71" Duration="0:0:0.1" />
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <!--  Template when the orientation of the Slider is Horizontal.  -->
+  <ControlTemplate x:Key="HorizontalSliderTemplate" TargetType="{x:Type Slider}">
+    <Grid>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="14" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="14" />
+      </Grid.RowDefinitions>
+      <TickBar x:Name="TopTick" Grid.Row="0" Height="6" Fill="{DynamicResource SliderTickBarFill}" Placement="Top" SnapsToDevicePixels="True" Visibility="Collapsed" />
+      <Border x:Name="TrackBackground" Grid.Row="1" Height="4" Margin="0" Background="{DynamicResource SliderTrackFill}" BorderThickness="0" CornerRadius="2">
+        <Canvas Margin="-10,0">
+          <Border x:Name="PART_SelectionRange" Height="4.0" Visibility="Hidden" CornerRadius="2" Background="{DynamicResource SliderThumbBackground}" BorderThickness="0" />
+          <Border x:Name="PART_SelectedRange" Height="4.0" Visibility="Hidden" CornerRadius="2" Margin="0,0,0,0" Background="{DynamicResource SliderThumbBackground}" BorderThickness="0" />
+        </Canvas>
+      </Border>
+      <TickBar x:Name="BottomTick" Grid.Row="2" Height="6" Fill="{DynamicResource SliderTickBarFill}" Placement="Bottom" SnapsToDevicePixels="True" Visibility="Collapsed" />
+      <Track x:Name="PART_Track" Grid.Row="0" Grid.RowSpan="3">
+        <Track.DecreaseRepeatButton>
+          <RepeatButton Command="Slider.DecreaseLarge" Style="{StaticResource SliderButtonStyle}" />
+        </Track.DecreaseRepeatButton>
+        <Track.Thumb>
+          <Thumb x:Name="Thumb" Style="{StaticResource SliderThumbStyle}" />
+        </Track.Thumb>
+        <Track.IncreaseRepeatButton>
+          <RepeatButton Command="Slider.IncreaseLarge" Style="{StaticResource SliderButtonStyle}" />
+        </Track.IncreaseRepeatButton>
+      </Track>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="TickPlacement" Value="TopLeft">
+        <Setter TargetName="TopTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="TickPlacement" Value="BottomRight">
+        <Setter TargetName="BottomTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="TickPlacement" Value="Both">
+        <Setter TargetName="TopTick" Property="Visibility" Value="Visible" />
+        <Setter TargetName="BottomTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter TargetName="TrackBackground" Property="Background" Value="{DynamicResource SliderTrackFillPointerOver}" />
+        <Setter TargetName="Thumb" Property="Foreground" Value="{DynamicResource SliderThumbBackgroundPointerOver}" />
+      </Trigger>
+      <Trigger Property="IsSelectionRangeEnabled" Value="True">
+        <Setter TargetName="PART_SelectionRange" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsSelectionRangeEnabled" Value="False">
+        <Setter TargetName="PART_SelectedRange" Property="Visibility" Value="Visible" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <!--  Template when the orientation of the Slider is Vertical.  -->
+  <ControlTemplate x:Key="VerticalSliderTemplate" TargetType="{x:Type Slider}">
+    <Grid>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="14" />
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="14" />
+      </Grid.ColumnDefinitions>
+      <TickBar x:Name="TopTick" Width="6" Fill="{DynamicResource SliderTickBarFill}" Placement="Left" SnapsToDevicePixels="True" Visibility="Collapsed" />
+      <Border x:Name="TrackBackground" Grid.Column="1" Width="4" Margin="0" Background="{DynamicResource SliderTrackFill}" BorderThickness="0" CornerRadius="2">
+        <Canvas Margin="0,-10">
+          <Border x:Name="PART_SelectionRange" Width="4.0" Visibility="Hidden" CornerRadius="2" Background="{DynamicResource SliderThumbBackground}" BorderThickness="0" />
+          <Border x:Name="PART_SelectedRange" Width="4.0" Visibility="Hidden" CornerRadius="2" Margin="0,0,0,0" Background="{DynamicResource SliderThumbBackground}" BorderThickness="0" />
+        </Canvas>
+      </Border>
+      <TickBar x:Name="BottomTick" Grid.Column="2" Width="6" Fill="{DynamicResource SliderTickBarFill}" Placement="Right" SnapsToDevicePixels="True" Visibility="Collapsed" />
+      <Track x:Name="PART_Track" Grid.Column="0" Grid.ColumnSpan="3">
+        <Track.DecreaseRepeatButton>
+          <RepeatButton Command="Slider.DecreaseLarge" Style="{StaticResource SliderButtonStyle}" />
+        </Track.DecreaseRepeatButton>
+        <Track.Thumb>
+          <Thumb x:Name="Thumb" Style="{StaticResource SliderThumbStyle}" />
+        </Track.Thumb>
+        <Track.IncreaseRepeatButton>
+          <RepeatButton Command="Slider.IncreaseLarge" Style="{StaticResource SliderButtonStyle}" />
+        </Track.IncreaseRepeatButton>
+      </Track>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="TickPlacement" Value="TopLeft">
+        <Setter TargetName="TopTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="TickPlacement" Value="BottomRight">
+        <Setter TargetName="BottomTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="TickPlacement" Value="Both">
+        <Setter TargetName="TopTick" Property="Visibility" Value="Visible" />
+        <Setter TargetName="BottomTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter TargetName="TrackBackground" Property="Background" Value="{DynamicResource SliderTrackFillPointerOver}" />
+        <Setter TargetName="Thumb" Property="Foreground" Value="{DynamicResource SliderThumbBackgroundPointerOver}" />
+      </Trigger>
+      <Trigger Property="IsSelectionRangeEnabled" Value="True">
+        <Setter TargetName="PART_SelectionRange" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsSelectionRangeEnabled" Value="False">
+        <Setter TargetName="PART_SelectedRange" Property="Visibility" Value="Visible" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <Style TargetType="{x:Type Slider}">
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Style.Triggers>
+      <Trigger Property="Orientation" Value="Horizontal">
+        <Setter Property="MinWidth" Value="104" />
+        <Setter Property="Template" Value="{StaticResource HorizontalSliderTemplate}" />
+      </Trigger>
+      <Trigger Property="Orientation" Value="Vertical">
+        <Setter Property="MinHeight" Value="104" />
+        <Setter Property="Template" Value="{StaticResource VerticalSliderTemplate}" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+  <Style x:Key="{x:Static StatusBar.SeparatorStyleKey}" TargetType="{x:Type Separator}">
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Margin" Value="6,0" />
+    <Setter Property="BorderThickness" Value="1,1,0,0" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Separator}">
+          <Border Width="{TemplateBinding Width}" Margin="{TemplateBinding Margin}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style TargetType="{x:Type StatusBar}">
+    <Setter Property="Foreground">
+      <Setter.Value>
+        <SolidColorBrush Color="{DynamicResource TextFillColorPrimary}" />
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Background">
+      <Setter.Value>
+        <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+      </Setter.Value>
+    </Setter>
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Padding" Value="12" />
+    <Setter Property="Margin" Value="0" />
+  </Style>
+  <Thickness x:Key="StatusBarItemPadding">4</Thickness>
+  <Style x:Key="DefaultStatusBarItemStyle" TargetType="{x:Type StatusBarItem}">
+    <Setter Property="Padding" Value="{DynamicResource StatusBarItemPadding}" />
+    <Setter Property="Background" Value="{DynamicResource StatusBarItemBackground}" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type StatusBarItem}">
+          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
+            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter Property="Foreground" Value="{DynamicResource StatusBarItemForegroundDisabled}" />
+              <Setter Property="Background" Value="{DynamicResource StatusBarItemBackgroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultStatusBarItemStyle}" TargetType="{x:Type StatusBarItem}" />
+  <!-- Styles when TabItems are on the Top -->
+  <ControlTemplate x:Key="DefaultTopTabControlStyle" TargetType="{x:Type TabControl}">
+    <Grid KeyboardNavigation.TabNavigation="Local">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="*" />
+      </Grid.RowDefinitions>
+      <TabPanel x:Name="HeaderPanel" Grid.Row="0" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
+      <Border x:Name="Border" Grid.Row="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      </Border>
+      <VisualStateManager.VisualStateGroups>
+        <VisualStateGroup x:Name="CommonStates">
+          <VisualState x:Name="Disabled" />
+        </VisualStateGroup>
+      </VisualStateManager.VisualStateGroups>
+    </Grid>
+  </ControlTemplate>
+  <!-- Styles when TabItems are placed Bottom -->
+  <ControlTemplate x:Key="DefaultBottomTabControlStyle" TargetType="{x:Type TabControl}">
+    <Grid KeyboardNavigation.TabNavigation="Local">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="*" />
+        <RowDefinition Height="Auto" />
+      </Grid.RowDefinitions>
+      <TabPanel x:Name="HeaderPanel" Grid.Row="1" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
+      <Border x:Name="Border" Grid.Row="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      </Border>
+      <VisualStateManager.VisualStateGroups>
+        <VisualStateGroup x:Name="CommonStates">
+          <VisualState x:Name="Disabled" />
+        </VisualStateGroup>
+      </VisualStateManager.VisualStateGroups>
+    </Grid>
+  </ControlTemplate>
+  <!-- Styles when TabItems are placed to the Left -->
+  <ControlTemplate x:Key="DefaultLeftTabControlStyle" TargetType="{x:Type TabControl}">
+    <Grid KeyboardNavigation.TabNavigation="Local">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="*" />
+      </Grid.ColumnDefinitions>
+      <TabPanel x:Name="HeaderPanel" Grid.Column="0" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
+      <Border x:Name="Border" Grid.Column="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      </Border>
+      <VisualStateManager.VisualStateGroups>
+        <VisualStateGroup x:Name="CommonStates">
+          <VisualState x:Name="Disabled" />
+        </VisualStateGroup>
+      </VisualStateManager.VisualStateGroups>
+    </Grid>
+  </ControlTemplate>
+  <!-- Styles when TabItems are placed to the Right -->
+  <ControlTemplate x:Key="DefaultRightTabControlStyle" TargetType="{x:Type TabControl}">
+    <Grid KeyboardNavigation.TabNavigation="Local">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+      </Grid.ColumnDefinitions>
+      <TabPanel x:Name="HeaderPanel" Grid.Column="1" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
+      <Border x:Name="Border" Grid.Column="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      </Border>
+      <VisualStateManager.VisualStateGroups>
+        <VisualStateGroup x:Name="CommonStates">
+          <VisualState x:Name="Disabled" />
+        </VisualStateGroup>
+      </VisualStateManager.VisualStateGroups>
+    </Grid>
+  </ControlTemplate>
+  <Style x:Key="DefaultTabControlStyle" TargetType="{x:Type TabControl}">
+    <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
+    <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="BorderThickness" Value="0,1,0,0" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="Template" Value="{StaticResource DefaultTopTabControlStyle}" />
+    <Style.Triggers>
+      <Trigger Property="TabStripPlacement" Value="Bottom">
+        <Setter Property="Template" Value="{StaticResource DefaultBottomTabControlStyle}" />
+        <Setter Property="BorderThickness" Value="0,0,0,1" />
+      </Trigger>
+      <Trigger Property="TabStripPlacement" Value="Left">
+        <Setter Property="Template" Value="{StaticResource DefaultLeftTabControlStyle}" />
+        <Setter Property="BorderThickness" Value="1,0,0,0" />
+      </Trigger>
+      <Trigger Property="TabStripPlacement" Value="Right">
+        <Setter Property="Template" Value="{StaticResource DefaultRightTabControlStyle}" />
+        <Setter Property="BorderThickness" Value="0,0,1,0" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+  <Style x:Key="DefaultTabItemStyle" TargetType="{x:Type TabItem}">
+    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackground}" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Stretch" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+    <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
+    <Setter Property="Focusable" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type TabItem}">
+          <Grid x:Name="Root">
+            <Border x:Name="Border" MinWidth="180" MinHeight="36" Margin="0" Padding="6" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,1,1,0" CornerRadius="8,8,0,0">
+              <ContentPresenter x:Name="ContentSite" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" ContentSource="Header" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" />
+            </Border>
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="SelectionStates">
+                <VisualState x:Name="Unselected" />
+                <VisualState x:Name="Selected" />
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="CommonStates">
+                <VisualState x:Name="Normal" />
+                <VisualState x:Name="MouseOver" />
+                <VisualState x:Name="Disabled">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="Border" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Opacity)" From="0.0" To="0.5" Duration="0:0:.16" />
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsSelected" Value="True">
+              <Setter Property="Panel.ZIndex" Value="100" />
+              <Setter TargetName="Border" Property="Background" Value="{DynamicResource TabViewItemHeaderBackgroundSelected}" />
+              <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource TabViewSelectedItemBorderBrush}" />
+              <Setter Property="Foreground" Value="{DynamicResource TabViewItemForegroundSelected}" />
+            </Trigger>
+            <MultiDataTrigger>
+              <MultiDataTrigger.Conditions>
+                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom" />
+              </MultiDataTrigger.Conditions>
+              <Setter TargetName="Border" Property="BorderThickness" Value="1,0,1,1" />
+              <Setter TargetName="Border" Property="CornerRadius" Value="0,0,8,8" />
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+              <MultiDataTrigger.Conditions>
+                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left" />
+              </MultiDataTrigger.Conditions>
+              <Setter TargetName="Border" Property="BorderThickness" Value="1,1,0,1" />
+              <Setter TargetName="Border" Property="CornerRadius" Value="8,0,0,8" />
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+              <MultiDataTrigger.Conditions>
+                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right" />
+              </MultiDataTrigger.Conditions>
+              <Setter TargetName="Border" Property="BorderThickness" Value="1,1,0,1" />
+              <Setter TargetName="Border" Property="CornerRadius" Value="0,8,8,0" />
+            </MultiDataTrigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultTabControlStyle}" TargetType="{x:Type TabControl}" />
+  <Style BasedOn="{StaticResource DefaultTabItemStyle}" TargetType="{x:Type TabItem}" />
+  <sys:Double x:Key="CaptionTextBlockFontSize">12</sys:Double>
+  <sys:Double x:Key="BodyTextBlockFontSize">14</sys:Double>
+  <sys:Double x:Key="SubtitleTextBlockFontSize">20</sys:Double>
+  <sys:Double x:Key="TitleTextBlockFontSize">28</sys:Double>
+  <sys:Double x:Key="TitleLargeTextBlockFontSize">40</sys:Double>
+  <sys:Double x:Key="DisplayTextBlockFontSize">68</sys:Double>
+  <Style x:Key="BaseTextBlockStyle" TargetType="TextBlock">
+    <Setter Property="FontSize" Value="{StaticResource BodyTextBlockFontSize}" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+    <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="LineStackingStrategy" Value="MaxHeight" />
+  </Style>
+  <Style x:Key="CaptionTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
+    <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}" />
+    <Setter Property="FontWeight" Value="Normal" />
+  </Style>
+  <Style x:Key="BodyTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
+    <Setter Property="FontWeight" Value="Normal" />
+  </Style>
+  <Style x:Key="BodyStrongTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" />
+  <Style x:Key="SubtitleTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
+    <Setter Property="FontSize" Value="{StaticResource SubtitleTextBlockFontSize}" />
+  </Style>
+  <Style x:Key="TitleTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
+    <Setter Property="FontSize" Value="{StaticResource TitleTextBlockFontSize}" />
+  </Style>
+  <Style x:Key="TitleLargeTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
+    <Setter Property="FontSize" Value="{StaticResource TitleLargeTextBlockFontSize}" />
+  </Style>
+  <Style x:Key="DisplayTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
+    <Setter Property="FontSize" Value="{StaticResource DisplayTextBlockFontSize}" />
+  </Style>
+  <!-- Deprecated TextBox Resources ( Used in .NET 9 ) -->
+  <Thickness x:Key="TextBoxAccentBorderThemeThickness">0,0,0,1</Thickness>
+  <Thickness x:Key="TextBoxLeftIconMargin">10,0,0,0</Thickness>
+  <Thickness x:Key="TextBoxRightIconMargin">0,0,10,0</Thickness>
+  <system:Double x:Key="TextBoxClearButtonHeight">24</system:Double>
+  <system:String x:Key="ClearGlyph"></system:String>
+  <!-- These both are redefined in .NET 10 -->
+  <!-- <Thickness x:Key="TextBoxBorderThemeThickness">1,1,1,1</Thickness> -->
+  <!-- <Thickness x:Key="TextBoxClearButtonMargin">0,0,4,0</Thickness> -->
+  <!-- <Thickness x:Key="TextBoxClearButtonPadding">0,0,0,0</Thickness> -->
+  <system:Double x:Key="TextBoxIconFontSize">12</system:Double>
+  <!-- Instead of TextBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
+            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
+  <system:Double x:Key="TextBoxThemeMinHeight">32</system:Double>
+  <Thickness x:Key="TextBoxClearButtonMargin">0,4,4,4</Thickness>
+  <Thickness x:Key="TextBoxClearButtonPadding">0,0,-2,0</Thickness>
+  <Style x:Key="DefaultTextBoxBaseStyle" TargetType="{x:Type TextBoxBase}">
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="Cursor" Value="IBeam" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
+    <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="AllowDrop" Value="True" />
+    <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
+    <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type TextBoxBase}">
+          <Grid>
+            <Border x:Name="ContentBorder" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+            <ScrollViewer x:Name="PART_ContentHost" Margin="{TemplateBinding BorderThickness}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}" IsTabStop="{TemplateBinding ScrollViewer.IsTabStop}" Padding="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsFocused" Value="True">
+              <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundDisabled}" />
+              <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushDisabled}" />
+              <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <ControlTemplate x:Key="DefaultTextBoxControlTemplate" TargetType="{x:Type TextBox}">
+    <Grid>
+      <Grid.Resources>
+        <Style x:Key="DeleteButtonStyle" TargetType="Button">
+          <Setter Property="Foreground" Value="{DynamicResource TextControlButtonForeground}" />
+          <Setter Property="Background" Value="{DynamicResource TextControlButtonBackground}" />
+          <Setter Property="BorderBrush" Value="{DynamicResource TextControlButtonBorderBrush}" />
+          <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+          <Setter Property="Width" Value="{Binding ActualHeight, RelativeSource={RelativeSource Self}}" />
+          <Setter Property="OverridesDefaultStyle" Value="True" />
+          <Setter Property="Template">
+            <Setter.Value>
+              <ControlTemplate TargetType="Button">
+                <Border x:Name="ButtonLayoutBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+                  <ContentPresenter x:Name="GlyphElement" TextElement.Foreground="{TemplateBinding Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                </Border>
+                <ControlTemplate.Triggers>
+                  <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource TextControlButtonBackgroundPointerOver}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource TextControlButtonBorderBrushPointerOver}" />
+                    <Setter Property="Foreground" Value="{DynamicResource TextControlButtonForegroundPointerOver}" />
+                  </Trigger>
+                  <Trigger Property="IsPressed" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource TextControlButtonBackgroundPressed}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource TextControlButtonBorderBrushPressed}" />
+                    <Setter Property="Foreground" Value="{DynamicResource TextControlButtonForegroundPressed}" />
+                  </Trigger>
+                  <Trigger Property="IsEnabled" Value="False">
+                    <Setter TargetName="ButtonLayoutBorder" Property="Opacity" Value="0" />
+                  </Trigger>
+                </ControlTemplate.Triggers>
+              </ControlTemplate>
+            </Setter.Value>
+          </Setter>
+        </Style>
+      </Grid.Resources>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+      </Grid.ColumnDefinitions>
+      <Border x:Name="ContentBorder" Grid.ColumnSpan="2" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" MinHeight="{TemplateBinding MinHeight}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+      <ScrollViewer x:Name="PART_ContentHost" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" Margin="{TemplateBinding BorderThickness}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}" IsTabStop="{TemplateBinding ScrollViewer.IsTabStop}" Padding="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Button x:Name="DeleteButton" Grid.Column="1" Style="{StaticResource DeleteButtonStyle}" Cursor="Arrow" IsTabStop="False" MinWidth="30" Visibility="Collapsed" VerticalAlignment="Stretch" Padding="{StaticResource TextBoxClearButtonPadding}" Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}">
+        <TextBlock x:Name="GlyphElement" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{DynamicResource TextBoxIconFontSize}" Text="" HorizontalAlignment="Center" VerticalAlignment="Center" />
+      </Button>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsKeyboardFocusWithin" Value="True">
+        <Setter TargetName="DeleteButton" Property="Visibility" Value="Visible" />
+        <Setter TargetName="DeleteButton" Property="Margin" Value="{StaticResource TextBoxClearButtonMargin}" />
+      </Trigger>
+      <Trigger Property="Text" Value="{x:Static system:String.Empty}">
+        <Setter TargetName="DeleteButton" Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <Trigger Property="IsReadOnly" Value="True">
+        <Setter TargetName="DeleteButton" Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <Trigger Property="IsMouseOver" Value="True">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
+        <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
+      </Trigger>
+      <Trigger Property="IsFocused" Value="True">
+        <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
+        <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />
+      </Trigger>
+      <Trigger SourceName="DeleteButton" Property="IsPressed" Value="True">
+        <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
+        <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundFocused}" />
+      </Trigger>
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundDisabled}" />
+        <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushDisabled}" />
+        <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource TextControlForegroundDisabled}" />
+      </Trigger>
+      <Trigger Property="AcceptsReturn" Value="True">
+        <Setter TargetName="DeleteButton" Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <Trigger Property="TextWrapping" Value="Wrap">
+        <Setter TargetName="DeleteButton" Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <Trigger Property="TextWrapping" Value="WrapWithOverflow">
+        <Setter TargetName="DeleteButton" Property="Visibility" Value="Collapsed" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <Style x:Key="DefaultTextBoxStyle" TargetType="{x:Type TextBox}">
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
+    <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Cursor" Value="IBeam" />
+    <Setter Property="AllowDrop" Value="True" />
+    <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
+    <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
+    <Setter Property="Template" Value="{StaticResource DefaultTextBoxControlTemplate}" />
+  </Style>
+  <Style BasedOn="{StaticResource DefaultTextBoxBaseStyle}" TargetType="{x:Type TextBoxBase}" />
+  <Style BasedOn="{StaticResource DefaultTextBoxStyle}" TargetType="{x:Type TextBox}" />
+  <Style x:Key="DefaultThumbStyle" TargetType="{x:Type Thumb}">
+    <Setter Property="Background" Value="{DynamicResource ThumbBackground}" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Thumb}">
+          <Border x:Name="Border" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}" />
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="Border" Property="Background" Value="{DynamicResource ThumbBackgroundDisabled}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultThumbStyle}" TargetType="{x:Type Thumb}" />
+  <Thickness x:Key="ToggleButtonPadding">11,5,11,6</Thickness>
+  <Thickness x:Key="ToggleButtonBorderThemeThickness">1</Thickness>
+  <Thickness x:Key="ToggleButtonIconMargin">0,0,8,0</Thickness>
+  <Style x:Key="DefaultToggleButtonStyle" TargetType="{x:Type ToggleButton}">
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="Background" Value="{DynamicResource ToggleButtonBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource ToggleButtonForeground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource ToggleButtonBorderThemeThickness}" />
+    <Setter Property="Padding" Value="{StaticResource ToggleButtonPadding}" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ToggleButton}">
+          <Border x:Name="ContentBorder" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Padding="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <ContentPresenter x:Name="ContentPresenter" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" TextElement.Foreground="{TemplateBinding Foreground}" TextElement.FontSize="{TemplateBinding FontSize}" />
+          </Border>
+          <ControlTemplate.Triggers>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsEnabled" Value="False" />
+                <Condition Property="IsChecked" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter Property="Background" Value="{DynamicResource ToggleButtonBackgroundDisabled}" />
+              <Setter Property="BorderBrush" Value="{DynamicResource ToggleButtonBorderBrushDisabled}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ToggleButtonForegroundDisabled}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsEnabled" Value="False" />
+                <Condition Property="IsChecked" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter Property="Background" Value="{DynamicResource ToggleButtonBackgroundCheckedDisabled}" />
+              <Setter Property="BorderBrush" Value="{DynamicResource ToggleButtonBorderBrushCheckedDisabled}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ToggleButtonForegroundCheckedDisabled}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsEnabled" Value="True" />
+                <Condition Property="IsChecked" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter Property="Background" Value="{DynamicResource ToggleButtonBackgroundChecked}" />
+              <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ToggleButtonForegroundChecked}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter Property="Background" Value="{DynamicResource ToggleButtonBackgroundPointerOver}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="IsChecked" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter Property="Background" Value="{DynamicResource ToggleButtonBackgroundCheckedPointerOver}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsPressed" Value="True" />
+                <Condition Property="IsChecked" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter Property="Background" Value="{DynamicResource ToggleButtonBackgroundPressed}" />
+              <Setter Property="BorderBrush" Value="{DynamicResource ToggleButtonBorderBrushPressed}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ToggleButtonForegroundPressed}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsPressed" Value="True" />
+                <Condition Property="IsChecked" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter Property="Background" Value="{DynamicResource ToggleButtonBackgroundCheckedPressed}" />
+              <Setter Property="BorderBrush" Value="{DynamicResource ToggleButtonBorderBrushCheckedPressed}" />
+              <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ToggleButtonForegroundCheckedPressed}" />
+            </MultiTrigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultToggleButtonStyle}" TargetType="{x:Type ToggleButton}" />
+  <system:String x:Key="ToolBarChevronDownGlyph"></system:String>
+  <Style x:Key="ToolBarButtonBaseStyle" TargetType="{x:Type ButtonBase}">
+    <Setter Property="Background">
+      <Setter.Value>
+        <SolidColorBrush Opacity="0.0" Color="{DynamicResource ControlFillColorDefault}" />
+      </Setter.Value>
+    </Setter>
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ButtonBase}">
+          <Border x:Name="Border" Padding="12,6" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+            <ContentPresenter Margin="2" HorizontalAlignment="Center" VerticalAlignment="Center" RecognizesAccessKey="True" />
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Trigger.EnterActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="Border" Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Opacity)" From="0.0" To="1.0" Duration="0:0:0.16" />
+                  </Storyboard>
+                </BeginStoryboard>
+              </Trigger.EnterActions>
+              <Trigger.ExitActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="Border" Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Opacity)" From="1.0" To="0.0" Duration="0:0:0.16" />
+                  </Storyboard>
+                </BeginStoryboard>
+              </Trigger.ExitActions>
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="{x:Static ToolBar.ButtonStyleKey}" BasedOn="{StaticResource ToolBarButtonBaseStyle}" TargetType="{x:Type Button}" />
+  <Style x:Key="{x:Static ToolBar.ToggleButtonStyleKey}" BasedOn="{StaticResource DefaultToggleButtonStyle}" TargetType="{x:Type ToggleButton}" />
+  <Style x:Key="{x:Static ToolBar.CheckBoxStyleKey}" BasedOn="{StaticResource DefaultCheckBoxStyle}" TargetType="{x:Type CheckBox}" />
+  <Style x:Key="{x:Static ToolBar.RadioButtonStyleKey}" BasedOn="{StaticResource DefaultRadioButtonStyle}" TargetType="{x:Type RadioButton}" />
+  <Style x:Key="{x:Static ToolBar.ComboBoxStyleKey}" BasedOn="{StaticResource DefaultComboBoxStyle}" TargetType="{x:Type ComboBox}" />
+  <Style x:Key="{x:Static ToolBar.MenuStyleKey}" BasedOn="{StaticResource DefaultMenuStyle}" TargetType="{x:Type Menu}" />
+  <Style x:Key="{x:Static ToolBar.SeparatorStyleKey}" BasedOn="{StaticResource DefaultSeparatorStyle}" TargetType="{x:Type Separator}" />
+  <Style x:Key="{x:Static ToolBar.TextBoxStyleKey}" TargetType="{x:Type TextBox}">
+    <Setter Property="KeyboardNavigation.TabNavigation" Value="None" />
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="AllowDrop" Value="True" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type TextBox}">
+          <Border x:Name="Border" Padding="2" Background="Transparent" BorderBrush="Transparent" BorderThickness="0">
+            <ScrollViewer x:Name="PART_ContentHost" Margin="0" />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="ToolBarThumbStyle" TargetType="{x:Type Thumb}">
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Cursor" Value="SizeAll" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Thumb}">
+          <Border Background="Transparent" SnapsToDevicePixels="True">
+            <Rectangle Margin="0,2">
+              <Rectangle.Fill>
+                <DrawingBrush TileMode="Tile" Viewbox="0,0,8,8" ViewboxUnits="Absolute" Viewport="0,0,4,4" ViewportUnits="Absolute">
+                  <DrawingBrush.Drawing>
+                    <DrawingGroup>
+                      <GeometryDrawing Brush="#AAA" Geometry="M 4 4 L 4 8 L 8 8 L 8 4 z" />
+                    </DrawingGroup>
+                  </DrawingBrush.Drawing>
+                </DrawingBrush>
+              </Rectangle.Fill>
+            </Rectangle>
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="ToolBarOverflowButtonStyle" TargetType="{x:Type ToggleButton}">
+    <Setter Property="Foreground">
+      <Setter.Value>
+        <SolidColorBrush Color="{DynamicResource TextFillColorTertiary}" />
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ToggleButton}">
+          <Border x:Name="Border" Background="{TemplateBinding Background}" CornerRadius="0,3,3,0" SnapsToDevicePixels="true">
+            <Grid>
+              <TextBlock Margin="0" VerticalAlignment="Bottom" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ToolBarChevronDownGlyph}" />
+              <ContentPresenter />
+            </Grid>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter Property="Width" Value="0" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="{x:Type ToolBar}" TargetType="{x:Type ToolBar}">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ToolBar}">
+          <Border x:Name="Border" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="4">
+            <DockPanel>
+              <ToggleButton ClickMode="Press" DockPanel.Dock="Right" IsChecked="{Binding IsOverflowOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" IsEnabled="{TemplateBinding HasOverflowItems}" Style="{StaticResource ToolBarOverflowButtonStyle}">
+                <Popup x:Name="OverflowPopup" AllowsTransparency="True" Focusable="False" IsOpen="{Binding IsOverflowOpen, RelativeSource={RelativeSource TemplatedParent}}" Placement="Bottom" PopupAnimation="Slide" StaysOpen="False">
+                  <Border x:Name="DropDownBorder" Margin="12,0,12,18" Padding="0,3,0,3" BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}" BorderThickness="1" CornerRadius="8" SnapsToDevicePixels="True">
+                    <Border.Background>
+                      <SolidColorBrush Color="{DynamicResource SystemFillColorSolidNeutralBackground}" />
+                    </Border.Background>
+                    <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel" Margin="0" FocusVisualStyle="{x:Null}" Focusable="True" KeyboardNavigation.DirectionalNavigation="Cycle" KeyboardNavigation.TabNavigation="Cycle" WrapWidth="200" />
+                  </Border>
+                </Popup>
+              </ToggleButton>
+              <Thumb x:Name="ToolBarThumb" Width="10" Style="{StaticResource ToolBarThumbStyle}" />
+              <ToolBarPanel x:Name="PART_ToolBarPanel" Margin="0,1,2,2" IsItemsHost="True" />
+            </DockPanel>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsOverflowOpen" Value="true">
+              <Setter TargetName="ToolBarThumb" Property="IsEnabled" Value="false" />
+            </Trigger>
+            <Trigger Property="ToolBarTray.IsLocked" Value="true">
+              <Setter TargetName="ToolBarThumb" Property="Visibility" Value="Collapsed" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="{x:Type ToolBarTray}" TargetType="{x:Type ToolBarTray}">
+    <Setter Property="Background">
+      <Setter.Value>
+        <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Margin" Value="0" />
+  </Style>
+  <Thickness x:Key="ToolTipBorderPadding">9,6,9,8</Thickness>
+  <sys:Double x:Key="ToolTipMaxWidth">320</sys:Double>
+  <Thickness x:Key="ToolTipBorderThemeThickness">1</Thickness>
+  <Style x:Key="DefaultToolTipStyle" TargetType="{x:Type ToolTip}">
+    <Setter Property="MaxWidth" Value="{StaticResource ToolTipMaxWidth}" />
+    <Setter Property="Height" Value="Auto" />
+    <Setter Property="Width" Value="Auto" />
+    <Setter Property="TextElement.FontSize" Value="12" />
+    <Setter Property="TextBlock.TextAlignment" Value="Justify" />
+    <Setter Property="TextElement.Foreground" Value="{DynamicResource ToolTipForeground}" />
+    <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
+    <Setter Property="FontFamily" Value="{DynamicResource {x:Static SystemFonts.StatusFontFamilyKey}}" />
+    <Setter Property="FontSize" Value="{DynamicResource {x:Static SystemFonts.StatusFontSizeKey}}" />
+    <Setter Property="FontStyle" Value="{DynamicResource {x:Static SystemFonts.StatusFontStyleKey}}" />
+    <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}" />
+    <Setter Property="Padding" Value="{StaticResource ToolTipBorderPadding}" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ToolTip">
+          <Border Name="Border" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MaxWidth="{TemplateBinding MaxWidth}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="4" SnapsToDevicePixels="True">
+            <Border.Effect>
+              <DropShadowEffect BlurRadius="30" Direction="0" Opacity="0.4" ShadowDepth="0" Color="#202020" />
+            </Border.Effect>
+            <ContentPresenter Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+              <ContentPresenter.Resources>
+                <Style TargetType="{x:Type TextBlock}">
+                  <Setter Property="TextWrapping" Value="WrapWithOverflow" />
+                </Style>
+              </ContentPresenter.Resources>
+            </ContentPresenter>
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultToolTipStyle}" TargetType="{x:Type ToolTip}" />
+  <Style x:Key="DefaultTreeViewStyle" TargetType="{x:Type TreeView}">
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="Foreground" Value="{DynamicResource TreeViewItemForeground}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="TreeView">
+          <Border Name="Border" Padding="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="4">
+            <ScrollViewer x:Name="ItemsPresenterScrollViewer" CanContentScroll="False" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+              <ItemsPresenter Margin="{TemplateBinding Padding}" />
+            </ScrollViewer>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing" Value="True">
+              <Setter TargetName="ItemsPresenterScrollViewer" Property="CanContentScroll" Value="True" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Style.Triggers>
+      <Trigger Property="VirtualizingPanel.IsVirtualizing" Value="True">
+        <Setter Property="ItemsPanel">
+          <Setter.Value>
+            <ItemsPanelTemplate>
+              <VirtualizingStackPanel />
+            </ItemsPanelTemplate>
+          </Setter.Value>
+        </Setter>
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultTreeViewStyle}" TargetType="{x:Type TreeView}" />
+  <system:Double x:Key="TreeViewItemChevronSize">10</system:Double>
+  <system:Double x:Key="TreeViewItemFontSize">14</system:Double>
+  <system:String x:Key="TreeViewChevronRightGlyph"></system:String>
+  <system:String x:Key="TreeViewChevronLeftGlyph"></system:String>
+  <Style x:Key="ExpandCollapseToggleButtonStyle" TargetType="{x:Type ToggleButton}">
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ToggleButton">
+          <Grid x:Name="ChevronContainer" Width="15" Height="15" Background="Transparent" RenderTransformOrigin="0.5, 0.5">
+            <Grid.RenderTransform>
+              <RotateTransform Angle="0" />
+            </Grid.RenderTransform>
+            <TextBlock x:Name="ChevronIcon" VerticalAlignment="Center" FontSize="{StaticResource TreeViewItemChevronSize}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource TreeViewChevronRightGlyph}" />
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="FlowDirection" Value="RightToLeft">
+              <Setter TargetName="ChevronIcon" Property="Text" Value="{StaticResource TreeViewChevronLeftGlyph}" />
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+              <Trigger.EnterActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="ChevronContainer" Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)" To="90" Duration="0:0:0.16" />
+                  </Storyboard>
+                </BeginStoryboard>
+              </Trigger.EnterActions>
+              <Trigger.ExitActions>
+                <BeginStoryboard>
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="ChevronContainer" Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)" To="0" Duration="0:0:0.16" />
+                  </Storyboard>
+                </BeginStoryboard>
+              </Trigger.ExitActions>
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DefaultTreeViewItemStyle" TargetType="{x:Type TreeViewItem}">
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
+    <!--  Universal WPF UI focus  -->
+    <Setter Property="Foreground" Value="{DynamicResource TreeViewItemForeground}" />
+    <Setter Property="Background" Value="{DynamicResource TreeViewItemBackground}" />
+    <Setter Property="Margin" Value="0,0,0,2" />
+    <Setter Property="Padding" Value="4" />
+    <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="IsTabStop" Value="True" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type TreeViewItem}">
+          <Grid Background="{TemplateBinding Background}">
+            <Grid.RowDefinitions>
+              <RowDefinition Height="Auto" />
+              <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Border x:Name="Border" Grid.Row="0" CornerRadius="{TemplateBinding Border.CornerRadius}" Margin="{TemplateBinding Margin}">
+              <Grid>
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="Auto" MinWidth="19" />
+                  <ColumnDefinition Width="Auto" />
+                  <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Rectangle x:Name="ActiveRectangle" Grid.Column="0" Width="3" Height="16" Margin="0,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Fill="{DynamicResource TreeViewItemSelectionIndicatorForeground}" RadiusX="2" RadiusY="2" Visibility="Collapsed" />
+                <ToggleButton x:Name="Expander" Grid.Column="0" Margin="8,0" ClickMode="Press" IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource ExpandCollapseToggleButtonStyle}" />
+                <ContentPresenter x:Name="PART_Header" Grid.Column="1" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" ContentSource="Header" TextElement.FontSize="{TemplateBinding FontSize}" />
+              </Grid>
+            </Border>
+            <Grid Grid.Row="1">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" MinWidth="19" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+              </Grid.ColumnDefinitions>
+              <ItemsPresenter x:Name="ItemsHost" Grid.Column="1" Grid.ColumnSpan="2" Visibility="Collapsed" />
+            </Grid>
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="HasItems" Value="False">
+              <Setter TargetName="Expander" Property="Visibility" Value="Hidden" />
+            </Trigger>
+            <Trigger Property="IsExpanded" Value="True">
+              <Setter TargetName="ItemsHost" Property="Visibility" Value="Visible" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="Border" Property="Background" Value="{DynamicResource TreeViewItemBackgroundPointerOver}" />
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+              <Setter TargetName="Border" Property="Background" Value="{DynamicResource TreeViewItemBackgroundSelected}" />
+              <Setter TargetName="ActiveRectangle" Property="Visibility" Value="Visible" />
+            </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="HasHeader" Value="False" />
+                <Condition Property="Width" Value="Auto" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_Header" Property="MinWidth" Value="75" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="HasHeader" Value="False" />
+                <Condition Property="Height" Value="Auto" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_Header" Property="MinHeight" Value="19" />
+            </MultiTrigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Style.Triggers>
+      <Trigger Property="VirtualizingPanel.IsVirtualizing" Value="True">
+        <Setter Property="ItemsPanel">
+          <Setter.Value>
+            <ItemsPanelTemplate>
+              <VirtualizingStackPanel />
+            </ItemsPanelTemplate>
+          </Setter.Value>
+        </Setter>
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultTreeViewItemStyle}" TargetType="{x:Type TreeViewItem}" />
+  <Style x:Key="DefaultUserControlStyle" TargetType="{x:Type UserControl}">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type UserControl}">
+          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
+            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultUserControlStyle}" TargetType="{x:Type UserControl}" />
+  <ControlTemplate x:Key="WindowTemplateKey" TargetType="{x:Type Window}">
+    <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+      <Grid>
+        <AdornerDecorator>
+          <ContentPresenter />
+        </AdornerDecorator>
+        <ResizeGrip x:Name="WindowResizeGrip" HorizontalAlignment="Right" VerticalAlignment="Bottom" Visibility="Collapsed" IsTabStop="false" />
+      </Grid>
+    </Border>
+    <ControlTemplate.Triggers>
+      <MultiTrigger>
+        <!-- There may be perf implications b/c of the following conditions.  We may cause
+                     an extra layout to happen when WindowState changes to Minimized and ResizeMode
+                     is set to CanResizeWithGrip.
+                     NavigationWindow's style requires the ResizeMode condition tag even though
+                     Window's style already takes care of this condition.
+                     -->
+        <MultiTrigger.Conditions>
+          <Condition Property="Window.ResizeMode" Value="CanResizeWithGrip" />
+          <Condition Property="Window.WindowState" Value="Normal" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="WindowResizeGrip" Property="Visibility" Value="Visible" />
+      </MultiTrigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+  <Style x:Key="DefaultWindowStyle" TargetType="{x:Type Window}">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource WindowForeground}" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type Window}">
+          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+            <AdornerDecorator>
+              <ContentPresenter x:Name="ContentPresenter" />
+            </AdornerDecorator>
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Style.Triggers>
+      <Trigger Property="Window.ResizeMode" Value="CanResizeWithGrip">
+        <Setter Property="Template" Value="{StaticResource WindowTemplateKey}" />
+      </Trigger>
+      <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+      </DataTrigger>
+    </Style.Triggers>
+  </Style>
+  <Style BasedOn="{StaticResource DefaultWindowStyle}" TargetType="{x:Type Window}" />
+  <!-- #endregion -->
 </ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
@@ -1,131 +1,86 @@
-<!--
-    This Source Code Form is subject to the terms of the MIT License.
-    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
-    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
-    All Rights Reserved.
--->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" xmlns:fluentcontrols="clr-namespace:Fluent.Controls" xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI" xmlns:theme="clr-namespace:Microsoft.Windows.Themes" xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework" xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
-  <!-- #region DefaultContextmenu -->
-    <ContextMenu x:Key="DefaultControlContextMenu">
-        <MenuItem Command="ApplicationCommands.Copy" />
-        <MenuItem Command="ApplicationCommands.Cut" />
-        <MenuItem Command="ApplicationCommands.Paste" />
-    </ContextMenu>
-  <!-- #endregion -->
-  <!-- #region DefaultFocusVisualStyle -->
-    <Style x:Key="DefaultControlFocusVisualStyle">
-        <Setter Property="Control.Template">
-            <Setter.Value>
-                <ControlTemplate>
-                    <Rectangle
-                        RadiusX="4"
-                        RadiusY="4"
-                        Margin = "-3"
-                        SnapsToDevicePixels="True"
-                        Stroke="{DynamicResource KeyboardFocusBorderColorBrush}"
-                        StrokeThickness="2" />
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-    <Style x:Key="DefaultCollectionFocusVisualStyle">
-        <Setter Property="Control.Template">
-            <Setter.Value>
-                <ControlTemplate>
-                    <Rectangle
-                        RadiusX="4"
-                        RadiusY="4"
-                        SnapsToDevicePixels="True"
-                        Stroke="{DynamicResource KeyboardFocusBorderColorBrush}"
-                        StrokeThickness="2" />
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-    <Style x:Key="{x:Static SystemParameters.FocusVisualStyleKey}" BasedOn="{StaticResource DefaultControlFocusVisualStyle}" />
-  <!-- #endregion -->
-  <!-- #region Fonts -->
+  <ContextMenu x:Key="DefaultControlContextMenu">
+    <MenuItem Command="ApplicationCommands.Copy" />
+    <MenuItem Command="ApplicationCommands.Cut" />
+    <MenuItem Command="ApplicationCommands.Paste" />
+  </ContextMenu>
+  <Style x:Key="DefaultControlFocusVisualStyle">
+    <Setter Property="Control.Template">
+      <Setter.Value>
+        <ControlTemplate>
+          <Rectangle RadiusX="4" RadiusY="4" Margin="-3" SnapsToDevicePixels="True" Stroke="{DynamicResource KeyboardFocusBorderColorBrush}" StrokeThickness="2" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="DefaultCollectionFocusVisualStyle">
+    <Setter Property="Control.Template">
+      <Setter.Value>
+        <ControlTemplate>
+          <Rectangle RadiusX="4" RadiusY="4" SnapsToDevicePixels="True" Stroke="{DynamicResource KeyboardFocusBorderColorBrush}" StrokeThickness="2" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style x:Key="{x:Static SystemParameters.FocusVisualStyleKey}" BasedOn="{StaticResource DefaultControlFocusVisualStyle}" />
   <FontFamily x:Key="SymbolThemeFontFamily">Segoe Fluent Icons, Segoe MDL2 Assets</FontFamily>
-  <!-- #endregion -->
-  <!-- #region StaticColors -->
-    <Color x:Key="TextFillColorLightPrimary">#FFFFFF</Color>
-    <Color x:Key="TextFillColorLightSecondary">#C5FFFFFF</Color>
-    <Color x:Key="TextFillColorLightTertiary">#87FFFFFF</Color>
-    <Color x:Key="TextFillColorLightDisabled">#5DFFFFFF</Color>
-    <Color x:Key="TextFillColorLightInverse">#E4000000</Color>
-
-    <SolidColorBrush x:Key="TextFillColorLightPrimaryBrush" Color="{StaticResource TextFillColorLightPrimary}" />
-    <SolidColorBrush x:Key="TextFillColorLightSecondaryBrush" Color="{StaticResource TextFillColorLightSecondary}" />
-    <SolidColorBrush x:Key="TextFillColorLightTertiaryBrush" Color="{StaticResource TextFillColorLightTertiary}" />
-    <SolidColorBrush x:Key="TextFillColorLightDisabledBrush" Color="{StaticResource TextFillColorLightDisabled}" />
-    <SolidColorBrush x:Key="TextFillColorLightInverseBrush" Color="{StaticResource TextFillColorLightInverse}" />
-
-    <Color x:Key="TextFillColorDarkPrimary">#E4000000</Color>
-    <Color x:Key="TextFillColorDarkSecondary">#BE000000</Color>
-    <Color x:Key="TextFillColorDarkTertiary">#A2000000</Color>
-    <Color x:Key="TextFillColorDarkDisabled">#5C000000</Color>
-    <Color x:Key="TextFillColorDarkInverse">#FFFFFF</Color>
-
-    <SolidColorBrush x:Key="TextFillColorDarkPrimaryBrush" Color="{StaticResource TextFillColorDarkPrimary}" />
-    <SolidColorBrush x:Key="TextFillColorDarkSecondaryBrush" Color="{StaticResource TextFillColorDarkSecondary}" />
-    <SolidColorBrush x:Key="TextFillColorDarkTertiaryBrush" Color="{StaticResource TextFillColorDarkTertiary}" />
-    <SolidColorBrush x:Key="TextFillColorDarkDisabledBrush" Color="{StaticResource TextFillColorDarkDisabled}" />
-    <SolidColorBrush x:Key="TextFillColorDarkInverseBrush" Color="{StaticResource TextFillColorDarkInverse}" />
-
-    <Color x:Key="ApplicationBackgroundColorLight">#FFFAFAFA</Color>
-    <SolidColorBrush x:Key="ApplicationBackgroundColorLightBrush" Color="{StaticResource ApplicationBackgroundColorLight}" />
-
-    <Color x:Key="ApplicationBackgroundColorDark">#FF202020</Color>
-    <SolidColorBrush x:Key="ApplicationBackgroundColorDarkBrush" Color="{StaticResource ApplicationBackgroundColorDark}" />
-
-    <Color x:Key="ControlStrongFillColorLight">#B3FFFFFF</Color>
-    <SolidColorBrush x:Key="ControlStrongFillColorLightBrush" Color="{StaticResource ControlStrongFillColorLight}" />
-
-    <Color x:Key="ControlStrongFillColorDark">#72000000</Color>
-    <SolidColorBrush x:Key="ControlStrongFillColorDarkBrush" Color="{StaticResource ControlStrongFillColorDark}" />
-
-  <!-- #endregion -->
-  <!-- #region Variables -->
+  <Color x:Key="TextFillColorLightPrimary">#FFFFFF</Color>
+  <Color x:Key="TextFillColorLightSecondary">#C5FFFFFF</Color>
+  <Color x:Key="TextFillColorLightTertiary">#87FFFFFF</Color>
+  <Color x:Key="TextFillColorLightDisabled">#5DFFFFFF</Color>
+  <Color x:Key="TextFillColorLightInverse">#E4000000</Color>
+  <SolidColorBrush x:Key="TextFillColorLightPrimaryBrush" Color="{StaticResource TextFillColorLightPrimary}" />
+  <SolidColorBrush x:Key="TextFillColorLightSecondaryBrush" Color="{StaticResource TextFillColorLightSecondary}" />
+  <SolidColorBrush x:Key="TextFillColorLightTertiaryBrush" Color="{StaticResource TextFillColorLightTertiary}" />
+  <SolidColorBrush x:Key="TextFillColorLightDisabledBrush" Color="{StaticResource TextFillColorLightDisabled}" />
+  <SolidColorBrush x:Key="TextFillColorLightInverseBrush" Color="{StaticResource TextFillColorLightInverse}" />
+  <Color x:Key="TextFillColorDarkPrimary">#E4000000</Color>
+  <Color x:Key="TextFillColorDarkSecondary">#BE000000</Color>
+  <Color x:Key="TextFillColorDarkTertiary">#A2000000</Color>
+  <Color x:Key="TextFillColorDarkDisabled">#5C000000</Color>
+  <Color x:Key="TextFillColorDarkInverse">#FFFFFF</Color>
+  <SolidColorBrush x:Key="TextFillColorDarkPrimaryBrush" Color="{StaticResource TextFillColorDarkPrimary}" />
+  <SolidColorBrush x:Key="TextFillColorDarkSecondaryBrush" Color="{StaticResource TextFillColorDarkSecondary}" />
+  <SolidColorBrush x:Key="TextFillColorDarkTertiaryBrush" Color="{StaticResource TextFillColorDarkTertiary}" />
+  <SolidColorBrush x:Key="TextFillColorDarkDisabledBrush" Color="{StaticResource TextFillColorDarkDisabled}" />
+  <SolidColorBrush x:Key="TextFillColorDarkInverseBrush" Color="{StaticResource TextFillColorDarkInverse}" />
+  <Color x:Key="ApplicationBackgroundColorLight">#FFFAFAFA</Color>
+  <SolidColorBrush x:Key="ApplicationBackgroundColorLightBrush" Color="{StaticResource ApplicationBackgroundColorLight}" />
+  <Color x:Key="ApplicationBackgroundColorDark">#FF202020</Color>
+  <SolidColorBrush x:Key="ApplicationBackgroundColorDarkBrush" Color="{StaticResource ApplicationBackgroundColorDark}" />
+  <Color x:Key="ControlStrongFillColorLight">#B3FFFFFF</Color>
+  <SolidColorBrush x:Key="ControlStrongFillColorLightBrush" Color="{StaticResource ControlStrongFillColorLight}" />
+  <Color x:Key="ControlStrongFillColorDark">#72000000</Color>
+  <SolidColorBrush x:Key="ControlStrongFillColorDarkBrush" Color="{StaticResource ControlStrongFillColorDark}" />
   <system:Double x:Key="DefaultIconFontSize">16</system:Double>
-
-    <system:Double x:Key="ControlContentThemeFontSize">14</system:Double>
-    <CornerRadius x:Key="ControlCornerRadius">4,4,4,4</CornerRadius>
-    <CornerRadius x:Key="OverlayCornerRadius">8,8,8,8</CornerRadius>
-    <CornerRadius x:Key="PopupCornerRadius">8,8,8,8</CornerRadius>
-
-    <!--
+  <system:Double x:Key="ControlContentThemeFontSize">14</system:Double>
+  <CornerRadius x:Key="ControlCornerRadius">4,4,4,4</CornerRadius>
+  <CornerRadius x:Key="OverlayCornerRadius">8,8,8,8</CornerRadius>
+  <CornerRadius x:Key="PopupCornerRadius">8,8,8,8</CornerRadius>
+  <!--
     <system:String x:Key="ControlFastOutSlowInKeySpline">0,0,0,1</system:String>
     <Duration x:Key="ControlNormalAnimationDuration">00:00:00.250</Duration>
     <Duration x:Key="ControlFastAnimationDuration">00:00:00.167</Duration>
     <Duration x:Key="ControlFastAnimationAfterDuration">00:00:00.168</Duration>
     <Duration x:Key="ControlFasterAnimationDuration">00:00:00.083</Duration>
     -->
-
-    <Thickness x:Key="TextControlBorderThemeThickness">1</Thickness>
-    <Thickness x:Key="TextControlThemePadding">10,5,6,6</Thickness>
-
-    <!-- Moved to Light, Dark and HC resource files -->
-    <!-- <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness> -->
-
-    <system:Double x:Key="ContentControlFontSize">14</system:Double>
-    <system:Double x:Key="TextControlThemeMinHeight">24</system:Double>
-    <system:Double x:Key="TextControlThemeMinWidth">0</system:Double>
-    <system:Double x:Key="TreeViewItemMultiSelectCheckBoxMinHeight">24</system:Double>
-    <system:Double x:Key="TreeViewItemPresenterMargin">0</system:Double>
-    <system:Double x:Key="TreeViewItemPresenterPadding">0</system:Double>
-
-    <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
-    <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
-    <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
-    <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
-
-    <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
-    <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
-    <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
-  <!-- #endregion -->
-  <!-- #region Controls -->
+  <Thickness x:Key="TextControlBorderThemeThickness">1</Thickness>
+  <Thickness x:Key="TextControlThemePadding">10,5,6,6</Thickness>
+  <!-- Moved to Light, Dark and HC resource files -->
+  <!-- <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness> -->
+  <system:Double x:Key="ContentControlFontSize">14</system:Double>
+  <system:Double x:Key="TextControlThemeMinHeight">24</system:Double>
+  <system:Double x:Key="TextControlThemeMinWidth">0</system:Double>
+  <system:Double x:Key="TreeViewItemMultiSelectCheckBoxMinHeight">24</system:Double>
+  <system:Double x:Key="TreeViewItemPresenterMargin">0</system:Double>
+  <system:Double x:Key="TreeViewItemPresenterPadding">0</system:Double>
+  <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
+  <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
+  <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
+  <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
+  <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
+  <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
+  <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
   <Thickness x:Key="ButtonPadding">11,5,11,6</Thickness>
   <Thickness x:Key="ButtonBorderThemeThickness">1</Thickness>
   <Thickness x:Key="ButtonIconMargin">0,0,8,0</Thickness>
@@ -329,6 +284,7 @@
       </Setter.Value>
     </Setter>
   </Style>
+  <!--  HINT: Month/year/decade button style  -->
   <Style x:Key="DefaultCalendarButtonStyle" TargetType="CalendarButton">
     <Setter Property="MinWidth" Value="40" />
     <Setter Property="MinHeight" Value="40" />
@@ -4839,5 +4795,4 @@
     </Style.Triggers>
   </Style>
   <Style BasedOn="{StaticResource DefaultWindowStyle}" TargetType="{x:Type Window}" />
-  <!-- #endregion -->
 </ResourceDictionary>


### PR DESCRIPTION
Fixes #10846

## Description
As explained in the issue above, setting `ThemeMode` to system led to crashes in DatePicker and NavigationWindow control. This was due to the fact that controls' ResourceDictionary was added as individual `MergedDictionaries` and the resolution of `StaticResources` being referenced in these controls was not part of these controls' itself. The current approach combines all the resources of controls, font, staticcolors, variables, and other common resources that were being used by both light and dark mode.
Given the above changes, the primary change of this PR is the update in ThemeGenerator script which includes the generation of newly configured `Fluent.xaml`.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build pass
A complete testing on the gallery application in light and dark themes (with system theme mode)
<!-- What kind of testing has been done with the fix. -->

## Risk
Moderate
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10862)