### PR TITLE
Fix TextServicesManager scan code forwarding for TSF

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesManager.cs
@@ -231,7 +231,7 @@ namespace System.Windows.Input
                     break;
                 default:
                     wParam = KeyInterop.VirtualKeyFromKey(keyArgs.RealKey);
-                    scancode = 0; 
+                    scancode = keyArgs.ScanCode;
                     break;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextServicesManager.cs
@@ -235,7 +235,12 @@ namespace System.Windows.Input
                     break;
             }
 
-            lParam = (int)(((uint)scancode << 16) | 1);
+            lParam = (int)((((uint)scancode & 0xFF) << 16) | 1);
+
+            if (keyArgs.IsExtendedKey)
+            {
+                lParam |= 1 << 24;
+            }
 
             if (keyArgs.RoutedEvent == Keyboard.PreviewKeyDownEvent/*keyArgs.IsDown*/)
             {


### PR DESCRIPTION
Fixes #11635 

## Description

`TextServicesManager` currently passes `0` as the scan code for almost all keys when forwarding keystrokes to TSF.

This change forwards `keyArgs.ScanCode` instead, so the scan-code bits in the `lParam` passed to `TextServicesContext.Keystroke` are populated correctly.

Existing LeftShift/RightShift special handling remains unchanged.

## Customer Impact

Text services, IMEs, or TIPs that rely on scan-code information will receive the correct scan code instead of just `0`.

## Regression

No. The issue reports this as not being a regression.

## Testing

```powershell
.\build.cmd -pack -plat x64 -test
```
Tested with a sample TextBox application using locally built WPF assemblies.

Manually verified generated `lParam` values passed to `TextServicesContext.Keystroke`, including:

- RightCtrl: scan=0x1D, extended=true
- RightAlt / AltGr: scan=0x38, extended=true
- Normal Enter: scan=0x1C, extended=false
- Numpad Enter: scan=0x1C, extended=true
- Dedicated Delete: scan=0x53, extended=true
- Numpad: scan=0x35, extended=true
- LeftShift: scan=0x2A, extended=false, wParam=VK_SHIFT
- RightShift: scan=0x36, extended=false, wParam=VK_SHIFT

## Risk

Low.
The change only forwards the existing scan code value. 
If there is any more testing to do please let me know.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11644)