### PR TITLE
Make Dependent implement IEquatable<T> to reduce boxing

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependentList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependentList.cs
@@ -181,7 +181,7 @@ namespace System.Windows
         
         public override bool Equals(object o)
         {
-            return o is Dependent d ? Equals(d) : false;
+            return o is Dependent d && Equals(d);
         }
         
         public bool Equals(Dependent d)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependentList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependentList.cs
@@ -126,7 +126,7 @@ namespace System.Windows
         }
     }
 
-    internal struct Dependent
+    internal struct Dependent : IEquatable<Dependent>
     {
         private DependencyProperty _DP;
         private WeakReference _wrDO;
@@ -178,14 +178,14 @@ namespace System.Windows
                     return (Expression)_wrEX.Target;
             }
         }
-
+        
         public override bool Equals(object o)
         {
-            if(! (o is Dependent))
-                return false;
-
-            Dependent d = (Dependent)o;
-
+            return o is Dependent d ? Equals(d) : false;
+        }
+        
+        public override bool Equals(Dependent d)
+        {
             // Not equal to Dead values.
             // This is assuming that at least one of the compared items is live.
             // This assumtion comes from knowing that Equal is used by FrugalList.Remove()

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependentList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependentList.cs
@@ -184,7 +184,7 @@ namespace System.Windows
             return o is Dependent d ? Equals(d) : false;
         }
         
-        public override bool Equals(Dependent d)
+        public bool Equals(Dependent d)
         {
             // Not equal to Dead values.
             // This is assuming that at least one of the compared items is live.


### PR DESCRIPTION
## Description

Calling Equals produces alot of memory traffic through boxing the struct as object.
<img width="1025" height="143" alt="MemoryTraffic Dependent" src="https://github.com/user-attachments/assets/0272daee-1628-476f-a008-c2afb576731a" />


## Customer Impact

Higher memory consumption and more cpu load through GC


## Testing

Made sure the correct Equals method gets called

## Risk

Low

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11179)