### PR TITLE
Fix #5428: DataGrid with template columns causes crash when scrolling

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlAutomationPeer.cs
@@ -162,6 +162,12 @@ namespace System.Windows.Automation.Peers
                         dataItem = item;
                     }
 
+                    if (dataItem == null)
+                    {
+                        // skip null items
+                        continue;
+                    }
+
                     // try to reuse old peer if it exists either in Current AT or in WeakRefStorage of Peers being sent to Client
                     ItemAutomationPeer peer = oldChildren[dataItem];
                     peer = ReusePeerForItem(peer, dataItem);


### PR DESCRIPTION
Fixes #5428

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

During scroll of items-controls there are occasional null reference exceptions that crash the application. There is no chance to handle these exceptions, because there is no user code in the stack trace.

This PR adds the missing null check to avoid the null reference exceptions.

## Customer Impact

Actually there are occasional crashes of the application that are not fixable by user code, see e.g. https://github.com/dotnet/ResXResourceManager/issues/430

This problem occurs in any version of DotNet or NetFramework.

This PR fixes the application crashes.

## Testing

No testing, impossible to build and run locally.

## Risk

Low, it's just adding a null-check before code that crashes on null items.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11068)