### PR TITLE
Fix incorrect registry path of StylusLogic (#11239)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusLogic.cs
@@ -76,12 +76,12 @@ namespace System.Windows.Input
         /// <summary>
         /// The event parameters for WISP pen input
         /// </summary>
-        private const string WispPenSystemEventParametersKey = WispRootKey + @"Software\Microsoft\Wisp\Pen\SysEventParameters";
+        private const string WispPenSystemEventParametersKey = WispRootKey + @"Pen\SysEventParameters";
 
         /// <summary>
         /// The WISP touch paramaters
         /// </summary>
-        private const string WispTouchConfigKey = WispRootKey + @"Software\Microsoft\Wisp\Touch";
+        private const string WispTouchConfigKey = WispRootKey + @"Touch";
 
         /// <summary>
         /// The max distance a double tap can vary


### PR DESCRIPTION
Fixes #11239

## Description

Delete the redundant part in the registry path.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11302)