### PR TITLE
Package ijwhost.dll as native asset for self-contained publish

### DIFF
--- a/eng/WpfArcadeSdk/tools/Packaging.targets
+++ b/eng/WpfArcadeSdk/tools/Packaging.targets
@@ -90,6 +90,21 @@ $(PreparePackageAssetsDependsOn):
     </PropertyGroup>
 
     <!--
+      For managed C++/CLI projects (vcxproj with UseDestinationLibFolder), ijwhost.dll is automatically
+      produced in the output directory but must be packaged as a native assembly under runtimes\<rid>\native\
+      rather than alongside managed assemblies under lib\<tfm>\.
+    -->
+    <PropertyGroup Condition="'$(MSBuildProjectExtension)'=='.vcxproj' and '$(UseDestinationLibFolder)' != ''">
+      <NativeRuntimeSubFolder Condition="'$(Platform)'=='AnyCPU' or '$(Platform)'=='x86' or '$(Platform)'=='Win32'">runtimes\win-x86\native\</NativeRuntimeSubFolder>
+      <NativeRuntimeSubFolder Condition="'$(Platform)'=='x64'">runtimes\win-x64\native\</NativeRuntimeSubFolder>
+      <NativeRuntimeSubFolder Condition="'$(Platform)'=='arm64'">runtimes\win-arm64\native\</NativeRuntimeSubFolder>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(MSBuildProjectExtension)'=='.vcxproj' and '$(UseDestinationLibFolder)' != ''">
+      <FileNamesExcludedFromPackaging Include="ijwhost.dll" />
+    </ItemGroup>
+
+    <!--
         Instead of showing an error when $(TargetFramework) or $(RuntimeIdentifier) cannot be identified
         we simply do no further work
 
@@ -115,6 +130,13 @@ $(PreparePackageAssetsDependsOn):
                 Exclude="@(FileNamesExcludedFromPackaging -> '$(OutDir)%(Filename)%(Extension)' )"
                 AdditionalMetadata="RelativePath=$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(DestinationSubFolder)"
                 Condition="'$(DestinationSubFolder)'!='' and '$(IsPackagingProject)'!='true' and '@(PackagingAssemblyContent)'==''">
+      <Output ItemName="PackageAsset" TaskParameter="Include"/>
+    </CreateItem>
+
+    <!-- Route ijwhost.dll to runtimes\<rid>\native\ for managed C++/CLI projects -->
+    <CreateItem Include="$(OutDir)ijwhost.dll"
+                AdditionalMetadata="RelativePath=$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(NativeRuntimeSubFolder)"
+                Condition="'$(NativeRuntimeSubFolder)'!='' and '$(DestinationSubFolder)'!='' and '$(IsPackagingProject)'!='true' and Exists('$(OutDir)ijwhost.dll')">
       <Output ItemName="PackageAsset" TaskParameter="Include"/>
     </CreateItem>
 

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/DirectWriteForwarder.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/DirectWriteForwarder.vcxproj
@@ -92,7 +92,25 @@
   <ItemGroup>
     <AdditionalPackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>
-  <!-- ijwhost.dll is required for mixed-mode C++/CLI assemblies -->
+  <!--
+    Exclude ijwhost.dll from the managed (lib/) folder packaging.
+    It must be placed in runtimes/win-{arch}/native/ instead so that it is
+    recognized as a native asset and included in RuntimeList.xml for
+    self-contained publish scenarios.
+  -->
+  <ItemGroup>
+    <FileNamesExcludedFromPackaging Include="ijwhost.dll" />
+  </ItemGroup>
+  <Target Name="_PackageIjwHostAsNativeAsset" BeforeTargets="CopyPackageAssets" AfterTargets="IdentifyPackageAssets" Condition="'$(PackageName)'!='' and Exists('$(OutDir)ijwhost.dll')">
+    <PropertyGroup>
+      <_IjwHostNativeDestFolder Condition="'$(Platform)'=='AnyCPU' or '$(Platform)'=='x86' or '$(Platform)'=='Win32'">runtimes\win-x86\native\</_IjwHostNativeDestFolder>
+      <_IjwHostNativeDestFolder Condition="'$(Platform)'=='x64'">runtimes\win-x64\native\</_IjwHostNativeDestFolder>
+      <_IjwHostNativeDestFolder Condition="'$(Platform)'=='arm64'">runtimes\win-arm64\native\</_IjwHostNativeDestFolder>
+    </PropertyGroup>
+    <ItemGroup>
+      <PackageAsset Include="$(OutDir)ijwhost.dll" RelativePath="$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(_IjwHostNativeDestFolder)" />
+    </ItemGroup>
+  </Target>
   <Target Name="AddWindowsBaseDefine" AfterTargets="ResolveProjectReferences">
     <Error Text="Unexpected result from _WindowsBaseReference '@(_WindowsBaseReference->Count())'" Condition="'@(_WindowsBaseReference->Count())' != '1'" />
     <PropertyGroup>

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/DirectWriteForwarder.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/DirectWriteForwarder.vcxproj
@@ -92,25 +92,7 @@
   <ItemGroup>
     <AdditionalPackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>
-  <!--
-    Exclude ijwhost.dll from the managed (lib/) folder packaging.
-    It must be placed in runtimes/win-{arch}/native/ instead so that it is
-    recognized as a native asset and included in RuntimeList.xml for
-    self-contained publish scenarios.
-  -->
-  <ItemGroup>
-    <FileNamesExcludedFromPackaging Include="ijwhost.dll" />
-  </ItemGroup>
-  <Target Name="_PackageIjwHostAsNativeAsset" BeforeTargets="CopyPackageAssets" AfterTargets="IdentifyPackageAssets" Condition="'$(PackageName)'!='' and Exists('$(OutDir)ijwhost.dll')">
-    <PropertyGroup>
-      <_IjwHostNativeDestFolder Condition="'$(Platform)'=='AnyCPU' or '$(Platform)'=='x86' or '$(Platform)'=='Win32'">runtimes\win-x86\native\</_IjwHostNativeDestFolder>
-      <_IjwHostNativeDestFolder Condition="'$(Platform)'=='x64'">runtimes\win-x64\native\</_IjwHostNativeDestFolder>
-      <_IjwHostNativeDestFolder Condition="'$(Platform)'=='arm64'">runtimes\win-arm64\native\</_IjwHostNativeDestFolder>
-    </PropertyGroup>
-    <ItemGroup>
-      <PackageAsset Include="$(OutDir)ijwhost.dll" RelativePath="$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(_IjwHostNativeDestFolder)" />
-    </ItemGroup>
-  </Target>
+  <!-- ijwhost.dll packaging is handled centrally in eng/WpfArcadeSdk/tools/Packaging.targets -->
   <Target Name="AddWindowsBaseDefine" AfterTargets="ResolveProjectReferences">
     <Error Text="Unexpected result from _WindowsBaseReference '@(_WindowsBaseReference->Count())'" Condition="'@(_WindowsBaseReference->Count())' != '1'" />
     <PropertyGroup>

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
@@ -161,7 +161,25 @@
   <ItemGroup>
     <AdditionalPackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>
-  <!-- ijwhost.dll is required for mixed-mode C++/CLI assemblies -->
+  <!--
+    Exclude ijwhost.dll from the managed (lib/) folder packaging.
+    It must be placed in runtimes/win-{arch}/native/ instead so that it is
+    recognized as a native asset and included in RuntimeList.xml for
+    self-contained publish scenarios.
+  -->
+  <ItemGroup>
+    <FileNamesExcludedFromPackaging Include="ijwhost.dll" />
+  </ItemGroup>
+  <Target Name="_PackageIjwHostAsNativeAsset" BeforeTargets="CopyPackageAssets" AfterTargets="IdentifyPackageAssets" Condition="'$(PackageName)'!='' and Exists('$(OutDir)ijwhost.dll')">
+    <PropertyGroup>
+      <_IjwHostNativeDestFolder Condition="'$(Platform)'=='AnyCPU' or '$(Platform)'=='x86' or '$(Platform)'=='Win32'">runtimes\win-x86\native\</_IjwHostNativeDestFolder>
+      <_IjwHostNativeDestFolder Condition="'$(Platform)'=='x64'">runtimes\win-x64\native\</_IjwHostNativeDestFolder>
+      <_IjwHostNativeDestFolder Condition="'$(Platform)'=='arm64'">runtimes\win-arm64\native\</_IjwHostNativeDestFolder>
+    </PropertyGroup>
+    <ItemGroup>
+      <PackageAsset Include="$(OutDir)ijwhost.dll" RelativePath="$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(_IjwHostNativeDestFolder)" />
+    </ItemGroup>
+  </Target>
   <Target Name="AddDefineReferences" BeforeTargets="ClCompile" AfterTargets="ResolveReferences" Returns="@(CLCompile)">
     <PropertyGroup>
       <_defineReferences>@(_defineReference->'%(Define)=&lt;%(Identity)&gt;')</_defineReferences>

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
@@ -161,25 +161,7 @@
   <ItemGroup>
     <AdditionalPackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>
-  <!--
-    Exclude ijwhost.dll from the managed (lib/) folder packaging.
-    It must be placed in runtimes/win-{arch}/native/ instead so that it is
-    recognized as a native asset and included in RuntimeList.xml for
-    self-contained publish scenarios.
-  -->
-  <ItemGroup>
-    <FileNamesExcludedFromPackaging Include="ijwhost.dll" />
-  </ItemGroup>
-  <Target Name="_PackageIjwHostAsNativeAsset" BeforeTargets="CopyPackageAssets" AfterTargets="IdentifyPackageAssets" Condition="'$(PackageName)'!='' and Exists('$(OutDir)ijwhost.dll')">
-    <PropertyGroup>
-      <_IjwHostNativeDestFolder Condition="'$(Platform)'=='AnyCPU' or '$(Platform)'=='x86' or '$(Platform)'=='Win32'">runtimes\win-x86\native\</_IjwHostNativeDestFolder>
-      <_IjwHostNativeDestFolder Condition="'$(Platform)'=='x64'">runtimes\win-x64\native\</_IjwHostNativeDestFolder>
-      <_IjwHostNativeDestFolder Condition="'$(Platform)'=='arm64'">runtimes\win-arm64\native\</_IjwHostNativeDestFolder>
-    </PropertyGroup>
-    <ItemGroup>
-      <PackageAsset Include="$(OutDir)ijwhost.dll" RelativePath="$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(_IjwHostNativeDestFolder)" />
-    </ItemGroup>
-  </Target>
+  <!-- ijwhost.dll packaging is handled centrally in eng/WpfArcadeSdk/tools/Packaging.targets -->
   <Target Name="AddDefineReferences" BeforeTargets="ClCompile" AfterTargets="ResolveReferences" Returns="@(CLCompile)">
     <PropertyGroup>
       <_defineReferences>@(_defineReference->'%(Define)=&lt;%(Identity)&gt;')</_defineReferences>


### PR DESCRIPTION
Fixes #11651

Main PR: N/A (this is the main branch fix)

## Description

After PR #11575 migrated C++/CLI projects from `/clr:pure` to `/clr:NetCore`, `DirectWriteForwarder.dll` and `System.Printing.dll` became mixed-mode assemblies requiring `ijwhost.dll` at runtime. The build was placing `ijwhost.dll` in the managed `lib/net11.0/` folder (via the `$(OutDir)*.dll` glob), where it is not recognized by `RuntimeList.xml`. This caused it to be missing from self-contained publish output.

The fix excludes `ijwhost.dll` from lib/ folder packaging and adds a target to place it in `runtimes/win-{arch}/native/` where it is properly listed in the runtime pack manifest.

## Customer Impact

Any WPF app published as self-contained (`dotnet publish -r win-x64 --self-contained`) crashes on launch with:
```
System.IO.FileNotFoundException: Could not load file or assembly '...\DirectWriteForwarder.dll'.
The specified module could not be found.
```
Framework-dependent apps are unaffected (they load from the shared framework folder).

## Regression

Yes. Introduced by #11575 (Remove /clr:pure from WPF C++/CLI projects), which shipped in SDK 11.0.100-preview.5.26264.105. Not present in 11.0.100-preview.5.26263.112.

## Testing

- Installed both SDK versions and confirmed the regression
- Built WPF with the fix (`build.cmd -c Release -platform x64 -pack`)
- Verified `ijwhost.dll` lands in `runtimes/win-x64/native/` (not `lib/net11.0/`)
- Patched the runtime pack in NuGet cache and confirmed `dotnet publish --self-contained` includes `Ijwhost.dll` in output
- Ran the published WPF app successfully

## Risk

Low. The change only affects packaging of `ijwhost.dll` — moving it from an incorrect location (lib/) to the correct one (native/). This matches how all other native DLLs (vcruntime140_cor3.dll, wpfgfx_cor3.dll, etc.) are already packaged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11664)