### PR TITLE
[Managed DWrite] Reintroduce IDWriteFactory.CreateTextAnalyzer HRESULT validation

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Text/TextInterface/Factory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Text/TextInterface/Factory.cs
@@ -325,7 +325,11 @@ namespace MS.Internal.Text.TextInterface
         {
             IDWriteTextAnalyzer* textAnalyzer = null;
 
-            _factory.Value->CreateTextAnalyzer(&textAnalyzer);
+            int hr = _factory.Value->CreateTextAnalyzer(&textAnalyzer);
+
+            GC.KeepAlive(this);
+
+            DWriteUtil.ConvertHresultToException(hr);
 
             return new TextAnalyzer((Native.IDWriteTextAnalyzer*)textAnalyzer);
         }


### PR DESCRIPTION
Contributes to dotnet/wpf#5305

## Description
Reintroduces code in `Factory.CreateTextAnalyzer` that I inadvertently removed when migrating from C++/CLI to C# in dotnet/wpf#6171. `IDWriteFactory.CreateTextAnalyzer` doesn't do much so the chance of it returning an error is low. Still, it's better to throw early than to let `Factory.CreateTextAnalyzer` succeed and throw `NullReferenceException` when using the resulting TextAnalyzer.

This also makes the tests in dotnet/wpf#11381 that validate that `Factory.CreateTextAnalyzer`  succeeds more meaningful.

Original C++/CLI code:
https://github.com/dotnet/wpf/blob/07edfec90dd54bb9126aedd31b6d2a22f4249ee1/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/Factory.cpp#L411-L418

## Customer Impact
I think the impact is very low, we now get proper exceptions when creating the TextAnalyzer instead of getting a NullReferenceException when using the TextAnalyzer.

## Regression
Yes, was introduced in .Net 9.0 though it has very low impact.

## Testing
Tested locally with the tests from dotnet/wpf#11381.

## Risk
Low, reintroduces code that was removed.