### PR TITLE
Add AppContext switch to guard automation peer disconnect behavior

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
@@ -177,6 +177,24 @@ namespace MS.Internal
 
         #endregion
 
+        #region UseLegacyAutomationPeerDisconnect
+
+        /// <summary>
+        /// Switch to opt-out of the automation peer disconnect behavior.
+        /// When true, removed automation peers are NOT disconnected from UIA (legacy behavior).
+        /// When false (default), removed automation peers are disconnected via UiaDisconnectProvider.
+        /// </summary>
+        public static bool UseLegacyAutomationPeerDisconnect
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return AccessibilitySwitches.UseLegacyAutomationPeerDisconnect;
+            }
+        }
+
+        #endregion
+
         #endregion
 
         #region ShouldRenderEvenWhenNoDisplayDevicesAreAvailable and ShouldNotRenderInNonInteractiveWindowStation

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
@@ -1499,7 +1499,7 @@ namespace System.Windows.Automation.Peers
                 _childrenValid = true;
 
                 // Disconnect removed peers (same logic as UpdateChildrenInternal)
-                if (oldChildren != null)
+                if (oldChildren != null && !CoreAppContextSwitches.UseLegacyAutomationPeerDisconnect)
                 {
                     HashSet<AutomationPeer> newSet = _children != null ? 
                     new HashSet<AutomationPeer>(_children) : null;
@@ -2007,7 +2007,7 @@ namespace System.Windows.Automation.Peers
             // never drops to zero, which prevents the managed peer (and its entire
             // visual sub-tree) from being garbage collected.
             // This must happen regardless of StructureChanged event registration.
-            if (removedCount > 0)
+            if (removedCount > 0 && !CoreAppContextSwitches.UseLegacyAutomationPeerDisconnect)
             {
                 foreach (AutomationPeer removedChild in hs)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AccessibilitySwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AccessibilitySwitches.cs
@@ -147,6 +147,29 @@ namespace System.Windows
 
         #endregion
 
+        #region UseLegacyAutomationPeerDisconnect
+
+        internal const string UseLegacyAutomationPeerDisconnectSwitchName = "Switch.System.Windows.Automation.Peers.UseLegacyAutomationPeerDisconnect";
+        private static int _UseLegacyAutomationPeerDisconnect;
+
+        /// <summary>
+        /// Switch to opt-out of the automation peer disconnect behavior.
+        /// When true, compatibility mode is enabled: removed automation peers are NOT
+        /// disconnected from UIA, preserving the legacy element lifetime semantics.
+        /// When false (default), removed automation peers are disconnected via
+        /// UiaDisconnectProvider, allowing CCWs and associated managed objects to be GC'd.
+        /// </summary>
+        public static bool UseLegacyAutomationPeerDisconnect
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return LocalAppContext.GetCachedSwitchValue(UseLegacyAutomationPeerDisconnectSwitchName, ref _UseLegacyAutomationPeerDisconnect);
+            }
+        }
+
+        #endregion
+
         #endregion
 
         #region Switch Functions
@@ -167,6 +190,7 @@ namespace System.Windows
             LocalAppContext.DefineSwitchDefault(UseLegacyAccessibilityFeatures3SwitchName, false);
             LocalAppContext.DefineSwitchDefault(UseLegacyToolTipDisplaySwitchName, false);
             LocalAppContext.DefineSwitchDefault(ItemsControlDoesNotSupportAutomationSwitchName, false);
+            LocalAppContext.DefineSwitchDefault(UseLegacyAutomationPeerDisconnectSwitchName, false);
         }
 
         /// <summary>
@@ -217,6 +241,10 @@ namespace System.Windows
             if (!ItemsControlDoesNotSupportAutomation && UseNetFx472CompatibleAccessibilityFeatures)
             {
                 DispatchOnError(dispatcher, String.Format(SR.AccessibilitySwitchDependencyNotSatisfied, ItemsControlDoesNotSupportAutomationSwitchName, UseLegacyAccessibilityFeatures3SwitchName, 3));
+            }
+            if (!UseLegacyAutomationPeerDisconnect && UseNetFx472CompatibleAccessibilityFeatures)
+            {
+                DispatchOnError(dispatcher, String.Format(SR.AccessibilitySwitchDependencyNotSatisfied, UseLegacyAutomationPeerDisconnectSwitchName, UseLegacyAccessibilityFeatures3SwitchName, 3));
             }
         }
 


### PR DESCRIPTION
Fixes #11337

Main PR #11717

## Description

Adds an AppContext compatibility switch (`Switch.System.Windows.Automation.Peers.UseLegacyAutomationPeerDisconnect`) to guard the new UIA disconnect behavior introduced in #11717 .

When false (default): removed automation peers are disconnected via `UiaDisconnectProvider`, fixing the memory leak where CCW ref counts never drop to zero.

When true: legacy behavior is preserved - removed peers are not disconnected, maintaining the old element lifetime semantics for consumers that depend on it.

## Customer Impact

 Without this switch, the disconnect fix in #11717 unconditionally changes observable UIA behavior: removed peers get UiaDisconnectProvider'd and their proxy _peer is cleared, so clients still holding cached elements receive `ElementNotAvailableException` instead of data. Test automation harnesses and AT products that depend on the old element lifetime would break with no escape hatch.

## Regression

No

## Testing

 - Verified no new C# compilation errors introduced by the changes.
 - Functional validation of the disconnect behavior itself is covered by #11717's testing.

## Risk

 Low. The switch is purely additive infrastructure - it defines a new AppContext switch and guards the #11717 call sites behind a property check.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11723)