### PR TITLE
Fix local pointer arithmetic

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/LineServicesCallbacks.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/LineServicesCallbacks.cs
@@ -128,7 +128,14 @@ namespace MS.Internal.TextFormatting
                 }
                 else
                 {
-                    pwchText += lsrun.OffsetToFirstChar + lsrunOffset;
+                    int totalOffset = lsrun.OffsetToFirstChar + lsrunOffset;
+                    int bufferLength = lsrun.CharacterBuffer.Length;
+                    if (totalOffset < 0 || totalOffset >= bufferLength)
+                    {
+                        // Offset is out of bounds, return error as in the buffer copy branch
+                        return LsErr.None;
+                    }
+                    pwchText += totalOffset;
                 }
 
 


### PR DESCRIPTION
https://github.com/dotnet/wpf/blob/3e7d1160037e5e328558210c328cc6af7f9b6b0d/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/LineServicesCallbacks.cs#L131-L131

It is dangerous to use the result of a virtual method call in pointer arithmetic without validation if external users can provide their own implementation of the virtual method. For example, if the analyzed project is distributed as a library or framework, then the end-user could provide a new implementation that returns any value.


fix the problem, we must validate that the pointer arithmetic does not result in an out-of-bounds pointer. Specifically, after obtaining the pointer from `GetCharacterPointer()`, and before adding `lsrun.OffsetToFirstChar + lsrunOffset`, we should ensure that the resulting pointer will still point within the valid range of the buffer. This requires knowing the length of the buffer that `pwchText` points to. If `lsrun.CharacterBuffer` exposes its length (e.g., via a `Length` property), we can check that `lsrun.OffsetToFirstChar + lsrunOffset` is non-negative and less than the buffer length. If not, we may need to add such a property or otherwise obtain the length. The check should be added just before the pointer arithmetic on line 131, and if the check fails, the function should return early or handle the error appropriately (as is done in the buffer copy branch above).

#### References
 [Microsoft Unsafe Code and Pointers](https://msdn.microsoft.com/en-us/library/t2yzs44b.aspx)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11013)