### PR TITLE
Suppress CodeQL SM03781 in WpfWebRequestHelper

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/WpfWebRequestHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/WpfWebRequestHelper.cs
@@ -62,7 +62,7 @@ namespace MS.Internal
         }
 
         #pragma warning disable SYSLIB0014 
-        WebRequest request = WebRequest.Create(uri);
+        WebRequest request = WebRequest.Create(uri); // CodeQL [SM03781] No practical exfiltration vector, response is unlikely to be relayed back
         #pragma warning restore SYSLIB0014 
 
         // It is not clear whether WebRequest.Create() can ever return null, but v1 code make this check in


### PR DESCRIPTION
## Description
Adds a suppression comment for CodeQL finding SM03781 (SSRF) on WebRequest.Create(uri) in `WpfWebRequestHelper.CreateRequest()`. After analysis of the flagged path and the framework's resource loading pipeline, it was determined that the exfiltration vector seems highly unlikely. The response data flows into internal framework parsers and is not accessible to external callers in a way that would enable too much of information disclosure.

## Customer Impact
None

## Regression
No
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
None, simple comment addition
<!-- What kind of testing has been done with the fix. -->

## Risk
Almost none from a regression POV.
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11585)