### PR TITLE
Fixed DataGrid column header text color in HC mode

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Dark.xaml
@@ -532,6 +532,7 @@
         <!-- DataGridHeaderBackground is used for PART_FillerColumnHeader and Row Headers
              whereas DataGridColumnHeaderBackground is used for Column Headers. This is a bit confusing
              but due to transparency in colors had to follow this.  -->
+    <SolidColorBrush x:Key="DataGridColumnHeaderForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="DataGridColumnHeaderBackground" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="DataGridHeaderBackground" Color="{StaticResource SubtleFillColorTertiary}" />
     <SolidColorBrush x:Key="DataGridHeaderBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
@@ -351,6 +351,7 @@
     <SolidColorBrush x:Key="DataGridColumnFloatingHeaderBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
     <SolidColorBrush x:Key="DataGridHeaderDropSeparatorBackground" Color="{StaticResource SystemColorHighlightColor}" />
     <SolidColorBrush x:Key="DataGridHeaderSeparatorBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="DataGridColumnHeaderForeground" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="DataGridColumnHeaderBackground" Color="Transparent" />
     <SolidColorBrush x:Key="DataGridHeaderBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
     <SolidColorBrush x:Key="DataGridHeaderBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Light.xaml
@@ -548,6 +548,7 @@
         <!-- DataGridHeaderBackground is used for PART_FillerColumnHeader and Row Headers
              whereas DataGridColumnHeaderBackground is used for Column Headers. This is a bit confusing
              but due to transparency in colors had to follow this.  -->
+    <SolidColorBrush x:Key="DataGridColumnHeaderForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="DataGridColumnHeaderBackground" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="DataGridHeaderBackground" Color="{StaticResource SubtleFillColorTertiary}" />
     <SolidColorBrush x:Key="DataGridHeaderBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DataGrid.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DataGrid.xaml
@@ -404,6 +404,7 @@
 
     <!--  Style and template for the DataGridColumnHeader.  -->
     <Style x:Key="DefaultDataGridColumnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
+        <Setter Property="Foreground" Value="{DynamicResource DataGridColumnHeaderForeground}" />
         <Setter Property="Background" Value="{DynamicResource DataGridColumnHeaderBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource DataGridHeaderBorderBrush}" />
         <Setter Property="MinHeight" Value="{StaticResource DataGridColumnHeaderMinHeight}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -526,6 +526,7 @@
   <!-- DataGridHeaderBackground is used for PART_FillerColumnHeader and Row Headers
              whereas DataGridColumnHeaderBackground is used for Column Headers. This is a bit confusing
              but due to transparency in colors had to follow this.  -->
+  <SolidColorBrush x:Key="DataGridColumnHeaderForeground" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="DataGridColumnHeaderBackground" Color="{StaticResource SubtleFillColorTransparent}" />
   <SolidColorBrush x:Key="DataGridHeaderBackground" Color="{StaticResource SubtleFillColorTertiary}" />
   <SolidColorBrush x:Key="DataGridHeaderBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
@@ -2161,6 +2162,7 @@
   </Style>
   <!--  Style and template for the DataGridColumnHeader.  -->
   <Style x:Key="DefaultDataGridColumnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
+    <Setter Property="Foreground" Value="{DynamicResource DataGridColumnHeaderForeground}" />
     <Setter Property="Background" Value="{DynamicResource DataGridColumnHeaderBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource DataGridHeaderBorderBrush}" />
     <Setter Property="MinHeight" Value="{StaticResource DataGridColumnHeaderMinHeight}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -370,6 +370,7 @@
   <SolidColorBrush x:Key="DataGridColumnFloatingHeaderBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
   <SolidColorBrush x:Key="DataGridHeaderDropSeparatorBackground" Color="{StaticResource SystemColorHighlightColor}" />
   <SolidColorBrush x:Key="DataGridHeaderSeparatorBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+  <SolidColorBrush x:Key="DataGridColumnHeaderForeground" Color="{StaticResource SystemColorButtonTextColor}" />
   <SolidColorBrush x:Key="DataGridColumnHeaderBackground" Color="Transparent" />
   <SolidColorBrush x:Key="DataGridHeaderBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
   <SolidColorBrush x:Key="DataGridHeaderBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
@@ -2061,6 +2062,7 @@
   </Style>
   <!--  Style and template for the DataGridColumnHeader.  -->
   <Style x:Key="DefaultDataGridColumnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
+    <Setter Property="Foreground" Value="{DynamicResource DataGridColumnHeaderForeground}" />
     <Setter Property="Background" Value="{DynamicResource DataGridColumnHeaderBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource DataGridHeaderBorderBrush}" />
     <Setter Property="MinHeight" Value="{StaticResource DataGridColumnHeaderMinHeight}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -541,6 +541,7 @@
   <!-- DataGridHeaderBackground is used for PART_FillerColumnHeader and Row Headers
              whereas DataGridColumnHeaderBackground is used for Column Headers. This is a bit confusing
              but due to transparency in colors had to follow this.  -->
+  <SolidColorBrush x:Key="DataGridColumnHeaderForeground" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="DataGridColumnHeaderBackground" Color="{StaticResource SubtleFillColorTransparent}" />
   <SolidColorBrush x:Key="DataGridHeaderBackground" Color="{StaticResource SubtleFillColorTertiary}" />
   <SolidColorBrush x:Key="DataGridHeaderBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
@@ -2176,6 +2177,7 @@
   </Style>
   <!--  Style and template for the DataGridColumnHeader.  -->
   <Style x:Key="DefaultDataGridColumnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
+    <Setter Property="Foreground" Value="{DynamicResource DataGridColumnHeaderForeground}" />
     <Setter Property="Background" Value="{DynamicResource DataGridColumnHeaderBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource DataGridHeaderBorderBrush}" />
     <Setter Property="MinHeight" Value="{StaticResource DataGridColumnHeaderMinHeight}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
@@ -1359,6 +1359,7 @@
   </Style>
   <!--  Style and template for the DataGridColumnHeader.  -->
   <Style x:Key="DefaultDataGridColumnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
+    <Setter Property="Foreground" Value="{DynamicResource DataGridColumnHeaderForeground}" />
     <Setter Property="Background" Value="{DynamicResource DataGridColumnHeaderBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource DataGridHeaderBorderBrush}" />
     <Setter Property="MinHeight" Value="{StaticResource DataGridColumnHeaderMinHeight}" />


### PR DESCRIPTION
## Description
In HC mode, the DataGrid column header text color was not visible. DataGrid column header was inheriting foreground color from the DataGrid control. This PR introduces a new resource DataGridColumnHeaderForeground color which is now used as the color of the column header text. 

## Customer Impact
Customers using Desert mode won't be able to see the column headers correctly.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes. Introduced in .NET 10 Preview 5 / 6.

## Testing
Local app testing.

## Risk
Minimal