### PR TITLE
Fix validation adorner race condition (#8969)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Validation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Validation.cs
@@ -388,7 +388,10 @@ namespace System.Windows.Controls
             object[] args = (object[])arg;
             DependencyObject targetElement = (DependencyObject)args[0];
             DependencyObject adornerSite = (DependencyObject)args[1];
-            bool show = (bool)args[2];
+            // bool show = (bool)args[2];  //stale scheduled value
+            //trying for issue #8969:always use the current error state..
+            //no race condition where the adorner is shown for an error that was already cleared
+            bool show=GetHasError(targetElement);
 
             // Check if the element is visible, if not try to show the adorner again once it gets visible.
             // This is needed because controls hosted in Expander or TabControl don't have a parent/AdornerLayer till the Expander is expanded or the TabItem is selected.


### PR DESCRIPTION
Fixes a race condition where the validation adorner (red border) remains visible even after errors are cleared programmatically. This occurred when the adorner layer didn't exist during error occurrence, causing a delayed dispatcher operation to show the adorner using stale state.

Fixes #8969


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11191)