### PR TITLE
Input/Stylus: Make WISP pen processing more resilient against disposal

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenThread.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenThread.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Input
 
     internal sealed class PenThread
     {
-        private PenThreadWorker _penThreadWorker;
+        private readonly PenThreadWorker _penThreadWorker;
 
         internal PenThread()
         {
@@ -37,12 +37,13 @@ namespace System.Windows.Input
 
         private void DisposeHelper()
         {
-            // NOTE: PenThreadWorker deals with already being disposed logic.
-            _penThreadWorker?.Dispose();
+            _penThreadWorker.Dispose();
             GC.KeepAlive(this);
         }
 
         /////////////////////////////////////////////////////////////////////
+
+        internal bool IsDisposed => _penThreadWorker.IsDisposed;
 
         internal bool AddPenContext(PenContext penContext)
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenThreadPool.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenThreadPool.cs
@@ -93,20 +93,15 @@ namespace System.Windows.Input
                 // We scan back to front to enable list cleanup.
                 for (int i = _penThreadWeakRefList.Count - 1; i >= 0; i--)
                 {
-                    PenThread candidatePenThread = null;
-
-                    // Select a thread if it's a valid WeakReference and we're not ignoring it
-                    // Allow selection to happen multiple times so we get the first valid candidate
-                    // in forward order.
-                    if (_penThreadWeakRefList[i].TryGetTarget(out candidatePenThread)
-                        && !ignoredThreads.Contains(candidatePenThread))
-                    {
-                        selectedPenThread = candidatePenThread;
-                    }
-                    // This is an invalid WeakReference and should be removed
-                    else if (candidatePenThread == null)
+                    // Check if the WeakReference is still alive and not disposed.
+                    if (!_penThreadWeakRefList[i].TryGetTarget(out PenThread candidatePenThread) ||
+                        candidatePenThread.IsDisposed)
                     {
                         _penThreadWeakRefList.RemoveAt(i);
+                    }
+                    else if (!ignoredThreads.Contains(candidatePenThread))
+                    {
+                        selectedPenThread = candidatePenThread;
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenThreadWorker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenThreadWorker.cs
@@ -559,8 +559,15 @@ namespace System.Windows.Input
 
         /////////////////////////////////////////////////////////////////////
 
+        internal bool IsDisposed => __disposed;
+
         internal TabletDeviceInfo[] WorkerGetTabletsInfo()
         {
+            if (__disposed)
+            {
+                return Array.Empty<TabletDeviceInfo>();
+            }
+
             // Set data up for this call
             WorkerOperationGetTabletsInfo getTablets = new WorkerOperationGetTabletsInfo();
             


### PR DESCRIPTION
## Summary
Fixes a hang in the WPF WISP stylus stack where calling `PenThreadWorker.WorkerGetTabletsInfo()` on an already-disposed worker causes the calling thread to block indefinitely, preventing the application process from exiting cleanly.

A secondary fix stops `PenThreadPool` from returning disposed `PenThread` objects as valid candidates.

## What changed

**`PenThreadWorker.cs`**
- Added `internal bool IsDisposed => __disposed;` property.
- Added a disposed guard at the start of `WorkerGetTabletsInfo()` — returns `Array.Empty<TabletDeviceInfo>()` immediately when disposed, consistent with all other `Worker*` methods (`WorkerAddPenContext`, `WorkerRemovePenContext`, `WorkerCreateContext`, `WorkerAcquireTabletLocks`, etc.).

**`PenThread.cs`**
- Added `internal bool IsDisposed => _penThreadWorker.IsDisposed;` property forwarding to the worker.
- Made `_penThreadWorker` field `readonly` (assigned in constructor only, never reassigned).
- Removed the now-redundant null check in `DisposeHelper` (field is `readonly` and always set).

**`PenThreadPool.cs`**
- Extended the existing `WeakReference` cleanup loop to also prune and skip `PenThread` entries that are disposed but still strongly referenced (e.g., kept alive via the `_handles` array).

## Why
`WorkerGetTabletsInfo` was the only `Worker*` method without a disposed guard. When the pen thread's `ThreadProc` has already exited (because `__disposed` is `true`), it will never call `DoneEvent.Set()`. Any caller of `WorkerGetTabletsInfo()` hitting the disposed worker blocks on `WaitOne()` forever.

`PenThreadPool` previously pruned only dead `WeakReference` targets. A disposed-but-still-alive `PenThread` (kept alive by its registered `PenContext` handles) passed the old aliveness check and was returned as a valid, ready-to-use thread — compounding the above hang.

## Validation notes
- Aligned with the previously validated internal source fix behavior.
- Manual validation: regression tested against the reported shutdown hang scenario.

Fixes #11486

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11487)