### PR TITLE
Fix StylusPlugIn OnStylusDown/Move/Up invoked on UI thread and called out of order

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenContexts.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenContexts.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Input.StylusWisp;
@@ -488,7 +488,7 @@ namespace System.Windows.Input
                 ptTablet *= stylusDevice.TabletDevice.TabletDeviceImpl.TabletToScreen;
                 ptTablet.X = (int)Math.Round(ptTablet.X); // Make sure we snap to whole window pixels.
                 ptTablet.Y = (int)Math.Round(ptTablet.Y);
-                ptTablet = _stylusLogic.MeasureUnitsFromDeviceUnits(stylusDevice.CriticalActiveSource, ptTablet); // change to measured units now.
+                ptTablet = _stylusLogic.MeasureUnitsFromDeviceUnits(inputReport.InputSource ?? stylusDevice.CriticalActiveSource, ptTablet); // change to measured units now.
 
                 pic = HittestPlugInCollection(ptTablet); // Use cached rectangles for UIElements.
             }


### PR DESCRIPTION
Fixes #11103

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

See https://github.com/dotnet/wpf/issues/11103

The `stylusDevice.CriticalActiveSource` may be null. And the `stylusDevice.CriticalActiveSource` will update from `inputReport.InputSource`. So that we directly use `inputReport.InputSource` will be safe and reasonable.

This PR can not 100% fix the #11103 , but this PR can alleviate the problem.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
Fix the out of roder issues.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

None.

## Testing

<!-- What kind of testing has been done with the fix. -->

Test pass in my touch device.

And I build and publish my version to NuGet: https://www.nuget.org/packages/dotnetCampus.WPF.Resource/6.0.4-alpha07-test10

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

Normal. As description says, the  `stylusDevice.CriticalActiveSource` will update from `inputReport.InputSource` in UI thread. We can directly use `inputReport.InputSource` in Stylus Input thread safely.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11108)