### PR TITLE
Fix Slider snapping precision issue (#8819)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Slider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Slider.cs
@@ -1189,6 +1189,11 @@ namespace System.Windows.Controls
                 value = DoubleUtil.GreaterThanOrClose(value, (previous + next) * 0.5) ? next : previous;
             }
 
+            // Normalize floating-point rounding errors introduced by
+            // repeated tick arithmetic (e.g. 0.1 + 0.2 ≠ 0.3 exactly in IEEE-754).
+            // This prevents visual artifacts like 1.1312000000000002.
+            value = Math.Round(value, 10);
+
             return value;
         }
 


### PR DESCRIPTION
Fixes #8819

## Description

This PR fixes floating-point precision issues in Slider snapping when TickFrequency is used.

Due to double precision limitations, calculations such as:

19 * 0.1 → 1.9000000000000001

can produce small rounding errors that affect snapping behavior.

This change ensures the final snapped value is rounded to a stable precision to avoid floating-point artifacts while preserving existing Slider logic.

Rounding is applied only to the final snapped value and does not modify Minimum, Maximum, or TickFrequency. This ensures that real precision coming from Min/Max offsets is preserved.

For example:

Minimum = 0.5001
TickFrequency = 0.1

continues to correctly produce values like 1.9001.

The intent is to remove IEEE floating-point noise, not to change logical tick precision.

## Customer Impact

Improves numerical stability of Slider snapping when fractional TickFrequency values are used, resulting in more predictable snapped values.

## Regression

No — this addresses a long-standing floating-point precision behavior rather than a recently introduced regression.

## Testing

- Reproduced the issue using a minimal WPF sample with fractional TickFrequency values (e.g., 0.1, 0.112).
- Confirmed incorrect snapping behavior prior to the fix due to floating-point precision artifacts.
- Verified corrected snapping behavior after the change across multiple ranges and tick frequencies.
- Tested slider movement in both increasing and decreasing directions.
- Tested with non-zero Minimum values to ensure correct offset handling.
- Tested with non-zero Minimum values to ensure correct offset handling.
- Validated behavior using values with multiple decimal places in a sample application to ensure stable snapping results.
- Tested values close to Minimum and Maximum limits.
- Ran the full WPF unit test suite locally — all tests pass.
- Confirmed no behavioral changes for integer TickFrequency scenarios.

## Risk

Low.

The change only affects the final snapped value calculation and does not alter core Slider logic or public APIs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11431)