### PR TITLE
License file for sRGB.icm file

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Resources/ColorProfiles/LICENSE.TXT
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Resources/ColorProfiles/LICENSE.TXT
@@ -1,0 +1,1 @@
+The sRGB.icm binary is licensed to Microsoft by Hewlett Packard for broad use and re-licensed using the MIT license.


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4590

That issue describes the concern around this file. It's included in the [VMR](https://github.com/dotnet/dotnet) by default. Offline discussion received guidance from CELA on the accompanying license to use for this file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11639)