### PR TITLE
Text Rendering: Add DirectWrite color glyph (COLR v0) rendering support

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/FontFace.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/FontFace.cpp
@@ -259,4 +259,33 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
         
         return success; 
     }
+
+    /// Checks whether the font face contains a COLR table by probing via
+    /// IDWriteFontFace::TryGetFontTable. The table data is immediately released
+    /// since we only need to know whether the table exists, not its contents.
+    /// TranslateColorGlyphRun does its own deep parsing of COLR/CPAL.
+    __declspec(noinline) bool FontFace::HasColorGlyphs()
+    {
+        const void* tableData;
+        void* tableContext;
+        UINT32 tableSize = 0;
+        BOOL exists = FALSE;
+
+        HRESULT hr = _fontFace->Value->TryGetFontTable(
+            DWRITE_MAKE_OPENTYPE_TAG('C','O','L','R'),
+            &tableData,
+            &tableSize,
+            &tableContext,
+            &exists
+            );
+
+        if (SUCCEEDED(hr) && exists)
+        {
+            _fontFace->Value->ReleaseFontTable(tableContext);
+        }
+
+        System::GC::KeepAlive(_fontFace);
+        return (!!exists);
+    }
+
 }}}}//MS::Internal::Text::TextInterface

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/FontFace.h
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/FontFace.h
@@ -218,6 +218,14 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
             bool ReadFontEmbeddingRights([System::Runtime::InteropServices::Out] unsigned short% fsType);
 
             /// <summary>
+            /// Returns true if the font face contains a COLR (Color) OpenType table,
+            /// indicating it has color glyph layer definitions. Only checks for table
+            /// presence, not validity -- a corrupt COLR table would return true here
+            /// but fail during TranslateColorGlyphRun.
+            /// </summary>
+            bool HasColorGlyphs();
+
+            /// <summary>
             /// dtor.
             /// </summary>
             ~FontFace();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Fonts/GlobalUserInterface.CompositeFont
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Fonts/GlobalUserInterface.CompositeFont
@@ -395,7 +395,7 @@
             Box Drawing                      2500-257F
             Block Elements                   2580-259F
             Geometric Shapes                 25A0-25FF
-            Geometric Shapes Extended        1F780-1F7FF
+            Geometric Shapes Extended        1F780-1F7FF (excluding 1F7E0-1F7EB and 1F7F0, which are emoji; see below)
             -->
             <!-- Windows 8.1: Segoe UI Emoji supports emoji characters in these ranges, but we don't want them to
              be used with precedence over other fonts in all cases. Separating ranges for which Emoji coverage
@@ -403,32 +403,96 @@
             <!-- Not ideographs, so after first choice can prioritize ClearType, sans-serif/serif over culture -->
             <!-- CHS -->
             <FontFamilyMap
-                Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7FF"
+                Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7DF, 1F7EC-1F7EF, 1F7F1-1F7FF"
                 Language    = "zh-Hans"
                 Target      = "Microsoft YaHei UI, Microsoft YaHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, SimSun, MS Gothic, MingLiU, Tahoma"
                 Scale       = "1.0" />
             <!-- CHT -->
             <FontFamilyMap
-                Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7FF"
+                Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7DF, 1F7EC-1F7EF, 1F7F1-1F7FF"
                 Language    = "zh-Hant"
                 Target      = "Microsoft JhengHei UI, Microsoft JhengHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft YaHei UI, Microsoft YaHei, MingLiU, MS Gothic, Tahoma"
                 Scale       = "1.0" />
             <!-- JA -->
             <FontFamilyMap
-                Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7FF"
+                Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7DF, 1F7EC-1F7EF, 1F7F1-1F7FF"
                 Language    = "ja"
                 Target      = "Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, MS Gothic, MingLiU, Tahoma"
                 Scale       = "1.0" />
             <!-- KO -->
             <FontFamilyMap
-                Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7FF"
+                Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7DF, 1F7EC-1F7EF, 1F7F1-1F7FF"
                 Language    = "ko"
                 Target      = "Malgun Gothic, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Gulim, MS Gothic, MingLiU, Tahoma"
                 Scale       = "1.0" />
             <!-- Other -->
             <FontFamilyMap
-                Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7FF"
+                Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7DF, 1F7EC-1F7EF, 1F7F1-1F7FF"
                 Target      = "Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, Tahoma, MS Gothic, MingLiU, MingLiU"
+                Scale       = "1.0" />
+
+            <!-- Unicode 12.0 colored circles (1F7E0-1F7E5) and squares (1F7E6-1F7EB) and Unicode 14.0 heavy equals sign (1F7F0).
+                 Although these sit in the Geometric Shapes Extended block, they are defined as emoji and have COLR glyphs in Segoe UI Emoji. -->
+            <!-- CHS -->
+            <FontFamilyMap
+                Unicode     = "1F7E0-1F7EB, 1F7F0"
+                Language    = "zh-Hans"
+                Target      = "Segoe UI Emoji, Microsoft YaHei UI, Microsoft YaHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, SimSun, MS Gothic, MingLiU"
+                Scale       = "1.0" />
+            <!-- CHT -->
+            <FontFamilyMap
+                Unicode     = "1F7E0-1F7EB, 1F7F0"
+                Language    = "zh-Hant"
+                Target      = "Segoe UI Emoji, Microsoft JhengHei UI, Microsoft JhengHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft YaHei UI, Microsoft YaHei, MingLiU, MS Gothic"
+                Scale       = "1.0" />
+            <!-- JA -->
+            <FontFamilyMap
+                Unicode     = "1F7E0-1F7EB, 1F7F0"
+                Language    = "ja"
+                Target      = "Segoe UI Emoji, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, MS Gothic, MingLiU"
+                Scale       = "1.0" />
+            <!-- KO -->
+            <FontFamilyMap
+                Unicode     = "1F7E0-1F7EB, 1F7F0"
+                Language    = "ko"
+                Target      = "Segoe UI Emoji, Malgun Gothic, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Gulim, MS Gothic, MingLiU"
+                Scale       = "1.0" />
+            <!-- Other -->
+            <FontFamilyMap
+                Unicode     = "1F7E0-1F7EB, 1F7F0"
+                Target      = "Segoe UI Emoji, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, MS Gothic, MingLiU, MingLiU"
+                Scale       = "1.0" />
+
+            <!-- Default-presentation emoji from Misc Symbols and Arrows block (Emoji_Presentation = Yes, no VS-16 needed):
+                 2B50 (star), 2B55 (hollow red circle). -->
+            <!-- CHS -->
+            <FontFamilyMap
+                Unicode     = "2B50, 2B55"
+                Language    = "zh-Hans"
+                Target      = "Segoe UI Emoji, Microsoft YaHei UI, Microsoft YaHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, SimSun, MS Gothic, MingLiU"
+                Scale       = "1.0" />
+            <!-- CHT -->
+            <FontFamilyMap
+                Unicode     = "2B50, 2B55"
+                Language    = "zh-Hant"
+                Target      = "Segoe UI Emoji, Microsoft JhengHei UI, Microsoft JhengHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft YaHei UI, Microsoft YaHei, MingLiU, MS Gothic"
+                Scale       = "1.0" />
+            <!-- JA -->
+            <FontFamilyMap
+                Unicode     = "2B50, 2B55"
+                Language    = "ja"
+                Target      = "Segoe UI Emoji, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, MS Gothic, MingLiU"
+                Scale       = "1.0" />
+            <!-- KO -->
+            <FontFamilyMap
+                Unicode     = "2B50, 2B55"
+                Language    = "ko"
+                Target      = "Segoe UI Emoji, Malgun Gothic, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Gulim, MS Gothic, MingLiU"
+                Scale       = "1.0" />
+            <!-- Other -->
+            <FontFamilyMap
+                Unicode     = "2B50, 2B55"
+                Target      = "Segoe UI Emoji, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, MS Gothic, MingLiU, MingLiU"
                 Scale       = "1.0" />
 
             <!-- Combining Diacritic Marks for Symbols 20D0-20FF -->
@@ -495,13 +559,12 @@
             Supplemental Arrows-B       2900-297F
             Misc Mathematical Symbols-B 2980-29FF
             Supplemental Math Operators 2A00-2AFF
-            Misc Symbols and Arrows     2B00-2BFF
+            Misc Symbols and Arrows     2B00-2BFF (excluding 2B50 and 2B55, which are emoji; see above)
             Supplemental Arrows-C       1F800-1F8FF
             -->
             <!-- Segoe UI Symbol covers all on Win8; Cambria Math covers 2900-2AFF; MS Gothic has little coverage -->
-            <!-- Segoe UI Emoji supports only emoji characters in these ranges; not adding to avoid uneven display -->
             <FontFamilyMap
-                Unicode     = "27C0-2BFF, 1F800-1F8FF"
+                Unicode     = "27C0-2B4F, 2B51-2B54, 2B56-2BFF, 1F800-1F8FF"
                 Target      = "Segoe UI Symbol, Cambria Math, MS Gothic"
                 Scale       = "1.0" />
 
@@ -1681,11 +1744,12 @@
             Ornamental Dingbats                     1F650-1F67F
             Transport And Map Symbols               1F680-1F6FF
             Supplemental Symbols and Pictographs    1F900-1F9FF
+            Symbols and Pictographs Extended-A      1FA70-1FAFF
             -->
             <!-- Windows 8+ -->
-            <!-- Segoe UI Emoji supports only emoji characters or emoji supplements in these ranges -->
+            <!-- Segoe UI Emoji supports emoji characters in these ranges -->
             <FontFamilyMap
-                Unicode     = "1F000-1F6FF, 1F900-1F9FF"
+                Unicode     = "1F000-1F6FF, 1F900-1FAFF"
                 Target      = "Segoe UI Emoji, Segoe UI Symbol"
                 Scale       = "1.0" />
 
@@ -1701,10 +1765,11 @@
 
             <!-- Supplemental Symbols and Pictographs (1F900-1F9FF): see above, by 1F000-1F02F -->
 
-            <!-- Chess Symbols                 1FA00-1FA6F -->
-            <!-- No font -->
+            <!-- Symbols and Pictographs Extended-A (1FA70-1FAFF): see above, by 1F000-1F02F -->
 
-            <!-- (unassigned)                  1FA70-1FFFF -->
+            <!-- Chess Symbols (1FA00-1FA6F): covered by 1F900-1FAFF range above -->
+
+            <!-- (unassigned)                  1FB00-1FFFF -->
 
             <!-- CJK Unified Ideographs ExtB   20000-2A6DF -->
             <!--
@@ -2253,7 +2318,7 @@
             Box Drawing                      2500-257F
             Block Elements                   2580-259F
             Geometric Shapes                 25A0-25FF
-            Geometric Shapes Extended        1F780-1F7FF
+            Geometric Shapes Extended        1F780-1F7FF (excluding 1F7E0-1F7EB and 1F7F0, which are emoji; see below)
             -->
       <!-- Windows 8.1: Segoe UI Emoji supports emoji characters in these ranges, but we don't want them to
              be used with precedence over other fonts in all cases. Separating ranges for which Emoji coverage
@@ -2261,32 +2326,96 @@
       <!-- Not ideographs, so after first choice can prioritize ClearType, sans-serif/serif over culture -->
       <!-- CHS -->
       <FontFamilyMap
-          Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7FF"
+          Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7DF, 1F7EC-1F7EF, 1F7F1-1F7FF"
           Language    = "zh-Hans"
           Target      = "Microsoft YaHei UI, Microsoft YaHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, SimSun, MS Gothic, MingLiU, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
           Scale       = "1.0" />
       <!-- CHT -->
       <FontFamilyMap
-          Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7FF"
+          Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7DF, 1F7EC-1F7EF, 1F7F1-1F7FF"
           Language    = "zh-Hant"
           Target      = "Microsoft JhengHei UI, Microsoft JhengHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft YaHei UI, Microsoft YaHei, MingLiU, MS Gothic, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
           Scale       = "1.0" />
       <!-- JA -->
       <FontFamilyMap
-          Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7FF"
+          Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7DF, 1F7EC-1F7EF, 1F7F1-1F7FF"
           Language    = "ja"
           Target      = "Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, MS Gothic, MingLiU, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
           Scale       = "1.0" />
       <!-- KO -->
       <FontFamilyMap
-          Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7FF"
+          Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7DF, 1F7EC-1F7EF, 1F7F1-1F7FF"
           Language    = "ko"
           Target      = "Malgun Gothic, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Gulim, MS Gothic, MingLiU, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
           Scale       = "1.0" />
       <!-- Other -->
       <FontFamilyMap
-          Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7FF"
+          Unicode     = "2000-202E, 2030-20CF, 2150-22FF, 2460-25FF, 1F780-1F7DF, 1F7EC-1F7EF, 1F7F1-1F7FF"
           Target      = "Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, Tahoma, Lucida Sans Unicode, Arial, MS Gothic, MingLiU, Arial Unicode MS, MingLiU"
+          Scale       = "1.0" />
+
+      <!-- Unicode 12.0 colored circles (1F7E0-1F7E5) and squares (1F7E6-1F7EB) and Unicode 14.0 heavy equals sign (1F7F0).
+           Although these sit in the Geometric Shapes Extended block, they are defined as emoji and have COLR glyphs in Segoe UI Emoji. -->
+      <!-- CHS -->
+      <FontFamilyMap
+          Unicode     = "1F7E0-1F7EB, 1F7F0"
+          Language    = "zh-Hans"
+          Target      = "Segoe UI Emoji, Microsoft YaHei UI, Microsoft YaHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, SimSun, MS Gothic, MingLiU, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
+          Scale       = "1.0" />
+      <!-- CHT -->
+      <FontFamilyMap
+          Unicode     = "1F7E0-1F7EB, 1F7F0"
+          Language    = "zh-Hant"
+          Target      = "Segoe UI Emoji, Microsoft JhengHei UI, Microsoft JhengHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft YaHei UI, Microsoft YaHei, MingLiU, MS Gothic, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
+          Scale       = "1.0" />
+      <!-- JA -->
+      <FontFamilyMap
+          Unicode     = "1F7E0-1F7EB, 1F7F0"
+          Language    = "ja"
+          Target      = "Segoe UI Emoji, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, MS Gothic, MingLiU, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
+          Scale       = "1.0" />
+      <!-- KO -->
+      <FontFamilyMap
+          Unicode     = "1F7E0-1F7EB, 1F7F0"
+          Language    = "ko"
+          Target      = "Segoe UI Emoji, Malgun Gothic, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Gulim, MS Gothic, MingLiU, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
+          Scale       = "1.0" />
+      <!-- Other -->
+      <FontFamilyMap
+          Unicode     = "1F7E0-1F7EB, 1F7F0"
+          Target      = "Segoe UI Emoji, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, Tahoma, Lucida Sans Unicode, Arial, MS Gothic, MingLiU, Arial Unicode MS, MingLiU"
+          Scale       = "1.0" />
+
+      <!-- Default-presentation emoji from Misc Symbols and Arrows block (Emoji_Presentation = Yes, no VS-16 needed):
+           2B50 (star), 2B55 (hollow red circle). -->
+      <!-- CHS -->
+      <FontFamilyMap
+          Unicode     = "2B50, 2B55"
+          Language    = "zh-Hans"
+          Target      = "Segoe UI Emoji, Microsoft YaHei UI, Microsoft YaHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, SimSun, MS Gothic, MingLiU, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
+          Scale       = "1.0" />
+      <!-- CHT -->
+      <FontFamilyMap
+          Unicode     = "2B50, 2B55"
+          Language    = "zh-Hant"
+          Target      = "Segoe UI Emoji, Microsoft JhengHei UI, Microsoft JhengHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft YaHei UI, Microsoft YaHei, MingLiU, MS Gothic, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
+          Scale       = "1.0" />
+      <!-- JA -->
+      <FontFamilyMap
+          Unicode     = "2B50, 2B55"
+          Language    = "ja"
+          Target      = "Segoe UI Emoji, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, MS Gothic, MingLiU, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
+          Scale       = "1.0" />
+      <!-- KO -->
+      <FontFamilyMap
+          Unicode     = "2B50, 2B55"
+          Language    = "ko"
+          Target      = "Segoe UI Emoji, Malgun Gothic, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Gulim, MS Gothic, MingLiU, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
+          Scale       = "1.0" />
+      <!-- Other -->
+      <FontFamilyMap
+          Unicode     = "2B50, 2B55"
+          Target      = "Segoe UI Emoji, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, Tahoma, Lucida Sans Unicode, Arial, MS Gothic, MingLiU, Arial Unicode MS, MingLiU"
           Scale       = "1.0" />
 
       <!-- Combining Diacritic Marks for Symbols 20D0-20FF -->
@@ -2355,13 +2484,12 @@
             Supplemental Arrows-B       2900-297F
             Misc Mathematical Symbols-B 2980-29FF
             Supplemental Math Operators 2A00-2AFF
-            Misc Symbols and Arrows     2B00-2BFF
+            Misc Symbols and Arrows     2B00-2BFF (excluding 2B50 and 2B55, which are emoji; see above)
             Supplemental Arrows-C       1F800-1F8FF
             -->
       <!-- Segoe UI Symbol covers all on Win8; Cambria Math covers 2900-2AFF; MS Gothic has little coverage -->
-      <!-- Segoe UI Emoji supports only emoji characters in these ranges; not adding to avoid uneven display -->
       <FontFamilyMap
-          Unicode     = "27C0-2BFF, 1F800-1F8FF"
+          Unicode     = "27C0-2B4F, 2B51-2B54, 2B56-2BFF, 1F800-1F8FF"
           Target      = "Segoe UI Symbol, Cambria Math, MS Gothic"
           Scale       = "1.0" />
 
@@ -3395,11 +3523,12 @@
             Ornamental Dingbats            1F650-1F67F
             Transport And Map Symbols      1F680-1F6FF
             Supplemental Symbols and Pictographs 1F900-1F9FF
+            Symbols and Pictographs Extended-A   1FA70-1FAFF
             -->
       <!-- Windows 8+ -->
-      <!-- Segoe UI Emoji supports only emoji characters or emoji supplements in these ranges -->
+      <!-- Segoe UI Emoji supports emoji characters in these ranges -->
       <FontFamilyMap
-          Unicode     = "1F000-1F6FF, 1F900-1F9FF"
+          Unicode     = "1F000-1F6FF, 1F900-1FAFF"
           Target      = "Segoe UI Emoji, Segoe UI Symbol"
           Scale       = "1.0" />
 
@@ -4009,6 +4138,38 @@
           Target      = "Segoe UI Emoji, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, Tahoma, Lucida Sans Unicode, Arial, MS Gothic, MingLiU, Arial Unicode MS, MingLiU"
           Scale       = "1.0" />
 
+      <!-- Default-presentation emoji from Misc Symbols and Arrows block (Emoji_Presentation = Yes, no VS-16 needed):
+           2B50 (star), 2B55 (hollow red circle). -->
+      <!-- CHS -->
+      <FontFamilyMap
+          Unicode     = "2B50, 2B55"
+          Language    = "zh-Hans"
+          Target      = "Segoe UI Emoji, Microsoft YaHei UI, Microsoft YaHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, SimSun, MS Gothic, MingLiU, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
+          Scale       = "1.0" />
+      <!-- CHT -->
+      <FontFamilyMap
+          Unicode     = "2B50, 2B55"
+          Language    = "zh-Hant"
+          Target      = "Segoe UI Emoji, Microsoft JhengHei UI, Microsoft JhengHei, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft YaHei UI, Microsoft YaHei, MingLiU, MS Gothic, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
+          Scale       = "1.0" />
+      <!-- JA -->
+      <FontFamilyMap
+          Unicode     = "2B50, 2B55"
+          Language    = "ja"
+          Target      = "Segoe UI Emoji, Yu Gothic UI, Meiryo UI, Meiryo, Segoe UI, Segoe UI Symbol, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, MS Gothic, MingLiU, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
+          Scale       = "1.0" />
+      <!-- KO -->
+      <FontFamilyMap
+          Unicode     = "2B50, 2B55"
+          Language    = "ko"
+          Target      = "Segoe UI Emoji, Malgun Gothic, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Gulim, MS Gothic, MingLiU, Tahoma, Lucida Sans Unicode, Arial, Arial Unicode MS"
+          Scale       = "1.0" />
+      <!-- Other -->
+      <FontFamilyMap
+          Unicode     = "2B50, 2B55"
+          Target      = "Segoe UI Emoji, Segoe UI, Segoe UI Symbol, Yu Gothic UI, Meiryo UI, Meiryo, Microsoft JhengHei UI, Microsoft JhengHei, Microsoft YaHei UI, Microsoft YaHei, Malgun Gothic, Tahoma, Lucida Sans Unicode, Arial, MS Gothic, MingLiU, Arial Unicode MS, MingLiU"
+          Scale       = "1.0" />
+
       <!-- Control Pictures           2400-243F -->
       <!-- Segoe UI Symbol for Windows 7+, Lucida Sans Unicode for down-level OS -->
       <FontFamilyMap
@@ -4030,12 +4191,11 @@
             Supplemental Arrows-B       2900-297F
             Misc Mathematical Symbols-B 2980-29FF
             Supplemental Math Operators 2A00-2AFF
-            Misc Symbols and Arrows     2B00-2BFF
+            Misc Symbols and Arrows     2B00-2BFF (excluding 2B50 and 2B55, which are emoji; see above)
             -->
       <!-- Segoe UI Symbol covers all on Win8; Cambria Math covers 2900-2AFF; MS Gothic has little coverage -->
-      <!-- Segoe UI Emoji supports only emoji characters in these ranges; not adding to avoid uneven display -->
       <FontFamilyMap
-          Unicode     = "27C0-2BFF"
+          Unicode     = "27C0-2B4F, 2B51-2B54, 2B56-2BFF"
           Target      = "Segoe UI Symbol, Cambria Math, MS Gothic"
           Scale       = "1.0" />
 
@@ -5027,18 +5187,20 @@
             Emoticons                      1F600-1F64F
             Ornamental Dingbats            1F650-1F67F
             Transport And Map Symbols      1F680-1F6FF
+            Supplemental Symbols and Pictographs 1F900-1F9FF
+            Symbols and Pictographs Extended-A   1FA70-1FAFF
             -->
       <!-- Windows 8+ -->
-      <!-- Segoe UI Emoji supports only emoji characters or emoji supplements in these ranges -->
+      <!-- Segoe UI Emoji supports emoji characters in these ranges -->
       <FontFamilyMap
-          Unicode     = "1F000-1F6FF"
+          Unicode     = "1F000-1F6FF, 1F900-1FAFF"
           Target      = "Segoe UI Emoji, Segoe UI Symbol"
           Scale       = "1.0" />
 
       <!-- Alchemical Symbols            1F700-1F77F -->
       <!-- No font -->
 
-      <!-- (unassigned)                  1F780-1FFFF -->
+      <!-- (unassigned)                  1FB00-1FFFF -->
 
       <!-- CJK Unified Ideographs ExtB 20000-2A6DF -->
       <!--

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Interop/DWrite/DWriteColorGlyphStructs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Interop/DWrite/DWriteColorGlyphStructs.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace MS.Internal.Interop.DWrite
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DWRITE_GLYPH_OFFSET
+    {
+        public float advanceOffset;
+        public float ascenderOffset;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct DWRITE_GLYPH_RUN
+    {
+        public void* fontFace;          // IDWriteFontFace*
+        public float fontEmSize;
+        public uint glyphCount;
+        public ushort* glyphIndices;
+        public float* glyphAdvances;
+        public DWRITE_GLYPH_OFFSET* glyphOffsets;
+        public int isSideways;          // BOOL (4 bytes)
+        public uint bidiLevel;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DWRITE_COLOR_F
+    {
+        public float r;
+        public float g;
+        public float b;
+        public float a;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct DWRITE_COLOR_GLYPH_RUN
+    {
+        public DWRITE_GLYPH_RUN glyphRun;
+        public void* glyphRunDescription;   // DWRITE_GLYPH_RUN_DESCRIPTION* (nullable)
+        public float baselineOriginX;
+        public float baselineOriginY;
+        public DWRITE_COLOR_F runColor;
+        public ushort paletteIndex;
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Interop/DWrite/IDWriteColorGlyphRunEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Interop/DWrite/IDWriteColorGlyphRunEnumerator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Interop/DWrite/IDWriteColorGlyphRunEnumerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Interop/DWrite/IDWriteColorGlyphRunEnumerator.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace MS.Internal.Interop.DWrite
+{
+    /// <summary>
+    /// Managed interop for IDWriteColorGlyphRunEnumerator COM interface.
+    /// Vtable layout: IUnknown (0-2), MoveNext (3), GetCurrentRun (4).
+    /// </summary>
+    internal unsafe struct IDWriteColorGlyphRunEnumerator
+    {
+        public void** lpVtbl;
+
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IDWriteColorGlyphRunEnumerator*, uint>)(lpVtbl[2]))((IDWriteColorGlyphRunEnumerator*)Unsafe.AsPointer(ref this));
+        }
+
+        public int MoveNext(int* hasRun)
+        {
+            return ((delegate* unmanaged<IDWriteColorGlyphRunEnumerator*, int*, int>)(lpVtbl[3]))((IDWriteColorGlyphRunEnumerator*)Unsafe.AsPointer(ref this), hasRun);
+        }
+
+        public int GetCurrentRun(DWRITE_COLOR_GLYPH_RUN** colorGlyphRun)
+        {
+            return ((delegate* unmanaged<IDWriteColorGlyphRunEnumerator*, DWRITE_COLOR_GLYPH_RUN**, int>)(lpVtbl[4]))((IDWriteColorGlyphRunEnumerator*)Unsafe.AsPointer(ref this), colorGlyphRun);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Interop/DWrite/IDWriteFactory2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Interop/DWrite/IDWriteFactory2.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace MS.Internal.Interop.DWrite
+{
+    internal unsafe struct IDWriteFactory2 : IUnknown
+    {
+        public void** lpVtbl;
+
+        public int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            return ((delegate* unmanaged<IDWriteFactory2*, Guid*, void**, int>)(lpVtbl[0]))((IDWriteFactory2*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IDWriteFactory2*, uint>)(lpVtbl[1]))((IDWriteFactory2*)Unsafe.AsPointer(ref this));
+        }
+
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IDWriteFactory2*, uint>)(lpVtbl[2]))((IDWriteFactory2*)Unsafe.AsPointer(ref this));
+        }
+
+        public int TranslateColorGlyphRun(
+            float baselineOriginX,
+            float baselineOriginY,
+            DWRITE_GLYPH_RUN* glyphRun,
+            void* glyphRunDescription,
+            int measuringMode,
+            void* worldAndDpiTransform,
+            uint colorPaletteIndex,
+            IDWriteColorGlyphRunEnumerator** colorLayers)
+        {
+            return ((delegate* unmanaged<IDWriteFactory2*, float, float, DWRITE_GLYPH_RUN*, void*, int, void*, uint, IDWriteColorGlyphRunEnumerator**, int>)(lpVtbl[28]))(
+                (IDWriteFactory2*)Unsafe.AsPointer(ref this),
+                baselineOriginX,
+                baselineOriginY,
+                glyphRun,
+                glyphRunDescription,
+                measuringMode,
+                worldAndDpiTransform,
+                colorPaletteIndex,
+                colorLayers);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Text/TextInterface/ColorGlyphLayer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Text/TextInterface/ColorGlyphLayer.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace MS.Internal.Text.TextInterface
+{
+    /// <summary>
+    /// Represents a single color layer from a COLR v0 color glyph run decomposition.
+    /// </summary>
+    internal struct ColorGlyphLayer
+    {
+        public ushort[] GlyphIndices;
+        public float[] GlyphAdvances;
+        public float[] GlyphOffsets;    // Interleaved (advanceOffset, ascenderOffset) pairs; may be null.
+        public float BaselineOriginX;
+        public float BaselineOriginY;
+        public float ColorR;
+        public float ColorG;
+        public float ColorB;
+        public float ColorA;
+        public bool UseForegroundColor;
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Text/TextInterface/Factory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Text/TextInterface/Factory.cs
@@ -41,7 +41,7 @@ namespace MS.Internal.Text.TextInterface
         /// Used for COLR v0 color glyph support (TranslateColorGlyphRun).
         /// Available on Windows 8.1+.
         /// </summary>
-        private void* _pFactory2;
+        private IDWriteFactory2* _pFactory2;
 
         /// <summary>
         /// Constructs a factory object.
@@ -66,7 +66,7 @@ namespace MS.Internal.Text.TextInterface
             void* pFactory2 = null;
             int qiHr = _factory.Value->QueryInterface(&iidFactory2, &pFactory2);
             if (qiHr == 0 && pFactory2 != null)
-                _pFactory2 = pFactory2;
+                _pFactory2 = (IDWriteFactory2*)pFactory2;
 
             _wpfFontFileLoader = new FontFileLoader(fontSourceFactory);
             _wpfFontCollectionLoader = new FontCollectionLoader(
@@ -420,16 +420,16 @@ namespace MS.Internal.Text.TextInterface
                         glyphRun.isSideways = isSideways ? 1 : 0;
                         glyphRun.bidiLevel = bidiLevel;
 
-                        void* pEnum = null;
-
-                        // IDWriteFactory2::TranslateColorGlyphRun is vtable slot 28.
-                        void** factory2Vtbl = *(void***)_pFactory2;
-                        int hr = ((delegate* unmanaged<void*, float, float, DWRITE_GLYPH_RUN*, void*, int, void*, uint, void**, int>)(factory2Vtbl[28]))(
-                            _pFactory2,
-                            baselineOriginX, baselineOriginY,
-                            &glyphRun, null,
-                            (int)measuringMode, null,
-                            0, &pEnum);
+                        IDWriteColorGlyphRunEnumerator* pEnum = null;
+                        int hr = _pFactory2->TranslateColorGlyphRun(
+                            baselineOriginX,
+                            baselineOriginY,
+                            &glyphRun,
+                            null,
+                            (int)measuringMode,
+                            null,
+                            0,
+                            &pEnum);
 
                         // Release the AddRef'd font face now that the DWrite call is complete.
                         ((IDWriteFontFace*)glyphRun.fontFace)->Release();
@@ -565,7 +565,7 @@ namespace MS.Internal.Text.TextInterface
                 // Release the IDWriteFactory2 interface obtained via QueryInterface.
                 if (_managedFactory._pFactory2 != null)
                 {
-                    ((IDWriteFactory*)_managedFactory._pFactory2)->Release();
+                    _managedFactory._pFactory2->Release();
                     _managedFactory._pFactory2 = null;
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Text/TextInterface/Factory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Text/TextInterface/Factory.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using MS.Internal.Interop;
 using MS.Internal.Interop.DWrite;
@@ -36,6 +37,13 @@ namespace MS.Internal.Text.TextInterface
         private readonly IFontSourceFactory _fontSourceFactory;
 
         /// <summary>
+        /// Pointer to the IDWriteFactory2 interface, or null if not available.
+        /// Used for COLR v0 color glyph support (TranslateColorGlyphRun).
+        /// Available on Windows 8.1+.
+        /// </summary>
+        private void* _pFactory2;
+
+        /// <summary>
         /// Constructs a factory object.
         /// </summary>
         /// <param name="factoryType">Identifies whether the factory object will be shared or isolated.</param>
@@ -49,6 +57,16 @@ namespace MS.Internal.Text.TextInterface
         private Factory(FactoryType factoryType, IFontSourceCollectionFactory fontSourceCollectionFactory, IFontSourceFactory fontSourceFactory)
         {
             Initialize(factoryType);
+
+            // QueryInterface for IDWriteFactory2, which provides TranslateColorGlyphRun
+            // for COLR v0 color glyph decomposition. Available on Windows 8.1+; on older
+            // versions the QI returns E_NOINTERFACE and _pFactory2 stays null, which
+            // disables color glyph rendering gracefully.
+            Guid iidFactory2 = new Guid(0x0439fc60, 0xca44, 0x4994, 0x8d, 0xee, 0x3a, 0x9a, 0xf7, 0xb7, 0x32, 0xec);
+            void* pFactory2 = null;
+            int qiHr = _factory.Value->QueryInterface(&iidFactory2, &pFactory2);
+            if (qiHr == 0 && pFactory2 != null)
+                _pFactory2 = pFactory2;
 
             _wpfFontFileLoader = new FontFileLoader(fontSourceFactory);
             _wpfFontCollectionLoader = new FontCollectionLoader(
@@ -330,6 +348,179 @@ namespace MS.Internal.Text.TextInterface
             return new TextAnalyzer((Native.IDWriteTextAnalyzer*)textAnalyzer);
         }
 
+        /// <summary>
+        /// Gets whether this factory supports color glyph rendering (IDWriteFactory2+).
+        /// </summary>
+        internal bool SupportsColorGlyphs => _pFactory2 != null;
+
+        // DWRITE_E_NOCOLOR: font has no COLR table or glyphs have no color layers.
+        private const int DWRITE_E_NOCOLOR = unchecked((int)0x8898500C);
+
+        /// <summary>
+        /// Translates a glyph run into color glyph layers using IDWriteFactory2.
+        /// Returns null if the glyph run has no color layers or color glyphs are not supported.
+        /// </summary>
+        internal List<ColorGlyphLayer> TranslateColorGlyphRun(
+            FontFace fontFace,
+            float fontEmSize,
+            ushort[] glyphIndices,
+            float[] glyphAdvances,
+            float[] glyphOffsets,
+            uint glyphCount,
+            bool isSideways,
+            uint bidiLevel,
+            float baselineOriginX,
+            float baselineOriginY,
+            uint measuringMode)
+        {
+            if (_pFactory2 == null || fontFace == null ||
+                glyphIndices == null || glyphAdvances == null || glyphCount == 0 ||
+                glyphCount > (uint)int.MaxValue ||
+                glyphIndices.Length < (int)glyphCount ||
+                glyphAdvances.Length < (int)glyphCount)
+            {
+                return null;
+            }
+
+            IDWriteColorGlyphRunEnumerator* pColorEnum = null;
+            try
+            {
+                fixed (ushort* pGlyphIndices = glyphIndices)
+                fixed (float* pGlyphAdvances = glyphAdvances)
+                {
+                    // Convert interleaved float pairs to DWRITE_GLYPH_OFFSET structs.
+                    DWRITE_GLYPH_OFFSET* pOffsets = null;
+                    DWRITE_GLYPH_OFFSET* allocatedOffsets = null;
+
+                    try
+                    {
+                        if (glyphOffsets != null && glyphCount <= (uint)(glyphOffsets.Length / 2))
+                        {
+                            allocatedOffsets = (DWRITE_GLYPH_OFFSET*)Marshal.AllocHGlobal(
+                                (int)(glyphCount * (uint)sizeof(DWRITE_GLYPH_OFFSET)));
+
+                            fixed (float* pGlyphOffsets = glyphOffsets)
+                            {
+                                for (uint i = 0; i < glyphCount; i++)
+                                {
+                                    allocatedOffsets[i].advanceOffset = pGlyphOffsets[i * 2];
+                                    allocatedOffsets[i].ascenderOffset = pGlyphOffsets[i * 2 + 1];
+                                }
+                            }
+                            pOffsets = allocatedOffsets;
+                        }
+
+                        DWRITE_GLYPH_RUN glyphRun;
+                        glyphRun.fontFace = (void*)fontFace.DWriteFontFaceAddRef;
+                        glyphRun.fontEmSize = fontEmSize;
+                        glyphRun.glyphCount = glyphCount;
+                        glyphRun.glyphIndices = pGlyphIndices;
+                        glyphRun.glyphAdvances = pGlyphAdvances;
+                        glyphRun.glyphOffsets = pOffsets;
+                        glyphRun.isSideways = isSideways ? 1 : 0;
+                        glyphRun.bidiLevel = bidiLevel;
+
+                        void* pEnum = null;
+
+                        // IDWriteFactory2::TranslateColorGlyphRun is vtable slot 28.
+                        void** factory2Vtbl = *(void***)_pFactory2;
+                        int hr = ((delegate* unmanaged<void*, float, float, DWRITE_GLYPH_RUN*, void*, int, void*, uint, void**, int>)(factory2Vtbl[28]))(
+                            _pFactory2,
+                            baselineOriginX, baselineOriginY,
+                            &glyphRun, null,
+                            (int)measuringMode, null,
+                            0, &pEnum);
+
+                        // Release the AddRef'd font face now that the DWrite call is complete.
+                        ((IDWriteFontFace*)glyphRun.fontFace)->Release();
+                        glyphRun.fontFace = null;
+
+                        GC.KeepAlive(fontFace);
+                        GC.KeepAlive(this);
+
+                        if (hr == DWRITE_E_NOCOLOR || hr < 0 || pEnum == null)
+                        {
+                            if (pEnum != null)
+                                ((IDWriteColorGlyphRunEnumerator*)pEnum)->Release();
+                            return null;
+                        }
+
+                        pColorEnum = (IDWriteColorGlyphRunEnumerator*)pEnum;
+                    }
+                    finally
+                    {
+                        if (allocatedOffsets != null)
+                            Marshal.FreeHGlobal((IntPtr)allocatedOffsets);
+                    }
+                }
+
+                // Enumerate color layers. DirectWrite returns them in back-to-front paint order.
+                const int MaxColorLayers = 1024;
+                var layers = new List<ColorGlyphLayer>();
+
+                int hasRun = 0;
+                while (pColorEnum->MoveNext(&hasRun) >= 0 && hasRun != 0 && layers.Count < MaxColorLayers)
+                {
+                    DWRITE_COLOR_GLYPH_RUN* pColorRun = null;
+                    int runHr = pColorEnum->GetCurrentRun(&pColorRun);
+                    if (runHr < 0 || pColorRun == null)
+                        break;
+
+                    ColorGlyphLayer layer;
+                    layer.BaselineOriginX = pColorRun->baselineOriginX;
+                    layer.BaselineOriginY = pColorRun->baselineOriginY;
+
+                    // paletteIndex 0xFFFF means "use the text foreground color".
+                    layer.UseForegroundColor = (pColorRun->paletteIndex == 0xFFFF);
+
+                    // Clamp RGBA to [0,1].
+                    layer.ColorR = Clamp01(pColorRun->runColor.r);
+                    layer.ColorG = Clamp01(pColorRun->runColor.g);
+                    layer.ColorB = Clamp01(pColorRun->runColor.b);
+                    layer.ColorA = Clamp01(pColorRun->runColor.a);
+
+                    uint layerGlyphCount = pColorRun->glyphRun.glyphCount;
+
+                    // Deep-copy glyph data (pointer is only valid until next MoveNext).
+                    layer.GlyphIndices = new ushort[layerGlyphCount];
+                    for (uint i = 0; i < layerGlyphCount; i++)
+                        layer.GlyphIndices[i] = pColorRun->glyphRun.glyphIndices[i];
+
+                    layer.GlyphAdvances = new float[layerGlyphCount];
+                    if (pColorRun->glyphRun.glyphAdvances != null)
+                    {
+                        for (uint i = 0; i < layerGlyphCount; i++)
+                            layer.GlyphAdvances[i] = pColorRun->glyphRun.glyphAdvances[i];
+                    }
+
+                    if (pColorRun->glyphRun.glyphOffsets != null)
+                    {
+                        layer.GlyphOffsets = new float[layerGlyphCount * 2];
+                        for (uint i = 0; i < layerGlyphCount; i++)
+                        {
+                            layer.GlyphOffsets[i * 2] = pColorRun->glyphRun.glyphOffsets[i].advanceOffset;
+                            layer.GlyphOffsets[i * 2 + 1] = pColorRun->glyphRun.glyphOffsets[i].ascenderOffset;
+                        }
+                    }
+                    else
+                    {
+                        layer.GlyphOffsets = null;
+                    }
+
+                    layers.Add(layer);
+                }
+
+                return layers.Count > 0 ? layers : null;
+            }
+            finally
+            {
+                if (pColorEnum != null)
+                    pColorEnum->Release();
+            }
+        }
+
+        private static float Clamp01(float v) => v < 0f ? 0f : v > 1f ? 1f : v;
+
         internal static bool IsLocalUri(Uri uri)
         {
             return uri.IsFile && uri.IsLoopback && !uri.IsUnc;
@@ -369,6 +560,13 @@ namespace MS.Internal.Text.TextInterface
                     Value->UnregisterFontFileLoader((IDWriteFontFileLoader*)pIDWriteFontFileLoaderMirror.ToPointer());
                     Marshal.Release(pIDWriteFontFileLoaderMirror);
                     _managedFactory._wpfFontFileLoader = null;
+                }
+
+                // Release the IDWriteFactory2 interface obtained via QueryInterface.
+                if (_managedFactory._pFactory2 != null)
+                {
+                    ((IDWriteFactory*)_managedFactory._pFactory2)->Release();
+                    _managedFactory._pFactory2 = null;
                 }
 
                 return base.ReleaseHandle();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -231,6 +231,7 @@
     <Compile Include="MS\Internal\Interop\DWrite\DWRITE_FONT_FACE_TYPE.cs" />
     <Compile Include="MS\Internal\Interop\DWrite\DWRITE_FONT_SIMULATIONS.cs" />
     <Compile Include="MS\Internal\Interop\DWrite\IDWriteFactory.cs" />
+    <Compile Include="MS\Internal\Interop\DWrite\IDWriteFactory2.cs" />
     <Compile Include="MS\Internal\Interop\DWrite\IDWriteFontCollection.cs" />
     <Compile Include="MS\Internal\Interop\DWrite\IDWriteFontCollectionLoader.cs" />
     <Compile Include="MS\Internal\Interop\DWrite\IDWriteFontFace.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -237,6 +237,8 @@
     <Compile Include="MS\Internal\Interop\DWrite\IDWriteFontFile.cs" />
     <Compile Include="MS\Internal\Interop\DWrite\IDWriteFontFileLoader.cs" />
     <Compile Include="MS\Internal\Interop\DWrite\IDWriteTextAnalyzer.cs" />
+    <Compile Include="MS\Internal\Interop\DWrite\DWriteColorGlyphStructs.cs" />
+    <Compile Include="MS\Internal\Interop\DWrite\IDWriteColorGlyphRunEnumerator.cs" />
     <Compile Include="MS\Internal\Interop\IUnknown.cs" />
     <Compile Include="MS\Internal\Interop\NativePointerCriticalHandle.cs" />
     <Compile Include="MS\Internal\Interop\TipTsfHelper.cs" />
@@ -276,6 +278,7 @@
     <Compile Include="MS\Internal\Text\TextInterface\DWriteLoader.cs" />
     <Compile Include="MS\Internal\Text\TextInterface\DWriteUtil.cs" />
     <Compile Include="MS\Internal\Text\TextInterface\Factory.cs" />
+    <Compile Include="MS\Internal\Text\TextInterface\ColorGlyphLayer.cs" />
     <Compile Include="MS\Internal\Text\TextInterface\FontCollectionLoader.cs" />
     <Compile Include="MS\Internal\Text\TextInterface\IFontSourceCollection.cs" />
     <Compile Include="MS\Internal\TextFormatting\Bidi.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/DrawingDrawingContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/DrawingDrawingContext.cs
@@ -1081,6 +1081,15 @@ namespace System.Windows.Media
                 return;
             }
 
+            // Color glyph support: decompose COLR-font glyph runs into colored geometry
+            // layers. See RenderDataDrawingContext.DrawGlyphRun for the full explanation.
+            Drawing colorDrawing = glyphRun.TryBuildColorGlyphDrawing(foregroundBrush);
+            if (colorDrawing != null)
+            {
+                AddDrawing(colorDrawing);
+                return;
+            }
+
             // Add a GlyphRunDrawing to the Drawing graph
 
             GlyphRunDrawing glyphRunDrawing = new GlyphRunDrawing

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RenderDataDrawingContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RenderDataDrawingContext.cs
@@ -737,6 +737,20 @@ namespace System.Windows.Media
                 return;
             }
 
+            // Color glyph support: if the glyph run uses a COLR font, decompose it into
+            // colored geometry layers and render as a Drawing instead of a monochrome glyph
+            // bitmap. WPF's MIL glyph pipeline (CDrawingContext::DrawGlyphRun -> SW/HW
+            // glyph painters) produces single-channel alpha maps with no per-layer color
+            // support, so color glyphs must be handled here at the managed level.
+            // TryBuildColorGlyphDrawing returns null for non-color fonts, so the normal
+            // monochrome path below is taken in that case.
+            Drawing colorDrawing = glyphRun.TryBuildColorGlyphDrawing(foregroundBrush);
+            if (colorDrawing != null)
+            {
+                DrawDrawing(colorDrawing);
+                return;
+            }
+
 
         #if DEBUG
             MediaTrace.DrawingContextOp.Trace("DrawGlyphRun(const)");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
@@ -1688,7 +1688,11 @@ namespace System.Windows.Media
                         );
 
                     if (colorLayers == null || colorLayers.Count == 0)
+                    {
+                        _cachedColorForeground = foregroundBrush;
+                        _cachedColorDrawing = null;
                         return null;
+                    }
 
                     // Build a DrawingGroup with one GeometryDrawing per color layer
                     DrawingGroup drawingGroup = new DrawingGroup();
@@ -1775,7 +1779,7 @@ namespace System.Windows.Media
             float baselineOriginY)
         {
             GeometryGroup layerGeometry = null;
-            double accAdvance = 0;
+            double accumulatedWidth = 0;
 
             for (int i = 0; i < layerGlyphIndices.Length; i++)
             {
@@ -1792,14 +1796,14 @@ namespace System.Windows.Media
                 double originX;
                 if (IsLeftToRight)
                 {
-                    originX = accAdvance + offsetX;
+                    originX = accumulatedWidth + offsetX;
                 }
                 else
                 {
                     double nominalAdvance = layerGlyphAdvances[i];
-                    originX = -accAdvance - (nominalAdvance + offsetX);
+                    originX = -accumulatedWidth - (nominalAdvance + offsetX);
                 }
-                accAdvance += layerGlyphAdvances[i];
+                accumulatedWidth += layerGlyphAdvances[i];
 
                 double originY = -offsetY;
 
@@ -2689,7 +2693,7 @@ namespace System.Windows.Media
         private object              _inkBoundingBox;    // Used when CacheInkBounds is on
         private Drawing             _cachedColorDrawing;   // Cached result of TryBuildColorGlyphDrawing
         private Brush               _cachedColorForeground; // Foreground brush used for _cachedColorDrawing
-        private TextFormattingMode      _textFormattingMode;
+        private TextFormattingMode  _textFormattingMode;
         private float               _pixelsPerDip = MS.Internal.FontCache.Util.PixelsPerDip;
 
         // the sine of 20 degrees

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
@@ -13,6 +13,7 @@
 //
 //
 
+using System.Buffers;
 using System.Collections;
 using System.ComponentModel;
 using System.Windows.Media.Converters;
@@ -1598,6 +1599,228 @@ namespace System.Windows.Media
         }
 
         /// <summary>
+        /// Attempts to decompose this glyph run into colored layers using the font's
+        /// COLR/CPAL tables via IDWriteFactory2::TranslateColorGlyphRun.
+        ///
+        /// Returns a frozen <see cref="Drawing"/> (specifically a <see cref="DrawingGroup"/>)
+        /// containing one <see cref="GeometryDrawing"/>
+        /// per COLR layer (painted back to front), or null if:
+        ///   - The font is not a color font (no COLR table)
+        ///   - The system does not support IDWriteFactory2 (pre-Windows 8.1)
+        ///   - The specific glyphs in this run have no color layers
+        ///
+        /// The fallback to geometry rendering (rather than bitmap glyph rasterization) means
+        /// color glyphs do not benefit from ClearType, which is acceptable because emoji
+        /// are typically rendered at sizes where subpixel hinting provides no visual benefit.
+        /// </summary>
+        /// <param name="foregroundBrush">The brush to use for layers with paletteIndex 0xFFFF
+        /// (the "use foreground color" sentinel in the COLR spec).</param>
+        /// <returns>A frozen Drawing, or null if the glyphs have no color layers.</returns>
+        internal Drawing TryBuildColorGlyphDrawing(Brush foregroundBrush)
+        {
+            CheckInitialized();
+
+            // Return cached result if available. GlyphRun is immutable after init,
+            // so only the foreground brush can vary between calls. _cachedColorForeground
+            // being non-null means we've computed at least once; _cachedColorDrawing may
+            // be null (for non-color fonts or glyphs with no color layers).
+            if (_cachedColorForeground != null && _cachedColorForeground == foregroundBrush)
+                return _cachedColorDrawing;
+
+            if (_glyphTypeface == null || !_glyphTypeface.IsColorFont)
+            {
+                _cachedColorForeground = foregroundBrush;
+                _cachedColorDrawing = null;
+                return null;
+            }
+
+            var factory = MS.Internal.FontCache.DWriteFactory.Instance;
+            if (!factory.SupportsColorGlyphs)
+            {
+                _cachedColorForeground = foregroundBrush;
+                _cachedColorDrawing = null;
+                return null;
+            }
+
+            // Get the DWrite FontFace for TranslateColorGlyphRun
+            MS.Internal.Text.TextInterface.FontFace fontFace = _glyphTypeface.FontDWrite.GetFontFace();
+            try
+            {
+                int glyphCount = GlyphCount;
+
+                // Rent temporary arrays from the pool to avoid per-call heap allocations.
+                // These are only needed for the duration of the TranslateColorGlyphRun call.
+                ushort[] glyphIndices = ArrayPool<ushort>.Shared.Rent(glyphCount);
+                float[] glyphAdvances = ArrayPool<float>.Shared.Rent(glyphCount);
+                float[] glyphOffsets = null;
+
+                try
+                {
+                    for (int i = 0; i < glyphCount; i++)
+                        glyphIndices[i] = _glyphIndices[i];
+
+                    for (int i = 0; i < glyphCount; i++)
+                        glyphAdvances[i] = (float)_advanceWidths[i];
+
+                    if (_glyphOffsets != null && _glyphOffsets.Count == glyphCount)
+                    {
+                        glyphOffsets = ArrayPool<float>.Shared.Rent(glyphCount * 2);
+                        for (int i = 0; i < glyphCount; i++)
+                        {
+                            Point offset = _glyphOffsets[i];
+                            glyphOffsets[i * 2] = (float)offset.X;
+                            glyphOffsets[i * 2 + 1] = (float)offset.Y;
+                        }
+                    }
+
+                    var colorLayers = factory.TranslateColorGlyphRun(
+                        fontFace,
+                        (float)_renderingEmSize,
+                        glyphIndices,
+                        glyphAdvances,
+                        glyphOffsets,
+                        (uint)glyphCount,
+                        IsSideways,
+                        (uint)_bidiLevel,
+                        (float)_baselineOrigin.X,
+                        (float)_baselineOrigin.Y,
+                        _textFormattingMode == TextFormattingMode.Display ? 1u : 0u  // GDI_CLASSIC = 1, NATURAL = 0
+                        );
+
+                    if (colorLayers == null || colorLayers.Count == 0)
+                        return null;
+
+                    // Build a DrawingGroup with one GeometryDrawing per color layer
+                    DrawingGroup drawingGroup = new DrawingGroup();
+                    foreach (var layer in colorLayers)
+                    {
+                        Brush layerBrush;
+                        if (layer.UseForegroundColor)
+                        {
+                            layerBrush = foregroundBrush;
+                        }
+                        else
+                        {
+                            // DWRITE_COLOR_F values from the CPAL table are sRGB gamma-encoded.
+                            // Use FromArgb (which expects sRGB) rather than FromScRgb (which
+                            // expects linear light) to avoid washed-out colors.
+                            layerBrush = new SolidColorBrush(
+                                Color.FromArgb(
+                                    (byte)(layer.ColorA * 255f + 0.5f),
+                                    (byte)(layer.ColorR * 255f + 0.5f),
+                                    (byte)(layer.ColorG * 255f + 0.5f),
+                                    (byte)(layer.ColorB * 255f + 0.5f)));
+                            layerBrush.Freeze();
+                        }
+
+                        // Build geometry for this layer's glyphs
+                        Geometry layerGeometry = BuildLayerGeometry(
+                            layer.GlyphIndices,
+                            layer.GlyphAdvances,
+                            layer.GlyphOffsets,
+                            layer.BaselineOriginX,
+                            layer.BaselineOriginY);
+
+                        if (layerGeometry != null && !layerGeometry.IsEmpty())
+                        {
+                            GeometryDrawing drawing = new GeometryDrawing(layerBrush, null, layerGeometry);
+                            drawingGroup.Children.Add(drawing);
+                        }
+                    }
+
+                    if (drawingGroup.Children.Count == 0)
+                    {
+                        _cachedColorDrawing = null;
+                        _cachedColorForeground = foregroundBrush;
+                        return null;
+                    }
+
+                    // Freeze when possible for thread safety and perf; cache either way
+                    // since the result is the same for the same foreground brush instance.
+                    if (drawingGroup.CanFreeze)
+                        drawingGroup.Freeze();
+
+                    _cachedColorDrawing = drawingGroup;
+                    _cachedColorForeground = foregroundBrush;
+                    return drawingGroup;
+                }
+                finally
+                {
+                    ArrayPool<ushort>.Shared.Return(glyphIndices);
+                    ArrayPool<float>.Shared.Return(glyphAdvances);
+                    if (glyphOffsets != null)
+                        ArrayPool<float>.Shared.Return(glyphOffsets);
+                }
+            }
+            finally
+            {
+                fontFace.Release();
+            }
+        }
+
+        /// <summary>
+        /// Builds geometry for a single COLR color layer's glyphs.
+        ///
+        /// DirectWrite's TranslateColorGlyphRun returns each layer with a pre-computed
+        /// baselineOrigin that already accounts for the glyph's position within the run
+        /// (advances, offsets, bidi). Within a single layer, glyphs are positioned using
+        /// their own advances relative to that layer's baseline origin — this mirrors the
+        /// layout logic in <see cref="BuildGeometry"/>.
+        /// </summary>
+        private Geometry BuildLayerGeometry(
+            ushort[] layerGlyphIndices,
+            float[] layerGlyphAdvances,
+            float[] layerGlyphOffsets,
+            float baselineOriginX,
+            float baselineOriginY)
+        {
+            GeometryGroup layerGeometry = null;
+            double accAdvance = 0;
+
+            for (int i = 0; i < layerGlyphIndices.Length; i++)
+            {
+                ushort glyphIndex = layerGlyphIndices[i];
+
+                double offsetX = 0;
+                double offsetY = 0;
+                if (layerGlyphOffsets != null && i * 2 + 1 < layerGlyphOffsets.Length)
+                {
+                    offsetX = layerGlyphOffsets[i * 2];
+                    offsetY = layerGlyphOffsets[i * 2 + 1];
+                }
+
+                double originX;
+                if (IsLeftToRight)
+                {
+                    originX = accAdvance + offsetX;
+                }
+                else
+                {
+                    double nominalAdvance = layerGlyphAdvances[i];
+                    originX = -accAdvance - (nominalAdvance + offsetX);
+                }
+                accAdvance += layerGlyphAdvances[i];
+
+                double originY = -offsetY;
+
+                Geometry glyphGeometry = _glyphTypeface.ComputeGlyphOutline(glyphIndex, IsSideways, _renderingEmSize);
+                if (glyphGeometry.IsEmpty())
+                    continue;
+
+                glyphGeometry.Transform = new TranslateTransform(
+                    originX + baselineOriginX,
+                    originY + baselineOriginY);
+
+                layerGeometry ??= new GeometryGroup() { FillRule = FillRule.Nonzero };
+                layerGeometry.Children.Add(glyphGeometry.GetOutlinedPathGeometry(RelativeFlatteningTolerance, ToleranceType.Relative));
+            }
+
+            if (layerGeometry == null || layerGeometry.IsEmpty())
+                return Geometry.Empty;
+            return layerGeometry;
+        }
+
+        /// <summary>
         /// Computes the alignment box for the glyph run.
         /// The alignment box is relative to origin.
         /// </summary>
@@ -2464,6 +2687,8 @@ namespace System.Windows.Media
         private XmlLanguage         _language;
         private string              _deviceFontName;
         private object              _inkBoundingBox;    // Used when CacheInkBounds is on
+        private Drawing             _cachedColorDrawing;   // Cached result of TryBuildColorGlyphDrawing
+        private Brush               _cachedColorForeground; // Foreground brush used for _cachedColorDrawing
         private TextFormattingMode      _textFormattingMode;
         private float               _pixelsPerDip = MS.Internal.FontCache.Util.PixelsPerDip;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphTypeface.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphTypeface.cs
@@ -2004,7 +2004,7 @@ namespace System.Windows.Media
         private FontSource                  _fontSource;
 
         private bool                        _isColorFont;
-        private bool                        _isColorFontInitialized;
+        private volatile bool               _isColorFontInitialized;
 
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphTypeface.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphTypeface.cs
@@ -985,6 +985,39 @@ namespace System.Windows.Media
         {
             return FontDWrite.HasCharacter(unicodeValue);
         }
+
+        /// <summary>
+        /// Returns true if this GlyphTypeface contains color glyph layers (COLR/CPAL tables).
+        /// The result is lazily computed and cached. The underlying check probes for the
+        /// COLR OpenType table via IDWriteFontFace::TryGetFontTable.
+        ///
+        /// Thread safety: the double-check pattern here may cause a redundant native call
+        /// on concurrent first access, but the result is idempotent — the same font face
+        /// always has the same table set. The flag write order (value before sentinel)
+        /// ensures no thread sees stale data.
+        /// </summary>
+        internal bool IsColorFont
+        {
+            get
+            {
+                CheckInitialized();
+                if (!_isColorFontInitialized)
+                {
+                    MS.Internal.Text.TextInterface.FontFace fontFaceDWrite = _font.GetFontFace();
+                    try
+                    {
+                        bool hasColor = fontFaceDWrite.HasColorGlyphs();
+                        _isColorFont = hasColor;            // write value first
+                        _isColorFontInitialized = true;     // then publish the sentinel
+                    }
+                    finally
+                    {
+                        fontFaceDWrite.Release();
+                    }
+                }
+                return _isColorFont;
+            }
+        }
         
         internal MS.Internal.Text.TextInterface.Font FontDWrite
         {
@@ -1969,6 +2002,9 @@ namespace System.Windows.Media
         private MS.Internal.Text.TextInterface.Font     _font;
 
         private FontSource                  _fontSource;
+
+        private bool                        _isColorFont;
+        private bool                        _isColorFontInitialized;
 
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/ColorEmojiTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/ColorEmojiTests.cs
@@ -23,7 +23,7 @@ public class ColorEmojiTests
     [Trait("Category", "ColorEmoji")]
     public void IsColorFont_SegoeUIEmoji_ReturnsTrue()
     {
-        if (!HasSegoeUIEmoji) return;
+        Assert.True(HasSegoeUIEmoji, "Segoe UI Emoji font not found; required for this test.");
 
         var typeface = new GlyphTypeface(new Uri(SegoeUIEmojiPath));
         Assert.True(typeface.IsColorFont);
@@ -33,7 +33,7 @@ public class ColorEmojiTests
     [Trait("Category", "ColorEmoji")]
     public void IsColorFont_SegoeUI_ReturnsFalse()
     {
-        if (!HasSegoeUI) return;
+        Assert.True(HasSegoeUI, "Segoe UI font not found; required for this test.");
 
         var typeface = new GlyphTypeface(new Uri(SegoeUIPath));
         Assert.False(typeface.IsColorFont);
@@ -43,19 +43,20 @@ public class ColorEmojiTests
     [Trait("Category", "ColorEmoji")]
     public void TryBuildColorGlyphDrawing_GrinningFace_ReturnsMultiLayerDrawingGroup()
     {
-        if (!HasSegoeUIEmoji) return;
+        Assert.True(HasSegoeUIEmoji, "Segoe UI Emoji font not found; required for this test.");
 
         var typeface = new GlyphTypeface(new Uri(SegoeUIEmojiPath));
 
         // U+1F600 Grinning Face
-        if (!typeface.CharacterToGlyphMap.TryGetValue(0x1F600, out ushort glyphIndex)) return;
+        Assert.True(typeface.CharacterToGlyphMap.TryGetValue(0x1F600, out ushort glyphIndex),
+            "U+1F600 glyph not found in Segoe UI Emoji.");
 
         var glyphRun = new GlyphRun(
             typeface,
             bidiLevel: 0,
             isSideways: false,
             renderingEmSize: 20.0,
-            pixelsPerDip: 96.0f,
+            pixelsPerDip: 1.0f,
             glyphIndices: new ushort[] { glyphIndex },
             baselineOrigin: new Point(0, 20),
             advanceWidths: new double[] { 20.0 },
@@ -80,18 +81,19 @@ public class ColorEmojiTests
     [Trait("Category", "ColorEmoji")]
     public void TryBuildColorGlyphDrawing_NonColorFont_ReturnsNull()
     {
-        if (!HasSegoeUI) return;
+        Assert.True(HasSegoeUI, "Segoe UI font not found; required for this test.");
 
         var typeface = new GlyphTypeface(new Uri(SegoeUIPath));
 
-        if (!typeface.CharacterToGlyphMap.TryGetValue((int)'A', out ushort glyphIndex)) return;
+        Assert.True(typeface.CharacterToGlyphMap.TryGetValue((int)'A', out ushort glyphIndex),
+            "Glyph for 'A' not found in Segoe UI.");
 
         var glyphRun = new GlyphRun(
             typeface,
             bidiLevel: 0,
             isSideways: false,
             renderingEmSize: 20.0,
-            pixelsPerDip: 96.0f,
+            pixelsPerDip: 1.0f,
             glyphIndices: new ushort[] { glyphIndex },
             baselineOrigin: new Point(0, 20),
             advanceWidths: new double[] { 20.0 },
@@ -111,21 +113,19 @@ public class ColorEmojiTests
     [Trait("Category", "ColorEmoji")]
     public void TryBuildColorGlyphDrawing_LayerBrushesHaveVibrantColors()
     {
-        if (!HasSegoeUIEmoji)
-            return;
+        Assert.True(HasSegoeUIEmoji, "Segoe UI Emoji font not found; required for this test.");
 
         var typeface = new GlyphTypeface(new Uri(SegoeUIEmojiPath));
 
-        var result = typeface.CharacterToGlyphMap.TryGetValue(0x1F600, out ushort glyphIndex);
-        if (!result)
-            return;
+        Assert.True(typeface.CharacterToGlyphMap.TryGetValue(0x1F600, out ushort glyphIndex),
+            "U+1F600 glyph not found in Segoe UI Emoji.");
 
         var glyphRun = new GlyphRun(
             typeface,
             bidiLevel: 0,
             isSideways: false,
             renderingEmSize: 20.0,
-            pixelsPerDip: 96.0f,
+            pixelsPerDip: 1.0f,
             glyphIndices: new ushort[] { glyphIndex },
             baselineOrigin: new Point(0, 20),
             advanceWidths: new double[] { 20.0 },

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/ColorEmojiTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/ColorEmojiTests.cs
@@ -1,0 +1,165 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Media;
+
+/// <summary>
+/// Tests for COLR v0 color emoji rendering support:
+///   - GlyphTypeface.IsColorFont detection via the COLR table
+///   - GlyphRun.TryBuildColorGlyphDrawing decomposition into color layers
+///   - Correct sRGB color interpretation (not linear/scRGB)
+///
+/// Requires Segoe UI Emoji (standard on Windows 10+).
+/// </summary>
+public class ColorEmojiTests
+{
+    private const string SegoeUIEmojiPath = @"C:\Windows\Fonts\seguiemj.ttf";
+    private const string SegoeUIPath = @"C:\Windows\Fonts\segoeui.ttf";
+
+    private static bool HasSegoeUIEmoji => File.Exists(SegoeUIEmojiPath);
+    private static bool HasSegoeUI => File.Exists(SegoeUIPath);
+
+    [Fact]
+    [Trait("Category", "ColorEmoji")]
+    public void IsColorFont_SegoeUIEmoji_ReturnsTrue()
+    {
+        if (!HasSegoeUIEmoji) return;
+
+        var typeface = new GlyphTypeface(new Uri(SegoeUIEmojiPath));
+        Assert.True(typeface.IsColorFont);
+    }
+
+    [Fact]
+    [Trait("Category", "ColorEmoji")]
+    public void IsColorFont_SegoeUI_ReturnsFalse()
+    {
+        if (!HasSegoeUI) return;
+
+        var typeface = new GlyphTypeface(new Uri(SegoeUIPath));
+        Assert.False(typeface.IsColorFont);
+    }
+
+    [Fact]
+    [Trait("Category", "ColorEmoji")]
+    public void TryBuildColorGlyphDrawing_GrinningFace_ReturnsMultiLayerDrawingGroup()
+    {
+        if (!HasSegoeUIEmoji) return;
+
+        var typeface = new GlyphTypeface(new Uri(SegoeUIEmojiPath));
+
+        // U+1F600 Grinning Face
+        if (!typeface.CharacterToGlyphMap.TryGetValue(0x1F600, out ushort glyphIndex)) return;
+
+        var glyphRun = new GlyphRun(
+            typeface,
+            bidiLevel: 0,
+            isSideways: false,
+            renderingEmSize: 20.0,
+            pixelsPerDip: 96.0f,
+            glyphIndices: new ushort[] { glyphIndex },
+            baselineOrigin: new Point(0, 20),
+            advanceWidths: new double[] { 20.0 },
+            glyphOffsets: null,
+            characters: null,
+            deviceFontName: null,
+            clusterMap: null,
+            caretStops: null,
+            language: null);
+
+        Drawing drawing = glyphRun.TryBuildColorGlyphDrawing(Brushes.Black);
+
+        Assert.NotNull(drawing);
+        Assert.IsType<DrawingGroup>(drawing);
+
+        var group = (DrawingGroup)drawing;
+        Assert.True(group.Children.Count > 1,
+            $"Expected multiple color layers, got {group.Children.Count}");
+    }
+
+    [Fact]
+    [Trait("Category", "ColorEmoji")]
+    public void TryBuildColorGlyphDrawing_NonColorFont_ReturnsNull()
+    {
+        if (!HasSegoeUI) return;
+
+        var typeface = new GlyphTypeface(new Uri(SegoeUIPath));
+
+        if (!typeface.CharacterToGlyphMap.TryGetValue((int)'A', out ushort glyphIndex)) return;
+
+        var glyphRun = new GlyphRun(
+            typeface,
+            bidiLevel: 0,
+            isSideways: false,
+            renderingEmSize: 20.0,
+            pixelsPerDip: 96.0f,
+            glyphIndices: new ushort[] { glyphIndex },
+            baselineOrigin: new Point(0, 20),
+            advanceWidths: new double[] { 20.0 },
+            glyphOffsets: null,
+            characters: null,
+            deviceFontName: null,
+            clusterMap: null,
+            caretStops: null,
+            language: null);
+
+        Drawing drawing = glyphRun.TryBuildColorGlyphDrawing(Brushes.Black);
+
+        Assert.Null(drawing);
+    }
+
+    [Fact]
+    [Trait("Category", "ColorEmoji")]
+    public void TryBuildColorGlyphDrawing_LayerBrushesHaveVibrantColors()
+    {
+        if (!HasSegoeUIEmoji)
+            return;
+
+        var typeface = new GlyphTypeface(new Uri(SegoeUIEmojiPath));
+
+        var result = typeface.CharacterToGlyphMap.TryGetValue(0x1F600, out ushort glyphIndex);
+        if (!result)
+            return;
+
+        var glyphRun = new GlyphRun(
+            typeface,
+            bidiLevel: 0,
+            isSideways: false,
+            renderingEmSize: 20.0,
+            pixelsPerDip: 96.0f,
+            glyphIndices: new ushort[] { glyphIndex },
+            baselineOrigin: new Point(0, 20),
+            advanceWidths: new double[] { 20.0 },
+            glyphOffsets: null,
+            characters: null,
+            deviceFontName: null,
+            clusterMap: null,
+            caretStops: null,
+            language: null);
+
+        Drawing drawing = glyphRun.TryBuildColorGlyphDrawing(Brushes.Black);
+        Assert.NotNull(drawing);
+        var group = (DrawingGroup)drawing;
+
+        // The grinning face emoji has vibrant warm layers (orange/yellow in sRGB).
+        // If colors were wrongly interpreted as linear (scRGB via FromScRgb), the sRGB
+        // byte values would be much lower, producing washed-out colors.
+        // We look for any layer with a warm, saturated color (R > 200, B < 100).
+        bool foundVibrantWarm = false;
+        foreach (Drawing child in group.Children)
+        {
+            if (child is GeometryDrawing gd && gd.Brush is SolidColorBrush scb)
+            {
+                Color c = scb.Color;
+                if (c.R > 200 && c.B < 100)
+                {
+                    foundVibrantWarm = true;
+                    break;
+                }
+            }
+        }
+
+        Assert.True(foundVibrantWarm,
+            "Expected at least one layer with a vibrant warm color (sRGB R>200, B<100). " +
+            "If colors appear washed out, FromScRgb may have been used instead of FromArgb.");
+    }
+}


### PR DESCRIPTION
## Summary

Add DirectWrite color glyph (COLR v0) rendering support to WPF and fix emoji font fallback so that emoji characters render in full color instead of monochrome outlines.

### Before and after

Text like the following now renders in full color instead of monochrome outlines:

| Category | Example text |
|---|---|
| Faces | Hello 😀😃😄😁😆 World |
| Gestures | Great job 👍👏🙌 |
| Animals | Nature 🐶🐱🦊🐻🐼 |
| Colored circles (U+1F7E0–1F7EB) | 🟠🟡🟢🟣🟤🔴🔵🟥🟧🟨🟩🟦🟪🟫 |
| Star / circle (U+2B50, U+2B55) | ⭐⭕ |
| Heavy equals sign (U+1F7F0) | 🟰 |
| Extended range (U+1FA00–1FAFF) | 🫠🫡🫢🫣🫤🫥🫨 |

**Before:** Emoji show as monochrome outlines or empty boxes.
**After:** Emoji render with full COLR v0 palette colors.

## What changed

### Color glyph rendering
- **`GlyphTypeface.IsColorFont`** — New property that detects whether a font has a COLR OpenType table (lazy-cached).
- **`GlyphRun.TryBuildColorGlyphDrawing()`** — Calls `IDWriteFactory2::TranslateColorGlyphRun` to decompose a glyph run into per-layer sub-runs, each with a CPAL palette color. Builds a frozen `DrawingGroup` of `GeometryDrawing` layers.
- **`DrawingDrawingContext` / `RenderDataDrawingContext`** — Intercept `DrawGlyphRun` to render color layers when available, falling through to the existing monochrome path for non-color fonts.
- **`Factory.TranslateColorGlyphRun()`** — Managed wrapper around `IDWriteFactory2::TranslateColorGlyphRun` with input validation and proper COM lifetime management. Queries for `IDWriteFactory2` at factory creation with graceful fallback on pre-Windows 8.1.
- **`FontFace.HasColorGlyphs()`** — Native helper that probes for the COLR OpenType table.
- **New interop types** — `IDWriteColorGlyphRunEnumerator`, `DWRITE_COLOR_GLYPH_RUN`, `ColorGlyphLayer` for managed/native interop.

### Font fallback fixes
- Extended emoji Unicode ranges in all three `FontFamilyMap` sections of `GlobalUserInterface.CompositeFont` from `1F900-1F9FF` to `1F900-1FAFF` (adds Symbols and Pictographs Extended-A coverage).
- Added explicit Segoe UI Emoji entries for default-presentation emoji code points (U+1F7E0–1F7EB colored circles/squares, U+1F7F0 heavy equals sign, U+2B50 star, U+2B55 hollow red circle) that were previously mapped to text-priority font families.

### Tests
- Added `ColorEmojiTests` covering `IsColorFont` detection, color glyph layer decomposition, and font fallback for previously missing emoji code points.

## Why

WPF renders all emoji as monochrome outlines because the glyph pipeline produces single-channel coverage bitmaps with no per-layer color support. Additionally, newer Unicode emoji ranges are not mapped to Segoe UI Emoji in the composite font, causing them to show as empty boxes.

This fix decomposes COLR v0 color glyphs via DirectWrite into individually colored geometry layers, and extends font fallback to cover all standard emoji Unicode ranges.

### Limitations
- COLR v0 only (IDWriteFactory2). COLRv1/SVG/CBDT color fonts would need IDWriteFactory4+.
- Color layers use geometry-based rendering (no ClearType), which is acceptable for emoji at typical display sizes.

### Validation
- Verified locally that emoji render in full color with the fix applied.
- All PresentationCore.Tests pass (976 total: 947 passed, 29 skipped for pre-existing reasons, 0 failures).

Fixes #91

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11684)