### PR TITLE
Exclue latest vswhere version from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,6 +331,7 @@ ASALocalRun/
 /.dotnet
 /.packages
 /.tools/vswhere/2.5.2
+/.tools/vswhere/3.1.7
 /.tools/native/iltools
 
 ### OSX ###


### PR DESCRIPTION
Exclude the 3.1.7 vswhere.exe build changes from git tracking.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11343)