### PR TITLE
Fix text mapping for special characters

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/IClassification.h
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/IClassification.h
@@ -21,8 +21,16 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
             [System::Runtime::InteropServices::Out] bool% isIndic,
             [System::Runtime::InteropServices::Out] bool% isDigit,
             [System::Runtime::InteropServices::Out] bool% isLatin,
-            [System::Runtime::InteropServices::Out] bool% isStrong
+            [System::Runtime::InteropServices::Out] bool% isStrong,
+            [System::Runtime::InteropServices::Out] bool% isExtended
             );
+
+        /// <summary>
+        /// Check whether two Unicode scalar values belong to the same script.
+        /// This is used to determine if combining marks should stay with their base character
+        /// for font fallback purposes. (See PR #6857 / Issue #6801)
+        /// </summary>
+        bool IsSameScript(int unicodeScalar1, int unicodeScalar2);
     };
 
 }}}}//MS::Internal::Text::TextInterface

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/IClassification.h
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/IClassification.h
@@ -22,7 +22,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
             [System::Runtime::InteropServices::Out] bool% isDigit,
             [System::Runtime::InteropServices::Out] bool% isLatin,
             [System::Runtime::InteropServices::Out] bool% isStrong,
-            [System::Runtime::InteropServices::Out] bool% isExtended
+            [System::Runtime::InteropServices::Out] bool% isScriptAgnosticCombining
             );
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextAnalyzer.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextAnalyzer.cpp
@@ -154,6 +154,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
         bool isLatin;
         bool isStrong;
         bool isExtended;
+        bool isScriptAgnosticCombining;
 
         WCHAR ch = text[0];
         classificationUtility->GetCharAttribute(
@@ -164,8 +165,10 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
             isDigit,
             isLatin,
             isStrong,
-            isExtended
+            isScriptAgnosticCombining
         );
+
+        isExtended = ItemizerHelper::IsExtendedCharacter(ch);
 
         UINT32 isDigitRangeStart = 0;
         UINT32 isDigitRangeEnd = 0;
@@ -178,12 +181,12 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
 
         // pCharAttribute is assumed to have the same length as text. This is enforced by Itemize().
         pCharAttribute[0] = (CharAttributeType)
-            (((isCombining) ? CharAttribute::IsCombining : CharAttribute::None)
-                | ((needsCaretInfo) ? CharAttribute::NeedsCaretInfo : CharAttribute::None)
-                | ((isLatin) ? CharAttribute::IsLatin : CharAttribute::None)
-                | ((isIndic) ? CharAttribute::IsIndic : CharAttribute::None)
-                | ((isStrong) ? CharAttribute::IsStrong : CharAttribute::None)
-                | ((isExtended) ? CharAttribute::IsExtended : CharAttribute::None));
+                            (((isCombining)    ? CharAttribute::IsCombining    : CharAttribute::None)
+                           | ((needsCaretInfo) ? CharAttribute::NeedsCaretInfo : CharAttribute::None)
+                           | ((isLatin)        ? CharAttribute::IsLatin        : CharAttribute::None)
+                           | ((isIndic)        ? CharAttribute::IsIndic        : CharAttribute::None)
+                           | ((isStrong)       ? CharAttribute::IsStrong       : CharAttribute::None)
+                           | ((isExtended)     ? CharAttribute::IsExtended     : CharAttribute::None));
 
         for (UINT32 i = 1; i < length; ++i)
         {
@@ -196,8 +199,10 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
                 isDigit,
                 isLatin,
                 isStrong,
-                isExtended
+                isScriptAgnosticCombining
             );
+
+            isExtended = ItemizerHelper::IsExtendedCharacter(ch);
 
             // For combining marks, check if they have the same script as the base character.
             // If not, they should not be treated as combining with the base (PR #6857 / Issue #6801).
@@ -205,7 +210,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
             // are designed to work with any base character regardless of script, so skip the check
             // for them to allow emoji sequences to stay together.
             bool isCombiningWithBase = isCombining;
-            if (isCombining && baseChar >= 0 && !isExtended)
+            if (isCombining && baseChar >= 0 && !isScriptAgnosticCombining)
             {
                 if (!classificationUtility->IsSameScript(baseChar, ch))
                 {
@@ -221,12 +226,12 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
             }
 
             pCharAttribute[i] = (CharAttributeType)
-                (((isCombiningWithBase) ? CharAttribute::IsCombining : CharAttribute::None)
-                    | ((needsCaretInfo) ? CharAttribute::NeedsCaretInfo : CharAttribute::None)
-                    | ((isLatin) ? CharAttribute::IsLatin : CharAttribute::None)
-                    | ((isIndic) ? CharAttribute::IsIndic : CharAttribute::None)
-                    | ((isStrong) ? CharAttribute::IsStrong : CharAttribute::None)
-                    | ((isExtended) ? CharAttribute::IsExtended : CharAttribute::None));
+                                (((isCombining)    ? CharAttribute::IsCombining    : CharAttribute::None)
+                               | ((needsCaretInfo) ? CharAttribute::NeedsCaretInfo : CharAttribute::None)
+                               | ((isLatin)        ? CharAttribute::IsLatin        : CharAttribute::None)
+                               | ((isIndic)        ? CharAttribute::IsIndic        : CharAttribute::None)
+                               | ((isStrong)       ? CharAttribute::IsStrong       : CharAttribute::None)
+                               | ((isExtended)     ? CharAttribute::IsExtended     : CharAttribute::None));
 
 
             currentIsDigitValue = (numberCulture == nullptr) ? false : isDigit;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Classification.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Classification.cs
@@ -109,7 +109,7 @@ namespace MS.Internal
                                     out bool isDigit,
                                     out bool isLatin,
                                     out bool isStrong,
-                                    out bool isExtended
+                                    out bool isScriptAgnosticCombining
                                     )
         {
             CharacterAttribute charAttribute = Classification.CharAttributeOf((int)Classification.GetUnicodeClass(unicodeScalar));
@@ -120,7 +120,7 @@ namespace MS.Internal
                         || Classification.IsIVS(unicodeScalar));
 
             isStrong = (itemClass == (byte)ItemClass.StrongClass);
-            
+
             int script = charAttribute.Script;
             needsCaretInfo = ScriptCaretInfo[script];
 
@@ -136,7 +136,7 @@ namespace MS.Internal
                 isIndic = IsScriptIndic(scriptId);
             }
 
-            isExtended = Classification.IsScriptAgnosticCombining(unicodeScalar);
+            isScriptAgnosticCombining = Classification.IsScriptAgnosticCombining(unicodeScalar);
         }
 
         /// <summary>
@@ -267,7 +267,7 @@ namespace MS.Internal
         /// <summary>
         /// Check whether two Unicode scalar values belong to the same script
         /// </summary>
-        static public bool IsSameScript(int unicodeScalar1, int unicodeScalar2)
+        public static bool IsSameScript(int unicodeScalar1, int unicodeScalar2)
         {
             unsafe
             {
@@ -296,7 +296,7 @@ namespace MS.Internal
         /// sequences like "1️⃣" (digit + VS16 + combining enclosing keycap).
         /// These characters are designed to modify any base character regardless of script.
         /// </remarks>
-        static public bool IsScriptAgnosticCombining(int unicodeScalar)
+        public static bool IsScriptAgnosticCombining(int unicodeScalar)
         {
             // ZWJ - used in many emoji/grapheme clusters
             if (unicodeScalar == 0x200D)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Classification.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Classification.cs
@@ -293,9 +293,10 @@ namespace MS.Internal
         /// </summary>
         /// <remarks>
         /// Corresponds to a subset of DWriteCore's is_font_extender predicate, covering characters
-        /// that are not already handled by IsCombining + IsSameScript.  These are combining marks
-        /// whose Unicode script is not the same as the base character's script, so that emoji
-        /// sequences like "1️⃣" (digit + VS16 + U+20E3 combining enclosing keycap) stay together.
+        /// that require special handling to prevent run-splitting when script comparisons would
+        /// otherwise split them. These are combining marks whose Unicode script is not the same
+        /// as the base character's script, so that emoji sequences like "1️⃣" (digit + VS16 +
+        /// U+20E3 combining enclosing keycap) stay together.
         /// <para>
         /// Note: ZWJ (U+200D) is NOT listed here because it is a JoinerClass character.
         /// IsCombining() returns false for it, so this function would never be reached for ZWJ.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Classification.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Classification.cs
@@ -288,20 +288,22 @@ namespace MS.Internal
         }
 
         /// <summary>
-        /// Check whether the character is a script-agnostic combining mark that should
+        /// Check whether the character is a script-agnostic combining mark (font extender) that should
         /// stay with its base character regardless of script differences.
         /// </summary>
         /// <remarks>
-        /// This includes variation selectors and combining enclosing marks used in emoji
-        /// sequences like "1️⃣" (digit + VS16 + combining enclosing keycap).
-        /// These characters are designed to modify any base character regardless of script.
+        /// Corresponds to a subset of DWriteCore's is_font_extender predicate, covering characters
+        /// that are not already handled by IsCombining + IsSameScript.  These are combining marks
+        /// whose Unicode script is not the same as the base character's script, so that emoji
+        /// sequences like "1️⃣" (digit + VS16 + U+20E3 combining enclosing keycap) stay together.
+        /// <para>
+        /// Note: ZWJ (U+200D) is NOT listed here because it is a JoinerClass character.
+        /// IsCombining() returns false for it, so this function would never be reached for ZWJ.
+        /// ZWJ is handled upstream by IsJoiner() and the prevWasJoiner logic in MapCharacters.
+        /// </para>
         /// </remarks>
         public static bool IsScriptAgnosticCombining(int unicodeScalar)
         {
-            // ZWJ - used in many emoji/grapheme clusters
-            if (unicodeScalar == 0x200D)
-                return true;
-
             // Variation Selectors VS1-VS16 (U+FE00-U+FE0F)
             if (unicodeScalar >= 0xFE00 && unicodeScalar <= 0xFE0F)
                 return true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontFace/PhysicalFontFamily.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontFace/PhysicalFontFamily.cs
@@ -358,7 +358,7 @@ namespace MS.Internal.FontFace
                     // Apply digit substitution, if any.
                     int ch = digitMap[originalChar];
 
-                    if (Classification.IsJoiner(ch))
+                    if (Classification.IsJoiner(originalChar))
                     {
                         prevWasJoiner = true;
                         continue;
@@ -387,7 +387,7 @@ namespace MS.Internal.FontFace
                         // Update baseChar for any strong char pulled into the unmapped run by a joiner so
                         // that combining marks that follow it are associated with the correct base.
                         if (prevWasJoiner && !Classification.IsCombining(ch))
-                            baseChar = originalChar;
+                            baseChar = ch;
                         prevWasJoiner = false;
                         continue;
                     }


### PR DESCRIPTION
Fixes #11386

## Problem

PR #6857 introduced a script comparison check to prevent combining marks from different scripts from staying with their base character during font fallback. While this fixed a legitimate issue, it inadvertently broke emoji sequences because:

1. **Emoji keycap sequences** like "1️⃣" consist of:
   - A digit (e.g., '1') - Script: `Common/Digit`
   - Variation Selector 16 (U+FE0F) - Script: `Inherited`
   - Combining Enclosing Keycap (U+20E3) - Script: `Common/Symbol`

2. The script check saw these as different scripts and broke the combining relationship, causing the text itemizer to split the sequence incorrectly, which led to a crash in Line Services.

## Solution

Introduced the concept of **script-agnostic combining marks** - characters that are designed to modify any base character regardless of script. These include:

- **Zero Width Joiner (ZWJ)** - U+200D
- **Variation Selectors** - VS1-VS16 (U+FE00-U+FE0F) and IVS (U+E0100-U+E01EF)
- **Combining Diacritical Marks Extended** - U+1AB0-U+1AFF
- **Combining Diacritical Marks Supplement** - U+1DC0-U+1DFF
- **Combining Diacritical Marks for Symbols** - U+20D0-U+20FF (includes U+20E3 keycap)
- **Combining Half Marks** - U+FE20-U+FE2F
- **Emoji Modifiers (Skin tones)** - U+1F3FB-U+1F3FF

The fix ensures these script-agnostic marks always stay with their base character, while the original PR #6857 script check still applies to regular combining marks.

## Changes

### Native Code (DirectWriteForwarder)

| File | Change |
|------|--------|
| `IClassification.h` | Added `isExtended` out parameter to `GetCharAttribute` and `IsSameScript` method |
| `TextAnalyzer.cpp` | Updated to use `isExtended` parameter and skip script check for script-agnostic marks |

### Managed Code (PresentationCore)

| File | Change |
|------|--------|
| `Classification.cs` | Added `IsScriptAgnosticCombining()` method, updated `GetCharAttribute()` with `isExtended` parameter, added `IsSameScript()` to `ClassificationUtility` |
| `PhysicalFontFamily.cs` | Updated font mapping to use `IsScriptAgnosticCombining` for proper emoji sequence handling |


## Testing

### Manual Testing
- Verified "1️⃣" and other keycap sequences render correctly
- Verified skin tone emoji modifiers work (e.g., "👋🏽")
- Verified ZWJ sequences work (e.g., family emoji)
- Verified the original issue from PR #6857 is still fixed (combining marks from different scripts still get proper font fallback)

### Test Cases
```
"1️⃣" - Keycap sequence (digit + VS16 + combining enclosing keycap)
"A\u0650test" - Latin with Arabic combining mark (should trigger font fallback - PR #6857 fix)
"👋🏽" - Emoji with skin tone modifier
```

## Risk

**Low** - The change is additive and only affects the specific case of script-agnostic combining marks. The existing script check from PR #6857 remains in place for all other combining marks.

## Related Issues/PRs

- Fixes #6801
- Related to PR #6857 (introduced the regression)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11390)