### PR TITLE
Disconnect stale automation peers from UIA to fix memory leak in virtualized ItemsControls

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/ElementProxy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/ElementProxy.cs
@@ -8,6 +8,7 @@
 //
 //
 
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Provider;
@@ -38,8 +39,13 @@ namespace MS.Internal.Automation
         // private ctor - the Wrap() pseudo-ctor is used instead.
         private ElementProxy(AutomationPeer peer)
         {
-            if ((AutomationInteropReferenceType == ReferenceType.Weak) && 
-                (peer is UIElementAutomationPeer || peer is ContentElementAutomationPeer || peer is UIElement3DAutomationPeer))
+            // Weak-reference peers whose lifetime is owned elsewhere (the visual tree element, or the parent
+            // ItemsControl/Calendar peer that tracks data-item peers in its own weak storage) so UIA client
+            // references don't pin recycled/virtualized peers - and the controls they root - in memory.
+            // Data-item peers (IsDataItemAutomationPeer) are gated by an opt-out switch.
+            if ((AutomationInteropReferenceType == ReferenceType.Weak) &&
+                (peer is UIElementAutomationPeer || peer is ContentElementAutomationPeer || peer is UIElement3DAutomationPeer ||
+                 (peer.IsDataItemAutomationPeer() && !CoreAppContextSwitches.UseStrongReferenceForItemAutomationPeers)))
             {
                 _peer = new WeakReference(peer);
             }
@@ -275,6 +281,11 @@ namespace MS.Internal.Automation
                         if(peer.IsDataItemAutomationPeer())
                         {
                             peer.AddToParentProxyWeakRefCache();
+
+                            // Root the peer for the duration of the in-flight traversal: it is being surfaced to UIA
+                            // here but is only weakly held by its proxy, so without this it could be collected in the
+                            // window between being returned to UIA and UIA's first call back on it.
+                            PeerKeepAlive.KeepAlive(peer);
                         }
                     }
                 }
@@ -292,6 +303,17 @@ namespace MS.Internal.Automation
                 if (_peer is WeakReference)
                 {
                     AutomationPeer peer = (AutomationPeer)((WeakReference)_peer).Target;
+
+                    // A data-item peer is rooted only by its parent ItemsControl/Calendar peer, whose
+                    // _dataChildren entry and wrapper-peer EventsSource link both vanish in one layout pass when
+                    // the row virtualizes out - so a GC mid-walk could collect it and surface
+                    // ElementNotAvailableException. Park a short-lived strong root (see PeerKeepAlive)
+                    // that outlives the walk but is released once the peer stops being touched.
+                    if (peer != null && peer.IsDataItemAutomationPeer())
+                    {
+                        PeerKeepAlive.KeepAlive(peer);
+                    }
+
                     return peer;
                 }
                 else
@@ -499,6 +521,72 @@ namespace MS.Internal.Automation
 
             return StaticWrap(root, peer);
         }
+
+        #region data-item peer keep-alive
+
+        // Bounds the lifetime of weakly-referenced data-item peers so an in-flight UIA traversal cannot observe one
+        // being collected mid-walk, without reintroducing the unbounded leak the weak reference exists to fix.
+        // Each peer surfaced to UIA (at StaticWrap) or touched on a UIA callback (the Peer getter) is stored in a
+        // strong-rooted "current" bucket; a Background-priority DispatcherTimer rotates the buckets once per window
+        // (drop the oldest, promote "current" to "previous").  A fixed time window is deliberate rather than a
+        // dispatcher-idle callback: under non-concurrent GC, blocking collection pauses leave the dispatcher
+        // transiently idle mid-walk, which an idle-driven rotation would mistake for "walk finished".  The retained
+        // set is bounded by the in-flight working set, not by the data-set size.
+        private static class PeerKeepAlive
+        {
+            // A peer stays rooted until it has gone untouched for at least one full window and at most two (9-18 s).
+            // The lower bound is sized from measurement: under forced-Gen2 GC stress a single FindAll + readback
+            // iteration peaks at ~4.4 s (walk-dominated, stretched by GC pauses) - the worst-case gap between an
+            // element's surface-time touch and its readback touch.  A 9 s window is ~2x that, so the guaranteed
+            // minimum survival (one window) covers it even under blocking GC, while still releasing peers the
+            // client has stopped touching within seconds (bounding the retained set to the in-flight working set).
+            private static readonly TimeSpan Window = TimeSpan.FromSeconds(9);
+            private static readonly object _lock = new object();
+            private static HashSet<AutomationPeer> _current = new HashSet<AutomationPeer>();
+            private static HashSet<AutomationPeer> _previous = new HashSet<AutomationPeer>();
+            private static DispatcherTimer _timer;
+
+            internal static void KeepAlive(AutomationPeer peer)
+            {
+                Dispatcher dispatcher = peer.Dispatcher;
+                if (dispatcher == null)
+                {
+                    return;
+                }
+
+                lock (_lock)
+                {
+                    _current.Add(peer);
+                    if (_timer == null)
+                    {
+                        // The constructor associates the timer with the supplied dispatcher and starts it, so this
+                        // is safe to call from the UIA worker thread that drives the proxy.
+                        _timer = new DispatcherTimer(Window, DispatcherPriority.Background, OnTick, dispatcher);
+                    }
+                }
+            }
+
+            private static void OnTick(object sender, EventArgs e)
+            {
+                lock (_lock)
+                {
+                    // Drop the oldest bucket and promote the current one.
+                    HashSet<AutomationPeer> recycled = _previous;
+                    recycled.Clear();
+                    _previous = _current;
+                    _current = recycled;
+
+                    // Nothing left to keep alive - stop ticking until the next peer is surfaced.
+                    if (_previous.Count == 0)
+                    {
+                        _timer.Stop();
+                        _timer = null;
+                    }
+                }
+            }
+        }
+
+        #endregion data-item peer keep-alive
 
         #region disable switch for ElementProxy weak reference fix
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/ElementProxy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/ElementProxy.cs
@@ -299,12 +299,9 @@ namespace MS.Internal.Automation
                             peer.AddToParentProxyWeakRefCache();
 
                             // Root the peer for the in-flight traversal: it is only weakly held by its proxy and
-                            // could be collected between being returned to UIA and its first callback. Skip when
-                            // peers are strongly referenced - the proxy already roots them.
-                            if (!CoreAppContextSwitches.UseStrongReferenceForItemAutomationPeers)
-                            {
-                                PeerKeepAlive.KeepAlive(peer);
-                            }
+                            // could be collected between being returned to UIA and its first callback. KeepAlive
+                            // self-guards on the switch / registry-key / data-item eligibility.
+                            PeerKeepAlive.KeepAlive(peer);
                         }
                     }
                 }
@@ -325,11 +322,8 @@ namespace MS.Internal.Automation
 
                     // A data-item peer can be collected mid-walk when its row virtualizes out, surfacing ENA.
                     // Park a short-lived strong root (see PeerKeepAlive) that outlives the walk but is
-                    // released once the peer stops being touched.
-                    if (peer != null && !CoreAppContextSwitches.UseStrongReferenceForItemAutomationPeers && peer.IsDataItemAutomationPeer())
-                    {
-                        PeerKeepAlive.KeepAlive(peer);
-                    }
+                    // released once the peer stops being touched. KeepAlive self-guards on eligibility.
+                    PeerKeepAlive.KeepAlive(peer);
 
                     return peer;
                 }
@@ -559,15 +553,32 @@ namespace MS.Internal.Automation
             private static readonly object _timerLock = new object();
             private static volatile DispatcherTimer _timer;
 
+            // Renew the keep-alive window for a weakly-held data-item peer. The full eligibility guard lives
+            // here (not at the call sites) so the two callers cannot drift apart: the opt-out switch, the
+            // legacy AutomationWeakReferenceDisallow registry key (surfaced as AutomationInteropReferenceType),
+            // and data-item-ness. A null peer or non-weak reference type is a no-op.
             internal static void KeepAlive(AutomationPeer peer)
             {
+                if (peer == null ||
+                    CoreAppContextSwitches.UseStrongReferenceForItemAutomationPeers ||
+                    AutomationInteropReferenceType != ReferenceType.Weak ||
+                    !peer.IsDataItemAutomationPeer())
+                {
+                    return;
+                }
+
                 Dispatcher dispatcher = peer.Dispatcher;
                 if (dispatcher == null)
                 {
                     return;
                 }
 
-                _tracked[peer] = _generation;
+                // Skip the striped-lock write when this peer is already stamped for the current generation:
+                // repeat touches within a window are the common case and need no update.
+                if (!_tracked.TryGetValue(peer, out int g) || g != _generation)
+                {
+                    _tracked[peer] = _generation;
+                }
 
                 if (_timer == null)
                 {
@@ -626,7 +637,9 @@ namespace MS.Internal.Automation
         private volatile bool _disconnecting;
         private volatile int[] _cachedRuntimeId;
 
-        // Safe because a collected peer already throws ENA, so disconnect can't disturb a live walk.
+        // True once the weakly-held peer has been collected. Must NOT touch Peer: doing so would hand out a
+        // transient strong reference and defeat the very collection the sweep is waiting for. Safe because a
+        // collected peer already throws ENA, so disconnect can't disturb a live walk.
         private bool IsPeerCollected
         {
             get { return _peer is WeakReference weak && weak.Target == null; }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/ElementProxy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/ElementProxy.cs
@@ -8,6 +8,7 @@
 //
 //
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Automation;
@@ -39,15 +40,20 @@ namespace MS.Internal.Automation
         // private ctor - the Wrap() pseudo-ctor is used instead.
         private ElementProxy(AutomationPeer peer)
         {
-            // Weak-reference peers whose lifetime is owned elsewhere (the visual tree element, or the parent
-            // ItemsControl/Calendar peer that tracks data-item peers in its own weak storage) so UIA client
-            // references don't pin recycled/virtualized peers - and the controls they root - in memory.
-            // Data-item peers (IsDataItemAutomationPeer) are gated by an opt-out switch.
+            // Weakly reference peers whose lifetime is owned elsewhere so UIA references don't pin
+            // recycled/virtualized peers - and the controls they root - in memory. Data-item peers
+            // are gated by an opt-out switch.
             if ((AutomationInteropReferenceType == ReferenceType.Weak) &&
                 (peer is UIElementAutomationPeer || peer is ContentElementAutomationPeer || peer is UIElement3DAutomationPeer ||
                  (peer.IsDataItemAutomationPeer() && !CoreAppContextSwitches.UseStrongReferenceForItemAutomationPeers)))
             {
                 _peer = new WeakReference(peer);
+
+                // Let the sweep release this proxy's CCW once its peer is collected.
+                if (!CoreAppContextSwitches.DisableUiaProviderDisconnect)
+                {
+                    ProxyDisconnector.Register(this, peer.Dispatcher);
+                }
             }
             else
             {
@@ -156,9 +162,19 @@ namespace MS.Internal.Automation
             AutomationPeer peer = Peer;
             if (peer == null)
             {
+                // Serve the cached id during disconnect so the call can identify this provider.
+                if (_disconnecting && _cachedRuntimeId != null)
+                {
+                    return _cachedRuntimeId;
+                }
                 throw new ElementNotAvailableException();
             }
-            return (int []) ElementUtil.Invoke( peer, state => ((ElementProxy)state).InContextGetRuntimeId(), this);
+            int[] runtimeId = (int []) ElementUtil.Invoke( peer, state => ((ElementProxy)state).InContextGetRuntimeId(), this);
+            if (_peer is WeakReference)
+            {
+                _cachedRuntimeId = runtimeId;
+            }
+            return runtimeId;
         }
 
         public Rect BoundingRectangle
@@ -282,10 +298,13 @@ namespace MS.Internal.Automation
                         {
                             peer.AddToParentProxyWeakRefCache();
 
-                            // Root the peer for the duration of the in-flight traversal: it is being surfaced to UIA
-                            // here but is only weakly held by its proxy, so without this it could be collected in the
-                            // window between being returned to UIA and UIA's first call back on it.
-                            PeerKeepAlive.KeepAlive(peer);
+                            // Root the peer for the in-flight traversal: it is only weakly held by its proxy and
+                            // could be collected between being returned to UIA and its first callback. Skip when
+                            // peers are strongly referenced - the proxy already roots them.
+                            if (!CoreAppContextSwitches.UseStrongReferenceForItemAutomationPeers)
+                            {
+                                PeerKeepAlive.KeepAlive(peer);
+                            }
                         }
                     }
                 }
@@ -304,12 +323,10 @@ namespace MS.Internal.Automation
                 {
                     AutomationPeer peer = (AutomationPeer)((WeakReference)_peer).Target;
 
-                    // A data-item peer is rooted only by its parent ItemsControl/Calendar peer, whose
-                    // _dataChildren entry and wrapper-peer EventsSource link both vanish in one layout pass when
-                    // the row virtualizes out - so a GC mid-walk could collect it and surface
-                    // ElementNotAvailableException. Park a short-lived strong root (see PeerKeepAlive)
-                    // that outlives the walk but is released once the peer stops being touched.
-                    if (peer != null && peer.IsDataItemAutomationPeer())
+                    // A data-item peer can be collected mid-walk when its row virtualizes out, surfacing ENA.
+                    // Park a short-lived strong root (see PeerKeepAlive) that outlives the walk but is
+                    // released once the peer stops being touched.
+                    if (peer != null && !CoreAppContextSwitches.UseStrongReferenceForItemAutomationPeers && peer.IsDataItemAutomationPeer())
                     {
                         PeerKeepAlive.KeepAlive(peer);
                     }
@@ -524,27 +541,23 @@ namespace MS.Internal.Automation
 
         #region data-item peer keep-alive
 
-        // Bounds the lifetime of weakly-referenced data-item peers so an in-flight UIA traversal cannot observe one
-        // being collected mid-walk, without reintroducing the unbounded leak the weak reference exists to fix.
-        // Each peer surfaced to UIA (at StaticWrap) or touched on a UIA callback (the Peer getter) is stored in a
-        // strong-rooted "current" bucket; a Background-priority DispatcherTimer rotates the buckets once per window
-        // (drop the oldest, promote "current" to "previous").  A fixed time window is deliberate rather than a
-        // dispatcher-idle callback: under non-concurrent GC, blocking collection pauses leave the dispatcher
-        // transiently idle mid-walk, which an idle-driven rotation would mistake for "walk finished".  The retained
-        // set is bounded by the in-flight working set, not by the data-set size.
+        // Bounds the lifetime of weakly-referenced data-item peers so an in-flight UIA traversal cannot
+        // observe one collected mid-walk, without reintroducing the unbounded leak. Touched peers are
+        // strong-rooted and rotated out by a Background DispatcherTimer once untouched for a window.
         private static class PeerKeepAlive
         {
-            // A peer stays rooted until it has gone untouched for at least one full window and at most two (9-18 s).
-            // The lower bound is sized from measurement: under forced-Gen2 GC stress a single FindAll + readback
-            // iteration peaks at ~4.4 s (walk-dominated, stretched by GC pauses) - the worst-case gap between an
-            // element's surface-time touch and its readback touch.  A 9 s window is ~2x that, so the guaranteed
-            // minimum survival (one window) covers it even under blocking GC, while still releasing peers the
-            // client has stopped touching within seconds (bounding the retained set to the in-flight working set).
+            // A peer stays rooted until untouched for one full window and at most two (9-18 s). 9 s is ~2x
+            // the measured worst-case ~4.4 s gap between an element's surface and readback touches under
+            // forced-Gen2 GC, so it survives blocking GC while still releasing idle peers within seconds.
             private static readonly TimeSpan Window = TimeSpan.FromSeconds(9);
-            private static readonly object _lock = new object();
-            private static HashSet<AutomationPeer> _current = new HashSet<AutomationPeer>();
-            private static HashSet<AutomationPeer> _previous = new HashSet<AutomationPeer>();
-            private static DispatcherTimer _timer;
+
+            // Lock-free on the hot path: KeepAlive runs at the top of nearly every UIA interface call and only
+            // stamps the peer with the current generation (a striped concurrent write). OnTick advances the
+            // generation and drops peers untouched for two windows. Only the rare timer start/stop takes a lock.
+            private static readonly ConcurrentDictionary<AutomationPeer, int> _tracked = new ConcurrentDictionary<AutomationPeer, int>();
+            private static volatile int _generation;
+            private static readonly object _timerLock = new object();
+            private static volatile DispatcherTimer _timer;
 
             internal static void KeepAlive(AutomationPeer peer)
             {
@@ -554,39 +567,212 @@ namespace MS.Internal.Automation
                     return;
                 }
 
-                lock (_lock)
+                _tracked[peer] = _generation;
+
+                if (_timer == null)
                 {
-                    _current.Add(peer);
-                    if (_timer == null)
+                    lock (_timerLock)
                     {
                         // The constructor associates the timer with the supplied dispatcher and starts it, so this
                         // is safe to call from the UIA worker thread that drives the proxy.
-                        _timer = new DispatcherTimer(Window, DispatcherPriority.Background, OnTick, dispatcher);
+                        _timer ??= new DispatcherTimer(Window, DispatcherPriority.Background, OnTick, dispatcher);
                     }
                 }
             }
 
             private static void OnTick(object sender, EventArgs e)
             {
-                lock (_lock)
+                // Runs only on the timer's dispatcher thread, so it is the sole writer of _generation.
+                int cutoff = ++_generation - 1;
+                foreach (KeyValuePair<AutomationPeer, int> entry in _tracked)
                 {
-                    // Drop the oldest bucket and promote the current one.
-                    HashSet<AutomationPeer> recycled = _previous;
-                    recycled.Clear();
-                    _previous = _current;
-                    _current = recycled;
-
-                    // Nothing left to keep alive - stop ticking until the next peer is surfaced.
-                    if (_previous.Count == 0)
+                    // Value-matched removal: a concurrent KeepAlive re-stamp changes the value, so a peer
+                    // touched again mid-tick is not evicted while UIA is still using it.
+                    if (entry.Value < cutoff)
                     {
-                        _timer.Stop();
-                        _timer = null;
+                        _tracked.TryRemove(entry);
+                    }
+                }
+
+                if (_tracked.IsEmpty)
+                {
+                    lock (_timerLock)
+                    {
+                        // Re-check under the lock so a peer added between the test and the stop keeps ticking.
+                        if (_tracked.IsEmpty && _timer != null)
+                        {
+                            _timer.Stop();
+                            _timer = null;
+
+                            // A KeepAlive can add a peer and still see the not-yet-cleared timer; recreate it so
+                            // that peer is not left rooted with no tick to release it.
+                            if (!_tracked.IsEmpty)
+                            {
+                                _timer = new DispatcherTimer(Window, DispatcherPriority.Background, OnTick, Dispatcher.CurrentDispatcher);
+                            }
+                        }
                     }
                 }
             }
         }
 
         #endregion data-item peer keep-alive
+
+        #region dead-peer proxy disconnect
+
+        // volatile: _cachedRuntimeId is written on the UIA worker thread but read on the dispatcher
+        // thread during the re-entrant GetRuntimeId that UiaDisconnectProvider issues, so the read needs
+        // an acquire barrier to avoid observing a stale null.
+        private volatile bool _disconnecting;
+        private volatile int[] _cachedRuntimeId;
+
+        // Safe because a collected peer already throws ENA, so disconnect can't disturb a live walk.
+        private bool IsPeerCollected
+        {
+            get { return _peer is WeakReference weak && weak.Target == null; }
+        }
+
+        private bool Disconnect()
+        {
+            _disconnecting = true;
+            try
+            {
+                AutomationInteropProvider.DisconnectProvider(this);
+                return true;
+            }
+            catch (Exception)
+            {
+                // Disconnect failed (e.g. transient input-sync re-entrancy); caller re-queues for retry.
+                return false;
+            }
+            finally
+            {
+                _disconnecting = false;
+            }
+        }
+
+        // Background sweep that disconnects weakly-held ElementProxy instances whose peer has been collected.
+        private static class ProxyDisconnector
+        {
+            private static readonly TimeSpan Window = TimeSpan.FromSeconds(2);
+
+            // Cap per-tick work so a large backlog drains over several ticks instead of one COM burst.
+            private const int MaxDisconnectsPerTick = 5000;
+
+            // Give up re-queuing a proxy after this many failed disconnects. Real transient failures clear
+            // in 1-2 ticks, so this never trips for them; it caps the pathological case (a disconnect that
+            // throws every time, e.g. runtime id never cached) so the timer can still self-stop.
+            private const int MaxDisconnectAttempts = 8;
+
+            private static readonly object _lock = new object();
+            private static readonly List<WeakReference<ElementProxy>> _registry = new List<WeakReference<ElementProxy>>();
+
+            // Attempt counts kept only for the rare re-queued failures, not as a field on every proxy.
+            private static readonly Dictionary<ElementProxy, int> _failedAttempts = new Dictionary<ElementProxy, int>();
+            private static DispatcherTimer _timer;
+
+            internal static void Register(ElementProxy proxy, Dispatcher dispatcher)
+            {
+                if (dispatcher == null)
+                {
+                    return;
+                }
+
+                lock (_lock)
+                {
+                    _registry.Add(new WeakReference<ElementProxy>(proxy));
+                    _timer ??= new DispatcherTimer(Window, DispatcherPriority.Background, OnTick, dispatcher);
+                }
+            }
+
+            private static void OnTick(object sender, EventArgs e)
+            {
+                // Pick targets under the lock; disconnect outside it so Register never blocks.
+                List<ElementProxy> toDisconnect = null;
+
+                lock (_lock)
+                {
+                    int write = 0;
+                    int disconnectCount = 0;
+
+                    for (int read = 0; read < _registry.Count; read++)
+                    {
+                        WeakReference<ElementProxy> slot = _registry[read];
+                        if (!slot.TryGetTarget(out ElementProxy proxy))
+                        {
+                            continue;
+                        }
+
+                        if (proxy.IsPeerCollected && disconnectCount < MaxDisconnectsPerTick)
+                        {
+                            (toDisconnect ??= new List<ElementProxy>()).Add(proxy);
+                            disconnectCount++;
+                            continue;
+                        }
+
+                        _registry[write++] = slot;
+                    }
+
+                    _registry.RemoveRange(write, _registry.Count - write);
+
+                    if (_registry.Count == 0 && toDisconnect == null)
+                    {
+                        _timer.Stop();
+                        _timer = null;
+                    }
+                }
+
+                if (toDisconnect != null)
+                {
+                    List<ElementProxy> succeeded = null;
+                    List<ElementProxy> failed = null;
+                    foreach (ElementProxy proxy in toDisconnect)
+                    {
+                        if (proxy.Disconnect())
+                        {
+                            (succeeded ??= new List<ElementProxy>()).Add(proxy);
+                        }
+                        else
+                        {
+                            (failed ??= new List<ElementProxy>()).Add(proxy);
+                        }
+                    }
+
+                    lock (_lock)
+                    {
+                        if (succeeded != null && _failedAttempts.Count != 0)
+                        {
+                            foreach (ElementProxy proxy in succeeded)
+                            {
+                                _failedAttempts.Remove(proxy);
+                            }
+                        }
+
+                        if (failed != null)
+                        {
+                            // Re-queue a failed disconnect (its CCW is a GC root that would otherwise leak the
+                            // proxy) until the attempt cap, then give up - leaking only the lightweight shell so
+                            // the timer can still self-stop. The timer is alive because this tick had targets.
+                            foreach (ElementProxy proxy in failed)
+                            {
+                                int attempts = _failedAttempts.TryGetValue(proxy, out int n) ? n + 1 : 1;
+                                if (attempts < MaxDisconnectAttempts)
+                                {
+                                    _failedAttempts[proxy] = attempts;
+                                    _registry.Add(new WeakReference<ElementProxy>(proxy));
+                                }
+                                else
+                                {
+                                    _failedAttempts.Remove(proxy);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        #endregion dead-peer proxy disconnect
 
         #region disable switch for ElementProxy weak reference fix
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
@@ -465,5 +465,25 @@ namespace MS.Internal
         }
 
         #endregion
+
+        #region DisableUiaProviderDisconnect
+
+        /// <summary>
+        /// When false (the default), a background sweep disconnects ElementProxy instances whose weak
+        /// automation peer has been collected, releasing the UIA wrapper that keeps the dead proxy alive.
+        /// Set to true to restore the legacy behavior.
+        /// </summary>
+        internal const string DisableUiaProviderDisconnectSwitchName = "Switch.System.Windows.Automation.Peers.DisableUiaProviderDisconnect";
+        private static int _disableUiaProviderDisconnect;
+        public static bool DisableUiaProviderDisconnect
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return LocalAppContext.GetCachedSwitchValue(DisableUiaProviderDisconnectSwitchName, ref _disableUiaProviderDisconnect);
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
@@ -445,5 +445,25 @@ namespace MS.Internal
         }
 
         #endregion
+
+        #region UseStrongReferenceForItemAutomationPeers
+
+        /// <summary>
+        /// When false (the default), <see cref="MS.Internal.Automation.ElementProxy"/> holds data-item automation
+        /// peers (<see cref="System.Windows.Automation.Peers.AutomationPeer.IsDataItemAutomationPeer"/>) weakly,
+        /// fixing a memory leak in virtualized ItemsControls; true restores the legacy strong reference.
+        /// </summary>
+        internal const string UseStrongReferenceForItemAutomationPeersSwitchName = "Switch.System.Windows.Automation.Peers.UseStrongReferenceForItemAutomationPeers";
+        private static int _useStrongReferenceForItemAutomationPeers;
+        public static bool UseStrongReferenceForItemAutomationPeers
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return LocalAppContext.GetCachedSwitchValue(UseStrongReferenceForItemAutomationPeersSwitchName, ref _useStrongReferenceForItemAutomationPeers);
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/MS/Internal/Automation/UiaCoreProviderApi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/MS/Internal/Automation/UiaCoreProviderApi.cs
@@ -39,6 +39,11 @@ namespace MS.Internal.Automation
             CheckError(RawUiaHostProviderFromHwnd(hwnd, out provider));
             return provider;
         }
+
+        internal static void UiaDisconnectProvider(IRawElementProviderSimple provider)
+        {
+            CheckError(RawUiaDisconnectProvider(provider));
+        }
         #endregion Provider methods
 
         //
@@ -118,6 +123,9 @@ namespace MS.Internal.Automation
 
         [DllImport(DllImport.UIAutomationCore, EntryPoint = "UiaHostProviderFromHwnd", CharSet = CharSet.Unicode)]
         private static extern int RawUiaHostProviderFromHwnd(IntPtr hwnd, [MarshalAs(UnmanagedType.Interface)] out IRawElementProviderSimple provider);
+
+        [DllImport(DllImport.UIAutomationCore, EntryPoint = "UiaDisconnectProvider", CharSet = CharSet.Unicode)]
+        private static extern int RawUiaDisconnectProvider(IRawElementProviderSimple provider);
 
         // Event APIs...
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/System/Windows/Automation/Provider/AutomationInteropProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/System/Windows/Automation/Provider/AutomationInteropProvider.cs
@@ -76,6 +76,18 @@ namespace System.Windows.Automation.Provider
         }
 
         /// <summary>
+        /// Releases UIA's references to a provider whose element is gone so it can be reclaimed; afterwards
+        /// requests for it throw ElementNotAvailableException. Not callable while handling a SendMessage.
+        /// </summary>
+        /// <param name="provider">The server-side provider to disconnect.</param>
+        public static void DisconnectProvider(IRawElementProviderSimple provider)
+        {
+            ArgumentNullException.ThrowIfNull(provider);
+
+            UiaCoreProviderApi.UiaDisconnectProvider(provider);
+        }
+
+        /// <summary>
         /// Called by a server to determine if there are any listeners for events.
         /// </summary>
         public static bool ClientsAreListening 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/ref/UIAutomationProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/ref/UIAutomationProvider.cs
@@ -10,6 +10,7 @@ namespace System.Windows.Automation.Provider
         public const int ItemsInvalidateLimit = 5;
         public const int RootObjectId = -25;
         public static bool ClientsAreListening { get { throw null; } }
+        public static void DisconnectProvider(System.Windows.Automation.Provider.IRawElementProviderSimple provider) { }
         public static System.Windows.Automation.Provider.IRawElementProviderSimple HostProviderFromHandle(System.IntPtr hwnd) { throw null; }
         public static void RaiseAutomationEvent(System.Windows.Automation.AutomationEvent eventId, System.Windows.Automation.Provider.IRawElementProviderSimple provider, System.Windows.Automation.AutomationEventArgs e) { }
         public static void RaiseAutomationPropertyChangedEvent(System.Windows.Automation.Provider.IRawElementProviderSimple element, System.Windows.Automation.AutomationPropertyChangedEventArgs e) { }


### PR DESCRIPTION
Fixes dotnet#11337

## Description
When a UIA client (screen reader, test-automation, inspector) repeatedly enumerates a virtualized `ItemsControl` (e.g. a large `DataGrid`), WPF accumulates two kinds of never-released objects, producing an unbounded leak:

 1. **AutomationPeers** — `ElementProxy` held its peer with a **strong** reference, and the UIA CCW held the proxy, so every peer surfaced to a client (and the data row / visual sub-tree it roots) was pinned forever.
 2. **`ElementProxy` CCWs** — even once a peer is no longer referenced, the proxy itself stays rooted by its UIA COM-callable wrapper (CCW), dragging its `WeakReference`, runtime-id and name strings with it.

This PR addresses both:

- **Weakly-held peers.** `ElementProxy` now holds `UIElement`/`ContentElement`/ `UIElement3D` peers - and newly **data-item** peers - via `WeakReference`, so UIA references no longer pin recycled/virtualized peers. Data-item behavior is gated by the `Switch.System.Windows.Automation.Peers.UseStrongReferenceForItemAutomationPeers` AppContext switch (default `false` = weak; set `true` to restore legacy strong refs).
- **Keep-alive window.** Because a weakly-held data-item peer could otherwise be collected *in the middle of* a live UIA traversal (surfacing `ElementNotAvailableException`), each peer surfaced to or touched by UIA is strong-rooted in a small rotating bucket for a bounded time window (one-to-two windows ≈ 9–18 s) via a `Background`-priority    `DispatcherTimer`, then released. Retention is bounded by the in-flight working set, not the data-set size.
- **Proxy/CCW disconnect.** A second `Background`-priority `DispatcherTimer` sweep (~2 s cadence, capped at 5000 disconnects/tick) calls the new `UiaDisconnectProvider` on `ElementProxy` instances **whose weak peer has already been collected**, releasing the CCW so the proxy and everything it roots can be reclaimed. Gated by `Switch.System.Windows.Automation.Peers.DisableUiaProviderDisconnect` (default `false` = sweep enabled). Both timers self-stop when there is nothing to track.

A new public API, `AutomationInteropProvider.DisconnectProvider(IRawElementProviderSimple)`, is added (with matching reference-assembly entry) to expose `UiaDisconnectProvider` to the bridge.

 UIA clients may observe `ElementNotAvailableException` when accessing an element whose peer has been collected/disconnected — standard UIA contract behavior that well-behaved clients already handle.

## Customer Impact
WPF applications that expose a virtualized `ItemsControl` (DataGrid, ListView, etc.) to UI Automation experience an unbounded memory leak (≈260 MB/min in the customer's 200k-row DataGrid repro), ending in `OutOfMemoryException` and crashes in long-running sessions. Any app with accessibility active (assistive technology or test automation present) is affected. The customer is currently held on a workaround.

## Regression

No.

## Testing

Controlled customer repro (200k-row DataGrid + a UIA client driving `FindAll` ~1×/s), memory sampled after forced Gen2 GC:

- **Baseline (no fix): ** ≈ +260 MB/min; `ElementProxy` and data-item peers grow without bound.
- **Peer fix only (weak refs + keep-alive): ** AutomationPeers bounded (e.g. `DataGridCellItemAutomationPeer` flat/declining), but `ElementProxy` CCWs still grew (~3.7× over 15 min).
- **Full fix (peer fix + proxy disconnect sweep): ** `ElementProxy` bounded over a 12-min run (2.5k ->3.6k, not growing); process working set flat (≈614–892 MB); no OOM.
- Kill-switch paths verified: setting either `AppContext` switch restores the prior behavior.

## Risk

**Moderate, well-contained, and fully reversible via two AppContext kill-switches.** 
The risk areas are:

1. **Weak data-item peers (behavioral default change).** Data-item peers are now held weakly by default. Any code that implicitly relied on a peer staying alive purely because UIA had seen it could see it collected earlier. Mitigated by the keep-alive window and fully reversible via `UseStrongReferenceForItemAutomationPeers=true`.
2. **Keep-alive retention window.** Peers are deliberately retained for ≈9–18 s after their last UIA touch. This is the main new behavioral trade-off: a small, bounded increase in peak retention in exchange for safety against mid-walk collection. The 9 s window is sized around 2x the measured worst-case gap (around 4.4 s under forced-Gen2 GC) between an element's surface-time touch and its read-back touch; pathological client timing slower than the window could still surface `ElementNotAvailableException`.
3. **New public API surface.** `AutomationInteropProvider.DisconnectProvider` is additive (plus a ref-assembly entry) and needs API-review sign-off; it is a thin wrapper over the documented `UiaDisconnectProvider`.
4. **Background disconnect sweep.**  Runs on the UI `Dispatcher` at `Background` priority and only disconnects proxies whose peer is already collected (which already throw ENA), so it cannot disturb a walk of a live element. Work is capped per tick (5000). Failed-disconnect handling. `AutomationInteropProvider.DisconnectProvider` can occasionally fail transiently (e.g. re-entrant input-sync, or a proxy whose runtime id was never cached because `GetRuntimeId` was never called on it). `ElementProxy.Disconnect()` returns a success/failure result, and the sweep re-queues a failed proxy for a later tick - its CCW is a GC root, so silently dropping it would leak the proxy. A per-proxy attempt counter ( `failedAttempts`) caps this at `MaxDisconnectAttempts` (8): genuine transients clear within 1–2 ticks and never approach the cap, while a proxy that fails every time is abandoned after 8 tries (leaking only the lightweight shell) so the timer can still self-stop instead of spinning forever. Reversible via `DisableUiaProviderDisconnect=true`.
 5. **ENA timing.** Clients may now receive `ElementNotAvailableException` during steady state (not only on tree changes). Conformant clients (Narrator, NVDA, JAWS) handle this; non-conformant tools that don't catch it could surface new errors.
 6. A client that retrieves an element for an unrealized item via `FindItemByProperty` and then calls `VirtualizedItemPattern.Realize` after the keep-alive window (~10–18 s) will get  `ElementNotAvailableException`, since the peer was collected and its proxy disconnected. This is within the UIA ENA contract but changes the pattern's previously indefinite realizability. Kill switch `DisableUiaProviderDisconnect` restores the old behavior.
 7. WPF runtime ids are `{7, ProcessId, GetHashCode()}`, so identity-hash collisions are possible. Because `UiaDisconnectProvider` matches by runtime id, a dead proxy's cached id that collides with a live peer's could invalidate a client's view of a healthy element. Pre-existing weakness; low probability, but the disconnect sweep is the first path to exercise it at scale.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11657)