### PR TITLE
Remove unused dead code in BamlMapTable / XamlTypeMapper

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -357,7 +357,6 @@ namespace System.Windows.Markup
         {
             if (AttributeIdMap.Count > 0 || TypeIdMap.Count > 0)
             {
-                _reusingMapTable = true;
                 // Populate the ObjectHashTable here only after the first parse has
                 // completed and the second is about to begin.  This is done so that
                 // a single parse does not pay the price of having the hash table, and
@@ -767,7 +766,6 @@ namespace System.Windows.Markup
                         {
                             Type type = assembly.GetType(typeInfo.TypeFullName);
                             typeInfo.Type = type;
-                            AddHashTableData(key, typeInfo);
                         }
                     }
                 }
@@ -1663,19 +1661,6 @@ namespace System.Windows.Markup
         }
 
 #if !PBTCOMPILER
-        // Add item to the hash table.  Only do this if the map table
-        // is being re-used for multiple parses.  Otherwise the hash table
-        // data is of no use for a single parse.
-        internal void AddHashTableData(object key, object data)
-        {
-            if (_reusingMapTable)
-            {
-                ObjectHashTable[key] = data;
-            }
-        }
-#endif
-
-#if !PBTCOMPILER
         internal BamlMapTable Clone() => new BamlMapTable(_xamlTypeMapper)
         {
             ObjectHashTable = (Hashtable)_objectHashTable.Clone(),
@@ -1840,13 +1825,6 @@ namespace System.Windows.Markup
 #if !PBTCOMPILER
         // Temporary cache of Known Type Converters for each baml reading session.
         private Hashtable _converterCache = null;
-#endif
-
-#if !PBTCOMPILER
-        // True if this instance of the BamlMapTable is being reused between
-        // different parses.  This is done to maintain the ObjectHashTable so that
-        // less reflection is done for types and properties.
-        private bool   _reusingMapTable = false;
 #endif
 
         #endregion Data

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -348,52 +348,6 @@ namespace System.Windows.Markup
         #region Methods
 
 #if !PBTCOMPILER
-        // This is called when a parse is begun when the very first baml record is
-        // processed.  If the BamlMapTable already contains data, then this means
-        // it is being re-used for multiple parses.  In this case set the _reusingMapTable
-        // flag and make certain that the ObjectHashTable is populated before clearing
-        // the existing assembly, type and property lists for the next parse.
-        internal void Initialize()
-        {
-            if (AttributeIdMap.Count > 0 || TypeIdMap.Count > 0)
-            {
-                // Populate the ObjectHashTable here only after the first parse has
-                // completed and the second is about to begin.  This is done so that
-                // a single parse does not pay the price of having the hash table, and
-                // the second through 'n' parses are added as they are read in.
-                if (ObjectHashTable.Count == 0)
-                {
-                    // Loop through attributes. We only care about having CLR properties in
-                    // the hash table.  DependencyProperties are already cached by the framework.
-                    for (int i = 0; i < AttributeIdMap.Count; i++)
-                    {
-                        BamlAttributeInfoRecord info = AttributeIdMap[i];
-                        if (info.PropInfo != null)
-                        {
-                            object key = GetAttributeInfoKey(info.OwnerType.FullName, info.Name);
-                            ObjectHashTable.Add(key, info);
-                        }
-                    }
-
-                    // Loop through types and cache them.
-                    for (int j = 0; j < TypeIdMap.Count; j++)
-                    {
-                        BamlTypeInfoRecord info = TypeIdMap[j];
-                        if (info.Type != null)
-                        {
-                            BamlAssemblyInfoRecord assyInfo = GetAssemblyInfoFromId(info.AssemblyId);
-                            TypeInfoKey key = GetTypeInfoKey(assyInfo.AssemblyFullName, info.TypeFullName);
-                            ObjectHashTable.Add(key, info);
-                        }
-                    }
-                }
-            }
-            AssemblyIdMap.Clear();
-            TypeIdMap.Clear();
-            AttributeIdMap.Clear();
-            StringIdMap.Clear();
-        }
-
         // Given an Id looks up the Type in the MapTable.  This works for known types
         // and types that are a part of BamlTypeInfoRecords in the baml file.
         internal Type GetTypeFromId(short id)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -142,7 +142,6 @@ namespace System.Windows.Markup
         /// </summary>
         internal void Initialize()
         {
-            MapTable.Initialize();
             XamlTypeMapper.Initialize();
             ParserContext.Initialize();
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
@@ -786,20 +786,6 @@ namespace System.Windows.Markup
 
 #if !PBTCOMPILER
         /// <summary>
-        /// Add cached member info for the property name.
-        /// </summary>
-        private void AddCachedAttributeInfo(
-               Type                    ownerType,
-               BamlAttributeInfoRecord infoRecord)
-        {
-            if (MapTable != null)
-            {
-                object key = MapTable.GetAttributeInfoKey(ownerType.FullName, infoRecord.Name);
-                MapTable.AddHashTableData(key, infoRecord);
-            }
-        }
-
-        /// <summary>
         /// Helper function for getting Clr PropertyInfo on a type and updating the
         /// passed attribute info record.  Also update the property cache with this
         /// attribute information if it was not already present.
@@ -836,10 +822,6 @@ namespace System.Windows.Markup
                     {
                         cachedInfoRecord.SetPropertyMember(attribInfo.PropInfo);
                         cachedInfoRecord.IsInternal = attribInfo.IsInternal;
-                    }
-                    else
-                    {
-                        AddCachedAttributeInfo(currentParentType, attribInfo);
                     }
                 }
             }


### PR DESCRIPTION
This follows #10636 which removes the uncalled `Initialize` method (here I just remove one of the called methods inside).

## Description

Removes unused code since `NetFX4` in `BamlMapTable` / `XamlTypeMapper`.
They're independent of each other actually but the removal makes sense to do together.

## Customer Impact

Smaller assembly size, cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low, unused dead code.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10881)