### PR TITLE
WpfGfx: Fix headless RenderTargetBitmap rendering

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/composition.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/composition.cpp
@@ -597,6 +597,7 @@ CComposition::EndProcessVideo()
 //-----------------------------------------------------------------------------
 
 HRESULT CComposition::ProcessComposition(
+    bool canRenderWithoutDisplayDevices,
     __out_ecount(1) bool *pfPresentNeeded
     )
 {
@@ -643,7 +644,7 @@ HRESULT CComposition::ProcessComposition(
         // 
         auto& compatSettings = g_pPartitionManager->GetCompatSettings();
         
-        doRenderPass = compatSettings.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable();
+        doRenderPass = canRenderWithoutDisplayDevices || compatSettings.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable();
         //
         // Make sure that we invalidate all of the render targets and caches,
         // and notify any listeners that display set is not valid
@@ -773,6 +774,7 @@ Cleanup:
 //------------------------------------------------------------------------------
 HRESULT 
 CComposition::Compose(
+    bool canRenderWithoutDisplayDevices,
     __out_ecount(1) bool *pfPresentNeeded
     )
 {
@@ -802,7 +804,7 @@ CComposition::Compose(
         // If not zombie, perform the render and optional present passes...
         //
 
-        IFC(ProcessComposition(&fPresentNeeded));
+        IFC(ProcessComposition(canRenderWithoutDisplayDevices, &fPresentNeeded));
     }
     else
     {

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/composition.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/composition.h
@@ -143,6 +143,7 @@ public:
     // Runs any necessary updates to the composition - all the resources
     // participating in the composition, the thread, or device management.
     override HRESULT Compose(
+        bool canRenderWithoutDisplayDevices,
         __out_ecount(1) bool *pfPresentNeeded
         );
 
@@ -285,6 +286,7 @@ protected:
     // Performs the compositor duties by processing any pending batches,
     // updating the video subsystem, rendering and ticking animations.
     HRESULT ProcessComposition(
+        bool canRenderWithoutDisplayDevices,
         __out_ecount(1) bool *pfPresentNeeded
         );
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/connectioncontext.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/connectioncontext.cpp
@@ -503,7 +503,14 @@ CConnectionContext::PresentAllPartitions()
             {
                 bool fPresentNeeded = false;
 
-                MIL_THR(pServerEntry->pCompDevice->Compose(&fPresentNeeded));
+                // So far this method is used only to synchronously present on managed UI
+                // thread when calling RenderTargetBitmap.Render or alike. This can happen
+                // when an app is running without any monitors, e.g. when Visual Studio
+                // restarts on a DevBox machine overnight after update. In this case we want
+                // to allow rendering without any displays. Otherwise RenderTargetBitmap images
+                // will appear blank when user reconnects to DevBox the next day.
+                MIL_THR(pServerEntry->pCompDevice->Compose(
+                    /*canRenderWithoutDisplayDevices*/true, &fPresentNeeded));
 
                 if (hr != WGXERR_DISPLAYSTATEINVALID) 
                 {

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/partition.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/partition.h
@@ -140,6 +140,7 @@ public:
     virtual ~Partition() {}
 
     virtual HRESULT Compose(
+        bool canRenderWithoutDisplayDevices,
         __out_ecount(1) bool *pfNeedsPresent
         ) = 0;
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/partitionthread.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/partitionthread.cpp
@@ -131,7 +131,14 @@ CPartitionThread::RenderPartition(
 {
     HRESULT hr = S_OK;
     bool presentThisPartition = false;
-    MIL_THR(pPartition->Compose(&presentThisPartition));
+
+    // This code path is for regular WPF rendering. By default we do not allow
+    // rendering without display devices being present. App authors can still
+    // allow that with following switch in their app config file:
+    //   <AppContextSwitchOverrides value="Switch.System.Windows.Media.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable=true" />
+    MIL_THR(pPartition->Compose(
+        /*canRenderWithoutDisplayDevices*/false, &presentThisPartition));
+
     if (FAILED(hr))
     {
         //

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/partitionthread.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/partitionthread.cpp
@@ -134,7 +134,7 @@ CPartitionThread::RenderPartition(
 
     // This code path is for regular WPF rendering. By default we do not allow
     // rendering without display devices being present. App authors can still
-    // allow that with following switch in their app config file:
+    // allow that with the following switch in their app config file:
     //   <AppContextSwitchOverrides value="Switch.System.Windows.Media.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable=true" />
     MIL_THR(pPartition->Compose(
         /*canRenderWithoutDisplayDevices*/false, &presentThisPartition));


### PR DESCRIPTION
## Summary
Fixes a rendering gap where `RenderTargetBitmap` could produce blank output when no display devices are attached.

## What changed
- Added `canRenderWithoutDisplayDevices` to compose pipeline signatures.
- Updated `CComposition::ProcessComposition` to allow rendering when this flag is set.
- Enabled the flag only for the synchronous UI-thread compose path used by `RenderTargetBitmap`-style rendering.
- Kept regular partition-thread rendering behavior unchanged by passing `false` there (compat switch behavior remains available).

## Why
The composition pass may skip rendering when display state is invalid. For the UI-thread bitmap rendering path, this caused blank image output in headless/disconnected environments. The change provides a targeted override for that path without broadening default behavior.

## Validation
Manual-only validation by repository owner.

Fixes #11466
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11467)