### PR TITLE
Fix .Net 10 SDK build issue when using internal members

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
@@ -2481,7 +2481,7 @@ namespace System.Windows.Markup
 
         private static bool IsInternalAllowedOnType(Type type)
         {
-            bool isInternalAllowed = ReflectionHelper.LocalAssemblyName == ReflectionUtils.GetAssemblyPartialName(type.Assembly) ||
+            bool isInternalAllowed = ReflectionUtils.GetAssemblyPartialName(type.Assembly).Equals(ReflectionHelper.LocalAssemblyName, StringComparison.Ordinal) ||
                                      IsFriendAssembly(type.Assembly);
             _hasInternals = _hasInternals || isInternalAllowed;
             return isInternalAllowed;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -503,7 +503,7 @@ namespace System.Xaml
 #if PBTCOMPILER
         internal static bool IsInternalAllowedOnType(Type type)
         {
-            return LocalAssemblyName == ReflectionUtils.GetAssemblyPartialName(type.Assembly) || IsFriendAssembly(type.Assembly);
+            return ReflectionUtils.GetAssemblyPartialName(type.Assembly).Equals(LocalAssemblyName, StringComparison.Ordinal) || IsFriendAssembly(type.Assembly);
         }
 #endif
 


### PR DESCRIPTION
Fixes dotnet/wpf#11235

## Description
The issue was because dotnet/wpf#9739 introduced the new method `ReflectionUtils.GetAssemblyPartialName` and updated several places to use it. The problem is that `ReflectionUtils.GetAssemblyPartialName` returns a `ReadOnlySpan<char>` when built using .Net 10 while in the .Net Framework build it returns a `string`. The problem is that comparison were not changed to replace `==` with `Equals` or something else and `==` on a `ReadOnlySpan<>` only compares the reference not the content (See [docs](https://learn.microsoft.com/en-us/dotnet/api/system.readonlyspan-1.op_equality?view=net-10.0#remarks)). The means that even if 2 `ReadOnlySpan<char>` had the same content the `==` comparison could return false if the 2 spans don't point to the same memory address.

I fixed the issue by replacing `==` with [MemoryExtensions.Equals](https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.equals?view=net-10.0#system-memoryextensions-equals(system-readonlyspan((system-char))-system-readonlyspan((system-char))-system-stringcomparison)) on .Net 10 and [String.Equals](https://learn.microsoft.com/en-us/dotnet/api/system.string.equals?view=net-10.0#system-string-equals(system-string-system-stringcomparison)) on .Net Framework. For .Net Framework, the behavior remains the same but on .Net 10 the comparison now compares the content instead of the memory address.

This PR should probably be backported to .Net 10.

## Customer Impact
Currently, projects that use internal members from a XAML file will fail to build.

## Regression
Yes, it was introduced in the .Net 10 SDK by this PR: dotnet/wpf#9739

## Testing
Tested locally using a custom build of `PresentationBuildTasks`.

## Risk
Low.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11289)