### PR TITLE
Refactor WeakReferenceList/CopyOnWriteList as type-safe generic collections

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
@@ -449,7 +449,7 @@ namespace System.Windows
             // To fire PresentationSourceChanged when the RootVisual changes;
             // rather than simulate a "parent" pointer change, we just walk the
             // collection of all nodes that need the event.
-            foreach (DependencyObject element in _watchers)
+            foreach (DependencyObject element in s_watchers)
             {
                 // We only need to update those elements that are in the
                 // same context as this presentation source.
@@ -475,7 +475,7 @@ namespace System.Windows
         /// </summary>
         protected void AddSource()
         {
-            _sources.Add(this);
+            s_sources.Add(this);
         }
 
         /// <summary>
@@ -483,7 +483,7 @@ namespace System.Windows
         /// </summary>
         protected void RemoveSource()
         {
-            _sources.Remove(this);
+            s_sources.Remove(this);
         }
 
         /// <summary>
@@ -613,17 +613,14 @@ namespace System.Windows
         ///   over a ReadOnly SnapShot of the List of sources.  The Enumerator
         ///   skips over the any dead weak references in the list.
         /// </summary>
-        internal static WeakReferenceList CriticalCurrentSources
+        internal static WeakReferenceList<PresentationSource> CriticalCurrentSources
         {
-            get
-            {
-                return _sources;
-            }
+            get => s_sources;
         }
 
         private static void AddElementToWatchList(DependencyObject element)
         {
-            if(_watchers.Add(element))
+            if (s_watchers.Add(element))
             {
                 element.SetValue(CachedSourceProperty, PresentationSource.FindSource(element));
                 element.SetValue(GetsSourceChangedEventProperty, true);
@@ -633,7 +630,7 @@ namespace System.Windows
 
         private static void RemoveElementFromWatchList(DependencyObject element)
         {
-            if(_watchers.Remove(element))
+            if (s_watchers.Remove(element))
             {
                 element.ClearValue(CachedSourceProperty);
                 element.ClearValue(GetsSourceChangedEventProperty);
@@ -741,11 +738,11 @@ namespace System.Windows
         private static readonly object _globalLock = new object();
 
         // An array of weak-references to sources that we know about.
-        private static WeakReferenceList _sources = new WeakReferenceList(_globalLock);
+        private static readonly WeakReferenceList<PresentationSource> s_sources = new(_globalLock);
 
         // An array of weak-references to elements that need to know
         // about source changes.
-        private static WeakReferenceList _watchers = new WeakReferenceList(_globalLock);
+        private static readonly WeakReferenceList<DependencyObject> s_watchers = new(_globalLock);
 
         #endregion
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/ResourceDictionaryDiagnostics.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/ResourceDictionaryDiagnostics.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -51,7 +51,7 @@ namespace System.Windows.Diagnostics
             {
                 if (!IsEnabled)
                 {
-                    return ResourceDictionaryDiagnostics.EmptyResourceDictionaryInfos;
+                    return ReadOnlyCollection<ResourceDictionaryInfo>.Empty;
                 }
 
                 return SystemResources.ThemedResourceDictionaries;
@@ -69,7 +69,7 @@ namespace System.Windows.Diagnostics
             {
                 if (!IsEnabled)
                 {
-                    return ResourceDictionaryDiagnostics.EmptyResourceDictionaryInfos;
+                    return ReadOnlyCollection<ResourceDictionaryInfo>.Empty;
                 }
 
                 return SystemResources.GenericResourceDictionaries;
@@ -276,46 +276,30 @@ namespace System.Windows.Diagnostics
 
         public static IEnumerable<FrameworkElement> GetFrameworkElementOwners(ResourceDictionary dictionary)
         {
-            return GetOwners<FrameworkElement>(dictionary.FrameworkElementOwners, EmptyFrameworkElementList);
+            return GetOwners(dictionary.FrameworkElementOwners);
         }
 
         public static IEnumerable<FrameworkContentElement> GetFrameworkContentElementOwners(ResourceDictionary dictionary)
         {
-            return GetOwners<FrameworkContentElement>(dictionary.FrameworkContentElementOwners, EmptyFrameworkContentElementList);
+            return GetOwners(dictionary.FrameworkContentElementOwners);
         }
 
         public static IEnumerable<Application> GetApplicationOwners(ResourceDictionary dictionary)
         {
-            return GetOwners<Application>(dictionary.ApplicationOwners, EmptyApplicationList);
+            return GetOwners(dictionary.ApplicationOwners);
         }
 
-        private static IEnumerable<T> GetOwners<T>(WeakReferenceList list, IEnumerable<T> emptyList)
+        private static IEnumerable<T> GetOwners<T>(WeakReferenceList<T> list)
             where T : DispatcherObject
         {
             if (!IsEnabled || list == null || list.Count == 0)
             {
-                return emptyList;
+                return Array.Empty<T>();
             }
 
-            List<T> result = new List<T>(list.Count);
-            foreach (Object o in list)
-            {
-                T owner = o as T;
-                if (owner != null)
-                {
-                    result.Add(owner);
-                }
-            }
-
-            return result.AsReadOnly();
+            // Create a read-only copy of the list
+            return new List<T>(list).AsReadOnly();
         }
-
-        private static IReadOnlyCollection<FrameworkElement> EmptyFrameworkElementList
-            => Array.Empty<FrameworkElement>();
-        private static IReadOnlyCollection<FrameworkContentElement> EmptyFrameworkContentElementList
-            => Array.Empty<FrameworkContentElement>();
-        private static IReadOnlyCollection<Application> EmptyApplicationList
-            => Array.Empty<Application>();
 
         #endregion
 
@@ -548,7 +532,5 @@ namespace System.Windows.Diagnostics
 
         internal static bool IsEnabled { get; private set; }
 
-        private static readonly ReadOnlyCollection<ResourceDictionaryInfo> EmptyResourceDictionaryInfos
-            = new List<ResourceDictionaryInfo>().AsReadOnly();
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/ResourceDictionaryDiagnostics.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/ResourceDictionaryDiagnostics.cs
@@ -297,8 +297,15 @@ namespace System.Windows.Diagnostics
                 return Array.Empty<T>();
             }
 
+            // Copy list manually as it doesn't implement ICollection<T>
+            List<T> owners = new List<T>(list.Count);
+            foreach (T item in list)
+            {
+                owners.Add(item);
+            }
+
             // Create a read-only copy of the list
-            return new List<T>(list).AsReadOnly();
+            return owners.AsReadOnly();
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1816,7 +1816,6 @@ namespace System.Windows
         /// </summary>
         private void ValidateDeferredResourceReferences(object resourceKey)
         {
-            
             if (_weakDeferredResourceReferencesMap is null)
             {
                 return;
@@ -1824,36 +1823,29 @@ namespace System.Windows
 
             if (resourceKey is null)
             {
-                foreach (var weakDeferredResourceReferences in _weakDeferredResourceReferencesMap.Values)
+                foreach (WeakReferenceList<DeferredResourceReference> weakReferencesList in _weakDeferredResourceReferencesMap.Values)
                 {
-                    foreach (var weakResourceReference in weakDeferredResourceReferences)
+                    foreach (DeferredResourceReference weakReference in weakReferencesList)
                     {
-                        DeferredResourceReference deferredResourceReference = weakResourceReference as DeferredResourceReference;
-
-                        Inflate(deferredResourceReference);
+                        Inflate(weakReference);
                     }
                 }
             }
             else
             {
-                if (_weakDeferredResourceReferencesMap.TryGetValue(resourceKey, out var weakDeferredResourceReferences))
+                if (_weakDeferredResourceReferencesMap.TryGetValue(resourceKey, out WeakReferenceList<DeferredResourceReference> weakReferencesList))
                 {
-                    foreach (var weakResourceReference in weakDeferredResourceReferences)
+                    foreach (DeferredResourceReference weakReference in weakReferencesList)
                     {
-                        DeferredResourceReference deferredResourceReference = weakResourceReference as DeferredResourceReference;
-
-                        Inflate(deferredResourceReference);
+                        Inflate(weakReference);
                     }
                 }
             }
 
-            return;
-
-            void Inflate(DeferredResourceReference deferredResourceReference)
+            static void Inflate(DeferredResourceReference deferredResourceReference)
             {
-                // This will inflate the deferred reference, causing it
-                // to be removed from the list.  The list may also be
-                // purged of dead references.
+                // This will inflate the deferred reference, causing it to be removed from the list.
+                // The list may also be purged of dead references.
                 deferredResourceReference?.GetValue(BaseValueSourceInternal.Unknown);
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1811,7 +1811,7 @@ namespace System.Windows
 
             if (!_weakDeferredResourceReferencesMap.TryGetValue(resourceKey, out var weakDeferredResourceReferences))
             {
-                weakDeferredResourceReferences = new WeakReferenceList<DeferredResourceReference>();
+                weakDeferredResourceReferences = new WeakReferenceList<DeferredResourceReference>(syncRoot: null);
                 _weakDeferredResourceReferencesMap[resourceKey] = weakDeferredResourceReferences;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1628,32 +1628,28 @@ namespace System.Windows
             RemoveOwnerFromAllMergedDictionaries(owner);
         }
 
-        // Check if the given is an owner to this dictionary
-        internal bool ContainsOwner(DispatcherObject owner)
+        /// <summary>
+        /// Checks if the given <paramref name="owner"/> is owning this dictionary
+        /// </summary>
+        internal bool ContainsOwner(FrameworkElement owner)
         {
-            FrameworkElement fe = owner as FrameworkElement;
-            if (fe != null)
-            {
-                return (_ownerFEs != null && _ownerFEs.Contains(fe));
-            }
-            else
-            {
-                FrameworkContentElement fce = owner as FrameworkContentElement;
-                if (fce != null)
-                {
-                    return (_ownerFCEs != null && _ownerFCEs.Contains(fce));
-                }
-                else
-                {
-                    Application app = owner as Application;
-                    if (app != null)
-                    {
-                        return (_ownerApps != null && _ownerApps.Contains(app));
-                    }
-                }
-            }
+            return _ownerFEs?.Contains(owner) ?? false;
+        }
 
-            return false;
+        /// <summary>
+        /// Checks if the given <paramref name="owner"/> is owning this dictionary
+        /// </summary>
+        internal bool ContainsOwner(FrameworkContentElement owner)
+        {
+            return _ownerFCEs?.Contains(owner) ?? false;
+        }
+
+        /// <summary>
+        /// Checks if the given <paramref name="owner"/> is owning this dictionary
+        /// </summary>
+        internal bool ContainsOwner(Application owner)
+        {
+            return _ownerApps?.Contains(owner) ?? false;
         }
 
         // Helper method that tries to set IsInitialized to true if BeginInit hasn't been called before this.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1495,7 +1495,7 @@ namespace System.Windows
             {
                 if (_ownerFEs == null)
                 {
-                    _ownerFEs = new WeakReferenceList(1);
+                    _ownerFEs = new WeakReferenceList<FrameworkElement>(1);
                 }
                 else if (_ownerFEs.Contains(fe) && ContainsCycle(this))
                 {
@@ -1517,7 +1517,7 @@ namespace System.Windows
                 {
                     if (_ownerFCEs == null)
                     {
-                        _ownerFCEs = new WeakReferenceList(1);
+                        _ownerFCEs = new WeakReferenceList<FrameworkContentElement>(1);
                     }
                     else if (_ownerFCEs.Contains(fce) && ContainsCycle(this))
                     {
@@ -1539,7 +1539,7 @@ namespace System.Windows
                     {
                         if (_ownerApps == null)
                         {
-                            _ownerApps = new WeakReferenceList(1);
+                            _ownerApps = new WeakReferenceList<Application>(1);
                         }
                         else if (_ownerApps.Contains(app) && ContainsCycle(this))
                         {
@@ -1805,14 +1805,14 @@ namespace System.Windows
             return GetValue(resourceKey, out canCache);
         }
 
-        private WeakReferenceList GetOrCreateWeakReferenceList(object resourceKey)
+        private WeakReferenceList<DeferredResourceReference> GetOrCreateWeakReferenceList(object resourceKey)
         {
-            this._weakDeferredResourceReferencesMap ??= new();
+            _weakDeferredResourceReferencesMap ??= new Dictionary<object, WeakReferenceList<DeferredResourceReference>>();
 
-            if (!this._weakDeferredResourceReferencesMap.TryGetValue(resourceKey, out var weakDeferredResourceReferences))
+            if (!_weakDeferredResourceReferencesMap.TryGetValue(resourceKey, out var weakDeferredResourceReferences))
             {
-                weakDeferredResourceReferences = new WeakReferenceList();
-                this._weakDeferredResourceReferencesMap[resourceKey] = weakDeferredResourceReferences;
+                weakDeferredResourceReferences = new WeakReferenceList<DeferredResourceReference>();
+                _weakDeferredResourceReferencesMap[resourceKey] = weakDeferredResourceReferences;
             }
 
             return weakDeferredResourceReferences;
@@ -1820,8 +1820,7 @@ namespace System.Windows
 
         internal void RemoveDeferredResourceReference(DeferredResourceReference deferredResourceReference)
         {
-            
-            if (this._weakDeferredResourceReferencesMap?.TryGetValue(deferredResourceReference.Key, out var weakDeferredResourceReferences) is true)
+            if (_weakDeferredResourceReferencesMap?.TryGetValue(deferredResourceReference.Key, out var weakDeferredResourceReferences) is true)
             {
                 weakDeferredResourceReferences.Remove(deferredResourceReference);
             }
@@ -2012,14 +2011,12 @@ namespace System.Windows
 
                 if (mergedDictionary._ownerFEs == null)
                 {
-                    mergedDictionary._ownerFEs = new WeakReferenceList(_ownerFEs.Count);
+                    mergedDictionary._ownerFEs = new WeakReferenceList<FrameworkElement>(_ownerFEs.Count);
                 }
 
-                foreach (object o in _ownerFEs)
+                foreach (FrameworkElement fe in _ownerFEs)
                 {
-                    FrameworkElement fe = o as FrameworkElement;
-                    if (fe != null)
-                        mergedDictionary.AddOwner(fe);
+                    mergedDictionary.AddOwner(fe);
                 }
             }
 
@@ -2029,14 +2026,12 @@ namespace System.Windows
 
                 if (mergedDictionary._ownerFCEs == null)
                 {
-                    mergedDictionary._ownerFCEs = new WeakReferenceList(_ownerFCEs.Count);
+                    mergedDictionary._ownerFCEs = new WeakReferenceList<FrameworkContentElement>(_ownerFCEs.Count);
                 }
 
-                foreach (object o in _ownerFCEs)
+                foreach (FrameworkContentElement fce in _ownerFCEs)
                 {
-                    FrameworkContentElement fce = o as FrameworkContentElement;
-                    if (fce != null)
-                        mergedDictionary.AddOwner(fce);
+                    mergedDictionary.AddOwner(fce);
                 }
             }
 
@@ -2046,14 +2041,12 @@ namespace System.Windows
 
                 if (mergedDictionary._ownerApps == null)
                 {
-                    mergedDictionary._ownerApps = new WeakReferenceList(_ownerApps.Count);
+                    mergedDictionary._ownerApps = new WeakReferenceList<Application>(_ownerApps.Count);
                 }
 
-                foreach (object o in _ownerApps)
+                foreach (Application app in _ownerApps)
                 {
-                    Application app = o as Application;
-                    if (app != null)
-                        mergedDictionary.AddOwner(app);
+                    mergedDictionary.AddOwner(app);
                 }
             }
         }
@@ -2118,19 +2111,19 @@ namespace System.Windows
 
         // three properties used by ResourceDictionaryDiagnostics
 
-        internal WeakReferenceList FrameworkElementOwners
+        internal WeakReferenceList<FrameworkElement> FrameworkElementOwners
         {
-            get { return _ownerFEs; }
+            get => _ownerFEs;
         }
 
-        internal WeakReferenceList FrameworkContentElementOwners
+        internal WeakReferenceList<FrameworkContentElement> FrameworkContentElementOwners
         {
-            get { return _ownerFCEs; }
+            get => _ownerFCEs;
         }
 
-        internal WeakReferenceList ApplicationOwners
+        internal WeakReferenceList<Application> ApplicationOwners
         {
-            get { return _ownerApps; }
+            get => _ownerApps;
         }
 
         #endregion HelperMethods
@@ -2619,11 +2612,12 @@ namespace System.Windows
 
         #region Data
 
+        private WeakReferenceList<FrameworkElement> _ownerFEs;
+        private WeakReferenceList<FrameworkContentElement> _ownerFCEs;
+        private WeakReferenceList<Application> _ownerApps;
+        private Dictionary<object, WeakReferenceList<DeferredResourceReference>> _weakDeferredResourceReferencesMap;
+
         private Hashtable                                 _baseDictionary = null;
-        private WeakReferenceList                         _ownerFEs = null;
-        private WeakReferenceList                         _ownerFCEs = null;
-        private WeakReferenceList                         _ownerApps = null;
-        private Dictionary<object, WeakReferenceList>     _weakDeferredResourceReferencesMap = null;
         private ObservableCollection<ResourceDictionary>  _mergedDictionaries = null;
         private Uri                                       _source = null;
         private Uri                                       _baseUri = null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1681,62 +1681,50 @@ namespace System.Windows
             if (shouldInvalidate || hasImplicitStyles)
             {
                 // Invalidate all FE owners
-                if (_ownerFEs != null)
+                if (_ownerFEs is not null)
                 {
-                    foreach (Object o in _ownerFEs)
+                    foreach (FrameworkElement fe in _ownerFEs)
                     {
-                        FrameworkElement fe = o as FrameworkElement;
-                        if (fe != null)
-                        {
-                            // Set the HasImplicitStyles flag on the owner
-                            if (hasImplicitStyles)
-                                fe.ShouldLookupImplicitStyles = true;
+                        // Set the HasImplicitStyles flag on the owner
+                        if (hasImplicitStyles)
+                            fe.ShouldLookupImplicitStyles = true;
 
-                            // If this dictionary has been initialized fire an invalidation
-                            // to let the tree know of this change.
-                            if (shouldInvalidate)
-                                TreeWalkHelper.InvalidateOnResourcesChange(fe, null, info);
-                        }
+                        // If this dictionary has been initialized fire an invalidation
+                        // to let the tree know of this change.
+                        if (shouldInvalidate)
+                            TreeWalkHelper.InvalidateOnResourcesChange(fe, null, info);
                     }
                 }
 
                 // Invalidate all FCE owners
-                if (_ownerFCEs != null)
+                if (_ownerFCEs is not null)
                 {
-                    foreach (Object o in _ownerFCEs)
+                    foreach (FrameworkContentElement fce in _ownerFCEs)
                     {
-                        FrameworkContentElement fce = o as FrameworkContentElement;
-                        if (fce != null)
-                        {
-                            // Set the HasImplicitStyles flag on the owner
-                            if (hasImplicitStyles)
-                                fce.ShouldLookupImplicitStyles = true;
+                        // Set the HasImplicitStyles flag on the owner
+                        if (hasImplicitStyles)
+                            fce.ShouldLookupImplicitStyles = true;
 
-                            // If this dictionary has been initialized fire an invalidation
-                            // to let the tree know of this change.
-                            if (shouldInvalidate)
-                                TreeWalkHelper.InvalidateOnResourcesChange(null, fce, info);
-                        }
+                        // If this dictionary has been initialized fire an invalidation
+                        // to let the tree know of this change.
+                        if (shouldInvalidate)
+                            TreeWalkHelper.InvalidateOnResourcesChange(null, fce, info);
                     }
                 }
 
                 // Invalidate all App owners
-                if (_ownerApps != null)
+                if (_ownerApps is not null)
                 {
-                    foreach (Object o in _ownerApps)
+                    foreach (Application app in _ownerApps)
                     {
-                        Application app = o as Application;
-                        if (app != null)
-                        {
-                            // Set the HasImplicitStyles flag on the owner
-                            if (hasImplicitStyles)
-                                app.HasImplicitStylesInResources = true;
+                        // Set the HasImplicitStyles flag on the owner
+                        if (hasImplicitStyles)
+                            app.HasImplicitStylesInResources = true;
 
-                            // If this dictionary has been initialized fire an invalidation
-                            // to let the tree know of this change.
-                            if (shouldInvalidate)
-                                app.InvalidateResourceReferences(info);
-                        }
+                        // If this dictionary has been initialized fire an invalidation
+                        // to let the tree know of this change.
+                        if (shouldInvalidate)
+                            app.InvalidateResourceReferences(info);
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -2048,37 +2048,31 @@ namespace System.Windows
         /// <param name="mergedDictionary"></param>
         internal void RemoveParentOwners(ResourceDictionary mergedDictionary)
         {
-            if (_ownerFEs != null)
+            if (_ownerFEs is not null)
             {
-                foreach (Object o in _ownerFEs)
+                foreach (FrameworkElement fe in _ownerFEs)
                 {
-                    FrameworkElement fe = o as FrameworkElement;
                     mergedDictionary.RemoveOwner(fe);
-
                 }
             }
 
-            if (_ownerFCEs != null)
+            if (_ownerFCEs is not null)
             {
                 Invariant.Assert(_ownerFCEs.Count > 0);
 
-                foreach (Object o in _ownerFCEs)
+                foreach (FrameworkContentElement fec in _ownerFCEs)
                 {
-                    FrameworkContentElement fec = o as FrameworkContentElement;
                     mergedDictionary.RemoveOwner(fec);
-
                 }
             }
 
-            if (_ownerApps != null)
+            if (_ownerApps is not null)
             {
                 Invariant.Assert(_ownerApps.Count > 0);
 
-                foreach (Object o in _ownerApps)
+                foreach (Application app in _ownerApps)
                 {
-                    Application app = o as Application;
                     mergedDictionary.RemoveOwner(app);
-
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -1791,10 +1791,8 @@ namespace System.Windows
 
         internal void AddInflatedListener(ResourceReferenceExpression listener)
         {
-            if (_inflatedList == null)
-            {
-                _inflatedList = new WeakReferenceList(this);
-            }
+            _inflatedList ??= new WeakReferenceList<ResourceReferenceExpression>(this);
+
             _inflatedList.Add(listener);
         }
 
@@ -1837,7 +1835,7 @@ namespace System.Windows
         private ResourceDictionary _dictionary;
         protected object _key;
         protected object _value;
-        private WeakReferenceList _inflatedList;
+        private WeakReferenceList<ResourceReferenceExpression> _inflatedList;
 
         #endregion Data
     }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CopyOnWriteList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CopyOnWriteList.cs
@@ -1,200 +1,198 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Collections.ObjectModel;
 
-namespace MS.Internal
+namespace MS.Internal;
+
+/// <summary>
+///   This is a ThreadSafe ArrayList that uses Copy On Write to support consistency.
+///   - When the "List" property is requested a readonly reference to the
+///   list is returned and a reference to the readonly list is cached.
+///   - If the "List" is requested again, the same cached reference is returned.
+///   - When the list is modified, if a readonly reference is present in the
+///   cache then the list is copied before it is modified and the readonly list is
+///   released from the cache.
+/// </summary>
+internal class CopyOnWriteList<T>
 {
-    /// <summary>
-    ///   This is a ThreadSafe ArrayList that uses Copy On Write to support consistency.
-    ///   - When the "List" property is requested a readonly reference to the
-    ///   list is returned and a reference to the readonly list is cached.
-    ///   - If the "List" is requested again, the same cached reference is returned.
-    ///   - When the list is modified, if a readonly reference is present in the
-    ///   cache then the list is copied before it is modified and the readonly list is
-    ///   released from the cache.
-    /// </summary>
-    internal class CopyOnWriteList<T>
+    private ReadOnlyCollection<T> _readonlyWrapper;
+    private List<T> _listList;
+
+    private readonly object _syncRoot;
+
+    public CopyOnWriteList() : this(null)
     {
-        private ReadOnlyCollection<T> _readonlyWrapper;
-        private List<T> _listList;
+    }
 
-        private readonly object _syncRoot;
+    public CopyOnWriteList(object syncRoot)
+    {
+        syncRoot ??= new object();
 
-        public CopyOnWriteList() : this(null)
+        _syncRoot = syncRoot;
+        _listList = new List<T>();
+    }
+
+    /// <summary>
+    ///   Return a readonly wrapper of the list.  Note: this is NOT a copy.
+    ///   A non-null _readonlyWrapper  is a "Copy on Write" flag.
+    ///   Methods that change the list (eg. Add() and Remove()) are
+    ///   responsible for:
+    ///    1) Checking _readonlyWrapper and copying the list before modifying it.
+    ///    2) Clearing _readonlyWrapper.
+    /// </summary>
+    public ReadOnlyCollection<T> List
+    {
+        get
         {
-        }
-
-        public CopyOnWriteList(object syncRoot)
-        {
-            syncRoot ??= new object();
-
-            _syncRoot = syncRoot;
-            _listList = new List<T>();
-        }
-
-        /// <summary>
-        ///   Return a readonly wrapper of the list.  Note: this is NOT a copy.
-        ///   A non-null _readonlyWrapper  is a "Copy on Write" flag.
-        ///   Methods that change the list (eg. Add() and Remove()) are
-        ///   responsible for:
-        ///    1) Checking _readonlyWrapper and copying the list before modifying it.
-        ///    2) Clearing _readonlyWrapper.
-        /// </summary>
-        public ReadOnlyCollection<T> List
-        {
-            get
-            {
-                ReadOnlyCollection<T> tempList;
-
-                lock (_syncRoot)
-                {
-                    _readonlyWrapper ??= _listList.AsReadOnly();
-
-                    tempList = _readonlyWrapper;
-                }
-
-                return tempList;
-            }
-        }
-
-        /// <summary>
-        ///   Add an object to the List.
-        ///   Returns true if successfully added.
-        ///   Returns false if object is already on the list.
-        /// </summary>
-        public virtual bool Add(T obj)
-        {
-            Debug.Assert(obj is not null, "CopyOnWriteList.Add() should not be passed null.");
+            ReadOnlyCollection<T> tempList;
 
             lock (_syncRoot)
             {
-                int index = Find(obj);
+                _readonlyWrapper ??= _listList.AsReadOnly();
 
-                if (index >= 0)
-                    return false;
-
-                return Internal_Add(obj);
+                tempList = _readonlyWrapper;
             }
+
+            return tempList;
         }
+    }
 
-        /// <summary>
-        ///   Remove an object from the List.
-        ///   Returns true if successfully removed.
-        ///   Returns false if object was not on the list.
-        /// </summary>
-        public virtual bool Remove(T obj)
+    /// <summary>
+    ///   Add an object to the List.
+    ///   Returns true if successfully added.
+    ///   Returns false if object is already on the list.
+    /// </summary>
+    public virtual bool Add(T obj)
+    {
+        Debug.Assert(obj is not null, "CopyOnWriteList.Add() should not be passed null.");
+
+        lock (_syncRoot)
         {
-            Debug.Assert(obj is not null, "CopyOnWriteList.Remove() should not be passed null.");
-            lock (_syncRoot)
-            {
-                int index = Find(obj);
+            int index = Find(obj);
 
-                // If the object is not on the list then
-                // we are done.  (return false)
-                if (index < 0)
-                    return false;
-
-                return RemoveAt(index);
-            }
-        }
-
-        /// <summary>
-        ///   This allows derived classes to take the lock.  This is mostly used
-        ///   to extend Add() and Remove() etc.
-        /// </summary>
-        protected object SyncRoot
-        {
-            get { return _syncRoot; }
-        }
-
-        /// <summary>
-        ///  This is protected and the caller can get into real serious trouble
-        ///  using this.  Because this points at the real current list without
-        ///  any copy on write protection.  So the caller must really know what
-        ///  they are doing.
-        /// </summary>
-        protected List<T> LiveList
-        {
-            get { return _listList; }
-        }
-
-        /// <summary>
-        ///   Add an object to the List.
-        ///   Without any error checks.
-        ///   For use by derived classes that implement there own error checks.
-        /// </summary>
-        protected bool Internal_Add(T obj)
-        {
-            DoCopyOnWriteCheck();
-
-            _listList.Add(obj);
-
-            return true;
-        }
-
-        /// <summary>
-        ///   Insert an object into the List at the given index.
-        ///   Without any error checks.
-        ///   For use by derived classes that implement there own error checks.
-        /// </summary>
-        protected bool Internal_Insert(int index, T obj)
-        {
-            DoCopyOnWriteCheck();
-
-            _listList.Insert(index, obj);
-
-            return true;
-        }
-
-        /// <summary>
-        ///   Find an object on the List.
-        /// </summary>
-        private int Find(T obj)
-        {
-            // syncRoot Lock MUST be held by the caller.
-            for (int i = 0; i < _listList.Count; i++)
-            {
-                if (obj.Equals(_listList[i]))
-                {
-                    return i;
-                }
-            }
-            return -1;
-        }
-
-        /// <summary>
-        ///   Remove the object at a given index from the List.
-        ///   Returns true if successfully removed.
-        ///   Returns false if index is outside the range of the list.
-        ///
-        ///  This is protected because it operates on the LiveList
-        /// </summary>
-        protected bool RemoveAt(int index)
-        {
-            // syncRoot Lock MUST be held by the caller.
-            if (index < 0 || index >= _listList.Count)
+            if (index >= 0)
                 return false;
 
-            DoCopyOnWriteCheck();
-
-            _listList.RemoveAt(index);
-
-            return true;
+            return Internal_Add(obj);
         }
+    }
 
-        protected void DoCopyOnWriteCheck()
+    /// <summary>
+    ///   Remove an object from the List.
+    ///   Returns true if successfully removed.
+    ///   Returns false if object was not on the list.
+    /// </summary>
+    public virtual bool Remove(T obj)
+    {
+        Debug.Assert(obj is not null, "CopyOnWriteList.Remove() should not be passed null.");
+        lock (_syncRoot)
         {
-            // syncRoot Lock MUST be held by the caller.
-            // If we have exposed (given out) a readonly reference to this
-            // version of the list, then clone a new internal copy and cut
-            // the old version free.
-            if (_readonlyWrapper is not null)
+            int index = Find(obj);
+
+            // If the object is not on the list then
+            // we are done.  (return false)
+            if (index < 0)
+                return false;
+
+            return RemoveAt(index);
+        }
+    }
+
+    /// <summary>
+    ///   This allows derived classes to take the lock.  This is mostly used
+    ///   to extend Add() and Remove() etc.
+    /// </summary>
+    protected object SyncRoot
+    {
+        get { return _syncRoot; }
+    }
+
+    /// <summary>
+    ///  This is protected and the caller can get into real serious trouble
+    ///  using this.  Because this points at the real current list without
+    ///  any copy on write protection.  So the caller must really know what
+    ///  they are doing.
+    /// </summary>
+    protected List<T> LiveList
+    {
+        get { return _listList; }
+    }
+
+    /// <summary>
+    ///   Add an object to the List.
+    ///   Without any error checks.
+    ///   For use by derived classes that implement there own error checks.
+    /// </summary>
+    protected bool Internal_Add(T obj)
+    {
+        DoCopyOnWriteCheck();
+
+        _listList.Add(obj);
+
+        return true;
+    }
+
+    /// <summary>
+    ///   Insert an object into the List at the given index.
+    ///   Without any error checks.
+    ///   For use by derived classes that implement there own error checks.
+    /// </summary>
+    protected bool Internal_Insert(int index, T obj)
+    {
+        DoCopyOnWriteCheck();
+
+        _listList.Insert(index, obj);
+
+        return true;
+    }
+
+    /// <summary>
+    ///   Find an object on the List.
+    /// </summary>
+    private int Find(T obj)
+    {
+        // syncRoot Lock MUST be held by the caller.
+        for (int i = 0; i < _listList.Count; i++)
+        {
+            if (obj.Equals(_listList[i]))
             {
-                _listList = new List<T>(_listList);
-                _readonlyWrapper = null;
+                return i;
             }
+        }
+        return -1;
+    }
+
+    /// <summary>
+    ///   Remove the object at a given index from the List.
+    ///   Returns true if successfully removed.
+    ///   Returns false if index is outside the range of the list.
+    ///
+    ///  This is protected because it operates on the LiveList
+    /// </summary>
+    protected bool RemoveAt(int index)
+    {
+        // syncRoot Lock MUST be held by the caller.
+        if (index < 0 || index >= _listList.Count)
+            return false;
+
+        DoCopyOnWriteCheck();
+
+        _listList.RemoveAt(index);
+
+        return true;
+    }
+
+    protected void DoCopyOnWriteCheck()
+    {
+        // syncRoot Lock MUST be held by the caller.
+        // If we have exposed (given out) a readonly reference to this
+        // version of the list, then clone a new internal copy and cut
+        // the old version free.
+        if (_readonlyWrapper is not null)
+        {
+            _listList = new List<T>(_listList);
+            _readonlyWrapper = null;
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CopyOnWriteList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CopyOnWriteList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -22,10 +22,8 @@ namespace MS.Internal
 
         public CopyOnWriteList(object syncRoot)
         {
-            if(syncRoot == null)
-            {
-                syncRoot = new Object();
-            }
+            syncRoot ??= new object();
+
             _syncRoot = syncRoot;
         }
 
@@ -34,7 +32,7 @@ namespace MS.Internal
         ///   A non-null _readonlyWrapper  is a "Copy on Write" flag.
         ///   Methods that change the list (eg. Add() and Remove()) are
         ///   responsible for:
-        ///    1) Checking _readonlyWrapper and copying the list before modifing it.
+        ///    1) Checking _readonlyWrapper and copying the list before modifying it.
         ///    2) Clearing _readonlyWrapper.
         /// </summary>
         public ArrayList List
@@ -43,9 +41,9 @@ namespace MS.Internal
             {
                 ArrayList tempList;
 
-                lock(_syncRoot)
+                lock (_syncRoot)
                 {
-                    if(null == _readonlyWrapper)
+                    if (null == _readonlyWrapper)
                         _readonlyWrapper = ArrayList.ReadOnly(_LiveList);
                     tempList = _readonlyWrapper;
                 }
@@ -60,12 +58,12 @@ namespace MS.Internal
         /// </summary>
         public virtual bool Add(object obj)
         {
-            Debug.Assert(null!=obj, "CopyOnWriteList.Add() should not be passed null.");
-            lock(_syncRoot)
+            Debug.Assert(null != obj, "CopyOnWriteList.Add() should not be passed null.");
+            lock (_syncRoot)
             {
                 int index = Find(obj);
 
-                if(index >= 0)
+                if (index >= 0)
                     return false;
 
                 return Internal_Add(obj);
@@ -79,14 +77,14 @@ namespace MS.Internal
         /// </summary>
         public virtual bool Remove(object obj)
         {
-            Debug.Assert(null!=obj, "CopyOnWriteList.Remove() should not be passed null.");
-            lock(_syncRoot)
+            Debug.Assert(null != obj, "CopyOnWriteList.Remove() should not be passed null.");
+            lock (_syncRoot)
             {
                 int index = Find(obj);
 
                 // If the object is not on the list then
                 // we are done.  (return false)
-                if(index < 0)
+                if (index < 0)
                     return false;
 
                 return RemoveAt(index);
@@ -99,7 +97,7 @@ namespace MS.Internal
         /// </summary>
         protected object SyncRoot
         {
-            get{ return _syncRoot; }
+            get { return _syncRoot; }
         }
 
         /// <summary>
@@ -110,7 +108,7 @@ namespace MS.Internal
         /// </summary>
         protected ArrayList LiveList
         {
-            get{ return _LiveList; }
+            get { return _LiveList; }
         }
 
         /// <summary>
@@ -143,9 +141,9 @@ namespace MS.Internal
         private int Find(object obj)
         {
             // syncRoot Lock MUST be held by the caller.
-            for(int i = 0; i < _LiveList.Count; i++)
+            for (int i = 0; i < _LiveList.Count; i++)
             {
-                if(obj == _LiveList[i])
+                if (obj == _LiveList[i])
                 {
                     return i;
                 }
@@ -163,7 +161,7 @@ namespace MS.Internal
         protected bool RemoveAt(int index)
         {
             // syncRoot Lock MUST be held by the caller.
-            if(index <0 || index >= _LiveList.Count )
+            if (index < 0 || index >= _LiveList.Count)
                 return false;
 
             DoCopyOnWriteCheck();
@@ -177,14 +175,14 @@ namespace MS.Internal
             // If we have exposed (given out) a readonly reference to this
             // version of the list, then clone a new internal copy and cut
             // the old version free.
-            if(null != _readonlyWrapper)
+            if (null != _readonlyWrapper)
             {
                 _LiveList = (ArrayList)_LiveList.Clone();
                 _readonlyWrapper = null;
             }
         }
 
-        private object _syncRoot;
+        private readonly object _syncRoot;
         private ArrayList _LiveList = new ArrayList();
         private ArrayList _readonlyWrapper;
     }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CopyOnWriteList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CopyOnWriteList.cs
@@ -16,7 +16,7 @@ namespace MS.Internal;
 ///   cache then the list is copied before it is modified and the readonly list is
 ///   released from the cache.
 /// </summary>
-internal class CopyOnWriteList<T> where T : notnull
+internal class CopyOnWriteList<T> where T : class
 {
     private ReadOnlyCollection<T>? _readonlyWrapper;
     private List<T> _listList;
@@ -159,7 +159,7 @@ internal class CopyOnWriteList<T> where T : notnull
         // syncRoot Lock MUST be held by the caller.
         for (int i = 0; i < _listList.Count; i++)
         {
-            if (obj.Equals(_listList[i]))
+            if (obj == _listList[i])
             {
                 return i;
             }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CopyOnWriteList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CopyOnWriteList.cs
@@ -31,6 +31,12 @@ internal class CopyOnWriteList<T> where T : notnull
         _listList = new List<T>();
     }
 
+    public CopyOnWriteList(int capacity)
+    {
+        _syncRoot = new object();
+        _listList = new List<T>(capacity);
+    }
+
     /// <summary>
     ///   Return a readonly wrapper of the list.  Note: this is NOT a copy.
     ///   A non-null _readonlyWrapper  is a "Copy on Write" flag.

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CopyOnWriteList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CopyOnWriteList.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.ObjectModel;
 
 namespace MS.Internal;
@@ -14,18 +16,14 @@ namespace MS.Internal;
 ///   cache then the list is copied before it is modified and the readonly list is
 ///   released from the cache.
 /// </summary>
-internal class CopyOnWriteList<T>
+internal class CopyOnWriteList<T> where T : notnull
 {
-    private ReadOnlyCollection<T> _readonlyWrapper;
+    private ReadOnlyCollection<T>? _readonlyWrapper;
     private List<T> _listList;
 
     private readonly object _syncRoot;
 
-    public CopyOnWriteList() : this(null)
-    {
-    }
-
-    public CopyOnWriteList(object syncRoot)
+    public CopyOnWriteList(object? syncRoot)
     {
         syncRoot ??= new object();
 
@@ -160,6 +158,7 @@ internal class CopyOnWriteList<T>
                 return i;
             }
         }
+
         return -1;
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceEnumerator.cs
@@ -9,15 +9,18 @@ using System.Collections.ObjectModel;
 namespace MS.Internal;
 
 /// <summary>
-///    This allows callers to "foreach" through a WeakReferenceList.
-///    Each weakreference is checked for liveness and "current"
-///    actually returns a strong reference to the current element.
+/// This allows callers to "foreach" through a WeakReferenceList.
+/// Each weak reference is checked for liveness and "current"
+/// actually returns a strong reference to the current element.
 /// </summary>
 /// <remarks>
-///    Due to the way enumerators function, this enumerator often
-///    holds a cached strong reference to the "Current" element.
-///    This should not be a problem unless the caller stops enumerating
-///    before the end of the list AND holds the enumerator alive forever.
+/// <para>
+/// Due to the way enumerators function, this enumerator often
+/// holds a cached strong reference to the "Current" element.
+/// This should not be a problem unless the caller stops enumerating
+/// before the end of the list AND holds the enumerator alive forever.
+/// </para>
+/// Explicitly calling Dispose, this removes the strong reference.
 /// </remarks>
 internal struct WeakReferenceListEnumerator<T> : IEnumerator<T> where T : class
 {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceEnumerator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.ObjectModel;
 
 namespace MS.Internal
 {
@@ -18,7 +19,7 @@ namespace MS.Internal
     /// </remarks>
     internal struct WeakReferenceListEnumerator : IEnumerator
     {
-        public WeakReferenceListEnumerator( ArrayList List)
+        public WeakReferenceListEnumerator( ReadOnlyCollection<object> List)
         {
             _i = 0;
             _List = List;
@@ -61,7 +62,7 @@ namespace MS.Internal
         }
 
         private int _i;
-        private ArrayList _List;
+        private ReadOnlyCollection<object> _List;
         private object _StrongReference;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceEnumerator.cs
@@ -71,9 +71,10 @@ internal struct WeakReferenceListEnumerator<T> : IEnumerator<T> where T : class
         _strongReference = null;
     }
 
-    public readonly void Dispose()
+    public void Dispose()
     {
-        // This method is here to satisfy the IEnumerator<T> interface.
+        // Clean up the instance to avoid holding strong references to elements
+        _strongReference = null;
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceEnumerator.cs
@@ -4,66 +4,66 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 
-namespace MS.Internal
+#nullable enable
+
+namespace MS.Internal;
+
+/// <summary>
+///    This allows callers to "foreach" through a WeakReferenceList.
+///    Each weakreference is checked for liveness and "current"
+///    actually returns a strong reference to the current element.
+/// </summary>
+/// <remarks>
+///    Due to the way enumerators function, this enumerator often
+///    holds a cached strong reference to the "Current" element.
+///    This should not be a problem unless the caller stops enumerating
+///    before the end of the list AND holds the enumerator alive forever.
+/// </remarks>
+internal struct WeakReferenceListEnumerator : IEnumerator
 {
-    /// <summary>
-    ///    This allows callers to "foreach" through a WeakReferenceList.
-    ///    Each weakreference is checked for liveness and "current"
-    ///    actually returns a strong reference to the current element.
-    /// </summary>
-    /// <remarks>
-    ///    Due to the way enumerators function, this enumerator often
-    ///    holds a cached strong reference to the "Current" element.
-    ///    This should not be a problem unless the caller stops enumerating
-    ///    before the end of the list AND holds the enumerator alive forever.
-    /// </remarks>
-    internal struct WeakReferenceListEnumerator : IEnumerator
+    private readonly ReadOnlyCollection<object> _backingList;
+
+    private object? _strongReference;
+    private int _index;
+
+    public WeakReferenceListEnumerator(ReadOnlyCollection<object> backingList)
     {
-        public WeakReferenceListEnumerator( ReadOnlyCollection<object> List)
+        _index = 0;
+        _backingList = backingList;
+        _strongReference = null;
+    }
+
+    readonly object IEnumerator.Current
+    {
+        get => Current;
+    }
+
+    public readonly object Current
+    {
+        get => _strongReference ?? throw new InvalidOperationException(SR.Enumerator_VerifyContext);
+    }
+
+    public bool MoveNext()
+    {
+        object? element = null;
+
+        while (_index < _backingList.Count)
         {
-            _i = 0;
-            _List = List;
-            _StrongReference = null;
+            WeakReference weakRef = (WeakReference)_backingList[_index++];
+            element = weakRef.Target;
+            if (element is not null)
+                break;
         }
 
-        object IEnumerator.Current
-        {  get{ return Current; } }
-        
-        public object Current
-        {
-            get
-            {
-                if( null == _StrongReference )
-                {
-                    throw new System.InvalidOperationException(SR.Enumerator_VerifyContext);
-                }
-                return _StrongReference;
-            }
-        }
+        _strongReference = element;
 
-        public bool MoveNext()
-        {
-            object obj=null;
-            while( _i < _List.Count )
-            {
-                WeakReference weakRef = (WeakReference) _List[ _i++ ];
-                obj = weakRef.Target;
-                if(null != obj)
-                    break;
-            }
-            _StrongReference = obj;
-            return (null != obj);
-        }
+        return element is not null;
+    }
 
-        public void Reset()
-        {
-            _i = 0;
-            _StrongReference = null;
-        }
-
-        private int _i;
-        private ReadOnlyCollection<object> _List;
-        private object _StrongReference;
+    public void Reset()
+    {
+        _index = 0;
+        _strongReference = null;
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
@@ -18,8 +18,15 @@ namespace MS.Internal;
 /// </summary>
 internal sealed class WeakReferenceList<T> : CopyOnWriteList<WeakReference<T>>, IEnumerable<T> where T : class
 {
-    public WeakReferenceList() : base(null)
+    public int Count
     {
+        get
+        {
+            lock (SyncRoot)
+            {
+                return LiveList.Count;
+            }
+        }
     }
 
     public WeakReferenceList(object? syncRoot) : base(syncRoot)
@@ -55,19 +62,6 @@ internal sealed class WeakReferenceList<T> : CopyOnWriteList<WeakReference<T>>, 
                 return true;
 
             return false;
-        }
-    }
-
-    public int Count
-    {
-        get
-        {
-            int count = 0;
-            lock (SyncRoot)
-            {
-                count = LiveList.Count;
-            }
-            return count;
         }
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
@@ -29,6 +29,10 @@ internal sealed class WeakReferenceList<T> : CopyOnWriteList<WeakReference<T>>, 
         }
     }
 
+    public WeakReferenceList(int capacity) : base(capacity)
+    {
+    }
+
     public WeakReferenceList(object? syncRoot) : base(syncRoot)
     {
     }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
@@ -14,13 +14,13 @@ namespace MS.Internal
     ///   cache then the list is copied before it is modified and the readonly list is
     ///   released from the cache.
     /// </summary>
-    internal class WeakReferenceList : CopyOnWriteList<object>, IEnumerable
+    internal sealed class WeakReferenceList : CopyOnWriteList<object>, IEnumerable
     {
-        public WeakReferenceList():base(null)
+        public WeakReferenceList() : base(null)
         {
         }
 
-        public WeakReferenceList(object syncRoot):base(syncRoot)
+        public WeakReferenceList(object syncRoot) : base(syncRoot)
         {
         }
 
@@ -36,7 +36,8 @@ namespace MS.Internal
 
         public bool Contains(object item)
         {
-            Debug.Assert(null != item, "WeakReferenceList.Contains() should not be passed null.");
+            Debug.Assert(item is not null, "WeakReferenceList.Contains() should not be passed null.");
+
             lock (base.SyncRoot)
             {
                 int index = FindWeakReference(item);
@@ -70,22 +71,24 @@ namespace MS.Internal
         /// </summary>
         public override bool Add(object obj)
         {
-            Debug.Assert(null!=obj, "WeakReferenceList.Add() should not be passed null.");
+            Debug.Assert(obj is not null, "WeakReferenceList.Add() should not be passed null.");
+
             return Add(obj, false /*skipFind*/);
 }
 
-        //Will insert a new WeakREference into the list.
+        //Will insert a new WeakReference into the list.
         //The object bein inserted MUST be unique as there is no check for it.
         public bool Add(object obj, bool skipFind)
         {
-            Debug.Assert(null!=obj, "WeakReferenceList.Add() should not be passed null.");
-            lock(base.SyncRoot)
+            Debug.Assert(obj is not null, "WeakReferenceList.Add() should not be passed null.");
+
+            lock (base.SyncRoot)
             {
                 if (skipFind)
                 {
                     // before growing the list, purge it of dead entries.
                     // The expense of purging amortizes to O(1) per entry, because
-                    // the the list doubles its capacity when it grows.
+                    // the list doubles its capacity when it grows.
                     if (LiveList.Count == LiveList.Capacity)
                     {
                         Purge();
@@ -101,14 +104,15 @@ namespace MS.Internal
         }
 
         /// <summary>
-        ///   Remove a weak reference to the List.
-        ///   Returns true if successfully added.
-        ///   Returns false if object is already on the list.
+        /// Remove a weak reference to the List.
+        /// Returns true if successfully removed.
+        /// Returns false if object is not in the list.
         /// </summary>
         public override bool Remove(object obj)
         {
-            Debug.Assert(null!=obj, "WeakReferenceList.Remove() should not be passed null.");
-            lock(base.SyncRoot)
+            Debug.Assert(obj is not null, "WeakReferenceList.Remove() should not be passed null.");
+
+            lock (base.SyncRoot)
             {
                 int index = FindWeakReference(obj);
 
@@ -128,8 +132,9 @@ namespace MS.Internal
         /// </summary>
         public bool Insert(int index, object obj)
         {
-            Debug.Assert(null!=obj, "WeakReferenceList.Add() should not be passed null.");
-            lock(base.SyncRoot)
+            Debug.Assert(obj is not null, "WeakReferenceList.Add() should not be passed null.");
+
+            lock (base.SyncRoot)
             {
                 int existingIndex = FindWeakReference(obj);
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
@@ -8,7 +8,7 @@ using System.Collections;
 namespace MS.Internal;
 
 /// <summary>
-/// This is a Cached ThreadSafe ArrayList of WeakReferences.
+/// This is a Cached ThreadSafe <see cref="List{T}"/> of WeakReferences.
 /// - When the "List" property is requested a readonly reference to the
 /// list is returned and a reference to the readonly list is cached.
 /// - If the "List" is requested again, the same cached reference is returned.

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
@@ -38,7 +38,7 @@ namespace MS.Internal
         {
             Debug.Assert(item is not null, "WeakReferenceList.Contains() should not be passed null.");
 
-            lock (base.SyncRoot)
+            lock (SyncRoot)
             {
                 int index = FindWeakReference(item);
 
@@ -56,9 +56,9 @@ namespace MS.Internal
             get
             {
                 int count = 0;
-                lock (base.SyncRoot)
+                lock (SyncRoot)
                 {
-                    count = base.LiveList.Count;
+                    count = LiveList.Count;
                 }
                 return count;
             }
@@ -82,7 +82,7 @@ namespace MS.Internal
         {
             Debug.Assert(obj is not null, "WeakReferenceList.Add() should not be passed null.");
 
-            lock (base.SyncRoot)
+            lock (SyncRoot)
             {
                 if (skipFind)
                 {
@@ -99,7 +99,7 @@ namespace MS.Internal
                     return false;
                 }
 
-                return base.Internal_Add(new WeakReference(obj));
+                return Internal_Add(new WeakReference(obj));
             }
         }
 
@@ -112,7 +112,7 @@ namespace MS.Internal
         {
             Debug.Assert(obj is not null, "WeakReferenceList.Remove() should not be passed null.");
 
-            lock (base.SyncRoot)
+            lock (SyncRoot)
             {
                 int index = FindWeakReference(obj);
 
@@ -121,7 +121,7 @@ namespace MS.Internal
                 if(index < 0)
                     return false;
 
-                return base.RemoveAt(index);
+                return RemoveAt(index);
             }
         }
 
@@ -134,7 +134,7 @@ namespace MS.Internal
         {
             Debug.Assert(obj is not null, "WeakReferenceList.Add() should not be passed null.");
 
-            lock (base.SyncRoot)
+            lock (SyncRoot)
             {
                 int existingIndex = FindWeakReference(obj);
 
@@ -143,7 +143,7 @@ namespace MS.Internal
                 if(existingIndex >=  0)
                     return false;
 
-                return base.Internal_Insert(index, new WeakReference(obj));
+                return Internal_Insert(index, new WeakReference(obj));
             }
         }
 
@@ -167,7 +167,7 @@ namespace MS.Internal
              while (foundDeadReferences)
              {
                  foundDeadReferences = false;
-                 List<object> list = base.LiveList;
+                 List<object> list = LiveList;
 
                  for(int i = 0; i < list.Count; i++)
                  {
@@ -208,7 +208,7 @@ namespace MS.Internal
          // caller is expected to lock the SyncRoot
          private void Purge()
          {
-            List<object> list = base.LiveList;
+            List<object> list = LiveList;
             int destIndex;
             int n = list.Count;
 
@@ -226,7 +226,7 @@ namespace MS.Internal
 
             // but if there is, check for copy-on-write
             DoCopyOnWriteCheck();
-            list = base.LiveList;
+            list = LiveList;
 
             // move remaining valid entries toward the beginning, into one
             // contiguous block

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -14,7 +14,7 @@ namespace MS.Internal
     ///   cache then the list is copied before it is modified and the readonly list is
     ///   released from the cache.
     /// </summary>
-    internal class WeakReferenceList : CopyOnWriteList, IEnumerable
+    internal class WeakReferenceList : CopyOnWriteList<object>, IEnumerable
     {
         public WeakReferenceList():base(null)
         {
@@ -162,7 +162,7 @@ namespace MS.Internal
              while (foundDeadReferences)
              {
                  foundDeadReferences = false;
-                 ArrayList list = base.LiveList;
+                 List<object> list = base.LiveList;
 
                  for(int i = 0; i < list.Count; i++)
                  {
@@ -203,7 +203,7 @@ namespace MS.Internal
          // caller is expected to lock the SyncRoot
          private void Purge()
          {
-            ArrayList list = base.LiveList;
+            List<object> list = base.LiveList;
             int destIndex;
             int n = list.Count;
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/WeakReferenceList.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections;
 
 namespace MS.Internal;
@@ -20,7 +22,7 @@ internal sealed class WeakReferenceList<T> : CopyOnWriteList<WeakReference<T>>, 
     {
     }
 
-    public WeakReferenceList(object syncRoot) : base(syncRoot)
+    public WeakReferenceList(object? syncRoot) : base(syncRoot)
     {
     }
 
@@ -177,7 +179,7 @@ internal sealed class WeakReferenceList<T> : CopyOnWriteList<WeakReference<T>>, 
             for (int i = 0; i < list.Count; i++)
             {
                 WeakReference<T> weakRef = list[i];
-                if (weakRef.TryGetTarget(out T target))
+                if (weakRef.TryGetTarget(out T? target))
                 {
                     if (obj == target)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
@@ -220,13 +220,13 @@ namespace MS.Win32
 
         public void AddHook(HwndWrapperHook hook)
         {
-            _hooks ??= [];
+            _hooks ??= new WeakReferenceList<HwndWrapperHook>(syncRoot: null);
             _hooks.Insert(0, hook);
         }
 
         internal void AddHookLast(HwndWrapperHook hook)
         {
-            _hooks ??= [];
+            _hooks ??= new WeakReferenceList<HwndWrapperHook>(syncRoot: null);
             _hooks.Add(hook);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
@@ -357,7 +357,7 @@ namespace MS.Win32
 
         private IntPtr _handle;
         private UInt16 _classAtom;
-        private WeakReferenceList _hooks;
+        private WeakReferenceList<HwndWrapperHook> _hooks;
         private int _ownerThreadID;
         
         private HwndWrapperHook _wndProc;


### PR DESCRIPTION
## Description

Refactors both `CopyOnWriteList` and `WeakReferenceList` as generic type-safe collections.
- Theoretically, they could have been merged into one but I chose not to currently.

Both lists now support initialization with capacity argument, previously integers passed in (e.g. in `PropagateParentOwners`) would end up being boxed and the instance of the box being used as a lock. This clearly feels like a mistake.

In `ResourceDictionaryDiagnostics` I've removed few static fields caching empty (readonly) arrays I didn' see in #10267.

Regarding the removed null-checks:
- Those are a part of the `as` casting pattern.
- The enumerator returns strong, non-null references, hence it will never be `null` in the first place.
- I've appropriately null-annotated the adjusted files.

Since `ContainsOwner` is only called from within the three classes, we can remove the type checks and speed it up.
- Similarly it can be done for Add/Remove but I'll do that after this is in.

## Customer Impact

Improved performance a tiny bit, strongly-typed code and newer practices.

## Regression

No.

## Testing

Local build, unit tests, testing with sample apps including themes and templates.

## Risk

Low to medium, I believe the changes are straightforward and understandable but happy to answer any questions (rather sooner than later).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10889)