### PR TITLE
PresentationFramework: Safer tooltip handling

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
@@ -330,7 +330,7 @@ namespace System.Windows.Controls
                 switch (triggerAction)
                 {
                     case ToolTipService.TriggerAction.Mouse:
-                        if (SafeArea != null)
+                        if (HasValidSafeArea)
                         {
                             // the mouse has moved over a tooltip owner o, while still
                             // within the safe area of the current tooltip (which must be from mouse).
@@ -909,8 +909,8 @@ namespace System.Windows.Controls
 
         private bool MouseHasLeftSafeArea()
         {
-            // if there is no SafeArea, the mouse didn't leave it
-            if (SafeArea == null)
+            // if there is no valid SafeArea, the mouse didn't leave it
+            if (!HasValidSafeArea)
                 return false;
 
             // if the current tooltip's owner is no longer being displayed, the safe area is no longer valid
@@ -925,6 +925,17 @@ namespace System.Windows.Controls
         }
 
         private ConvexHull SafeArea { get; set; }
+
+        private bool HasValidSafeArea
+        {
+            get
+            {
+                // There are plenty of Watsons which indicate that source might get disposed
+                // (i.e. underlying HWND gets destroyed) while we are still holding on it.
+                // If such a case treat it as if there is no valid safe area.
+                return SafeArea != null && SafeArea.IsValid;
+            }
+        }
 
         #endregion
 
@@ -1373,6 +1384,8 @@ namespace System.Windows.Controls
                     BuildHullIncrementally(points);
                 }
             }
+
+            internal bool IsValid => !_source.IsDisposed;
 
             // sort by y (and by x among equal y's)
             private void SortPoints(PointList points)


### PR DESCRIPTION
## Summary
Port tooltip safety fix to prevent exceptions when tooltip safe-area source is disposed during hover transitions.

## What changed
- Added `HasValidSafeArea` gate so tooltip mouse-trigger logic only uses safe area when source is still valid.
- Updated `MouseHasLeftSafeArea` to treat invalid/disposed safe area as absent.
- Added `ConvexHull.IsValid` to expose underlying source validity (`!_source.IsDisposed`).

## Why
Tooltip handling could race with tooltip window/source teardown, leaving a stale safe-area source and causing coordinate conversion paths to throw. Validating source liveness before safe-area use prevents this failure mode.

Fixes #11462

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11463)