### PR TITLE
Removing extra space in Sdk.props to avoid MSB4281 error

### DIFF
--- a/eng/WpfArcadeSdk/Sdk/Sdk.props
+++ b/eng/WpfArcadeSdk/Sdk/Sdk.props
@@ -17,7 +17,7 @@
     <LangVersion Condition="'$(LangVersion)'=='' and ($(PreReleaseVersionLabel.Contains('rc')) or $(PreReleaseVersionLabel.Contains('preview')) or $(PreReleaseVersionLabel.Contains('alpha')))">preview</LangVersion>
     <LangVersion Condition="'$(LangVersion)'==''">14</LangVersion>
     <CLSCompliant Condition="'$(CLSCompliant)'==''">true</CLSCompliant>
-    <IncludeDllSafeSearchPathAttribute Condition="'$(IncludeDllSafeSearchPathAttribute )'==''">true</IncludeDllSafeSearchPathAttribute>
+    <IncludeDllSafeSearchPathAttribute Condition="'$(IncludeDllSafeSearchPathAttribute)'==''">true</IncludeDllSafeSearchPathAttribute>
 
     <!--
     Properly calculates the RuntimeIdentifier based on the Platform type. We don't want to affect the build by actually setting RuntimeIdentifier.


### PR DESCRIPTION
## Description
When using the 11.0.0 Wpf.Arcade.Sdk package in internal repo, we get the error
```
C:\Nuget\microsoft.dotnet.arcade.wpf.sdk\11.0.0-preview.3.26119.117\Sdk\Sdk.props(20,40): error MSB4281: Unexpected space at position "36" of property reference "$(IncludeDllSafeSearchPathAttribute )". Did you forget to remove a space? [C:\Users\
dipeshkumar\repos\dotnet-wpf-int\packaging\Microsoft.DotNet.Wpf.DncEng\Microsoft.DotNet.Wpf.DncEng.ArchNeutral.csproj]
```
This has been fixed in release\10.0 and some other branches, but this was missed in the main branch

## Customer Impact
Allows us to move from 10.0-servicing to 11.0-preview Microsoft.Dotnet.Arcade.Wpf.Sdk package. 

## Regression
No

## Testing
The build works in internal repo after the change

## Risk
None
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11470)