### PR TITLE
Fix: reordered import in temporary project to ensure correct property…

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -264,9 +264,6 @@ namespace Microsoft.Build.Tasks.Windows
                 // Add Analyzers to Analyzer item list.
                 AddNewItems(xmlProjectDoc, AnalyzerTypeName, Analyzers);
 
-                // Replace implicit SDK imports with explicit SDK imports
-                ReplaceImplicitImports(xmlProjectDoc);
-
                 // Add properties required for temporary assembly compilation
                 var properties = new List<(string PropertyName, string PropertyValue)>
                 {
@@ -282,6 +279,10 @@ namespace Microsoft.Build.Tasks.Windows
                 RemovePropertiesByName(xmlProjectDoc, nameof(AssemblyName));
 
                 AddNewProperties(xmlProjectDoc, properties);
+
+                // Replace implicit SDK imports with explicit SDK imports
+                // In this temorary project file, the SDK import must be inserted before the added PropertyGroup.
+                ReplaceImplicitImports(xmlProjectDoc);
 
                 // Save the xmlDocument content into the temporary project file.
                 xmlProjectDoc.Save(TemporaryTargetAssemblyProjectName);


### PR DESCRIPTION
… override

Fixes #11150

## Description

Properties explicitly set in the temporary project file are incorrectly override by Directory.Build.props.

This pull request addresses an issue where properties explicitly defined in temporary project files were unintentionally overridden by values from Directory.Build.props. 

This fix will cause the import element for SDK.props to be written to the temporary project file before PropertyGroup elements.

## Customer Impact

The build cannot be completed successfully.
Known workarounds are incompatible with the code generator.

This fix improves reliability in build environments that rely on temporary project files, such as automated tooling or SDK-generated projects.

## Regression

This may be a regression that occurred in .NET 9, according to #10068.

## Testing

I placed the built PresentationBuildTasks.dll in C:\Program Files\dotnet\sdk\9.0.304\Sdks\Microsoft.NET.Sdk.WindowsDesktop\tools\net472 and confirmed that I can build WPF project from Visual Studio and msbuid.exe .

[Sample repository](https://github.com/gekka/TestWPFDirectoryProps)

## Risk

Build behavior breaks only if the old code author intended to pass a properties (IntermediateOutputPath, BaseIntermediateOutputPath, MSBuildProjectExtensionsPath, and _TargetAssemblyProjectName) to the Sdk.props.
