### PR TITLE
Add Containment for DWMCrash retry mechanism

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
@@ -400,6 +400,5 @@ namespace MS.Internal
         }
 
         #endregion
-
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
@@ -147,6 +147,18 @@ namespace MS.Internal
                 return LocalAppContext.GetCachedSwitchValue(DisableDynamicResourceOptimizationSwitchName, ref _DisableDynamicResourceOptimization);
             }
         }
+
+        // Swtich to disable DWM crash containment
+        internal const string DisableDWMCrashContainmentSwitchName = "Switch.System.Windows.Media.DisableDWMCrashContainment";
+        private static int _disableDWMCrashContainment;
+        public static bool DisableDWMCrashContainment
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return LocalAppContext.GetCachedSwitchValue(DisableDWMCrashContainmentSwitchName, ref _disableDWMCrashContainment);
+            }
+        }
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
@@ -32,7 +32,7 @@ namespace System
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.ItemAutomationPeerKeepsItsItemAliveSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableFluentThemeWindowBackdropSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableDynamicResourceOptimizationSwitchName, false);
-
+            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableDWMCrashContainmentSwitchName, false);
 #pragma warning restore CS0436 // Type conflicts with imported type
         }
     }


### PR DESCRIPTION
## Description
Using AppContextSwitch, we are trying to contain the retry mechanism of DWM's `ExtendFrameIntoClientArea` API call.

## Customer Impact
Developers can use the AppContextSwtich as below to avoid the retry mechanism:
```xml
<ItemGroup>
	<RuntimeHostConfigurationOption Include="Switch.System.Windows.Media.DisableDWMCrashContainment" Value="true" />
</ItemGroup>
```
## Regression
No

## Testing
Local Build Pass
Tested a sample application in runtime to make sure the switch is adhered to.

## Risk
Minimal
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11285)