### PR TITLE
Add System.Private.Windows.Core.TestUtilities to Version.Details.xml

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -24,6 +24,7 @@ This file should be imported by eng/Versions.props
     <SystemDrawingCommonPackageVersion>10.0.0-rc.1.25411.109</SystemDrawingCommonPackageVersion>
     <SystemFormatsNrbfPackageVersion>10.0.0-rc.1.25411.109</SystemFormatsNrbfPackageVersion>
     <SystemIOPackagingPackageVersion>10.0.0-rc.1.25411.109</SystemIOPackagingPackageVersion>
+    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>10.0.0-rc.1.25411.109</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
     <SystemReflectionMetadataLoadContextPackageVersion>10.0.0-rc.1.25411.109</SystemReflectionMetadataLoadContextPackageVersion>
     <SystemResourcesExtensionsPackageVersion>10.0.0-rc.1.25411.109</SystemResourcesExtensionsPackageVersion>
     <SystemRuntimeSerializationFormattersPackageVersion>10.0.0-rc.1.25411.109</SystemRuntimeSerializationFormattersPackageVersion>
@@ -53,6 +54,7 @@ This file should be imported by eng/Versions.props
     <SystemDrawingCommonVersion>$(SystemDrawingCommonPackageVersion)</SystemDrawingCommonVersion>
     <SystemFormatsNrbfVersion>$(SystemFormatsNrbfPackageVersion)</SystemFormatsNrbfVersion>
     <SystemIOPackagingVersion>$(SystemIOPackagingPackageVersion)</SystemIOPackagingVersion>
+    <SystemPrivateWindowsCoreTestUtilitiesVersion>$(SystemPrivateWindowsCoreTestUtilitiesPackageVersion)</SystemPrivateWindowsCoreTestUtilitiesVersion>
     <SystemReflectionMetadataLoadContextVersion>$(SystemReflectionMetadataLoadContextPackageVersion)</SystemReflectionMetadataLoadContextVersion>
     <SystemResourcesExtensionsVersion>$(SystemResourcesExtensionsPackageVersion)</SystemResourcesExtensionsVersion>
     <SystemRuntimeSerializationFormattersVersion>$(SystemRuntimeSerializationFormattersPackageVersion)</SystemRuntimeSerializationFormattersVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -76,6 +76,10 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
+    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="10.0.0-rc.1.25411.109">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>520c71b5277fc1f72dbec14da03ca55205d6c8e5</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25411.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>520c71b5277fc1f72dbec14da03ca55205d6c8e5</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -68,8 +68,6 @@
     <SystemDrawingCommonTestDataVersion>8.0.0-beta.23107.1</SystemDrawingCommonTestDataVersion>
     <SystemWindowsExtensionsTestDataVersion>8.0.0-beta.23107.1</SystemWindowsExtensionsTestDataVersion>
     <VerifyXunitV3Version>30.1.0</VerifyXunitV3Version>
-    <!-- Shared test utilities with WinForms -->
-    <SystemPrivateWindowsCoreTestUtilitiesVersion>10.0.0-preview.6.25313.5</SystemPrivateWindowsCoreTestUtilitiesVersion>
   </PropertyGroup>
   <!-- Code Coverage -->
   <PropertyGroup>


### PR DESCRIPTION
So the VMR can properly override the version used.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11049)