### PR TITLE
Removed separate MinHeight resources for text based controls

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
@@ -33,7 +33,7 @@
     <!-- <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness> -->
 
     <system:Double x:Key="ContentControlFontSize">14</system:Double>
-    <system:Double x:Key="TextControlThemeMinHeight">24</system:Double>
+    <system:Double x:Key="TextControlThemeMinHeight">32</system:Double>
     <system:Double x:Key="TextControlThemeMinWidth">0</system:Double>
     <system:Double x:Key="TreeViewItemMultiSelectCheckBoxMinHeight">24</system:Double>
     <system:Double x:Key="TreeViewItemPresenterMargin">0</system:Double>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
@@ -44,7 +44,7 @@
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Top" />
         <Setter Property="Cursor" Value="IBeam" />
-        <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+        <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
         <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
         <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -569,7 +569,7 @@
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="VerticalContentAlignment" Value="Top" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
         <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
         <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DatePicker.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DatePicker.xaml
@@ -117,6 +117,7 @@
         <Setter Property="Background" Value="{DynamicResource DatePickerBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
         <Setter Property="BorderThickness" Value="{StaticResource DatePickerBorderThickness}" />
+        <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -188,7 +189,7 @@
                                     BorderThickness="{TemplateBinding BorderThickness}"
                                     Background="{TemplateBinding Background}"
                                     CornerRadius="{TemplateBinding Border.CornerRadius}"
-                                    MinHeight="32">
+                                    MinHeight="{TemplateBinding MinHeight}">
                             </Border>
 
                             <DatePickerTextBox x:Name="PART_TextBox" 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/PasswordBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/PasswordBox.xaml
@@ -26,9 +26,6 @@
         <!-- <Thickness x:Key="PasswordBoxBorderThemeThickness">1,1,1,1</Thickness> -->
 
     <Thickness x:Key="PasswordBoxBorderThemeThickness">1</Thickness>
-    <!-- Instead of PasswordBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-    <sys:Double x:Key="PasswordBoxThemeMinHeight">32</sys:Double>
 
     <ContextMenu x:Key="DefaultPasswordBoxContextMenu">
         <MenuItem Command="ApplicationCommands.Paste" />
@@ -47,7 +44,7 @@
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Top" />
         <Setter Property="Cursor" Value="IBeam" />
-        <Setter Property="MinHeight" Value="{DynamicResource PasswordBoxThemeMinHeight}" />
+        <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
         <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
         <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/RichTextBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/RichTextBox.xaml
@@ -12,10 +12,6 @@
     
     <!-- Deprecated RichTextBox Resources ( Used in .NET 9 ) -->
     <Thickness x:Key="RichTextBoxAccentBorderThemeThickness">0,0,0,1</Thickness>
-    
-    <!-- Instead of RichTextBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-    <system:Double x:Key="RichTextBoxThemeMinHeight">32</system:Double>
 
     <Style x:Key="DefaultRichTextBoxStyle" TargetType="{x:Type RichTextBox}">
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -30,7 +26,7 @@
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Top" />
         <Setter Property="Cursor" Value="IBeam" />
-        <Setter Property="MinHeight" Value="{DynamicResource RichTextBoxThemeMinHeight}" />
+        <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
         <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
         <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TextBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TextBox.xaml
@@ -26,9 +26,6 @@
         <!-- <Thickness x:Key="TextBoxClearButtonPadding">0,0,0,0</Thickness> -->
 
     <system:Double x:Key="TextBoxIconFontSize">12</system:Double>
-    <!-- Instead of TextBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-    <system:Double x:Key="TextBoxThemeMinHeight">32</system:Double>
     <Thickness x:Key="TextBoxClearButtonMargin">0,4,4,4</Thickness>
     <Thickness x:Key="TextBoxClearButtonPadding">0,0,-2,0</Thickness>
 
@@ -45,7 +42,7 @@
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Top" />
         <Setter Property="Cursor" Value="IBeam" />
-        <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+        <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
         <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
         <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -256,7 +253,7 @@
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Top" />
-        <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+        <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
         <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
         <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -69,7 +69,7 @@
   <!-- Moved to Light, Dark and HC resource files -->
   <!-- <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness> -->
   <system:Double x:Key="ContentControlFontSize">14</system:Double>
-  <system:Double x:Key="TextControlThemeMinHeight">24</system:Double>
+  <system:Double x:Key="TextControlThemeMinHeight">32</system:Double>
   <system:Double x:Key="TextControlThemeMinWidth">0</system:Double>
   <system:Double x:Key="TreeViewItemMultiSelectCheckBoxMinHeight">24</system:Double>
   <system:Double x:Key="TreeViewItemPresenterMargin">0</system:Double>
@@ -1480,7 +1480,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -1793,7 +1793,7 @@
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />
@@ -2552,6 +2552,7 @@
     <Setter Property="Background" Value="{DynamicResource DatePickerBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
     <Setter Property="BorderThickness" Value="{StaticResource DatePickerBorderThickness}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -2605,7 +2606,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
               </Grid.ColumnDefinitions>
-              <Border x:Name="BorderElement" Grid.ColumnSpan="2" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}" MinHeight="32">
+              <Border x:Name="BorderElement" Grid.ColumnSpan="2" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}" MinHeight="{TemplateBinding MinHeight}">
               </Border>
               <DatePickerTextBox x:Name="PART_TextBox" Padding="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" KeyboardNavigation.TabIndex="0" />
               <Button x:Name="PART_Button" Grid.Column="1" VerticalAlignment="Stretch" Style="{StaticResource CalendarButtonStyle}" KeyboardNavigation.TabIndex="1" MinWidth="30" />
@@ -4137,9 +4138,6 @@
   <!-- These rsources are redefined in .NET 10 -->
   <!-- <Thickness x:Key="PasswordBoxBorderThemeThickness">1,1,1,1</Thickness> -->
   <Thickness x:Key="PasswordBoxBorderThemeThickness">1</Thickness>
-  <!-- Instead of PasswordBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-  <sys:Double x:Key="PasswordBoxThemeMinHeight">32</sys:Double>
   <ContextMenu x:Key="DefaultPasswordBoxContextMenu">
     <MenuItem Command="ApplicationCommands.Paste" />
   </ContextMenu>
@@ -4156,7 +4154,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource PasswordBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -4487,9 +4485,6 @@
   <Style BasedOn="{StaticResource DefaultResizeGripStyle}" TargetType="{x:Type ResizeGrip}" />
   <!-- Deprecated RichTextBox Resources ( Used in .NET 9 ) -->
   <Thickness x:Key="RichTextBoxAccentBorderThemeThickness">0,0,0,1</Thickness>
-  <!-- Instead of RichTextBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-  <system:Double x:Key="RichTextBoxThemeMinHeight">32</system:Double>
   <Style x:Key="DefaultRichTextBoxStyle" TargetType="{x:Type RichTextBox}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
@@ -4503,7 +4498,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource RichTextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -5219,9 +5214,6 @@
   <!-- <Thickness x:Key="TextBoxClearButtonMargin">0,0,4,0</Thickness> -->
   <!-- <Thickness x:Key="TextBoxClearButtonPadding">0,0,0,0</Thickness> -->
   <system:Double x:Key="TextBoxIconFontSize">12</system:Double>
-  <!-- Instead of TextBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-  <system:Double x:Key="TextBoxThemeMinHeight">32</system:Double>
   <Thickness x:Key="TextBoxClearButtonMargin">0,4,4,4</Thickness>
   <Thickness x:Key="TextBoxClearButtonPadding">0,0,-2,0</Thickness>
   <Style x:Key="DefaultTextBoxBaseStyle" TargetType="{x:Type TextBoxBase}">
@@ -5237,7 +5229,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -5383,7 +5375,7 @@
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
-    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -69,7 +69,7 @@
   <!-- Moved to Light, Dark and HC resource files -->
   <!-- <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness> -->
   <system:Double x:Key="ContentControlFontSize">14</system:Double>
-  <system:Double x:Key="TextControlThemeMinHeight">24</system:Double>
+  <system:Double x:Key="TextControlThemeMinHeight">32</system:Double>
   <system:Double x:Key="TextControlThemeMinWidth">0</system:Double>
   <system:Double x:Key="TreeViewItemMultiSelectCheckBoxMinHeight">24</system:Double>
   <system:Double x:Key="TreeViewItemPresenterMargin">0</system:Double>
@@ -1380,7 +1380,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -1693,7 +1693,7 @@
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />
@@ -2452,6 +2452,7 @@
     <Setter Property="Background" Value="{DynamicResource DatePickerBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
     <Setter Property="BorderThickness" Value="{StaticResource DatePickerBorderThickness}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -2505,7 +2506,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
               </Grid.ColumnDefinitions>
-              <Border x:Name="BorderElement" Grid.ColumnSpan="2" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}" MinHeight="32">
+              <Border x:Name="BorderElement" Grid.ColumnSpan="2" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}" MinHeight="{TemplateBinding MinHeight}">
               </Border>
               <DatePickerTextBox x:Name="PART_TextBox" Padding="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" KeyboardNavigation.TabIndex="0" />
               <Button x:Name="PART_Button" Grid.Column="1" VerticalAlignment="Stretch" Style="{StaticResource CalendarButtonStyle}" KeyboardNavigation.TabIndex="1" MinWidth="30" />
@@ -4037,9 +4038,6 @@
   <!-- These rsources are redefined in .NET 10 -->
   <!-- <Thickness x:Key="PasswordBoxBorderThemeThickness">1,1,1,1</Thickness> -->
   <Thickness x:Key="PasswordBoxBorderThemeThickness">1</Thickness>
-  <!-- Instead of PasswordBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-  <sys:Double x:Key="PasswordBoxThemeMinHeight">32</sys:Double>
   <ContextMenu x:Key="DefaultPasswordBoxContextMenu">
     <MenuItem Command="ApplicationCommands.Paste" />
   </ContextMenu>
@@ -4056,7 +4054,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource PasswordBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -4387,9 +4385,6 @@
   <Style BasedOn="{StaticResource DefaultResizeGripStyle}" TargetType="{x:Type ResizeGrip}" />
   <!-- Deprecated RichTextBox Resources ( Used in .NET 9 ) -->
   <Thickness x:Key="RichTextBoxAccentBorderThemeThickness">0,0,0,1</Thickness>
-  <!-- Instead of RichTextBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-  <system:Double x:Key="RichTextBoxThemeMinHeight">32</system:Double>
   <Style x:Key="DefaultRichTextBoxStyle" TargetType="{x:Type RichTextBox}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
@@ -4403,7 +4398,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource RichTextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -5119,9 +5114,6 @@
   <!-- <Thickness x:Key="TextBoxClearButtonMargin">0,0,4,0</Thickness> -->
   <!-- <Thickness x:Key="TextBoxClearButtonPadding">0,0,0,0</Thickness> -->
   <system:Double x:Key="TextBoxIconFontSize">12</system:Double>
-  <!-- Instead of TextBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-  <system:Double x:Key="TextBoxThemeMinHeight">32</system:Double>
   <Thickness x:Key="TextBoxClearButtonMargin">0,4,4,4</Thickness>
   <Thickness x:Key="TextBoxClearButtonPadding">0,0,-2,0</Thickness>
   <Style x:Key="DefaultTextBoxBaseStyle" TargetType="{x:Type TextBoxBase}">
@@ -5137,7 +5129,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -5283,7 +5275,7 @@
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
-    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -69,7 +69,7 @@
   <!-- Moved to Light, Dark and HC resource files -->
   <!-- <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness> -->
   <system:Double x:Key="ContentControlFontSize">14</system:Double>
-  <system:Double x:Key="TextControlThemeMinHeight">24</system:Double>
+  <system:Double x:Key="TextControlThemeMinHeight">32</system:Double>
   <system:Double x:Key="TextControlThemeMinWidth">0</system:Double>
   <system:Double x:Key="TreeViewItemMultiSelectCheckBoxMinHeight">24</system:Double>
   <system:Double x:Key="TreeViewItemPresenterMargin">0</system:Double>
@@ -1495,7 +1495,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -1808,7 +1808,7 @@
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />
@@ -2567,6 +2567,7 @@
     <Setter Property="Background" Value="{DynamicResource DatePickerBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
     <Setter Property="BorderThickness" Value="{StaticResource DatePickerBorderThickness}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -2620,7 +2621,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
               </Grid.ColumnDefinitions>
-              <Border x:Name="BorderElement" Grid.ColumnSpan="2" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}" MinHeight="32">
+              <Border x:Name="BorderElement" Grid.ColumnSpan="2" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}" MinHeight="{TemplateBinding MinHeight}">
               </Border>
               <DatePickerTextBox x:Name="PART_TextBox" Padding="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" KeyboardNavigation.TabIndex="0" />
               <Button x:Name="PART_Button" Grid.Column="1" VerticalAlignment="Stretch" Style="{StaticResource CalendarButtonStyle}" KeyboardNavigation.TabIndex="1" MinWidth="30" />
@@ -4152,9 +4153,6 @@
   <!-- These rsources are redefined in .NET 10 -->
   <!-- <Thickness x:Key="PasswordBoxBorderThemeThickness">1,1,1,1</Thickness> -->
   <Thickness x:Key="PasswordBoxBorderThemeThickness">1</Thickness>
-  <!-- Instead of PasswordBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-  <sys:Double x:Key="PasswordBoxThemeMinHeight">32</sys:Double>
   <ContextMenu x:Key="DefaultPasswordBoxContextMenu">
     <MenuItem Command="ApplicationCommands.Paste" />
   </ContextMenu>
@@ -4171,7 +4169,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource PasswordBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -4502,9 +4500,6 @@
   <Style BasedOn="{StaticResource DefaultResizeGripStyle}" TargetType="{x:Type ResizeGrip}" />
   <!-- Deprecated RichTextBox Resources ( Used in .NET 9 ) -->
   <Thickness x:Key="RichTextBoxAccentBorderThemeThickness">0,0,0,1</Thickness>
-  <!-- Instead of RichTextBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-  <system:Double x:Key="RichTextBoxThemeMinHeight">32</system:Double>
   <Style x:Key="DefaultRichTextBoxStyle" TargetType="{x:Type RichTextBox}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
@@ -4518,7 +4513,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource RichTextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -5234,9 +5229,6 @@
   <!-- <Thickness x:Key="TextBoxClearButtonMargin">0,0,4,0</Thickness> -->
   <!-- <Thickness x:Key="TextBoxClearButtonPadding">0,0,0,0</Thickness> -->
   <system:Double x:Key="TextBoxIconFontSize">12</system:Double>
-  <!-- Instead of TextBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-  <system:Double x:Key="TextBoxThemeMinHeight">32</system:Double>
   <Thickness x:Key="TextBoxClearButtonMargin">0,4,4,4</Thickness>
   <Thickness x:Key="TextBoxClearButtonPadding">0,0,-2,0</Thickness>
   <Style x:Key="DefaultTextBoxBaseStyle" TargetType="{x:Type TextBoxBase}">
@@ -5252,7 +5244,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -5398,7 +5390,7 @@
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
-    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
@@ -69,7 +69,7 @@
   <!-- Moved to Light, Dark and HC resource files -->
   <!-- <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness> -->
   <system:Double x:Key="ContentControlFontSize">14</system:Double>
-  <system:Double x:Key="TextControlThemeMinHeight">24</system:Double>
+  <system:Double x:Key="TextControlThemeMinHeight">32</system:Double>
   <system:Double x:Key="TextControlThemeMinWidth">0</system:Double>
   <system:Double x:Key="TreeViewItemMultiSelectCheckBoxMinHeight">24</system:Double>
   <system:Double x:Key="TreeViewItemPresenterMargin">0</system:Double>
@@ -677,7 +677,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -990,7 +990,7 @@
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />
@@ -1749,6 +1749,7 @@
     <Setter Property="Background" Value="{DynamicResource DatePickerBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
     <Setter Property="BorderThickness" Value="{StaticResource DatePickerBorderThickness}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -1802,7 +1803,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
               </Grid.ColumnDefinitions>
-              <Border x:Name="BorderElement" Grid.ColumnSpan="2" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}" MinHeight="32">
+              <Border x:Name="BorderElement" Grid.ColumnSpan="2" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}" MinHeight="{TemplateBinding MinHeight}">
               </Border>
               <DatePickerTextBox x:Name="PART_TextBox" Padding="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" KeyboardNavigation.TabIndex="0" />
               <Button x:Name="PART_Button" Grid.Column="1" VerticalAlignment="Stretch" Style="{StaticResource CalendarButtonStyle}" KeyboardNavigation.TabIndex="1" MinWidth="30" />
@@ -3334,9 +3335,6 @@
   <!-- These rsources are redefined in .NET 10 -->
   <!-- <Thickness x:Key="PasswordBoxBorderThemeThickness">1,1,1,1</Thickness> -->
   <Thickness x:Key="PasswordBoxBorderThemeThickness">1</Thickness>
-  <!-- Instead of PasswordBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-  <sys:Double x:Key="PasswordBoxThemeMinHeight">32</sys:Double>
   <ContextMenu x:Key="DefaultPasswordBoxContextMenu">
     <MenuItem Command="ApplicationCommands.Paste" />
   </ContextMenu>
@@ -3353,7 +3351,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource PasswordBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -3684,9 +3682,6 @@
   <Style BasedOn="{StaticResource DefaultResizeGripStyle}" TargetType="{x:Type ResizeGrip}" />
   <!-- Deprecated RichTextBox Resources ( Used in .NET 9 ) -->
   <Thickness x:Key="RichTextBoxAccentBorderThemeThickness">0,0,0,1</Thickness>
-  <!-- Instead of RichTextBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-  <system:Double x:Key="RichTextBoxThemeMinHeight">32</system:Double>
   <Style x:Key="DefaultRichTextBoxStyle" TargetType="{x:Type RichTextBox}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
@@ -3700,7 +3695,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource RichTextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -4416,9 +4411,6 @@
   <!-- <Thickness x:Key="TextBoxClearButtonMargin">0,0,4,0</Thickness> -->
   <!-- <Thickness x:Key="TextBoxClearButtonPadding">0,0,0,0</Thickness> -->
   <system:Double x:Key="TextBoxIconFontSize">12</system:Double>
-  <!-- Instead of TextBoxThemeMinHeight, we need to use TextControlThemeMinHeight, but modifying that right now
-            will affect the other styles as well. Once the remaining styles using it are fixed, will remove this resource -->
-  <system:Double x:Key="TextBoxThemeMinHeight">32</system:Double>
   <Thickness x:Key="TextBoxClearButtonMargin">0,4,4,4</Thickness>
   <Thickness x:Key="TextBoxClearButtonPadding">0,0,-2,0</Thickness>
   <Style x:Key="DefaultTextBoxBaseStyle" TargetType="{x:Type TextBoxBase}">
@@ -4434,7 +4426,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -4580,7 +4572,7 @@
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Top" />
-    <Setter Property="MinHeight" Value="{DynamicResource TextBoxThemeMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />


### PR DESCRIPTION
## Description
This PR reverts a workaround that I had to introduce while fixing the layout of text controls ( DatePicker, TextBox, RichTextBox, PasswordBox, etc ). These all controls use a shared resource TextControlThemeMinHeight, which needed to be changed from 24 to 32. However, in each PR I only fixed a single style, I had to introduce individual resources for these controls at the time.

In this PR, I remove the extra resources and their references are replaced with TextControlThemeMinHeight resource.

## Customer Impact
Anyone modifying this resource will see the uniform behavior for all text based controls.

## Regression
N/A

## Testing
Local app testing

## Risk
Minimal. Minor issues in content alignment may come up.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10980)