### PR TITLE
Remove duplicate @ prefix from issueAuthor in GitOps

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -387,7 +387,7 @@ configuration:
       then:
       - addReply:
           reply: >-
-            Hi @${issueAuthor}. Please make sure you've updated the PR description to use the [Shiproom Template](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/545/NET-Servicing#pr-template). Also, make sure this PR is not marked as a draft and is ready-to-merge.
+            Hi ${issueAuthor}. Please make sure you've updated the PR description to use the [Shiproom Template](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/545/NET-Servicing#pr-template). Also, make sure this PR is not marked as a draft and is ready-to-merge.
 
 
             To learn more about how to prepare a servicing PR [click here](https://aka.ms/aspnet/servicing).


### PR DESCRIPTION
https://github.com/GitOps-microsoft/GitOps.PullRequestIssueManagement/pull/262 (internal Microsoft link) changed the `${issueAuthor}` placeholder to include the `@` character.

Remove the one we added so we don't duplicate it.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11568)