### PR TITLE
Reverting release/10.0 to VS2022 build queues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,6 +331,7 @@ ASALocalRun/
 /.dotnet
 /.packages
 /.tools/vswhere/2.5.2
+/.tools/vswhere/3.1.7
 /.tools/native/iltools
 
 ### OSX ###

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,10 @@
     <WpfArcadeSdkTargets>$(WpfArcadeSdkPath)Sdk\Sdk.targets</WpfArcadeSdkTargets>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <AfterMicrosoftNETSdkTargets>$(MSBuildThisFileDirectory)eng\vs-workaround.targets</AfterMicrosoftNETSdkTargets>
+  </PropertyGroup>
+
   <Import Project="$(WpfArcadeSdkProps)"
           Condition="Exists('$(WpfArcadeSdkProps)') And Exists('$(WpfArcadeSdkTargets)')"/>
 

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -3,8 +3,8 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <CharacterSet>Unicode</CharacterSet>
 
-    <!-- v145 = Visual Studio 2026 -->
-    <PlatformToolset>v145</PlatformToolset>
+    <!-- v143 = Visual Studio 2022 -->
+    <PlatformToolset>v143</PlatformToolset>
 
     <!-- 26100 is Windows 11 SDK -->
     <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>

--- a/eng/pipeline-pr.yml
+++ b/eng/pipeline-pr.yml
@@ -32,10 +32,10 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2026preview.scout.amd64.Open
+          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+          demands: ImageOverride -equals windows.vs2022preview.amd64
     helixRepo: $(repoName)
 
     jobs:
@@ -47,10 +47,10 @@ jobs:
         # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2026preview.scout.amd64.Open
+          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+          demands: ImageOverride -equals windows.vs2022preview.amd64
       variables:
         - name: Codeql.Enabled
           value: true

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -28,10 +28,10 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2026preview.scout.amd64.Open
+          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+          demands: ImageOverride -equals windows.vs2022preview.amd64
     helixRepo: $(repoName)
     jobs:
     - job: Windows_NT
@@ -39,10 +39,10 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2026preview.scout.amd64.Open
+          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+          demands: ImageOverride -equals windows.vs2022preview.amd64
       variables:
       - name: Codeql.Enabled
         value: true

--- a/eng/vs-workaround.targets
+++ b/eng/vs-workaround.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Target Name="_WarnWhenUsingNET10AndVSPriorTo18" />
+</Project>

--- a/src/Microsoft.DotNet.Wpf/redist/VCRuntime/VCRuntime.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/redist/VCRuntime/VCRuntime.vcxproj
@@ -33,8 +33,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(WpfCppProps)" />
   <PropertyGroup>
-    <VCRedistCrtFolderName Condition="'$(Configuration)'=='Release'">Microsoft.VC145.CRT</VCRedistCrtFolderName>
-    <VCRedistCrtFolderName Condition="'$(Configuration)'=='Debug'">Microsoft.VC145.DebugCRT</VCRedistCrtFolderName>
+    <VCRedistCrtFolderName Condition="'$(Configuration)'=='Release'">Microsoft.VC143.CRT</VCRedistCrtFolderName>
+    <VCRedistCrtFolderName Condition="'$(Configuration)'=='Debug'">Microsoft.VC143.DebugCRT</VCRedistCrtFolderName>
     <!-- 
       In Release builds,  the Target assembly will be a privatized copy of VC runtime with a name like vcruntime140_cor3.dll
       In Debug builds, the Target assembly will be a privatize copy of the VC runtime with no name changes - like vcruntime140d.dll


### PR DESCRIPTION
### Description

> @dipeshmsft is there a particular reason why you updated to VS2026 / MSVC v145 in release/10.0? we discovered that MSVC v145 dropped support for Server 2012-R2 which is still supported by .NET 10. Can you please revert back to VS2022?

Reverting the release/10.0 branch to use VS2022 queue as the new MSVC compiler (v145) dropped support for Server 2012-R@

### Testing 
CI Build

### Customer Impact 
.NET 10 is unblocked for Server 2012-R2

### Risk
Minimal

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11411)