### PR TITLE
Use StrongBox<Rect> over object field in GlyphRun

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
@@ -15,6 +15,7 @@
 
 using System.Collections;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Windows.Media.Converters;
 using System.Windows.Media.Composition;
 using System.Windows.Media.TextFormatting;
@@ -1226,9 +1227,9 @@ namespace System.Windows.Media
 
             if ((_flags & GlyphRunFlags.CacheInkBounds) != 0)
             {
-                if (_inkBoundingBox != null)
+                if (_inkBoundingBox is not null)
                 {
-                    return (Rect)_inkBoundingBox;
+                    return _inkBoundingBox.Value;
                 }
             }
 
@@ -1401,7 +1402,7 @@ namespace System.Windows.Media
 
             if ((_flags & GlyphRunFlags.CacheInkBounds) != 0)
             {
-                _inkBoundingBox = bounds;
+                _inkBoundingBox = new StrongBox<Rect>(bounds);
             }
 
             return bounds;
@@ -2463,7 +2464,7 @@ namespace System.Windows.Media
         private IList<bool>         _caretStops;
         private XmlLanguage         _language;
         private string              _deviceFontName;
-        private object              _inkBoundingBox;    // Used when CacheInkBounds is on
+        private StrongBox<Rect>     _inkBoundingBox;    // Used when CacheInkBounds is on
         private TextFormattingMode      _textFormattingMode;
         private float               _pixelsPerDip = MS.Internal.FontCache.Util.PixelsPerDip;
 


### PR DESCRIPTION
## Description

Swaps an `object` field with `StrongBox<Rect>` when caching ink bounds to allow for faster unboxing when required and increase type-safety in the codebase. Given that caching is present on most codepaths, this could theoretically be better nowadays to embed the `Rect` directly into `GlyphRun`, but that requires more measurements.

In StrongBox<T>, we just load the field:
```asm
   mov       rax,[rsi+8]
   test      rax,rax
   je        short M01_L00
   vmovdqu   ymm1,ymmword ptr [rax+8]
   vmovdqu   ymmword ptr [rbx],ymm1
   mov       rax,rbx
```
With object, we have to go through type-check etc:
```asm
     mov       rdi,[rsi+8]
     test      rdi,rdi
     je        short M01_L01
     mov       rcx,offset MT_System.Windows.Rect
     cmp       [rdi],rcx
     je        short M01_L00
     mov       rdx,rdi
     call      System.Runtime.CompilerServices.CastHelpers.Unbox(Void*, System.Object)
M01_L00:
     vmovdqu   ymm1,ymmword ptr [rdi+8]
     vmovdqu   ymmword ptr [rbx],ymm1
     mov       rax,rbx
```

With 1 box, 100 returns, this gets down to:
| Method    | Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Gen0   | Allocated [B] |
|---------- |----------:|-----------:|------------:|--------------:|-------:|--------------:|
| Original | 196.4 ns |    1.71 ns |     1.60 ns |         424 B | 0.0048 |          80 B |
| PR__EDIT  |  174.3 ns |    1.48 ns |     1.32 ns |         395 B | 0.0048 |          80 B |

## Customer Impact

Increased performance, increased type safety and cleaner code.

## Regression

No.

## Testing

Local build.

## Risk

Low.
