### PR TITLE
WpfGfx: Mitigate RemoveChild crash

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/node.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/node.cpp
@@ -320,6 +320,14 @@ CMilVisual::RemoveChild(
 
     if (!m_rgpChildren.Remove(pChild))
     {
+        // We've seen a handful of Watson dumps where incoming child is already detached
+        // from parent and about to be deleted by the next MilCmdChannelDeleteResource
+        // command. There are no known repros. For now we'll pretend we processed it.
+        if (pChild->GetParent() == NULL)
+        {
+            return S_OK;
+        }
+
         IFC(E_INVALIDARG);
     }
 


### PR DESCRIPTION
## Summary
Mitigates a crash in visual child removal by making `CMilVisual::RemoveChild` tolerant of already-detached children.

## What changed
- Updated `src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/node.cpp` in `CMilVisual::RemoveChild`.
- Added a guard for the case where `m_rgpChildren.Remove(pChild)` fails but `pChild->GetParent()` is `NULL`.
- Return `S_OK` for this detached-child case to make the operation idempotent.

## Why
In practice, child removal can occasionally be requested for a child that is already detached. Treating this as a hard invalid-argument failure can crash the process. Returning success for the already-detached case preserves stability while keeping strict failure behavior for other invalid states.

## Validation
- Manual validation only, per repository workflow.
- No local build or test commands were run.

Fixes #11464

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11465)