### PR TITLE
Optimize GlyphTypeface: Avoid create the cmap Dictionary when get Count only

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontFaceLayoutInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontFaceLayoutInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -733,7 +733,26 @@ namespace MS.Internal.FontCache
 
             public int Count
             {
-                get { return CMap.Count; }
+                get
+                {
+                    if (_cmap == null)
+                    {
+                        // When _cmap is not created yet, we can get the count directly from the font. We don't use the CMap property, because that would create the cmap and initialize it slowly.
+                        MS.Internal.Text.TextInterface.FontFace fontFace = _font.GetFontFace();
+                        try
+                        {
+                            return fontFace.GlyphCount;
+                        }
+                        finally
+                        {
+                            fontFace.Release();
+                        }
+                    }
+                    else
+                    {
+                        return _cmap.Count;
+                    }
+                }
             }
 
             public bool IsReadOnly


### PR DESCRIPTION
## Description

As the code shows:

https://github.com/dotnet/wpf/blob/f7ebd69146f3ec9b771e92c13250efa99a65a26c/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontFaceLayoutInfo.cs#L585-L609

We can know that the cost of creating CMap is expensive. When we get the `Count` only, we do not need to create the CMap Dictionary.

We can get the count from FontFace directly:

https://github.com/dotnet/wpf/blob/f7ebd69146f3ec9b771e92c13250efa99a65a26c/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/FontFace.h#L126

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

Performance

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->

CI only.

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

Low. I do not change the behavior. The old behavior is get the count after the CMap Dictionary created, and the new behavior is get the count from FontFace directly.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11139)