### PR TITLE
Suppress SM04191 BinaryFormatter CodeQL Warnings

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/DataStreams.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/DataStreams.cs
@@ -265,7 +265,7 @@ namespace MS.Internal.AppModel
                         {
                             dataStream.Position = 0;
                             #pragma warning disable SYSLIB0011 // BinaryFormatter is obsolete 
-                            newValue = this.Formatter.Deserialize(dataStream);
+                            newValue = this.Formatter.Deserialize(dataStream); // CodeQL [SM04191] : This is a fallback deserialization to maintain backward compatibility for unsupported NRBF Data Types
                             #pragma warning restore SYSLIB0011 // BinaryFormatter is obsolete 
                         }
                         


### PR DESCRIPTION
## Description
The following changes suppresses SM04191: Use of deserialization without Binder

## Justification
This is a known issue. The NRBF deserialization does not support custom data types and is (to a majority of instance) limited to primitives data types. Since `BinaryFormatter` is now obsolete, at runtime, this should likely throw a `PlatformNotSupportedException` unless developers explicitly include unsupported package in their application. This approach ensures backward compatibility, as there are wide variety of usage around this area and we don't want to break existing applications.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
None
<!-- What is the impact to customers of not taking this fix? -->

## Regression
No
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
None
<!-- What kind of testing has been done with the fix. -->

## Risk
Low
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11385)