### PR TITLE
Fix InvalidCastException in ComboBoxAutomationPeer / forward Scroll to ItemsControl

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ComboBoxAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ComboBoxAutomationPeer.cs
@@ -37,27 +37,20 @@ namespace System.Windows.Automation.Peers
         ///
         public override object GetPattern(PatternInterface pattern)
         {
-            object iface = null;
             ComboBox owner = (ComboBox)Owner;
 
-            if (pattern == PatternInterface.Value)
+            if ((pattern is PatternInterface.Value && owner.IsEditable) || pattern is PatternInterface.ExpandCollapse)
             {
-                if (owner.IsEditable) iface = this;
-            }
-            else if(pattern == PatternInterface.ExpandCollapse)
-            {
-                iface = this;
-            }
-            else if (pattern == PatternInterface.Scroll && !owner.IsDropDownOpen)
-            {
-                iface = this;
-            }
-            else
-            {
-                iface = base.GetPattern(pattern);
+                return this;
             }
 
-            return iface;
+            if (pattern is PatternInterface.Scroll && !owner.IsDropDownOpen)
+            {
+                return null;
+            }
+
+            // PatternInterface.Scroll is handled by ItemsControlAutomationPeer when Expanded/DropDown is open
+            return base.GetPattern(pattern);
         }
 
         ///


### PR DESCRIPTION
## Description

Fixes `InvalidCastException` in `ComboBoxAutomationPeer` which occurs because `ComboBoxAutomationPeer` nor its parents implement `IScrollProvider` directly and hence the whole code block is just wrong as it will never work.

We should use the `ItemsControlAutomationPeer` implementation to provide the interface via `ScrollHost` / `ScrollViewer`, which should be done only if the drop-down is open. See https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-supportcomboboxcontroltype.

Reproduction steps are easy:
1) Put a ComboBox onto your window with some items
2) Open the app, optionally enable native managed boundary exceptions in VS
3) Start Narrator or any other UIA app, and watch the exceptions flow

## Customer Impact

Better performance and correct interface when the dropdown is open, improved accessibility.

## Regression

Yes, this was introduced in #1278, guess the [comment](https://github.com/dotnet/wpf/pull/1278#discussion_r304089297) was misunderstood by the implementor and nobody bothered to check/test during review. 

## Testing

Local build, exploring the automation tree, ensuring the exception no longer happens.

## Risk

Low.
