### PR TITLE
[release/8.0] Update branding to 8.0.27

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>26</PatchVersion>
+    <PatchVersion>27</PatchVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>


### PR DESCRIPTION
This PR updates version branding on branch `release/8.0`.

**Changes:**
- Repository: wpf
  - PatchVersion: `26` → `27`

**Files Modified:**
- eng/Versions.props (+1 -1)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11569)