### PR TITLE
Removing unnecessary comments in Fluent theme files

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
@@ -129,9 +129,7 @@
     </Style>
 
     <Style x:Key="DefaultComboBoxItemStyle" TargetType="{x:Type ComboBoxItem}">
-        <!--  Universal WPF UI focus  -->
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-        <!--  Universal WPF UI focus  -->
         <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Margin" Value="{StaticResource ComboBoxItemMargin}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DataGrid.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DataGrid.xaml
@@ -689,9 +689,7 @@
     <system:Double x:Key="DataGridCheckBoxWidth">22</system:Double>
 
     <Style x:Key="DataGridCheckBoxElementDefaultStyle" TargetType="{x:Type CheckBox}">
-        <!--  Universal WPF UI focus  -->
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-        <!--  Universal WPF UI focus  -->
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground">
             <Setter.Value>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/RadioButton.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/RadioButton.xaml
@@ -22,9 +22,7 @@
     <Thickness x:Key="RadioButtonPadding">8,6,0,0</Thickness>
 
     <Style x:Key="DefaultRadioButtonStyle" TargetType="{x:Type RadioButton}">
-        <!--  Universal WPF UI focus  -->
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-        <!--  Universal WPF UI focus  -->
         <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource RadioButtonForeground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/RepeatButton.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/RepeatButton.xaml
@@ -11,9 +11,7 @@
     <Thickness x:Key="RepeatButtonIconMargin">0,0,8,0</Thickness>
 
     <Style x:Key="DefaultRepeatButtonStyle" TargetType="{x:Type RepeatButton}">
-        <!--  Universal WPF UI focus  -->
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-        <!--  Universal WPF UI focus  -->
         <Setter Property="Background" Value="{DynamicResource RepeatButtonBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForeground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ToggleButton.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ToggleButton.xaml
@@ -15,9 +15,7 @@
     <Thickness x:Key="ToggleButtonIconMargin">0,0,8,0</Thickness>
 
     <Style x:Key="DefaultToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-        <!--  Universal WPF UI focus  -->
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-        <!--  Universal WPF UI focus  -->
         <Setter Property="Background" Value="{DynamicResource ToggleButtonBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource ToggleButtonForeground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TreeViewItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TreeViewItem.xaml
@@ -17,9 +17,7 @@
     <system:String x:Key="TreeViewChevronLeftGlyph">&#xE76B;</system:String>
 
     <Style x:Key="ExpandCollapseToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-        <!--  Universal WPF UI focus  -->
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-        <!--  Universal WPF UI focus  -->
         <Setter Property="Focusable" Value="False" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -78,9 +76,7 @@
     </Style>
 
     <Style x:Key="DefaultTreeViewItemStyle" TargetType="{x:Type TreeViewItem}">
-        <!--  Universal WPF UI focus  -->
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-        <!--  Universal WPF UI focus  -->
         <Setter Property="Foreground" Value="{DynamicResource TreeViewItemForeground}" />
         <Setter Property="Background" Value="{DynamicResource TreeViewItemBackground}" />
         <Setter Property="Margin" Value="0,0,0,2" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -1536,9 +1536,7 @@
     </Setter>
   </Style>
   <Style x:Key="DefaultComboBoxItemStyle" TargetType="{x:Type ComboBoxItem}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Margin" Value="{StaticResource ComboBoxItemMargin}" />
@@ -2352,9 +2350,7 @@
   <system:Double x:Key="DataGridCheckBoxHeight">22</system:Double>
   <system:Double x:Key="DataGridCheckBoxWidth">22</system:Double>
   <Style x:Key="DataGridCheckBoxElementDefaultStyle" TargetType="{x:Type CheckBox}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Foreground">
       <Setter.Value>
@@ -4267,9 +4263,7 @@
   <system:Double x:Key="RadioButtonStrokeThickness">1</system:Double>
   <Thickness x:Key="RadioButtonPadding">8,6,0,0</Thickness>
   <Style x:Key="DefaultRadioButtonStyle" TargetType="{x:Type RadioButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource RadioButtonForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />
@@ -4422,9 +4416,7 @@
   <Thickness x:Key="RepeatButtonBorderThemeThickness">1</Thickness>
   <Thickness x:Key="RepeatButtonIconMargin">0,0,8,0</Thickness>
   <Style x:Key="DefaultRepeatButtonStyle" TargetType="{x:Type RepeatButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="{DynamicResource RepeatButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
@@ -5421,9 +5413,7 @@
   <Thickness x:Key="ToggleButtonBorderThemeThickness">1</Thickness>
   <Thickness x:Key="ToggleButtonIconMargin">0,0,8,0</Thickness>
   <Style x:Key="DefaultToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="{DynamicResource ToggleButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource ToggleButtonForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
@@ -5753,9 +5743,7 @@
   <system:String x:Key="TreeViewChevronRightGlyph"></system:String>
   <system:String x:Key="TreeViewChevronLeftGlyph"></system:String>
   <Style x:Key="ExpandCollapseToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Focusable" Value="False" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -5794,9 +5782,7 @@
     </Setter>
   </Style>
   <Style x:Key="DefaultTreeViewItemStyle" TargetType="{x:Type TreeViewItem}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Foreground" Value="{DynamicResource TreeViewItemForeground}" />
     <Setter Property="Background" Value="{DynamicResource TreeViewItemBackground}" />
     <Setter Property="Margin" Value="0,0,0,2" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -1436,9 +1436,7 @@
     </Setter>
   </Style>
   <Style x:Key="DefaultComboBoxItemStyle" TargetType="{x:Type ComboBoxItem}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Margin" Value="{StaticResource ComboBoxItemMargin}" />
@@ -2252,9 +2250,7 @@
   <system:Double x:Key="DataGridCheckBoxHeight">22</system:Double>
   <system:Double x:Key="DataGridCheckBoxWidth">22</system:Double>
   <Style x:Key="DataGridCheckBoxElementDefaultStyle" TargetType="{x:Type CheckBox}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Foreground">
       <Setter.Value>
@@ -4167,9 +4163,7 @@
   <system:Double x:Key="RadioButtonStrokeThickness">1</system:Double>
   <Thickness x:Key="RadioButtonPadding">8,6,0,0</Thickness>
   <Style x:Key="DefaultRadioButtonStyle" TargetType="{x:Type RadioButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource RadioButtonForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />
@@ -4322,9 +4316,7 @@
   <Thickness x:Key="RepeatButtonBorderThemeThickness">1</Thickness>
   <Thickness x:Key="RepeatButtonIconMargin">0,0,8,0</Thickness>
   <Style x:Key="DefaultRepeatButtonStyle" TargetType="{x:Type RepeatButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="{DynamicResource RepeatButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
@@ -5321,9 +5313,7 @@
   <Thickness x:Key="ToggleButtonBorderThemeThickness">1</Thickness>
   <Thickness x:Key="ToggleButtonIconMargin">0,0,8,0</Thickness>
   <Style x:Key="DefaultToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="{DynamicResource ToggleButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource ToggleButtonForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
@@ -5653,9 +5643,7 @@
   <system:String x:Key="TreeViewChevronRightGlyph"></system:String>
   <system:String x:Key="TreeViewChevronLeftGlyph"></system:String>
   <Style x:Key="ExpandCollapseToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Focusable" Value="False" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -5694,9 +5682,7 @@
     </Setter>
   </Style>
   <Style x:Key="DefaultTreeViewItemStyle" TargetType="{x:Type TreeViewItem}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Foreground" Value="{DynamicResource TreeViewItemForeground}" />
     <Setter Property="Background" Value="{DynamicResource TreeViewItemBackground}" />
     <Setter Property="Margin" Value="0,0,0,2" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -1551,9 +1551,7 @@
     </Setter>
   </Style>
   <Style x:Key="DefaultComboBoxItemStyle" TargetType="{x:Type ComboBoxItem}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Margin" Value="{StaticResource ComboBoxItemMargin}" />
@@ -2367,9 +2365,7 @@
   <system:Double x:Key="DataGridCheckBoxHeight">22</system:Double>
   <system:Double x:Key="DataGridCheckBoxWidth">22</system:Double>
   <Style x:Key="DataGridCheckBoxElementDefaultStyle" TargetType="{x:Type CheckBox}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Foreground">
       <Setter.Value>
@@ -4282,9 +4278,7 @@
   <system:Double x:Key="RadioButtonStrokeThickness">1</system:Double>
   <Thickness x:Key="RadioButtonPadding">8,6,0,0</Thickness>
   <Style x:Key="DefaultRadioButtonStyle" TargetType="{x:Type RadioButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource RadioButtonForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />
@@ -4437,9 +4431,7 @@
   <Thickness x:Key="RepeatButtonBorderThemeThickness">1</Thickness>
   <Thickness x:Key="RepeatButtonIconMargin">0,0,8,0</Thickness>
   <Style x:Key="DefaultRepeatButtonStyle" TargetType="{x:Type RepeatButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="{DynamicResource RepeatButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
@@ -5436,9 +5428,7 @@
   <Thickness x:Key="ToggleButtonBorderThemeThickness">1</Thickness>
   <Thickness x:Key="ToggleButtonIconMargin">0,0,8,0</Thickness>
   <Style x:Key="DefaultToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="{DynamicResource ToggleButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource ToggleButtonForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
@@ -5768,9 +5758,7 @@
   <system:String x:Key="TreeViewChevronRightGlyph"></system:String>
   <system:String x:Key="TreeViewChevronLeftGlyph"></system:String>
   <Style x:Key="ExpandCollapseToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Focusable" Value="False" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -5809,9 +5797,7 @@
     </Setter>
   </Style>
   <Style x:Key="DefaultTreeViewItemStyle" TargetType="{x:Type TreeViewItem}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Foreground" Value="{DynamicResource TreeViewItemForeground}" />
     <Setter Property="Background" Value="{DynamicResource TreeViewItemBackground}" />
     <Setter Property="Margin" Value="0,0,0,2" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
@@ -734,9 +734,7 @@
     </Setter>
   </Style>
   <Style x:Key="DefaultComboBoxItemStyle" TargetType="{x:Type ComboBoxItem}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Margin" Value="{StaticResource ComboBoxItemMargin}" />
@@ -1550,9 +1548,7 @@
   <system:Double x:Key="DataGridCheckBoxHeight">22</system:Double>
   <system:Double x:Key="DataGridCheckBoxWidth">22</system:Double>
   <Style x:Key="DataGridCheckBoxElementDefaultStyle" TargetType="{x:Type CheckBox}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Foreground">
       <Setter.Value>
@@ -3465,9 +3461,7 @@
   <system:Double x:Key="RadioButtonStrokeThickness">1</system:Double>
   <Thickness x:Key="RadioButtonPadding">8,6,0,0</Thickness>
   <Style x:Key="DefaultRadioButtonStyle" TargetType="{x:Type RadioButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource RadioButtonForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />
@@ -3620,9 +3614,7 @@
   <Thickness x:Key="RepeatButtonBorderThemeThickness">1</Thickness>
   <Thickness x:Key="RepeatButtonIconMargin">0,0,8,0</Thickness>
   <Style x:Key="DefaultRepeatButtonStyle" TargetType="{x:Type RepeatButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="{DynamicResource RepeatButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
@@ -4619,9 +4611,7 @@
   <Thickness x:Key="ToggleButtonBorderThemeThickness">1</Thickness>
   <Thickness x:Key="ToggleButtonIconMargin">0,0,8,0</Thickness>
   <Style x:Key="DefaultToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Background" Value="{DynamicResource ToggleButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource ToggleButtonForeground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
@@ -4951,9 +4941,7 @@
   <system:String x:Key="TreeViewChevronRightGlyph"></system:String>
   <system:String x:Key="TreeViewChevronLeftGlyph"></system:String>
   <Style x:Key="ExpandCollapseToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Focusable" Value="False" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -4992,9 +4980,7 @@
     </Setter>
   </Style>
   <Style x:Key="DefaultTreeViewItemStyle" TargetType="{x:Type TreeViewItem}">
-    <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
-    <!--  Universal WPF UI focus  -->
     <Setter Property="Foreground" Value="{DynamicResource TreeViewItemForeground}" />
     <Setter Property="Background" Value="{DynamicResource TreeViewItemBackground}" />
     <Setter Property="Margin" Value="0,0,0,2" />


### PR DESCRIPTION
Particall fixes #8554 

## Description
In this PR, I have removed the extra comments regarding focus from the Fluent theme files. This is part of the work for #8554.

## Customer Impact
--

## Regression
NA

## Testing
None

## Risk
None
