### PR TITLE
Fix ToolBarTray negative measure constraint

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ToolBarTray.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ToolBarTray.cs
@@ -360,7 +360,7 @@ namespace System.Windows.Controls
                 {
                     ToolBar toolBar = band[toolBarIndex];
                     remainingLength -= toolBar.MinLength;
-                    if (DoubleUtil.LessThan(remainingLength, 0))
+                    if (remainingLength < 0)
                     {
                         remainingLength = 0;
                         break;
@@ -380,7 +380,7 @@ namespace System.Windows.Controls
                     bandThickness = Math.Max(bandThickness, fHorizontal ? toolBar.DesiredSize.Height : toolBar.DesiredSize.Width);
                     bandLength += fHorizontal ? toolBar.DesiredSize.Width : toolBar.DesiredSize.Height;
                     remainingLength -= fHorizontal ? toolBar.DesiredSize.Width : toolBar.DesiredSize.Height;
-                    if (DoubleUtil.LessThan(remainingLength, 0))
+                    if (remainingLength < 0)
                     {
                         remainingLength = 0;
                     }


### PR DESCRIPTION
Fixes #2189

## Description

ToolBarTray.MeasureOverride used DoubleUtil.LessThan(remainingLength, 0) when deciding whether to clamp remainingLength to zero.

Because DoubleUtil.LessThan uses an epsilon comparison, a very small negative value may not be treated as less than zero. That value can then be used as a measure constraint, which can result in an ArgumentException.

This changes the guard to use a direct negative check so any negative remainingLength is clamped before it is used during measure.

## Customer Impact

Customers can hit an ArgumentException during ToolBarTray layout measurement when floating-point rounding leaves remainingLength slightly negative.

## Regression

No.

## Testing

Built locally with .\build.cmd

## Risk

Low. The change is limited to ToolBarTray.MeasureOverride and only affects negative remainingLength values.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11648)