### PR TITLE
Fix screen readers reading the wrong line on blank lines in textboxes (closes #7190)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextRangeAdaptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextRangeAdaptor.cs
@@ -607,8 +607,11 @@ namespace MS.Internal.Automation
                                     _start = lineRange.Start.CreatePointer();
                                 }
                                 // If this line contains also end position, move it to the
-                                // end of this line.
-                                if (lineRange.Contains(_end))
+                                // end of this line. Also handle blank/empty lines where
+                                // lineRange.Start == lineRange.End (ContentLength == 0):
+                                // snap _end to the blank line boundary so expandEnd doesn't
+                                // bleed into the next line.
+                                if (lineRange.Contains(_end) || lineRange.Start.CompareTo(lineRange.End) == 0)
                                 {
                                     snapEndPosition = false;
                                     if (_end.CompareTo(lineRange.End) != 0)


### PR DESCRIPTION
Fixes #7190

## Description

When navigating a TextBox or RichTextBox line-by-line with a screen reader (e.g. Narrator, NVDA), blank lines caused the next line's content to be announced instead of "blank", and that next line would then be announced again on the following navigation.

Root cause: In TextRangeAdaptor.ExpandToEnclosingUnit(TextUnit.Line), blank lines produce a degenerate lineRange where Start == End (ContentLength == 0). The condition lineRange.Contains(_end) fails when _end has already advanced past the blank line, so snapEndPosition stays true and the expandEnd block runs, bleeding _end into the next non-blank line. The resulting range spans both the blank line and the next line, so GetText() returns the next line's content.

Fix: add an additional guard clause for the degenerate case: When lineRange.Start == lineRange.End (blank line), snapEndPosition is set to false and _end is snapped to lineRange.End (same position), preventing expandEnd from running. GetText() returns "" and screen readers correctly announce "blank".

Covers TextBox (TextBoxView.GetLineRange returns [offset, offset] for blank lines) and RichTextBox (TextDocumentView returns a degenerate segment for empty paragraphs).

## Customer Impact

Incredibly inconsistent and confusing behavior for screen reader users in WPF text boxes.

## Regression

No, this has existed since at least 2011, when the issue was first raised against NVDA.

## Testing

Built WPF, coppied in the required DLLs into a new wpf app created with `dotnet new`, added a text box with blank lines and content, and confirmed it reads correctly with NVDA, my screen reader.

## Risk

None


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11509)