### PR TITLE
Fix(Fluent): TextBox invalidation style

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
@@ -44,6 +44,7 @@
     <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
     <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
     <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
+    <Thickness x:Key="ErrorTemplateBorderPadding">1</Thickness>
 
     <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
     <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
@@ -44,7 +44,7 @@
     <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
     <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
     <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
-    <Thickness x:Key="ErrorTemplateBorderPadding">1</Thickness>
+    <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
 
     <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
     <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TextBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TextBox.xaml
@@ -233,8 +233,19 @@
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
+    <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
+        <Border
+            BorderBrush="{DynamicResource SystemFillColorCriticalBrush}"
+            BorderThickness="{DynamicResource TextControlBorderThemeThickness}"
+            CornerRadius="{DynamicResource ControlCornerRadius}"
+            Padding="{StaticResource ErrorTemplateBorderPadding}">
+            <AdornedElementPlaceholder />
+        </Border>
+    </ControlTemplate>
+
     <Style x:Key="DefaultTextBoxStyle" TargetType="{x:Type TextBox}">
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource DefaultTextBoxInvalidationStyle}" />
         <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
         <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TextBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TextBox.xaml
@@ -238,7 +238,7 @@
             BorderBrush="{DynamicResource SystemFillColorCriticalBrush}"
             BorderThickness="{DynamicResource TextControlBorderThemeThickness}"
             CornerRadius="{DynamicResource ControlCornerRadius}"
-            Padding="{StaticResource ErrorTemplateBorderPadding}">
+            Padding="{StaticResource TextControlErrorBorderPadding}">
             <AdornedElementPlaceholder />
         </Border>
     </ControlTemplate>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -4959,8 +4959,14 @@
       </Trigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>
+  <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
+    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="1">
+      <AdornedElementPlaceholder />
+    </Border>
+  </ControlTemplate>
   <Style x:Key="DefaultTextBoxStyle" TargetType="{x:Type TextBox}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource DefaultTextBoxInvalidationStyle}" />
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
     <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
     <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -78,6 +78,7 @@
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
   <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
+  <Thickness x:Key="ErrorTemplateBorderPadding">1</Thickness>
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
@@ -4960,7 +4961,7 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
-    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="1">
+    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="{StaticResource ErrorTemplateBorderPadding}">
       <AdornedElementPlaceholder />
     </Border>
   </ControlTemplate>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -78,7 +78,7 @@
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
   <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
-  <Thickness x:Key="ErrorTemplateBorderPadding">1</Thickness>
+  <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
@@ -4961,7 +4961,7 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
-    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="{StaticResource ErrorTemplateBorderPadding}">
+    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="{StaticResource TextControlErrorBorderPadding}">
       <AdornedElementPlaceholder />
     </Border>
   </ControlTemplate>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -4872,8 +4872,14 @@
       </Trigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>
+  <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
+    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="1">
+      <AdornedElementPlaceholder />
+    </Border>
+  </ControlTemplate>
   <Style x:Key="DefaultTextBoxStyle" TargetType="{x:Type TextBox}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource DefaultTextBoxInvalidationStyle}" />
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
     <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
     <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -78,7 +78,7 @@
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
   <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
-  <Thickness x:Key="ErrorTemplateBorderPadding">1</Thickness>
+  <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
@@ -4874,7 +4874,7 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
-    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="{StaticResource ErrorTemplateBorderPadding}">
+    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="{StaticResource TextControlErrorBorderPadding}">
       <AdornedElementPlaceholder />
     </Border>
   </ControlTemplate>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -78,6 +78,7 @@
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
   <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
+  <Thickness x:Key="ErrorTemplateBorderPadding">1</Thickness>
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
@@ -4873,7 +4874,7 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
-    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="1">
+    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="{StaticResource ErrorTemplateBorderPadding}">
       <AdornedElementPlaceholder />
     </Border>
   </ControlTemplate>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -78,6 +78,7 @@
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
   <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
+  <Thickness x:Key="ErrorTemplateBorderPadding">1</Thickness>
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
@@ -4969,7 +4970,7 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
-    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="1">
+    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="{StaticResource ErrorTemplateBorderPadding}">
       <AdornedElementPlaceholder />
     </Border>
   </ControlTemplate>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -4968,8 +4968,14 @@
       </Trigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>
+  <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
+    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="1">
+      <AdornedElementPlaceholder />
+    </Border>
+  </ControlTemplate>
   <Style x:Key="DefaultTextBoxStyle" TargetType="{x:Type TextBox}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource DefaultTextBoxInvalidationStyle}" />
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
     <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
     <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -78,7 +78,7 @@
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
   <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
-  <Thickness x:Key="ErrorTemplateBorderPadding">1</Thickness>
+  <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
@@ -4970,7 +4970,7 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
-    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="{StaticResource ErrorTemplateBorderPadding}">
+    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="{StaticResource TextControlErrorBorderPadding}">
       <AdornedElementPlaceholder />
     </Border>
   </ControlTemplate>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
@@ -78,6 +78,7 @@
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
   <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
+  <Thickness x:Key="ErrorTemplateBorderPadding">1</Thickness>
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
@@ -4219,7 +4220,7 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
-    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="1">
+    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="{StaticResource ErrorTemplateBorderPadding}">
       <AdornedElementPlaceholder />
     </Border>
   </ControlTemplate>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
@@ -78,7 +78,7 @@
   <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
   <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
   <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
-  <Thickness x:Key="ErrorTemplateBorderPadding">1</Thickness>
+  <Thickness x:Key="TextControlErrorBorderPadding">1</Thickness>
   <system:Double x:Key="ComboBoxMinHeight">24</system:Double>
   <!-- <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness> -->
   <system:Double x:Key="NavigationViewItemOnLeftMinHeight">32</system:Double>
@@ -4220,7 +4220,7 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
-    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="{StaticResource ErrorTemplateBorderPadding}">
+    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="{StaticResource TextControlErrorBorderPadding}">
       <AdornedElementPlaceholder />
     </Border>
   </ControlTemplate>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
@@ -4218,8 +4218,14 @@
       </Trigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>
+  <ControlTemplate x:Key="DefaultTextBoxInvalidationStyle">
+    <Border BorderBrush="{DynamicResource SystemFillColorCriticalBrush}" BorderThickness="{DynamicResource TextControlBorderThemeThickness}" CornerRadius="{DynamicResource ControlCornerRadius}" Padding="1">
+      <AdornedElementPlaceholder />
+    </Border>
+  </ControlTemplate>
   <Style x:Key="DefaultTextBoxStyle" TargetType="{x:Type TextBox}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource DefaultTextBoxInvalidationStyle}" />
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
     <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
     <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />


### PR DESCRIPTION
Fixes #10826 

## Description
The invalidation style for the Fluent theme was not altered, resulting in the rendering of styles defined by the Aero theme. These changes add an error template for a textbox to align with Fluent design.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Better looking UI
<!-- What is the impact to customers of not taking this fix? -->

## Regression
_None_
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local build pass
Validated with a sample application
<!-- What kind of testing has been done with the fix. -->

## Risk
Low
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10887)