### PR TITLE
Use Environment.ProcessPath instead of Process.GetCurrentProcess().Pr…

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
@@ -203,7 +203,7 @@ namespace MS.Win32
         {
             string msg = String.Format("BEGIN: {0:X} -- Setting DWP, process = {1} ({2}) {3}",
                    hwnd,
-                   System.Diagnostics.Process.GetCurrentProcess().ProcessName,
+                   Path.GetFileNameWithoutExtension(Environment.ProcessPath),
                    fromWhere,
                    System.Environment.NewLine);
 
@@ -214,7 +214,7 @@ namespace MS.Win32
         {
             string msg = String.Format("END:   {0:X} -- Setting DWP, process = {1} ({2}) {3}",
                    hwnd,
-                   System.Diagnostics.Process.GetCurrentProcess().ProcessName,
+                   Path.GetFileNameWithoutExtension(Environment.ProcessPath),
                    fromWhere,
                    System.Environment.NewLine);
 


### PR DESCRIPTION

Fixes # <!-- Issue Number -->

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

Replace Process.GetCurrentProcess().ProcessName with Path.GetFileNameWithoutExtension(Environment.ProcessPath) for better performance and cleaner code.

## Customer Impact

- Reduced system call overhead
- No temporary Process object creation

## Regression


## Testing


## Risk


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/10998)