### PR TITLE
Enable retry mechanism is Fluent Crashes

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
@@ -400,6 +400,5 @@ namespace MS.Internal
         }
 
         #endregion
-
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
@@ -147,6 +147,18 @@ namespace MS.Internal
                 return LocalAppContext.GetCachedSwitchValue(DisableDynamicResourceOptimizationSwitchName, ref _DisableDynamicResourceOptimization);
             }
         }
+
+        // Swtich to disable DWM crash containment
+        internal const string DisableDWMCrashContainmentSwitchName = "Switch.System.Windows.Media.DisableDWMCrashContainment";
+        private static int _disableDWMCrashContainment;
+        public static bool DisableDWMCrashContainment
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return LocalAppContext.GetCachedSwitchValue(DisableDWMCrashContainmentSwitchName, ref _disableDWMCrashContainment);
+            }
+        }
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
@@ -32,7 +32,7 @@ namespace System
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.ItemAutomationPeerKeepsItsItemAliveSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableFluentThemeWindowBackdropSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableDynamicResourceOptimizationSwitchName, false);
-
+            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableDWMCrashContainmentSwitchName, false);
 #pragma warning restore CS0436 // Type conflicts with imported type
         }
     }


### PR DESCRIPTION
## Description
The following changes aim to fix certain repetitive crashes due to win32 DWM API. The idea here is to re-try extending content into client area which might result in a crash for about 2 times and if that still results in an exception, we log the same.

**cc:/** @himgoyalmicro 
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Possibly lesser crashes in fluent and might help in fluent adoption
<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
Sample Application Testing
Tested with a runtime application
<!-- What kind of testing has been done with the fix. -->

## Risk
Low, things are very much in parity with previous impl.
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11284)