### PR TITLE
Remove auditSources from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -18,9 +18,5 @@
     <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" />
     <add key="dotnet11-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11-transport/nuget/v3/index.json" />
   </packageSources>
-  <auditSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </auditSources>
   <disabledPackageSources />
 </configuration>


### PR DESCRIPTION
The api.nuget.org source will clash with the CFSClean network isolation policy and the same data is provided by AzDO now.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11184)