### PR TITLE
Update CODEOWNERS to remove a default owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # These owners will be the default owners for everything in the repo,
 # and will automatically be added as reviewers to all pull requests.
-*       @dotnet/wpf-developers @dotnet/dotnet-coherency-qbs
+*       @dotnet/wpf-developers


### PR DESCRIPTION
Removed '@dotnet/dotnet-coherency-qbs' as a default owner.
Avoid unnecessary pings
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11437)