### PR TITLE
DWM Crash Fix Backport

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
@@ -147,6 +147,18 @@ namespace MS.Internal
                 return LocalAppContext.GetCachedSwitchValue(DisableDynamicResourceOptimizationSwitchName, ref _DisableDynamicResourceOptimization);
             }
         }
+
+        // Swtich to disable DWM crash containment
+        internal const string DisableDWMCrashContainmentSwitchName = "Switch.System.Windows.Media.DisableDWMCrashContainment";
+        private static int _disableDWMCrashContainment;
+        public static bool DisableDWMCrashContainment
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return LocalAppContext.GetCachedSwitchValue(DisableDWMCrashContainmentSwitchName, ref _disableDWMCrashContainment);
+            }
+        }
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
@@ -32,7 +32,7 @@ namespace System
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.ItemAutomationPeerKeepsItsItemAliveSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableFluentThemeWindowBackdropSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableDynamicResourceOptimizationSwitchName, false);
-
+             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DisableDWMCrashContainmentSwitchName, false);
 #pragma warning restore CS0436 // Type conflicts with imported type
         }
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Appearance/WindowBackdropManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Appearance/WindowBackdropManager.cs
@@ -131,8 +131,7 @@ internal static class WindowBackdropManager
             margins = new MARGINS { cxLeftWidth = -1, cxRightWidth = -1, cyTopHeight = -1, cyBottomHeight = -1 };
         }
 
-        var dwmApiResult = NativeMethods.DwmExtendFrameIntoClientArea(hwnd, ref margins);
-        return new HRESULT((uint)dwmApiResult) == HRESULT.S_OK;
+        return NativeMethods.DwmExtendFrameIntoClientArea(hwnd, ref margins);
     }
 
     #endregion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/WindowChromeWorker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/WindowChromeWorker.cs
@@ -1002,7 +1002,11 @@ namespace Microsoft.Windows.Shell
                     cyBottomHeight = (int)Math.Ceiling(deviceGlassThickness.Bottom),
                 };
 
-                NativeMethods.DwmExtendFrameIntoClientArea(_hwnd, ref dwmMargin);
+                bool dwmApiResult = NativeMethods.DwmExtendFrameIntoClientArea(_hwnd, ref dwmMargin);
+                if(!dwmApiResult)
+                {
+                    _hwndSource.CompositionTarget.BackgroundColor = SystemColors.WindowColor;
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/NativeMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/NativeMethods.cs
@@ -9,7 +9,9 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Text;
+using System.Threading;
 using Microsoft.Win32.SafeHandles;
+using MS.Internal;
 
 // Some COM interfaces and Win32 structures are already declared in the framework.
 // Interesting ones to remember in System.Runtime.InteropServices.ComTypes are:
@@ -2501,8 +2503,8 @@ namespace Standard
         [DllImport("dwmapi.dll", PreserveSig = false)]
         public static extern int DwmGetWindowAttribute(IntPtr hWnd, DWMWA dwAttributeToGet, ref int pvAttributeValue, int cbAttribute);
 
-        [DllImport("dwmapi.dll", PreserveSig = false)]
-        public static extern int DwmExtendFrameIntoClientArea(IntPtr hwnd, ref MARGINS pMarInset);
+        [DllImport("dwmapi.dll", EntryPoint = "DwmExtendFrameIntoClientArea", PreserveSig = true, SetLastError = true)]
+        private static extern HRESULT _DwmExtendFrameIntoClientArea(IntPtr hwnd, ref MARGINS pMarInset);
 
         [DllImport("dwmapi.dll", EntryPoint = "DwmIsCompositionEnabled", PreserveSig = false)]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -2510,6 +2512,29 @@ namespace Standard
 
         [DllImport("dwmapi.dll", EntryPoint = "DwmGetColorizationColor", PreserveSig = true)]
         private static extern HRESULT _DwmGetColorizationColor(out uint pcrColorization, [Out, MarshalAs(UnmanagedType.Bool)] out bool pfOpaqueBlend);
+
+        public static bool DwmExtendFrameIntoClientArea(IntPtr hwnd, ref MARGINS pMarInset)
+        {
+            HRESULT hr = _DwmExtendFrameIntoClientArea(hwnd, ref pMarInset);
+            if(hr == HRESULT.S_OK)
+            {
+                return true;
+            }
+            
+            if(FrameworkAppContextSwitches.DisableDWMCrashContainment)
+            {
+                // Original behavior: just call the native method and let any exceptions propagate.
+                HRESULT.ThrowLastError();
+            }
+
+            // Crash only if the arguments are invalid.
+            if(hr == HRESULT.E_INVALIDARG)
+            {
+                HRESULT.ThrowLastError();
+            }
+
+            return false;
+        }
 
         public static bool DwmGetColorizationColor(out uint pcrColorization, out bool pfOpaqueBlend)
         {


### PR DESCRIPTION
Main PR: https://github.com/dotnet/wpf/pull/11417

## Description

It’s possible for DWM to crash or exit unexpectedly, and when that happens, DwmExtendFrameIntoClientArea returns a failure.

This change adds a safety check to prevent that failure from propagating and causing a crash in WPF and reverting the app to the previous behavior.

We will only crash if we encounter Invalid Args exception.

## Customer Impact

Possibly lesser crashes in fluent and might help in fluent adoption

## Regression
NA


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11621)