### PR TITLE
Update XpsOMDocumentPageSerializerAsync.cs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMDocumentPageSerializerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMDocumentPageSerializerAsync.cs
@@ -44,7 +44,7 @@ namespace System.Windows.Xps.Serialization
 
                 case SerializerAction.endSerializeDocumentPage:
                     {
-                        ReachFixedPageSerializerContext thisContext = context as ReachFixedPageSerializerContext;
+                        ReachFixedPageSerializerContext thisContext = (ReachFixedPageSerializerContext)context;
                         _syncSerializer.EndSerializeDocumentPage(thisContext.TreeWalker);
                         break;
                     }


### PR DESCRIPTION
as-cast could give null but property is directly used without nullcheck, so direct cast is preferred

Fixes #10270



## Description

cleanup and performance

## Customer Impact

low

## Regression

-

## Testing

none

## Risk

low

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11181)