### PR TITLE
Fix off-by-one in PriorityBinding.InitializeClone

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/PriorityBinding.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/PriorityBinding.cs
@@ -113,7 +113,7 @@ public class PriorityBinding : BindingBase, IAddChild
     {
         PriorityBinding clone = (PriorityBinding)baseClone;
 
-        for (int i=0; i<=_bindingCollection.Count; ++i)
+        for (int i=0; i<_bindingCollection.Count; ++i)
         {
             clone._bindingCollection.Add(_bindingCollection[i].Clone(mode));
         }


### PR DESCRIPTION
Index must be less than the size of _bindingCollection

Fixes #11419

## Description

`PriorityBinding.InitializeClone` has the same off-by-one bug that was fixed for `MultiBinding` in #3220 / #3221.

The fix for `MultiBinding` changed `i<=_bindingCollection.Count` to `i<_bindingCollection.Count`, but the identical bug in `PriorityBinding` was not addressed.

## Customer Impact

Low - the `Clone` method is internal. However, it may be called internally by WPF in certain scenarios

## Regression

No. This bug has existed since the code was written. The same bug in `MultiBinding` was fixed in #3221, but `PriorityBinding` was not included in that fix

## Testing

Manual testing

## Risk

Low - trivial change

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11420)