### PR TITLE
Update Nuget.config to include .NET 11 paths

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -14,6 +14,8 @@
     <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
+    <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" />
+    <add key="dotnet11-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11-transport/nuget/v3/index.json" />
   </packageSources>
   <auditSources>
     <clear />


### PR DESCRIPTION
Unblocks the PR: https://github.com/dotnet/wpf/pull/11109

## Description
The changes adds the keys to .NET 11 configs. 

## Testing
Local Build Pass
<!-- What kind of testing has been done with the fix. -->

## Risk
Low
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
