### PR TITLE
Remove non-CLS exceptions handlers and CS1058 suppressions (+ cleanup)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/FileClassifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/FileClassifier.cs
@@ -95,33 +95,18 @@ namespace Microsoft.Build.Tasks.Windows
                     CLRSatelliteEmbeddedResource = clrSatelliteEmbeddedResourceList.ToArray();
                 }
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not (NullReferenceException or SEHException))
             {
-                if (e is NullReferenceException || e is SEHException)
+                string errorId = Log.ExtractMessageCode(e.Message, out string message);
+
+                if (string.IsNullOrEmpty(errorId))
                 {
-                    throw;
-                }
-                else
-                {
-                    string message;
-                    string errorId;
-
-                    errorId = Log.ExtractMessageCode(e.Message, out message);
-
-                    if (String.IsNullOrEmpty(errorId))
-                    {
-                        errorId = UnknownErrorID;
-                        message = SR.Format(SR.UnknownBuildError, message);
-                    }
-
-                    Log.LogError(null, errorId, null, null, 0, 0, 0, 0, message, null);
+                    errorId = UnknownErrorID;
+                    message = SR.Format(SR.UnknownBuildError, message);
                 }
 
-                return false;
-            }
-            catch // Non-CLS compliant errors
-            {
-                Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
+                Log.LogError(null, errorId, null, null, 0, 0, 0, 0, message, null);
+
                 return false;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
@@ -191,11 +191,6 @@ namespace Microsoft.Build.Tasks.Windows
 
                 _nErrors++;
             }
-            catch // Non-CLS compliant errors
-            {
-                Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
-                _nErrors++;
-            }
 
             if (_nErrors > 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass2.cs
@@ -146,12 +146,6 @@ namespace Microsoft.Build.Tasks.Windows
                 _nErrors++;
 
             }
-            catch // Non-CLS compliant errors
-            {
-                Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
-
-                _nErrors++;
-            }
 
             if (_nErrors > 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MergeLocalizationDirectives.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MergeLocalizationDirectives.cs
@@ -83,21 +83,9 @@ namespace Microsoft.Build.Tasks.Windows
                         Log.LogMessageFromResources(nameof(SR.CommentFileGenerated), _outputFile);
                     }
                 }
-                catch (Exception e)
+                catch (Exception e) when (e is not (NullReferenceException or SEHException))
                 {
-                    if (e is NullReferenceException || e is SEHException)
-                    {
-                        throw;
-                    }
-                    else
-                    {
-                        Log.LogErrorFromException(e);
-                        return false;
-                    }
-                }
-                catch // Non-CLS compliant errors
-                {
-                    Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
+                    Log.LogErrorFromException(e);
                     return false;
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
@@ -194,30 +194,17 @@ namespace Microsoft.Build.Tasks.Windows
 
                 Log.LogMessageFromResources(MessageImportance.Low, nameof(SR.ResourcesGenerated), resourcesFile);
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not (NullReferenceException or SEHException))
             {
-                if (e is NullReferenceException || e is SEHException)
-                {
-                    throw;
-                }
-                else
-                {
-                    string message;
-                    string errorId = Log.ExtractMessageCode(e.Message, out message);
+                string errorId = Log.ExtractMessageCode(e.Message, out string message);
 
-                    if (string.IsNullOrEmpty(errorId))
-                    {
-                        errorId = UnknownErrorID;
-                        message = SR.Format(SR.UnknownBuildError, message);
-                    }
-
-                    Log.LogError(null, errorId, null, null, 0, 0, 0, 0, message, null);
-                    return false;
+                if (string.IsNullOrEmpty(errorId))
+                {
+                    errorId = UnknownErrorID;
+                    message = SR.Format(SR.UnknownBuildError, message);
                 }
-            }
-            catch   // Non-cls compliant errors
-            {
-                Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
+
+                Log.LogError(null, errorId, null, null, 0, 0, 0, 0, message, null);
                 return false;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -90,33 +90,18 @@ namespace Microsoft.Build.Tasks.Windows
             {
                 allFilesOk = ManageUids();
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not (NullReferenceException or SEHException))
             {
-                if (e is NullReferenceException || e is SEHException)
+                string errorId = Log.ExtractMessageCode(e.Message, out string message);
+
+                if (string.IsNullOrEmpty(errorId))
                 {
-                    throw;
+                    errorId = UnknownErrorID;
+                    message = SR.Format(SR.UnknownBuildError, message);
                 }
-                else
-                {
-                    string message;
-                    string errorId;
 
-                    errorId = Log.ExtractMessageCode(e.Message, out message);
+                Log.LogError(null, errorId, null, null, 0, 0, 0, 0, message, null);
 
-                    if (String.IsNullOrEmpty(errorId))
-                    {
-                        errorId = UnknownErrorID;
-                        message = SR.Format(SR.UnknownBuildError, message);
-                    }
-
-                    Log.LogError(null, errorId, null, null, 0, 0, 0, 0, message, null);
-
-                    allFilesOk = false;
-                }
-            }
-            catch // Non-CLS compliant errors
-            {
-                Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
                 allFilesOk = false;
             }
 
@@ -388,27 +373,13 @@ namespace Microsoft.Build.Tasks.Windows
 
                 return true;
             }
-            catch (Exception e)
-            {
-                if (e is NullReferenceException || e is SEHException)
-                {
-                    throw;
-                }
-                else
-                {
-                    Log.LogErrorWithCodeFromResources(nameof(SR.IntermediateDirectoryError), _backupPath);
-                    return false;
-                }
-            }
-            catch   // Non-cls compliant errors
+            catch (Exception e) when (e is not (NullReferenceException or SEHException))
             {
                 Log.LogErrorWithCodeFromResources(nameof(SR.IntermediateDirectoryError), _backupPath);
+
                 return false;
             }
         }
-
-
-
 
         /// <summary>
         /// Verify the Uids in the file
@@ -985,16 +956,7 @@ namespace Microsoft.Build.Tasks.Windows
                 WriteTillEof();
                 return true;
             }
-            catch (Exception e)
-            {
-                if (e is NullReferenceException || e is SEHException)
-                {
-                    throw;
-                }
-
-                return false;
-            }
-            catch
+            catch (Exception e) when (e is not (NullReferenceException or SEHException))
             {
                 return false;
             }
@@ -1024,16 +986,7 @@ namespace Microsoft.Build.Tasks.Windows
                 WriteTillEof();
                 return true;
             }
-            catch (Exception e)
-            {
-                if (e is NullReferenceException || e is SEHException)
-                {
-                    throw;
-                }
-
-                return false;
-            }
-            catch
+            catch (Exception e) when (e is not (NullReferenceException or SEHException))
             {
                 return false;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UpdateManifestForBrowserApplication.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UpdateManifestForBrowserApplication.cs
@@ -122,21 +122,9 @@ namespace Microsoft.Build.Tasks.Windows
                 }
 
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not (NullReferenceException or SEHException))
             {
-                if (e is NullReferenceException || e is SEHException)
-                {
-                    throw;
-                }
-                else
-                {
-                    Log.LogErrorFromException(e);
-                    successful = false;
-                }
-            }
-            catch   // Non-cls compliant errors
-            {
-                Log.LogErrorWithCodeFromResources(nameof(SR.NonClsError));
+                Log.LogErrorFromException(e);
                 successful = false;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -12,13 +12,7 @@
       -->
     <AssemblyVersion />
 
-    <!--
-            Suppressed Compiler Warnings:
-
-                CS1058: A previous catch clause already catches all exceptions. All exceptions
-                thrown will be wrapped in a System.Runtime.CompilerServices.RuntimeWrappedException
-    -->
-    <NoWarn>$(NoWarn);1058</NoWarn>
+    <NoWarn>$(NoWarn)</NoWarn>
 
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <AssemblyName>PresentationBuildTasks</AssemblyName>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/Strings.resx
@@ -219,9 +219,6 @@
   <data name="UnknownBuildError" xml:space="preserve">
     <value>Unknown build error, '{0}' </value>
   </data>
-  <data name="NonClsError" xml:space="preserve">
-    <value>BG1001: Unknown CLS exception.</value>
-  </data>
   <data name="FileNotFound" xml:space="preserve">
     <value>BG1002: File '{0}' cannot be found.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/IO/Packaging/ByteRangeDownloader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/IO/Packaging/ByteRangeDownloader.cs
@@ -556,14 +556,6 @@ namespace MS.Internal.IO.Packaging
 
                     throw;
                 }
-                catch   // catch (and re-throw) all kinds of exceptions so we can inform the other thread
-                {
-                    // inform other thread of error condition
-                    _erroredOut= true;
-                    _erroredOutException = null;
-
-                    throw;
-                }
                 finally
                 {
                     webResponse?.Close();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -2,7 +2,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);CORE_NATIVEMETHODS;PRESENTATION_CORE;COMMONDPS</DefineConstants>
-    <NoWarn>$(NoWarn);0618;0436;1058;1705;3001;3002;3003;3009;3024</NoWarn>
+    <NoWarn>$(NoWarn);0618;0436;1705;3001;3002;3003;3009;3024</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- SYSLIB5005: System.Formats.Nrbf is experimental -->
     <NoWarn>$(NoWarn);SYSLIB5005</NoWarn>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1747,9 +1747,6 @@
   <data name="NextPageText" xml:space="preserve">
     <value>Next Page</value>
   </data>
-  <data name="NonCLSException" xml:space="preserve">
-    <value>Text formatting engine encountered a non-CLS exception.</value>
-  </data>
   <data name="NonPackAppAbsoluteUriNotAllowed" xml:space="preserve">
     <value>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">Další stránka</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">Nástroj formátování textu narazil na výjimku, která není CLS.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">Nepodporovaná metoda syntaxe identifikátoru URI. Metoda očekává relativní identifikátor URI nebo balík://application:,,,/ jako formu absolutního identifikátoru URI.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">Nächste Seite</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">Vom Textformatierungsmodul wurde eine Nicht-CLS-Ausnahme entdeckt.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">Nicht unterstützte URI-Syntax. Von der Methode wird ein relativer URI oder die folgende Form eines absoluten URI erwartet: "pack://application:,,,/".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">Página siguiente</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">El motor de formato de texto encontró una excepción no CLS.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">Sintaxis de Uri no admitida. El método espera un Uri relativo o un formato pack://aplicación:,,,/ de un Uri absoluto.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">Page suivante</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">Le moteur de mise en forme du texte a rencontré une exception autre qu'une exception CLS.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">Syntaxe d'URI non prise en charge. La méthode attend un URI relatif ou un pack://application:,,,/ sous la forme d'un URI absolu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">Pagina successiva</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">Motore di formattazione del testo: rilevata eccezione non CLS.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">Sintassi URI non supportata. Per il metodo è previsto un URI relativo oppure un URI assoluto di tipo pack://applicazione:,,,/.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">次のページ</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">テキスト形式設定エンジンに、非 CLS 例外が発生しました。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">サポートされていない URI 構文です。メソッドでは、相対 URI または絶対 URI の pack://application:,,,/ 形式が必要です。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">다음 페이지</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">텍스트 서식 엔진에서 비 CLS 예외가 발생했습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">지원되지 않는 URI 구문입니다. 메서드에 상대 URI 또는 pack://application:,,,/ 형식의 절대 URI가 필요합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">Następna strona</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">Aparat formatowania tekstu napotkał wyjątek niezgodny z CLS.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">Nieobsługiwana składnia identyfikatora URI. Metoda oczekuje względnego identyfikatora URI lub absolutnego identyfikatora URI w postaci pakiet://aplikacja:,,,/.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">Próxima Página</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">O mecanismo de formatação de texto encontrou uma exceção diferente de CLS.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">Sintaxe de Uri sem suporte. O método espera um Uri relativo ou uma forma de Uri absoluto pack://aplicativo:,,,/.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">Следующая страница</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">Процессор форматирования текста обнаружил исключение, которое не относится к CLS.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">Недопустимый синтаксис идентификатора URI. Методу требуется относительный идентификатор URI или форма "pack://application:,,,/" абсолютного идентификатора URI.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">Sonraki Sayfa</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">Metin biçimlendirme altyapısı CLS dışı bir özel durumla karşılaştı.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">Desteklenmeyen Uri sözdizimi. Metot göreli bir Uri veya pack://application:,,,/ biçiminde mutlak Uri bekliyor.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">下一页</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">文本格式化引擎遇到非 CLS 异常。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">不支持的 URI 语法。方法需要相对 URI 或“pack://application:,,,/”格式的绝对 URI。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -2402,11 +2402,6 @@
         <target state="translated">下一頁</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Text formatting engine encountered a non-CLS exception.</source>
-        <target state="translated">文字格式設定引擎發現非 CLS 例外狀況。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported Uri syntax. Method expects a relative Uri or a pack://application:,,,/ form of absolute Uri.</source>
         <target state="translated">不支援的 URI 語法。方法預期應有相對 URI 或 pack://application:,,,/ 格式的絕對 URI。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore-ref.csproj
@@ -4,7 +4,7 @@
     <PackageId>PresentationCore-ref</PackageId>
     <TargetOutputRelPath>$(TargetGroup)-$(PackageId)/</TargetOutputRelPath>
     <DefineConstants>$(DefineConstants);CORE_NATIVEMETHODS;PRESENTATION_CORE;COMMONDPS</DefineConstants>
-    <NoWarn>$(NoWarn);0618;0436;1058;1705;3001;3002;3003;3009;3024</NoWarn>
+    <NoWarn>$(NoWarn);0618;0436;1705;3001;3002;3003;3009;3024</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn)</NoWarn>
     <EnablePInvokeAnalyzer>false</EnablePInvokeAnalyzer>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DefaultAsyncDataDispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DefaultAsyncDataDispatcher.cs
@@ -77,10 +77,6 @@ namespace MS.Internal.Data
 
                 request.Fail(ex);
             }
-            catch // non CLS compliant exception
-            {
-                request.Fail(new InvalidOperationException(SR.Format(SR.NonCLSException, "processing an async data request")));
-            }
 
             // remove the request from the list
             lock (_list.SyncRoot)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PropertyPathWorker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PropertyPathWorker.cs
@@ -1411,10 +1411,7 @@ namespace MS.Internal.Data
                 {
                     if (CriticalExceptions.IsCriticalApplicationException(ex))
                         throw;
-                    return false;
-                }
-                catch
-                {
+
                     return false;
                 }
             }
@@ -1526,10 +1523,6 @@ namespace MS.Internal.Data
                         throw;
                     BindingOperations.LogException(ex);
                     _host?.ReportGetValueError(k, item, ex);
-                }
-                catch // non CLS compliant exception
-                {
-                    _host?.ReportGetValueError(k, item, new InvalidOperationException(SR.Format(SR.NonCLSException, "GetValue")));
                 }
 
                 // catch the pseudo-exception as well

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnablePInvokeAnalyzer>false</EnablePInvokeAnalyzer>
     <!-- SYSLIB5005: System.Formats.Nrbf is experimental -->
-    <NoWarn>$(NoWarn);0618;1058;SYSLIB5005</NoWarn>
+    <NoWarn>$(NoWarn);0618;SYSLIB5005</NoWarn>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>x86;x64;arm64</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
@@ -2130,12 +2130,6 @@ Do you want to replace it?</value>
   <data name="NoMulticastHandlers" xml:space="preserve">
     <value>WeakEventManager supports only delegates with one target.</value>
   </data>
-  <data name="NonClsActivationException" xml:space="preserve">
-    <value>Nonstandard exception occurred while activating the application.</value>
-  </data>
-  <data name="NonCLSException" xml:space="preserve">
-    <value>Unknown exception during '{0}'.</value>
-  </data>
   <data name="NonPackAppAbsoluteUriNotAllowed" xml:space="preserve">
     <value>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</value>
   </data>
@@ -2195,12 +2189,6 @@ Do you want to replace it?</value>
   </data>
   <data name="ObjectDataProviderHasNoSource" xml:space="preserve">
     <value>ObjectDataProvider needs either an ObjectType or ObjectInstance.</value>
-  </data>
-  <data name="ObjectDataProviderNonCLSException" xml:space="preserve">
-    <value>Unknown exception while creating type '{0}' for ObjectDataProvider.</value>
-  </data>
-  <data name="ObjectDataProviderNonCLSExceptionInvoke" xml:space="preserve">
-    <value>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</value>
   </data>
   <data name="ObjectDataProviderParameterCollectionIsNotInUse" xml:space="preserve">
     <value>ConstructorParameters cannot be changed because ObjectDataProvider is using user-assigned ObjectInstance.</value>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
@@ -3418,16 +3418,6 @@ Chcete ho nahradit?</target>
         <target state="translated">Nelze nastavit UpdateSourceTrigger ve vnitřním Binding funkce MultiBinding. Platný je pouze výchozí Immediate UpdateSourceTrigger.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">Neznámá výjimka během {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">Při aktivaci aplikace se vyskytla nestandardní výjimka.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">Nepodporovaná metoda syntaxe identifikátoru URI. Metoda očekává relativní identifikátor URI nebo balík://application:,,,/ jako formu absolutního identifikátoru URI.</target>
@@ -3506,16 +3496,6 @@ Chcete ho nahradit?</target>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">ObjectDataProvider potřebuje buď ObjectType, nebo ObjectInstance.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">Neznámá výjimka pro vytváření typu {0} pro ObjectDataProvider.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">Neznámá výjimka pro vyvolávání metody {0} u typu {1} pro ObjectDataProvider.</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
@@ -3418,16 +3418,6 @@ Möchten Sie das Element ersetzen?</target>
         <target state="translated">"UpdateSourceTrigger" kann nicht für internes Binding von "MultiBinding" festgelegt werden. Nur der standardmäßige direkte "UpdateSourceTrigger" ist gültig.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">Unbekannte Ausnahme während "{0}".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">Beim Aktivieren der Anwendung ist eine nicht dem Standard entsprechende Ausnahme aufgetreten.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">Nicht unterstützte URI-Syntax. Von der Methode wird ein relativer URI oder die Form "pack://application:,,,/" eines absoluten URI erwartet.</target>
@@ -3506,16 +3496,6 @@ Möchten Sie das Element ersetzen?</target>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">"ObjectDataProvider" erfordert entweder "ObjectType" oder "ObjectInstance".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">Unbekannte Ausnahme beim Erstellen des Typs "{0}" für "ObjectDataProvider".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">Unbekannte Ausnahme beim Abrufen der Methode "{0}" für den Typ "{1}" für ObjectDataProvider.</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
@@ -3418,16 +3418,6 @@ Do you want to replace it?</source>
         <target state="translated">No se puede establecer UpdateSourceTrigger en el Binding interno de MultiBinding. Sólo el Immediate UpdateSourceTrigger predeterminado es válido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">Excepción desconocida durante '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">Ocurrió una excepción no estándar al activar la aplicación.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">Sintaxis de URI no admitida. El método espera un URI relativo o un formato pack://aplicación:,,,/ de URI absoluto.</target>
@@ -3506,16 +3496,6 @@ Do you want to replace it?</source>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">ObjectDataProvider necesita ObjectType u ObjectInstance.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">Excepción desconocida al crear el tipo '{0}' para ObjectDataProvider.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">Excepción desconocida al invocar el método "{0}" en el tipo "{1}" para ObjectDataProvider.</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
@@ -3418,16 +3418,6 @@ Voulez-vous le remplacer ?</target>
         <target state="translated">Impossible de définir UpdateSourceTrigger sur un Binding interne de MultiBinding. Seul l'Immediate UpdateSourceTrigger par défaut est valide.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">Exception inconnue pendant '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">Une exception non standard s'est produite lors de l'activation de l'application.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">Syntaxe d'URI non prise en charge. La méthode attend un URI relatif ou un pack://application:,,,/ sous la forme d'un URI absolu.</target>
@@ -3506,16 +3496,6 @@ Voulez-vous le remplacer ?</target>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">ObjectDataProvider a besoin d'un ObjectType ou ObjectInstance.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">Exception inconnue lors de la création du type '{0}' pour ObjectDataProvider.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">Exception inconnue pendant l'appel de la méthode '{0}' pour le type '{1}' de ObjectDataProvider.</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
@@ -3418,16 +3418,6 @@ Sostituirlo?</target>
         <target state="translated">Impossibile impostare UpdateSourceTrigger per il Binding interno di MultiBinding. È valido solo l'UpdateSourceTrigger diretto predefinito.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">Eccezione sconosciuta durante '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">Eccezione non standard durante l'attivazione dell'applicazione.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">Sintassi URI non supportata. Per il metodo è previsto un URI relativo oppure un URI assoluto di tipo pack://applicazione:,,,/.</target>
@@ -3506,16 +3496,6 @@ Sostituirlo?</target>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">ObjectDataProvider richiede un ObjectType o una ObjectInstance.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">Eccezione sconosciuta durante la creazione del tipo '{0}' per ObjectDataProvider.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">Eccezione sconosciuta durante la chiamata del metodo '{0}' sul tipo '{1}' per ObjectDataProvider.</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
@@ -3418,16 +3418,6 @@ Do you want to replace it?</source>
         <target state="translated">MultiBinding の内部 Binding で UpdateSourceTrigger を設定できません。既定の Immediate UpdateSourceTrigger のみが有効です。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">'{0}' 中の不明な例外です。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">アプリケーションのアクティブ化中に、標準でない例外が発生しました。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">サポートされていない URI 構文です。メソッドでは、相対 URI または絶対 URI の pack://application:,,,/ 形式が必要です。</target>
@@ -3506,16 +3496,6 @@ Do you want to replace it?</source>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">ObjectDataProvider には、ObjectType または ObjectInstance が必要です。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">ObjectDataProvider で型 '{0}' を作成中に、不明な例外が発生しました。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">ObjectDataProvider で型 '{1}' のメソッド '{0}' を起動中に、不明な例外が発生しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
@@ -3418,16 +3418,6 @@ Do you want to replace it?</source>
         <target state="translated">MultiBinding의 내부 Binding에 UpdateSourceTrigger를 설정할 수 없습니다. 직접 관련된 기본 UpdateSourceTrigger만 사용할 수 있습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">'{0}' 동안 알 수 없는 예외가 발생했습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">애플리케이션을 활성화하는 동안 비표준 예외가 발생했습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">지원되지 않는 URI 구문입니다. 메서드에 상대 URI 또는 pack://application:,,,/ 형식의 절대 URI가 필요합니다.</target>
@@ -3506,16 +3496,6 @@ Do you want to replace it?</source>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">ObjectDataProvider에 ObjectType 또는 ObjectInstance가 있어야 합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">ObjectDataProvider에 대한 '{0}' 형식을 만드는 동안 알 수 없는 예외가 발생했습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">ObjectDataProvider에 대한 '{1}' 형식에 '{0}' 메서드를 호출하는 동안 알 수 없는 예외가 발생했습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
@@ -3418,16 +3418,6 @@ Czy chcesz go zastąpić?</target>
         <target state="translated">Nie można ustawić UpdateSourceTrigger dla wewnętrznego elementu Binding obiektu MultiBinding. Prawidłowy jest tylko domyślny element Immediate UpdateSourceTrigger.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">Nieznany wyjątek podczas „{0}”.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">Podczas aktywacji aplikacji wystąpił niestandardowy wyjątek.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">Nieobsługiwana składnia identyfikatora URI. Metoda oczekuje względnego identyfikatora URI lub absolutnego identyfikatora URI w postaci pakiet://aplikacja:,,,/.</target>
@@ -3506,16 +3496,6 @@ Czy chcesz go zastąpić?</target>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">ObjectDataProvider wymaga typu ObjectType lub wystąpienia ObjectInstance.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">Nieznany wyjątek podczas tworzenia typu „{0}” dla ObjectDataProvider.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">Nieznany wyjątek podczas wywoływania metody „{0}” w typie „{1}” dla ObjectDataProvider.</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
@@ -3418,16 +3418,6 @@ Deseja substituí-lo?</target>
         <target state="translated">Não é possível definir UpdateSourceTrigger no Binding interno de MultiBinding. Somente Immediate UpdateSourceTrigger padrão é válido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">Exceção desconhecida durante '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">Exceção diferente do padrão ao ativar o aplicativo.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">Sintaxe de URI sem-suporte. O método espera um URI relativo ou uma forma de URI absoluto pack://aplicativo:,,,/.</target>
@@ -3506,16 +3496,6 @@ Deseja substituí-lo?</target>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">ObjectDataProvider precisa de um ObjectType ou ObjectInstance.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">Exceção desconhecida durante a criação do tipo '{0}' para ObjectDataProvider.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">Exceção desconhecida durante a invocação do método '{0}' no tipo '{1}' para ObjectDataProvider.</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
@@ -3418,16 +3418,6 @@ Do you want to replace it?</source>
         <target state="translated">Невозможно задать UpdateSourceTrigger для внутренней привязки Binding элемента MultiBinding. Для UpdateSourceTrigger допускается только значение по умолчанию Immediate.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">Неизвестное исключение во время "{0}".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">При активации приложения возникло нестандартное исключение.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">Неподдерживаемый синтаксис URI. Метод ожидает относительный URI или абсолютный URI в формате pack://application:,,,/ .</target>
@@ -3506,16 +3496,6 @@ Do you want to replace it?</source>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">Для ObjectDataProvider необходим ObjectType или ObjectInstance.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">Неизвестное исключение при создании типа "{0}" для ObjectDataProvider.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">Неизвестное исключение при вызове метода "{0}" для типа "{1}" для ObjectDataProvider.</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
@@ -3418,16 +3418,6 @@ Değiştirmek istiyor musunuz?</target>
         <target state="translated">MultiBinding'in iç Binding'de UpdateSourceTrigger ayarlanamaz. Yalnızca varsayılan Acil UpdateSourceTrigger geçerlidir.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">'{0}' sırasında bilinmeyen özel durum.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">Uygulama etkinleştirilirken standart olmayan özel durum oluştu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">Desteklenmeyen Uri sözdizimi. Metot göreli bir Uri veya pack://application:,,,/ biçiminde mutlak Uri bekliyor.</target>
@@ -3506,16 +3496,6 @@ Değiştirmek istiyor musunuz?</target>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">ObjectDataProvider, ObjectType veya ObjectInstance'a gereksinim duyar.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">ObjectDataProvider için '{0}' türü oluşturulurken bilinmeyen özel durum oluştu.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">ObjectDataProvider için '{1}' türünde '{0}' metodu çağrılırken bilinmeyen özel durum oluştu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
@@ -3418,16 +3418,6 @@ Do you want to replace it?</source>
         <target state="translated">无法在 MultiBinding 的内部 Binding 上设置 UpdateSourceTrigger。只有默认的 Immediate UpdateSourceTrigger 是有效的。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">“{0}”期间发生未知异常。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">激活应用程序时发生非标准异常。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">不支持的 URI 语法。方法需要相对 URI 或“pack://application:,,,/”格式的绝对 URI。</target>
@@ -3506,16 +3496,6 @@ Do you want to replace it?</source>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">ObjectDataProvider 需要 ObjectType 或 ObjectInstance。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">创建 ObjectDataProvider 的类型“{0}”时，发生未知异常。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">为 ObjectDataProvider 调用类型“{1}”上的方法“{0}”时，发生未知异常。</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
@@ -3418,16 +3418,6 @@ Do you want to replace it?</source>
         <target state="translated">無法在 MultiBinding 的內部 Binding 上設定 UpdateSourceTrigger。只有預設的 Immediate UpdateSourceTrigger 才有效。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonCLSException">
-        <source>Unknown exception during '{0}'.</source>
-        <target state="translated">'{0}' 時發生不明的例外狀況。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NonClsActivationException">
-        <source>Nonstandard exception occurred while activating the application.</source>
-        <target state="translated">啟動應用程式時發生非標準的例外狀況。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NonPackAppAbsoluteUriNotAllowed">
         <source>Unsupported URI syntax. Method expects a relative URI or a pack://application:,,,/ form of absolute URI.</source>
         <target state="translated">不支援的 URI 語法。方法預期應有相對 URI 或 pack://application:,,,/ 格式的絕對 URI。</target>
@@ -3506,16 +3496,6 @@ Do you want to replace it?</source>
       <trans-unit id="ObjectDataProviderHasNoSource">
         <source>ObjectDataProvider needs either an ObjectType or ObjectInstance.</source>
         <target state="translated">ObjectDataProvider 需要 ObjectType 或 ObjectInstance。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSException">
-        <source>Unknown exception while creating type '{0}' for ObjectDataProvider.</source>
-        <target state="translated">為 ObjectDataProvider 建立型別 '{0}' 時發生不明的例外狀況。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
-        <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">在類型 '{1}'為 ObjectDataProvider 叫用 方法 '{0}' 時，發生不明的例外狀況。</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
@@ -1657,19 +1657,6 @@ namespace System.Windows.Data
                 }
                 convertedValue = DependencyProperty.UnsetValue;
             }
-            catch // non CLS compliant exception
-            {
-                if (TraceData.IsEnabled)
-                {
-                    TraceData.TraceAndNotify(TraceLevel,
-                            TraceData.BadConverterForTransfer(
-                                converter.GetType().Name,
-                                AvTrace.ToStringHelper(value),
-                                AvTrace.TypeName(value)),
-                            this);
-                }
-                convertedValue = DependencyProperty.UnsetValue;
-            }
 
             return convertedValue;
         }
@@ -1709,18 +1696,6 @@ namespace System.Windows.Data
                 }
 
                 ProcessException(ex, ValidatesOnExceptions);
-                convertedValue = DependencyProperty.UnsetValue;
-            }
-            catch // non CLS compliant exception
-            {
-                if (TraceData.IsEnabled)
-                {
-                    TraceData.TraceAndNotify(TraceEventType.Error,
-                        TraceData.BadConverterForUpdate(
-                            AvTrace.ToStringHelper(Value),
-                            AvTrace.TypeName(value)),
-                        this);
-                }
                 convertedValue = DependencyProperty.UnsetValue;
             }
 
@@ -1985,14 +1960,6 @@ namespace System.Windows.Data
                     TraceData.TraceAndNotify(TraceEventType.Error, TraceData.WorkerUpdateFailed, this, ex);
 
                 ProcessException(ex, (ValidatesOnExceptions || BindingGroup != null));
-                SetStatus(BindingStatusInternal.UpdateSourceError);
-                value = DependencyProperty.UnsetValue;
-            }
-            catch // non CLS compliant exception
-            {
-                if (TraceData.IsEnabled)
-                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.WorkerUpdateFailed, this);
-
                 SetStatus(BindingStatusInternal.UpdateSourceError);
                 value = DependencyProperty.UnsetValue;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
@@ -2198,9 +2198,6 @@ namespace System.Windows.Data
                     {
                         e = ex;
                     }
-                    catch // non CLS compliant exception
-                    {
-                    }
                 }
 
                 if (!success)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ObjectDataProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ObjectDataProvider.cs
@@ -474,11 +474,6 @@ namespace System.Windows.Data
                 error = null;   // indicate unknown error
                 e = ex;
             }
-            catch // non CLS compliant exception
-            {
-                error = null;   // indicate unknown error
-                e = new InvalidOperationException(SR.Format(SR.ObjectDataProviderNonCLSException, _objectType.Name));
-            }
 
             if (e != null || error != null)
             {
@@ -552,11 +547,6 @@ namespace System.Windows.Data
                 }
                 error = null;   // indicate unknown error
                 e = ex;
-            }
-            catch   //FXCop Fix: CatchNonClsCompliantExceptionsInGeneralHandlers
-            {
-                error = null;   // indicate unknown error
-                e = new InvalidOperationException(SR.Format(SR.ObjectDataProviderNonCLSExceptionInvoke, MethodName, _objectType.Name));
             }
 
             if (e != null || error != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlDataProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlDataProvider.cs
@@ -598,11 +598,6 @@ namespace System.Windows.Data
                         eventParameters: new object[] { ex });
                 }
             }
-            //FXCop Fix: CatchNonClsCompliantExceptionsInGeneralHandlers
-            catch
-            {
-                throw;
-            }
 
             if (ex != null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/PropertyPath.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/PropertyPath.cs
@@ -794,16 +794,10 @@ namespace System.Windows
                     // we treat null as an "error", and keep trying for something
                     // better.  (See bug 861966)
                 }
-                // catch all exceptions.  We simply want to move on to the next
-                // candidate indexer.
+                // Catch all exceptions. We simply want to move on to the next candidate indexer.
                 catch (Exception ex)
                 {
                     if (CriticalExceptions.IsCriticalApplicationException(ex) || throwOnError)
-                        throw;
-                }
-                catch
-                {
-                    if (throwOnError)
                         throw;
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -5909,10 +5909,6 @@ namespace System.Windows
                                 throw;
                             // if the conversion failed, just use the unconverted value
                         }
-                        catch // non CLS compliant exception
-                        {
-                            // if the conversion failed, just use the unconverted value
-                        }
                     }
 
                     // cache the converted value

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework-ref.csproj
@@ -7,7 +7,7 @@
     <DefineConstants Condition="'$(WeakEventTelemetry)'=='true'">$(DefineConstants);WeakEventTelemetry</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnablePInvokeAnalyzer>false</EnablePInvokeAnalyzer>
-    <NoWarn>$(NoWarn);0618;1058,3003</NoWarn>
+    <NoWarn>$(NoWarn);0618;3003</NoWarn>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU</Platforms>
     <GenerateDependencyFile>false</GenerateDependencyFile>


### PR DESCRIPTION
This is blocked by #10874 / #10875, hence draft.

## Description

Removes non-CLS exceptions handlers (general catch handler blocks) in `LineServicesCallbacks` that are never executed (basically a dead-code). This originates from pre-`NetFXv2` / `C# 2.0` behaviour before non-CLS exceptions were being wrapped by default as `RuntimeWrappedException` which derives from `Exception` and hence you needed a general `catch` handler.

Nowadays Roslyn emits `[assembly: RuntimeCompatibility(WrapNonExceptionThrows = true)]` by default so all non-CLS exceptions are already handled via `catch (Exception e)` blocks and never fallthrough to the general `catch { }` handler.

## Customer Impact

Smaller assembly size, codegen size and cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low, those would be generally catched by CS1058 but the warning was suppressed. Reviewers just need to make sure the removed blocks are preceeded by `catch (Exception e)` to achieve the same effect.