### PR TITLE
Implement opt-in weak reference handling for ElementProxy in automation peers to mitigate memory leaks in virtualized ItemsControls

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/ElementProxy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/ElementProxy.cs
@@ -39,7 +39,8 @@ namespace MS.Internal.Automation
         private ElementProxy(AutomationPeer peer)
         {
             if ((AutomationInteropReferenceType == ReferenceType.Weak) && 
-                (peer is UIElementAutomationPeer || peer is ContentElementAutomationPeer || peer is UIElement3DAutomationPeer))
+                (peer is UIElementAutomationPeer || peer is ContentElementAutomationPeer || peer is UIElement3DAutomationPeer 
+                    || peer.ShouldUseWeakReferenceFromElementProxy))
             {
                 _peer = new WeakReference(peer);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
@@ -523,6 +523,13 @@ namespace System.Windows.Automation.Peers
             return false;
         }
 
+        // When true, ElementProxy holds this peer via WeakReference. Opt-in fix for the
+        // UIA-retained-ElementProxy leak in virtualized ItemsControls (see ItemAutomationPeer).
+        internal virtual bool ShouldUseWeakReferenceFromElementProxy
+        {
+            get { return false; }
+        }
+
         // UpdatePeer is called asynchronously.  Between the time the call is
         // posted (InvalidatePeer) and the time the call is executed (UpdatePeer),
         // changes to the visual tree and/or automation tree may have eliminated

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
@@ -125,7 +125,9 @@ namespace MS.Internal
         // Opt-in: when true, ElementProxy holds ItemAutomationPeer (and subclasses) via WeakReference,
         // letting the GC reclaim peers and their data-item/container chain when UIA Core retains the
         // ElementProxy aggressively (heap growth in virtualized ItemsControls, e.g. DataGrid).
-        // Re-discovery: parent ItemsControlAutomationPeer's WeakRefElementProxyStorage.
+        // The parent ItemsControlAutomationPeer's WeakRefElementProxyStorage may reuse still-live
+        // ElementProxy/peer pairs, but it does not guarantee peer re-discovery after GC; callers may
+        // need to handle ElementNotAvailableException and re-walk when the peer has been collected.
         internal const string UseWeakReferenceFromElementProxyToItemPeerSwitchName = "Switch.System.Windows.Automation.Peers.UseWeakReferenceFromElementProxyToItemPeer";
         private static int _UseWeakReferenceFromElementProxyToItemPeer;
         public static bool UseWeakReferenceFromElementProxyToItemPeer

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
@@ -121,7 +121,21 @@ namespace MS.Internal
                 return LocalAppContext.GetCachedSwitchValue(ItemAutomationPeerKeepsItsItemAliveSwitchName, ref _ItemAutomationPeerKeepsItsItemAlive);
             }
         }
-    
+
+        // Opt-in: when true, ElementProxy holds ItemAutomationPeer (and subclasses) via WeakReference,
+        // letting the GC reclaim peers and their data-item/container chain when UIA Core retains the
+        // ElementProxy aggressively (heap growth in virtualized ItemsControls, e.g. DataGrid).
+        // Re-discovery: parent ItemsControlAutomationPeer's WeakRefElementProxyStorage.
+        internal const string UseWeakReferenceFromElementProxyToItemPeerSwitchName = "Switch.System.Windows.Automation.Peers.UseWeakReferenceFromElementProxyToItemPeer";
+        private static int _UseWeakReferenceFromElementProxyToItemPeer;
+        public static bool UseWeakReferenceFromElementProxyToItemPeer
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return LocalAppContext.GetCachedSwitchValue(UseWeakReferenceFromElementProxyToItemPeerSwitchName, ref _UseWeakReferenceFromElementProxyToItemPeer);
+            }
+        }    
     
         // Switch to opt-out Fluent theme Window Backdrop feature
         internal const string DisableFluentThemeWindowBackdropSwitchName = "Switch.System.Windows.Appearance.DisableFluentThemeWindowBackdrop";

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemAutomationPeer.cs
@@ -155,6 +155,14 @@ namespace System.Windows.Automation.Peers
             return true;
         }
 
+        // Gated by FrameworkAppContextSwitches.UseWeakReferenceFromElementProxyToItemPeer. When on,
+        // a long-lived UIA ElementProxy no longer pins the data item, container, or parent
+        // ItemsControlAutomationPeer caches; re-discovery goes via WeakRefElementProxyStorage on the parent.
+        internal override bool ShouldUseWeakReferenceFromElementProxy
+        {
+            get { return FrameworkAppContextSwitches.UseWeakReferenceFromElementProxyToItemPeer; }
+        }
+
         internal override void AddToParentProxyWeakRefCache()
         {
             ItemsControlAutomationPeer itemsControlAutomationPeer = ItemsControlAutomationPeer;


### PR DESCRIPTION
Fixes #11337

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description
UIA Core retains `ElementProxy` instances longer than WPF expects. Since `ElementProxy` held `ItemAutomationPeer` via a *strong* reference, this pinned the data item, the container, and the parent `ItemsControlAutomationPeer`'s caches - manifesting as large managed-heap growth in virtualized `ItemsControl`s (`DataGrid`, `TreeView`, etc.).

This PR extends the existing `WeakReference` lifetime model — already used for `UIElement`, `ContentElement`, and `UIElement3DAutomationPeer` - to `ItemAutomationPeer` and its subclasses. Peer re-discovery after collection is preserved by the parent `ItemsControlAutomationPeer`'s `WeakRefElementProxyStorage`, so the UIA tree remains correct: UIA clients receive `ElementNotAvailableException` and re-walk as they already do for `UIElement`-derived peers.

The behavior is gated by a new opt-in AppContext switch (`Switch.System.Windows.Automation.Peers.UseWeakReferenceFromElementProxyToItemPeer`), default **off**, so no existing application is affected unless it explicitly opts in.

## Customer Impact
Currently it is not possible to test WPF/WinForms application with UI Automation in a leak-free way. This prevents early detection of memory leaks.

## Regression
No

## Testing
<!-- What kind of testing has been done with the fix. -->

## Risk
**Low overall**, because the change is **opt-in and default-off** behind a new AppContext switch
  (`Switch.System.Windows.Automation.Peers.UseWeakReferenceFromElementProxyToItemPeer`).

  ### Default behavior (switch off)
  No code path changes. `ElementProxy` still holds `ItemAutomationPeer` strongly. The only added cost is one virtual property read in the `ElementProxy` constructor, which returns `false` on the base `AutomationPeer` and is hit only when `AutomationInteropReferenceType == ReferenceType.Weak`.

  ### Opt-in behavior (switch on)
  `ItemAutomationPeer` adopts the same lifetime model already used by `UIElement`, `ContentElement`, and `UIElement3DAutomationPeer`. Specifically:
  - Peer re-discovery is handled by the parent `ItemsControlAutomationPeer`'s `WeakRefElementProxyStorage` - the same mechanism that already supports the `UIElement`-derived peers under the existing `Weak` reference mode.
  - UIA clients that race a GC and observe a collected peer receive `ElementNotAvailableException` and re-walk, which is documented and expected UIA behavior.

  ### Scope of change
  - One new virtual property on `AutomationPeer` (default `false`).
  - One override on `ItemAutomationPeer` that reads the switch.
  - One extra clause in the `ElementProxy` constructor.
  - One new AppContext switch definition.

  No public API changes. All new members are `internal`.

  ### Residual risks considered
  - **Accessibility regressions** (Narrator/NVDA losing focus on a virtualized item) — mitigated by re-discovery via `WeakRefElementProxyStorage`; requires validation, but the recovery path is the same one `UIElementAutomationPeer` already relies on.
  - **Subclass coverage** — all `ItemAutomationPeer` derivatives (`DataGridItemAutomationPeer`, DataGridCellItemAutomationPeer`, `DateTimeAutomationPeer`, `TreeViewDataItemAutomationPeer`, etc.) automatically inherit the new behavior, which is the intent.
  - **Servicing risk** — none for shipped apps unless they explicitly opt in.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11638)