### PR TITLE
Added license headers in fluent style files

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/Generator/ThemeGenerator.Fluent.ps1
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/Generator/ThemeGenerator.Fluent.ps1
@@ -14,18 +14,29 @@ foreach($themeColor in $themeColors)
         $outFilePath = Join-Path $fluentThemeDir "Themes\Fluent.xaml"
     }
    
-    [xml]$combinedXaml = '<ResourceDictionary 
-                            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-                            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
-                            xmlns:sys="clr-namespace:System;assembly=mscorlib" 
-                            xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" 
-                            xmlns:fluentcontrols="clr-namespace:Fluent.Controls"
-                            xmlns:system="clr-namespace:System;assembly=System.Runtime"
-                            xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI"
-                            xmlns:theme="clr-namespace:Microsoft.Windows.Themes"
-                            xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework"
-                            xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
-                        </ResourceDictionary>'
+    [xml]$combinedXaml = '
+    <!--=================================================================
+        Licensed to the .NET Foundation under one or more agreements.
+        The .NET Foundation licenses this file to you under the MIT license.
+        See the LICENSE file in the project root for more information.
+        
+        THIS IS A GENERATED FILE. NO CHANGES SHOULD BE MADE HERE DIRECTLY.
+        
+        Use ThemeGenerator.Fluent.ps1 file to generate this file.
+        ==================================================================-->
+
+        <ResourceDictionary 
+            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+            xmlns:sys="clr-namespace:System;assembly=mscorlib" 
+            xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" 
+            xmlns:fluentcontrols="clr-namespace:Fluent.Controls"
+            xmlns:system="clr-namespace:System;assembly=System.Runtime"
+            xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI"
+            xmlns:theme="clr-namespace:Microsoft.Windows.Themes"
+            xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework"
+            xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
+        </ResourceDictionary>'
                         
     foreach ($file in Get-ChildItem $resouceFilesDir -Filter "*.xaml") {
         if($file.BaseName -eq "Fluent") {

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DocumentViewer.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DocumentViewer.xaml
@@ -1,3 +1,9 @@
+<!--=================================================================
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+    ==================================================================-->
+    
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/GridSplitter.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/GridSplitter.xaml
@@ -1,3 +1,9 @@
+<!--=================================================================
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+    ==================================================================-->
+    
 <ResourceDictionary 
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/GridView.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/GridView.xaml
@@ -1,3 +1,9 @@
+<!--=================================================================
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+    ==================================================================-->
+    
 <ResourceDictionary 
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/GroupBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/GroupBox.xaml
@@ -1,3 +1,9 @@
+<!--=================================================================
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+    ==================================================================-->
+    
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Hyperlink.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Hyperlink.xaml
@@ -1,3 +1,9 @@
+<!--=================================================================
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+    ==================================================================-->
+    
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ItemsControl.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ItemsControl.xaml
@@ -1,3 +1,9 @@
+<!--=================================================================
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+    ==================================================================-->
+    
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/NavigationWindow.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/NavigationWindow.xaml
@@ -1,3 +1,9 @@
+<!--=================================================================
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+    ==================================================================-->
+    
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:system="clr-namespace:System;assembly=System.Runtime"   

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ResizeGrip.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ResizeGrip.xaml
@@ -1,3 +1,9 @@
+<!--=================================================================
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+    ==================================================================-->
+    
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/StatusBarItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/StatusBarItem.xaml
@@ -1,3 +1,9 @@
+<!--=================================================================
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+    ==================================================================-->
+    
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Thumb.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Thumb.xaml
@@ -1,3 +1,9 @@
+<!--=================================================================
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+    ==================================================================-->
+    
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/UserControl.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/UserControl.xaml
@@ -1,3 +1,9 @@
+<!--=================================================================
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+    ==================================================================-->
+    
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -1,3 +1,12 @@
+<!--=================================================================
+        Licensed to the .NET Foundation under one or more agreements.
+        The .NET Foundation licenses this file to you under the MIT license.
+        See the LICENSE file in the project root for more information.
+        
+        THIS IS A GENERATED FILE. NO CHANGES SHOULD BE MADE HERE DIRECTLY.
+        
+        Use ThemeGenerator.Fluent.ps1 file to generate this file.
+        ==================================================================-->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" xmlns:fluentcontrols="clr-namespace:Fluent.Controls" xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI" xmlns:theme="clr-namespace:Microsoft.Windows.Themes" xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework" xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
   <ContextMenu x:Key="DefaultControlContextMenu">
     <MenuItem Command="ApplicationCommands.Copy" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -1,3 +1,12 @@
+<!--=================================================================
+        Licensed to the .NET Foundation under one or more agreements.
+        The .NET Foundation licenses this file to you under the MIT license.
+        See the LICENSE file in the project root for more information.
+        
+        THIS IS A GENERATED FILE. NO CHANGES SHOULD BE MADE HERE DIRECTLY.
+        
+        Use ThemeGenerator.Fluent.ps1 file to generate this file.
+        ==================================================================-->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" xmlns:fluentcontrols="clr-namespace:Fluent.Controls" xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI" xmlns:theme="clr-namespace:Microsoft.Windows.Themes" xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework" xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
   <ContextMenu x:Key="DefaultControlContextMenu">
     <MenuItem Command="ApplicationCommands.Copy" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -1,3 +1,12 @@
+<!--=================================================================
+        Licensed to the .NET Foundation under one or more agreements.
+        The .NET Foundation licenses this file to you under the MIT license.
+        See the LICENSE file in the project root for more information.
+        
+        THIS IS A GENERATED FILE. NO CHANGES SHOULD BE MADE HERE DIRECTLY.
+        
+        Use ThemeGenerator.Fluent.ps1 file to generate this file.
+        ==================================================================-->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" xmlns:fluentcontrols="clr-namespace:Fluent.Controls" xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI" xmlns:theme="clr-namespace:Microsoft.Windows.Themes" xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework" xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
   <ContextMenu x:Key="DefaultControlContextMenu">
     <MenuItem Command="ApplicationCommands.Copy" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml
@@ -1,3 +1,12 @@
+<!--=================================================================
+        Licensed to the .NET Foundation under one or more agreements.
+        The .NET Foundation licenses this file to you under the MIT license.
+        See the LICENSE file in the project root for more information.
+        
+        THIS IS A GENERATED FILE. NO CHANGES SHOULD BE MADE HERE DIRECTLY.
+        
+        Use ThemeGenerator.Fluent.ps1 file to generate this file.
+        ==================================================================-->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework" xmlns:fluentcontrols="clr-namespace:Fluent.Controls" xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:ui="clr-namespace:System.Windows.Documents;assembly=PresentationUI" xmlns:theme="clr-namespace:Microsoft.Windows.Themes" xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework" xmlns:base="clr-namespace:System.Windows;assembly=WindowsBase">
   <ContextMenu x:Key="DefaultControlContextMenu">
     <MenuItem Command="ApplicationCommands.Copy" />


### PR DESCRIPTION
Partially Fixes #8554 

## Description
Some files added in fluent styles were missing licensing headers. This PR just adds those licensing header for XAML files. For C# files the rule is enforced by _editorconfig_.

## Customer Impact
--

## Regression
No

## Testing
None

## Risk
None
