### PR TITLE
Break the reference chain so old containers can be garbage collected.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/ElementProxy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Automation/ElementProxy.cs
@@ -540,9 +540,22 @@ namespace MS.Internal.Automation
         //
         //------------------------------------------------------
  
+        #region Internal Methods for Disconnect
+
+        // Called during UIA disconnect to sever the strong reference from this
+        // proxy to the automation peer.  This allows the peer (and its associated
+        // data items) to be garbage collected even if UIA/client still holds a
+        // COM reference to this CCW temporarily.
+        internal void ClearPeer()
+        {
+            _peer = null;
+        }
+
+        #endregion Internal Methods for Disconnect
+
         #region Private Fields
 
-        private readonly object _peer;
+        private object _peer;
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
@@ -1484,6 +1484,7 @@ namespace System.Windows.Automation.Peers
             // UpdateSubtree is not called on it yet.
             if (!_childrenValid || _ancestorsInvalid)
             {
+                List<AutomationPeer> oldChildren = _children;
                 _children = GetChildrenCore();
                 if (_children != null)
                 {
@@ -1496,6 +1497,20 @@ namespace System.Windows.Automation.Peers
                     }
                 }
                 _childrenValid = true;
+
+                // Disconnect removed peers (same logic as UpdateChildrenInternal)
+                if (oldChildren != null)
+                {
+                    HashSet<AutomationPeer> newSet = _children != null ? 
+                    new HashSet<AutomationPeer>(_children) : null;
+                    foreach (var old in oldChildren)
+                    {
+                        if (newSet == null || !newSet.Contains(old))
+                        {
+                            DisconnectPeerFromUia(old);
+                        }
+                    }
+                }
             }
         }
 
@@ -1820,27 +1835,47 @@ namespace System.Windows.Automation.Peers
         /// the CCW ref count to drop to zero so the managed objects can be GC'd.
         /// </summary>
         /// <remarks>
-        /// This method intentionally does NOT recursively disconnect children.
-        /// In virtualized controls, a removed item peer's cached _children may
-        /// reference container peers (e.g. DataGridCellAutomationPeer) that have
-        /// been recycled and are now serving new items. Disconnecting those would
-        /// break accessibility on currently visible elements.
-        /// Children are disconnected naturally when their own parent's
-        /// UpdateChildrenInternal runs and detects them as removed.
+        /// After disconnecting a peer from UIA, this method also clears the peer's
+        /// _children list to sever references to child peers.  Without this, a
+        /// disconnected ItemAutomationPeer would still root its cached cell peers,
+        /// which in turn root DataGridCell/DataGridRow containers via their _owner
+        /// field — preventing GC of recycled/discarded containers.
+        /// We do NOT call UiaDisconnectProvider on children (they may be shared with
+        /// recycled containers that are still live), but clearing the parent's
+        /// _children list removes the strong reference chain.
         /// </remarks>
         private static void DisconnectPeerFromUia(AutomationPeer peer)
         {
             if (peer == null)
                 return;
 
-            // Disconnect the peer's own ElementProxy CCW from UIA.
+            // UiaDisconnectProvider MUST NOT be called during a UIA callback
+            // (e.g., during Navigate/FindAll handling).  EnsureChildren and
+            // UpdateChildrenInternal are invoked from within UIA callbacks, so
+            // we must defer the actual disconnect to a separate dispatcher operation.
             WeakReference proxyWeakRef = peer._elementProxyWeakReference;
             if (proxyWeakRef?.Target is ElementProxy proxy)
             {
-                UiaDisconnectProvider(proxy);
+                // Sever the strong reference from proxy back to the peer immediately.
+                // This allows the peer (and its data items) to be GC'd even before
+                // the deferred UiaDisconnectProvider call executes.
+                proxy.ClearPeer();
+
+                // Defer the UIA disconnect to run outside the UIA callback context.
+                peer.Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Background,
+                    new Action(() =>
+                    {
+                        UiaDisconnectProvider(proxy);
+                    }));
             }
 
             peer._elementProxyWeakReference = null;
+
+            // Sever the reference from this peer to its cached children.
+            // This breaks the chain: disconnected peer → child peers → _owner → UI containers,
+            // allowing old containers (DataGridRow/Cell) to be collected.
+            peer._children = null;
+            peer._childrenValid = false;
         }
 
         [DllImport("UIAutomationCore.dll", EntryPoint = "UiaDisconnectProvider", CharSet = CharSet.Unicode)]

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
@@ -1501,8 +1501,7 @@ namespace System.Windows.Automation.Peers
                 // Disconnect removed peers (same logic as UpdateChildrenInternal)
                 if (oldChildren != null)
                 {
-                    HashSet<AutomationPeer> newSet = _children != null ? 
-                    new HashSet<AutomationPeer>(_children) : null;
+                    HashSet<AutomationPeer> newSet = (_children != null) ? new HashSet<AutomationPeer>(_children) : null;
                     foreach (var old in oldChildren)
                     {
                         if (newSet == null || !newSet.Contains(old))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
@@ -4,6 +4,7 @@
 //#define ENABLE_AUTOMATIONPEER_LOGGING   // uncomment to include logging of various activities
 
 using System.Collections;
+using System.Runtime.InteropServices;
 using System.Windows.Threading;
 using System.Windows.Automation.Provider;
 using MS.Internal;
@@ -1812,6 +1813,39 @@ namespace System.Windows.Automation.Peers
             return ElementProxy.StaticWrap(peer, referencePeer);
         }
 
+        /// <summary>
+        /// Disconnects a peer from the UI Automation framework by calling
+        /// UiaDisconnectProvider on its ElementProxy CCW.
+        /// This causes the UIA client-side to release its COM references, allowing
+        /// the CCW ref count to drop to zero so the managed objects can be GC'd.
+        /// </summary>
+        /// <remarks>
+        /// This method intentionally does NOT recursively disconnect children.
+        /// In virtualized controls, a removed item peer's cached _children may
+        /// reference container peers (e.g. DataGridCellAutomationPeer) that have
+        /// been recycled and are now serving new items. Disconnecting those would
+        /// break accessibility on currently visible elements.
+        /// Children are disconnected naturally when their own parent's
+        /// UpdateChildrenInternal runs and detects them as removed.
+        /// </remarks>
+        private static void DisconnectPeerFromUia(AutomationPeer peer)
+        {
+            if (peer == null)
+                return;
+
+            // Disconnect the peer's own ElementProxy CCW from UIA.
+            WeakReference proxyWeakRef = peer._elementProxyWeakReference;
+            if (proxyWeakRef?.Target is ElementProxy proxy)
+            {
+                UiaDisconnectProvider(proxy);
+            }
+
+            peer._elementProxyWeakReference = null;
+        }
+
+        [DllImport("UIAutomationCore.dll", EntryPoint = "UiaDisconnectProvider", CharSet = CharSet.Unicode)]
+        private static extern int UiaDisconnectProvider(IRawElementProviderSimple provider);
+
         ///<Summary>
         /// When one AutomationPeer is using the pattern of another AutomationPeer instead of exposing
         /// it in the children collection (example - ListBox exposes IScrollProvider from internal ScrollViewer
@@ -1892,10 +1926,6 @@ namespace System.Windows.Automation.Peers
             _childrenValid = false;
             EnsureChildren();
 
-            // Callers have only checked if automation clients are present so filter for any interest in this particular event.
-            if (!EventMap.HasRegisteredEvent(AutomationEvents.StructureChanged))
-                return;
-
             //store old children in a hashset
             if(oldChildren != null)
             {
@@ -1936,6 +1966,23 @@ namespace System.Windows.Automation.Peers
             //now the hs only has "removed" children. If the count does not yet
             //calls for "bulk" notification, use per-child notification, otherwise use "bulk"
             int removedCount = (hs == null ? 0 : hs.Count);
+
+            // Disconnect removed children from UIA so the client-side releases its
+            // COM references to the ElementProxy CCWs.  Without this the CCW ref count
+            // never drops to zero, which prevents the managed peer (and its entire
+            // visual sub-tree) from being garbage collected.
+            // This must happen regardless of StructureChanged event registration.
+            if (removedCount > 0)
+            {
+                foreach (AutomationPeer removedChild in hs)
+                {
+                    DisconnectPeerFromUia(removedChild);
+                }
+            }
+
+            // Callers have only checked if automation clients are present so filter for any interest in this particular event.
+            if (!EventMap.HasRegisteredEvent(AutomationEvents.StructureChanged))
+                return;
 
             if(removedCount + addedCount > invalidateLimit) //bilk invalidation
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/11337

## Description

**ElementProxy.cs:**
 - `_peer` made non-readonly + `ClearPeer()` method — allows `DisconnectPeerFromUia` to sever the strong proxy → peer reference immediately (for non-UIElement peers like `DataGridItemAutomationPeer`)

**AutomationPeer.cs:**

 1. `EnsureChildren()` disconnect logic — detects removed peers when `_children` is refreshed during UIA traversal and calls `DisconnectPeerFromUia` on them.
 2. `DisconnectPeerFromUia` changes:
 - `proxy.ClearPeer()` — severs proxy→peer strong reference
 - `Dispatcher.BeginInvoke` for `UiaDisconnectProvider` — defers COM disconnect to outside UIA callback context
 - `peer._children = null; peer._childrenValid = false;` — the critical fix that breaks the chain from disconnected peer → cached cell peers → old DataGridCell/Row containers

## Regression

No

## Testing

 Test Environment

   - Repro app (WPFUI): DataGrid with 200k rows, ItemsSource rebound every 3 seconds
   - UIA client (WPFAutomationClient): Calls FindAll(TreeScope.Descendants, TrueCondition) every 1 second
   - Runtime: Custom-built PresentationCore.dll deployed to local .NET 11 Preview 5 SDK

  Tests Performed
   | # | Fix Applied | Result | Duration |
   |---|---|---|---|
   | 1 | PR #11657 only (EnsureChildren disconnect) | ❌ Memory grew to ~2500 MB | 20 min |
   | 2 | + ClearPeer() on ElementProxy | ❌ No improvement | ~5 min |
   | 3 | + Deferred UiaDisconnectProvider via Dispatcher.BeginInvoke | ❌ Still ~6-9 MB/cycle growth | ~5 min |
   | 4 | + Diagnostic counters (verified disconnects fire: 45/cycle, refreshes accelerating) | ❌ 911→1019 MB in 14 cycles | ~1 min |
   | 5 | + `peer._children = null; peer._childrenValid = false;` in DisconnectPeerFromUia | ✅ **Stable 449-534 MB** | 3+ min |

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11717)