### PR TITLE
Stop duplicating Scroll code in TreeViewAutomationPeer / forward to base

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlAutomationPeer.cs
@@ -22,23 +22,24 @@ namespace System.Windows.Automation.Peers
         ///
         public override object GetPattern(PatternInterface patternInterface)
         {
-            if(patternInterface == PatternInterface.Scroll)
+            if (patternInterface is PatternInterface.Scroll)
             {
                 ItemsControl owner = (ItemsControl)Owner;
-                if(owner.ScrollHost != null)
+                if (owner.ScrollHost is not null)
                 {
-                    AutomationPeer scrollPeer = UIElementAutomationPeer.CreatePeerForElement(owner.ScrollHost);
-                    if(scrollPeer != null && scrollPeer is IScrollProvider)
+                    AutomationPeer scrollPeer = CreatePeerForElement(owner.ScrollHost);
+                    if (scrollPeer is IScrollProvider scrollProvider)
                     {
                         scrollPeer.EventsSource = this;
-                        return (IScrollProvider)scrollPeer;
+                        return scrollProvider;
                     }
                 }
             }
-            else if (patternInterface == PatternInterface.ItemContainer)
+            else if (patternInterface is PatternInterface.ItemContainer)
             {
-                if(Owner as ItemsControl != null)
+                if (Owner is ItemsControl)
                     return this;
+
                 return null;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/TreeViewAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/TreeViewAutomationPeer.cs
@@ -28,24 +28,12 @@ namespace System.Windows.Automation.Peers
         ///
         public override object GetPattern(PatternInterface patternInterface)
         {
-            if (patternInterface == PatternInterface.Selection)
+            if (patternInterface is PatternInterface.Selection)
             {
                 return this;
             }
-            else if(patternInterface == PatternInterface.Scroll)
-            {
-                ItemsControl owner = (ItemsControl)Owner;
-                if(owner.ScrollHost != null)
-                {
-                    AutomationPeer scrollPeer = UIElementAutomationPeer.CreatePeerForElement(owner.ScrollHost);
-                    if(scrollPeer != null && scrollPeer is IScrollProvider)
-                    {
-                        scrollPeer.EventsSource = this;
-                        return (IScrollProvider)scrollPeer;
-                    }
-                }
-            }
 
+            // PatternInterface.Scroll is handled by ItemsControlAutomationPeer
             return base.GetPattern(patternInterface);
         }
 
@@ -164,12 +152,7 @@ namespace System.Windows.Automation.Peers
                 }
             }
 
-            if (selection == null)
-            {
-                selection = Array.Empty<IRawElementProviderSimple>();
-            }
-
-            return selection;
+            return selection ?? Array.Empty<IRawElementProviderSimple>();
         }
 
         bool ISelectionProvider.CanSelectMultiple


### PR DESCRIPTION
## Description

Removes 1:1 duplicate code for `PatternInterface.Scroll` and forwards it to base (specifically, `ItemsControlAutomationPeer`).

## Customer Impact

Cleaner codebase for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low.
