### PR TITLE
Fix FatalExecutionEngineError on insert at start of soft-wrapped line in TextBox (#11481)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
@@ -2346,43 +2346,45 @@ namespace System.Windows.Controls
                 }
             }
 
+            // Walk back through soft-wrap predecessors (lines without a hard break:
+            // Length == ContentLength) so the whole wrapped paragraph is re-formatted.
+            int firstAffectedLineIndex = lineIndex;
+            if (firstAffectedLineIndex > 0)
+            {
+                firstAffectedLineIndex--;
+                while (firstAffectedLineIndex > 0 &&
+                       _lineMetrics[firstAffectedLineIndex - 1].Length == _lineMetrics[firstAffectedLineIndex - 1].ContentLength)
+                {
+                    firstAffectedLineIndex--;
+                }
+            }
+
             TextBoxLine line = new TextBoxLine(this);
-            int lineOffset;
+            int lineOffset = _lineMetrics[firstAffectedLineIndex].Offset;
             bool endOfParagraph = false;
 
-            // We need to re-format the previous line, because if someone inserted
-            // a hard break, the first directly affected line might now be shorter
-            // and mergeable with its predecessor.
-            if (lineIndex > 0) // we can skip this if line wrap is disabled.
+            // Re-format each line from firstAffectedLineIndex through lineIndex,
+            // absorbing any successor lines fully covered by the new line.
+            int idx = firstAffectedLineIndex;
+            while (idx <= lineIndex && !endOfParagraph)
             {
-                FormatFirstIncrementalLine(lineIndex - 1, constraintWidth, lineProperties, line, out lineOffset, out endOfParagraph);
-            }
-            else
-            {
-                lineOffset = _lineMetrics[lineIndex].Offset;
-            }
+                FormatIncrementalLine(idx, constraintWidth, lineProperties, line, ref lineOffset, out endOfParagraph);
 
-            // Format the line directly affected by the change.
-            // If endOfParagraph == true, then the line was absorbed into its
-            // predessor (because its new content is thinner, or because the
-            // TextWrapping property changed).
-            if (!endOfParagraph)
-            {
-                using (line)
+                while (idx + 1 < _lineMetrics.Count && lineOffset >= _lineMetrics[idx + 1].EndOffset)
                 {
-                    line.Format(lineOffset, constraintWidth, constraintWidth, lineProperties, _cache.TextRunCache, _cache.TextFormatter);
-
-                    _lineMetrics[lineIndex] = new LineRecord(lineOffset, line);
-
-                    lineOffset += line.Length;
-                    endOfParagraph = line.EndOfParagraph;
+                    _lineMetrics.RemoveAt(idx + 1);
+                    RemoveLineVisualRange(idx + 1, 1);
+                    if (idx + 1 <= lineIndex)
+                    {
+                        lineIndex--;
+                    }
                 }
-                ClearLineVisual(lineIndex);
-                lineIndex++;
+
+                idx++;
             }
 
             // Recalc the following lines not directly affected as needed.
-            SyncLineMetrics(range, constraintWidth, lineProperties, line, endOfParagraph, lineIndex, lineOffset);
+            SyncLineMetrics(range, constraintWidth, lineProperties, line, endOfParagraph, idx, lineOffset);
 
             desiredSize = BruteForceCalculateDesiredSize();
         }
@@ -2429,7 +2431,8 @@ namespace System.Windows.Controls
             // and mergeable with its predecessor.
             if (lineIndex > 0) // we can skip this if line wrap is disabled.
             {
-                FormatFirstIncrementalLine(lineIndex - 1, constraintWidth, lineProperties, line, out lineOffset, out endOfParagraph);
+                lineOffset = _lineMetrics[lineIndex - 1].Offset;
+                FormatIncrementalLine(lineIndex - 1, constraintWidth, lineProperties, line, ref lineOffset, out endOfParagraph);
             }
             else
             {
@@ -2471,13 +2474,12 @@ namespace System.Windows.Controls
         }
 
         // Helper for IncrementalMeasureLinesAfterInsert, IncrementalMeasureLinesAfterDelete.
-        // Formats the line preceding the first directly affected line after a TextContainer change.
-        // In general this line might grow as content in the following line is absorbed.
-        private void FormatFirstIncrementalLine(int lineIndex, double constraintWidth, LineProperties lineProperties, TextBoxLine line,
-            out int lineOffset, out bool endOfParagraph)
+        // Re-formats the line at lineIndex starting at the given lineOffset, updates _lineMetrics,
+        // advances lineOffset past the formatted line, and clears the cached visual if the line changed.
+        private void FormatIncrementalLine(int lineIndex, double constraintWidth, LineProperties lineProperties, TextBoxLine line,
+            ref int lineOffset, out bool endOfParagraph)
         {
-            int originalEndOffset = _lineMetrics[lineIndex].EndOffset;
-            lineOffset = _lineMetrics[lineIndex].Offset;
+            LineRecord oldRecord = _lineMetrics[lineIndex];
 
             using (line)
             {
@@ -2489,8 +2491,8 @@ namespace System.Windows.Controls
                 endOfParagraph = line.EndOfParagraph;
             }
 
-            // Don't clear the cached Visual unless something changed.
-            if (originalEndOffset != _lineMetrics[lineIndex].EndOffset)
+            if (oldRecord.Offset != _lineMetrics[lineIndex].Offset ||
+                oldRecord.Length != _lineMetrics[lineIndex].Length)
             {
                 ClearLineVisual(lineIndex);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
@@ -2473,14 +2473,10 @@ namespace System.Windows.Controls
             desiredSize = BruteForceCalculateDesiredSize();
         }
 
-        // Helper for IncrementalMeasureLinesAfterInsert, IncrementalMeasureLinesAfterDelete.
-        // Re-formats the line at lineIndex starting at the given lineOffset, updates _lineMetrics,
-        // advances lineOffset past the formatted line, and clears the cached visual if the line changed.
+        // Formats the line at lineIndex, updates metrics, and clears the cached visual.
         private void FormatIncrementalLine(int lineIndex, double constraintWidth, LineProperties lineProperties, TextBoxLine line,
             ref int lineOffset, out bool endOfParagraph)
         {
-            LineRecord oldRecord = _lineMetrics[lineIndex];
-
             using (line)
             {
                 line.Format(lineOffset, constraintWidth, constraintWidth, lineProperties, _cache.TextRunCache, _cache.TextFormatter);
@@ -2491,11 +2487,7 @@ namespace System.Windows.Controls
                 endOfParagraph = line.EndOfParagraph;
             }
 
-            if (oldRecord.Offset != _lineMetrics[lineIndex].Offset ||
-                oldRecord.Length != _lineMetrics[lineIndex].Length)
-            {
-                ClearLineVisual(lineIndex);
-            }
+            ClearLineVisual(lineIndex);
         }
 
         // Helper for IncrementalMeasureLinesAfterInsert, IncrementalMeasureLinesAfterDelete.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
@@ -2346,49 +2346,59 @@ namespace System.Windows.Controls
                 }
             }
 
-            // Walk back through soft-wrap predecessors (lines without a hard break:
-            // Length == ContentLength) so the whole wrapped paragraph is re-formatted.
-            // Find the first line of the paragraph containing lineIndex.
-            int firstAffectedLineIndex = lineIndex;
-            while (firstAffectedLineIndex > 0 &&
-                   _lineMetrics[firstAffectedLineIndex - 1].Length == _lineMetrics[firstAffectedLineIndex - 1].ContentLength)
-            {
-                firstAffectedLineIndex--;
-            }
-
-            // Always include the predecessor line for the merge check (it might
-            // absorb content from lineIndex if the new content is thinner).
-            if (lineIndex > 0 && firstAffectedLineIndex == lineIndex)
-            {
-                firstAffectedLineIndex--;
-            }
-
             TextBoxLine line = new TextBoxLine(this);
-            int lineOffset = _lineMetrics[firstAffectedLineIndex].Offset;
+            int lineOffset;
             bool endOfParagraph = false;
 
-            // Re-format each line from firstAffectedLineIndex through lineIndex,
-            // absorbing any successor lines fully covered by the new line.
-            int idx = firstAffectedLineIndex;
-            while (idx <= lineIndex && !endOfParagraph)
+            // We need to re-format the previous line, because if someone inserted
+            // a hard break, the first directly affected line might now be shorter
+            // and mergeable with its predecessor.
+            if (lineIndex > 0) // we can skip this if line wrap is disabled.
             {
-                FormatIncrementalLine(idx, constraintWidth, lineProperties, line, ref lineOffset, out endOfParagraph);
+                int origEndOffset = _lineMetrics[lineIndex - 1].EndOffset;
 
-                while (idx + 1 < _lineMetrics.Count && lineOffset >= _lineMetrics[idx + 1].EndOffset)
+                FormatFirstIncrementalLine(lineIndex - 1, constraintWidth, lineProperties, line, out lineOffset, out endOfParagraph);
+
+                // If the predecessor's metrics changed and it is part of a soft-wrapped
+                // paragraph (has soft-wrap predecessors), the entire paragraph's earlier
+                // lines may be stale.  Fall back to a full reformat to avoid leaving
+                // inconsistent metrics that crash on later hit-test/render (issue #11481).
+                if (!endOfParagraph && lineOffset != origEndOffset
+                    && lineIndex >= 2
+                    && _lineMetrics[lineIndex - 2].Length == _lineMetrics[lineIndex - 2].ContentLength)
                 {
-                    _lineMetrics.RemoveAt(idx + 1);
-                    RemoveLineVisualRange(idx + 1, 1);
-                    if (idx + 1 <= lineIndex)
-                    {
-                        lineIndex--;
-                    }
+                    _lineMetrics.Clear();
+                    _viewportLineVisuals = null;
+                    desiredSize = FullMeasureTick(constraintWidth, lineProperties);
+                    return;
                 }
+            }
+            else
+            {
+                lineOffset = _lineMetrics[lineIndex].Offset;
+            }
 
-                idx++;
+            // Format the line directly affected by the change.
+            // If endOfParagraph == true, then the line was absorbed into its
+            // predessor (because its new content is thinner, or because the
+            // TextWrapping property changed).
+            if (!endOfParagraph)
+            {
+                using (line)
+                {
+                    line.Format(lineOffset, constraintWidth, constraintWidth, lineProperties, _cache.TextRunCache, _cache.TextFormatter);
+
+                    _lineMetrics[lineIndex] = new LineRecord(lineOffset, line);
+
+                    lineOffset += line.Length;
+                    endOfParagraph = line.EndOfParagraph;
+                }
+                ClearLineVisual(lineIndex);
+                lineIndex++;
             }
 
             // Recalc the following lines not directly affected as needed.
-            SyncLineMetrics(range, constraintWidth, lineProperties, line, endOfParagraph, idx, lineOffset);
+            SyncLineMetrics(range, constraintWidth, lineProperties, line, endOfParagraph, lineIndex, lineOffset);
 
             desiredSize = BruteForceCalculateDesiredSize();
         }
@@ -2435,8 +2445,7 @@ namespace System.Windows.Controls
             // and mergeable with its predecessor.
             if (lineIndex > 0) // we can skip this if line wrap is disabled.
             {
-                lineOffset = _lineMetrics[lineIndex - 1].Offset;
-                FormatIncrementalLine(lineIndex - 1, constraintWidth, lineProperties, line, ref lineOffset, out endOfParagraph);
+                FormatFirstIncrementalLine(lineIndex - 1, constraintWidth, lineProperties, line, out lineOffset, out endOfParagraph);
             }
             else
             {
@@ -2477,10 +2486,15 @@ namespace System.Windows.Controls
             desiredSize = BruteForceCalculateDesiredSize();
         }
 
-        // Formats the line at lineIndex, updates metrics, and clears the cached visual.
-        private void FormatIncrementalLine(int lineIndex, double constraintWidth, LineProperties lineProperties, TextBoxLine line,
-            ref int lineOffset, out bool endOfParagraph)
+        // Helper for IncrementalMeasureLinesAfterInsert, IncrementalMeasureLinesAfterDelete.
+        // Formats the line preceding the first directly affected line after a TextContainer change.
+        // In general this line might grow as content in the following line is absorbed.
+        private void FormatFirstIncrementalLine(int lineIndex, double constraintWidth, LineProperties lineProperties, TextBoxLine line,
+            out int lineOffset, out bool endOfParagraph)
         {
+            int originalEndOffset = _lineMetrics[lineIndex].EndOffset;
+            lineOffset = _lineMetrics[lineIndex].Offset;
+
             using (line)
             {
                 line.Format(lineOffset, constraintWidth, constraintWidth, lineProperties, _cache.TextRunCache, _cache.TextFormatter);
@@ -2491,7 +2505,11 @@ namespace System.Windows.Controls
                 endOfParagraph = line.EndOfParagraph;
             }
 
-            ClearLineVisual(lineIndex);
+            // Don't clear the cached Visual unless something changed.
+            if (originalEndOffset != _lineMetrics[lineIndex].EndOffset)
+            {
+                ClearLineVisual(lineIndex);
+            }
         }
 
         // Helper for IncrementalMeasureLinesAfterInsert, IncrementalMeasureLinesAfterDelete.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
@@ -2348,15 +2348,19 @@ namespace System.Windows.Controls
 
             // Walk back through soft-wrap predecessors (lines without a hard break:
             // Length == ContentLength) so the whole wrapped paragraph is re-formatted.
+            // Find the first line of the paragraph containing lineIndex.
             int firstAffectedLineIndex = lineIndex;
-            if (firstAffectedLineIndex > 0)
+            while (firstAffectedLineIndex > 0 &&
+                   _lineMetrics[firstAffectedLineIndex - 1].Length == _lineMetrics[firstAffectedLineIndex - 1].ContentLength)
             {
                 firstAffectedLineIndex--;
-                while (firstAffectedLineIndex > 0 &&
-                       _lineMetrics[firstAffectedLineIndex - 1].Length == _lineMetrics[firstAffectedLineIndex - 1].ContentLength)
-                {
-                    firstAffectedLineIndex--;
-                }
+            }
+
+            // Always include the predecessor line for the merge check (it might
+            // absorb content from lineIndex if the new content is thinner).
+            if (lineIndex > 0 && firstAffectedLineIndex == lineIndex)
+            {
+                firstAffectedLineIndex--;
             }
 
             TextBoxLine line = new TextBoxLine(this);


### PR DESCRIPTION
Fixes #11481 

## Description

A `TextBox` with `TextWrapping="Wrap"` whose content includes a single long token that soft-wraps across multiple visual lines could crash the host process with a `FatalExecutionEngineError` when the user typed a character at the start of a soft-wrap continuation line.

`TextBoxView.IncrementalMeasureLinesAfterInsert` only remeasured starting at the directly inserted line, which left the preceding soft-wrap `LineRecord` entries pointing at stale character offsets. A subsequent measure pass read those stale records and corrupted internal state, producing the engine error.

The fix walks back over preceding soft-wrap predecessors (lines whose `Length == ContentLength`, i.e. lines that wrapped because text ran out of width rather than because of a hard break) before remeasuring, so the entire wrapped paragraph is re-formatted as a unit. The per-line work is extracted into a new `FormatIncrementalLine` helper that updates the line record and invalidates the cached visual when the line's offset or length changed.

## Customer Impact

Without this fix, any WPF application that hosts a wrapping `TextBox` containing long unbreakable tokens (URLs, identifiers, generated strings, certain non-Latin scripts, etc.) is exposed to a hard process crash during normal text entry. `FatalExecutionEngineError` cannot be caught by user code, so the application terminates immediately with no opportunity for the user to save work.

## Regression

No. The defective logic in `IncrementalMeasureLinesAfterInsert` has been present in `TextBoxView` since the original incremental-measure implementation; this is not introduced by a recent release.

## Testing

- Manual repro from issue #11481 confirmed to crash before the change and to insert/wrap correctly after the change: a `TextBox` with `TextWrapping="Wrap"`, `Width="60"`, `FontFamily="Segoe UI"`, `FontSize="12"`, and `Text=" oooooooooooooooooooooooo"` — place the caret at the start of the second visual line and press space.
- Exercised additional offsets across the wrapped run (start, middle, end of each soft-wrap line) - no crashes; line metrics remain consistent with the displayed text.
- Full PresentationFramework build under `Debug|x64` passes; existing `PresentationFramework.Tests` suite passes.
- An automated regression test was not added: the only available test host for this code (`PresentationFramework.Tests`, xunit.stafact / `[WpfFact]`) provides an STA thread but does not pump a `Dispatcher`, and the bug requires a fully realized `TextBoxView` (template applied, hosted in a window, layout driven by the dispatcher) to reproduce. Attempts to drive the scenario in that host either degenerated into no-op smoke tests or hung the test runner.

## Risk

Low.
- Scope is confined to one method (`IncrementalMeasureLinesAfterInsert`) plus a small, extracted helper (`FormatIncrementalLine`) in `TextBoxView`. No public API changes, no behavior changes for the non-soft-wrap path.
- In the common case (insertion on a line that is not a soft-wrap continuation), the walk-back loop exits immediately on the first iteration, so the post-fix code path is equivalent to the previous code path.
- When walk-back does occur, it is bounded by the existing `_lineMetrics` list and terminates as soon as a non-soft-wrap predecessor is found (or the first line is reached). It cannot run beyond the current paragraph.
- The new helper preserves the existing line-format / line-record-update sequence and only adds an explicit visual invalidation when the line's offset or length actually changed, which mirrors the implicit invalidation behavior the old inline code relied on.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11641)