### PR TITLE
Stop preventing inlining of `Matrix.Identity` by making `Matrix.s_identity` readonly.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Matrix.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Media/Matrix.cs
@@ -45,7 +45,7 @@ namespace System.Windows.Media
     {
         // the transform is identity by default
         // Actually fill in the fields - some (internal) code uses the fields directly for perf.
-        private static Matrix s_identity = CreateIdentity();
+        private static readonly Matrix s_identity = CreateIdentity();
 
 #region Constructor
 


### PR DESCRIPTION
## Description

While trying to vectorize the WPF `Vector`/`Point`/`Matrix` code with limited success, I stumbled on some low-hanging fruits that could bring noticeable performance improvements to code using `Matrix`.
(See here for my tentatives: https://github.com/hexawyz/WpfVectorBenchmark/tree/master/WpfVectorBenchmark/A)

This first change is very simple but does allow the JIT to inline `Matrix.Identity`, which was previously not the case. This might have been intentional at the time, I wouldn't know, but on the few simple benchmarks i was running, this improved performance by 10% to 23%.
Also, if this ever intentional, this would have been done at a time where support for SIMD in the runtime was inexistant, so making the code more "correct" here should delegate the decision making to the JIT.

## Customer Impact

## Regression

This won't break any code, but it will change the performance characteristics of the code. While I would expect the change to be mostly positive, there could be scenarios where it induces a performance regression.

## Testing

Benchmark

````
| Method                           | Mean      | Error     | StdDev    | Code Size |
|--------------------------------- |----------:|----------:|----------:|----------:|
| Rotate_Ref                       | 21.586 ns | 0.1903 ns | 0.1780 ns |   1,115 B |
| Rotate_A                         | 15.334 ns | 0.0559 ns | 0.0496 ns |   1,124 B |
| TranslateRotateTranslate_Ref     | 11.076 ns | 0.0367 ns | 0.0325 ns |   1,409 B |
| TranslateRotateTranslate_A       |  9.640 ns | 0.0257 ns | 0.0201 ns |   1,162 B |
````

````csharp
private static Vector_Ref Direction_Ref
{
	[MethodImpl(MethodImplOptions.NoInlining)]
	get => new(7, 5);
}

private static Vector_A Direction_A
{
	[MethodImpl(MethodImplOptions.NoInlining)]
	get => new(7, 5);
}

[Benchmark]
public Vector_Ref Rotate_Ref()
{
	var v = Direction_Ref;
	var m = Matrix_Ref.Identity;
	m.Rotate(55);
	return m.Transform(v);
}

[Benchmark]
public Vector_A Rotate_A()
{
	var v = Direction_A;
	var m = Matrix_A.Identity;
	m.Rotate(55);
	return m.Transform(v);
}

[Benchmark]
public Vector_Ref TranslateRotateTranslate_Ref()
{
	var v = Direction_Ref;
	var m = Matrix_Ref.Identity;
	m.Translate(15, 12);
	m.Rotate(55);
	m.Translate(-1, 4);
	return m.Transform(v);
}

[Benchmark]
public Vector_A TranslateRotateTranslate_A()
{
	var v = Direction_A;
	var m = Matrix_A.Identity;
	m.Translate(15, 12);
	m.Rotate(55);
	m.Translate(-1, 4);
	return m.Transform(v);
}
````

## Risk

See the regression part

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11364)