### PR TITLE
Fix SplashScreen fade-out transparency regression after CsWin32 refactor (#11321)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
@@ -173,7 +173,7 @@ namespace System.Windows
             using CreateDcScope memoryContext = new(screenContext);
             using SelectObjectScope selectObjectScope = new(memoryContext, hBitmap);
 
-            BLENDFUNCTION blendFunction = new()
+            _blendFunction = new()
             {
                 BlendOp = (byte)PInvoke.AC_SRC_OVER,
                 SourceConstantAlpha = 255,
@@ -188,7 +188,7 @@ namespace System.Windows
                 memoryContext,
                 new(0, 0),
                 default,
-                blendFunction,
+                _blendFunction,
                 UPDATE_LAYERED_WINDOW_FLAGS.ULW_ALPHA))
             {
                 ((HRESULT)Marshal.GetHRForLastWin32Error()).ThrowOnFailure();


### PR DESCRIPTION
Fixes #11321

## Description

During the migration of `SplashScreen` to CsWin32 APIs, `CreateWindow` 
initialized a local `BLENDFUNCTION` variable and passed it to 
`UpdateLayeredWindow`, but never assigned it to the `_blendFunction` field.

As a result, `_blendFunction` used in `Fadeout_Tick` remained 
default-initialized with `AlphaFormat = 0`. Without `AC_SRC_ALPHA`, 
`UpdateLayeredWindow` ignores per-pixel alpha entirely, causing transparent 
regions of the splash image to briefly render as black during fade-out.

The fix assigns directly to `_blendFunction` in `CreateWindow` so that 
`Fadeout_Tick` inherits the correct `AlphaFormat = AC_SRC_ALPHA`.

## Customer Impact

Applications using `SplashScreen` with PNG images containing transparency 
will see transparent regions turn black during fade-out.

## Regression

Yes. Introduced during the CsWin32 refactor of `SplashScreen`.

## Testing

- Reproduced using PNG with transparent regions on .NET 10 / VS Insiders.
- Confirmed correct fade-out behavior after fix — transparent regions 
  remain transparent throughout.
- Tested both `autoClose` and manual `Close(TimeSpan)` scenarios.
- Confirmed no regression for fully opaque images.

## Risk

Low. Single-field initialization change. No logic, API, or behavioral 
changes beyond correcting the regression.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11485)