### PR TITLE
HwRender: fix ARM64 crash when GPU is suspended during Present (DXGI_ERROR_DEVICE_REMOVED)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/wgx_error.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/wgx_error.h
@@ -12,6 +12,16 @@
 #pragma once
 
 /*=========================================================================*\
+    DXGI error codes
+    Defined here to avoid a dependency on dxgi.h, which is not included
+    in WpfGfx. These values are stable ABI constants defined by DirectX.
+\*=========================================================================*/
+
+#ifndef DXGI_ERROR_DEVICE_REMOVED
+#define DXGI_ERROR_DEVICE_REMOVED   ((HRESULT)0x887A0005L)
+#endif
+
+/*=========================================================================*\
     MIL Status Codes
 \*=========================================================================*/
 


### PR DESCRIPTION
## Summary

On ARM64 devices, WPF crashes when the GPU is suspended during an active `IDirect3DSwapChain9::Present` call. The D3D9-over-DXGI compatibility layer on ARM64 surfaces `DXGI_ERROR_DEVICE_REMOVED` (`0x887A0005`) directly instead of translating it to `D3DERR_DEVICELOST`. WPF's `PresentWithD3D` did not recognize this code; it fell through to `MIL_THR`, which treats `0x887A0005` as fatal and crashes the process. `HandlePresentFailure` — and the device-lost recovery path — was never reached.

## What changed

**`src/Microsoft.DotNet.Wpf/src/WpfGfx/include/wgx_error.h`**
- Added a local `#define DXGI_ERROR_DEVICE_REMOVED ((HRESULT)0x887A0005L)` guarded by `#ifndef`, avoiding a new dependency on `dxgi.h`. The value is a stable DirectX ABI constant.

**`src/Microsoft.DotNet.Wpf/src/WpfGfx/core/hw/d3ddevice.cpp`**
- `PresentWithD3D`: new `else if (hr == DXGI_ERROR_DEVICE_REMOVED)` branch placed **before** the `MIL_THR` call, converting the error to `D3DERR_DEVICELOST` so the existing device-lost recovery path handles it.
- `HandlePresentFailure`: added `DXGI_ERROR_DEVICE_REMOVED` to the device-lost `if` condition, as defense-in-depth for other callers such as `PresentWithGDI`.

## Why

The fix is aligned with the previously validated internal source fix behavior. The change is surgical: no new recovery logic is introduced; WPF reuses the existing TDR / device-lost path (`MarkUnusable()` → `WGXERR_DISPLAYSTATEINVALID` → `RENDERING_STATUS_DEVICE_LOST` → resource recreation on GPU resume).

### Recovery sequence

| State | What happens |
|---|---|
| `Present` returns `DXGI_ERROR_DEVICE_REMOVED` | Converted to `D3DERR_DEVICELOST`; `HandlePresentFailure` calls `MarkUnusable()`, invalidates GPU resources, notifies device manager |
| Same frame — render thread | `CRenderTargetManager::HandlePresentErrors` swallows `WGXERR_DISPLAYSTATEINVALID`; fires `RENDERING_STATUS_DEVICE_LOST` to UI thread. No crash, no zombie. |
| Subsequent frames (GPU suspended) | `UpdateDisplayState` returns `WGXERR_DISPLAYSTATEINVALID`; render passes are skipped |
| GPU comes back | `UpdateDisplayState` succeeds; `NotifyTierChange` fires; render targets recreated; window repainted |

## Validation

Validated manually on ARM64 hardware by triggering GPU suspension events while a WPF application is actively rendering. The application recovered without crashing after applying this fix. No automated test infrastructure changes are included.

Fixes #11471

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11472)