### PR TITLE
Clear IsThemeDictionary flag when ResourceDictionary gains an owner

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1508,6 +1508,10 @@ namespace System.Windows
                     fe.ShouldLookupImplicitStyles = true;
                 }
 
+                // Owned dictionaries are never theme dictionaries; clear the flag the ctor may
+                // have inherited from SystemResources.IsSystemResourcesParsing. Propagates to merged dictionaries.
+                IsThemeDictionary = false;
+
                 _ownerFEs.Add(fe);
             }
             else
@@ -1529,6 +1533,10 @@ namespace System.Windows
                     {
                         fce.ShouldLookupImplicitStyles = true;
                     }
+
+                    // Owned dictionaries are never theme dictionaries; clear the flag the ctor may
+                    // have inherited from SystemResources.IsSystemResourcesParsing. Propagates to merged dictionaries.
+                    IsThemeDictionary = false;
 
                     _ownerFCEs.Add(fce);
                 }
@@ -1556,6 +1564,10 @@ namespace System.Windows
 
                         // An Application ResourceDictionary can be accessed across threads
                         CanBeAccessedAcrossThreads = true;
+
+                        // Owned dictionaries are never theme dictionaries; clear the flag the ctor may
+                        // have inherited from SystemResources.IsSystemResourcesParsing. Propagates to merged dictionaries.
+                        IsThemeDictionary = false;
 
                         // Seal all the styles and templates in this app dictionary
                         SealValues();

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/System/Windows/ResourceDictionaryTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/System/Windows/ResourceDictionaryTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using System.Reflection;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -158,5 +159,20 @@ public class ResourceDictionaryTests
 
         // The default foreground color of textBlock (as in aero2)
         textBlock.Foreground.Should().BeSameAs(Brushes.Black);
+    }
+
+    [WpfFact]
+    public void AddOwner_ClearsInheritedIsThemeDictionaryFlag()
+    {
+        // Simulate a ResourceDictionary whose ctor inherited
+        // IsThemeDictionary from SystemResources.IsSystemResourcesParsing.
+        PropertyInfo isThemeDictionary = typeof(ResourceDictionary).GetProperty(
+            "IsThemeDictionary", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var rd = new ResourceDictionary();
+        isThemeDictionary.SetValue(rd, true);
+
+        _ = new Button { Resources = rd };
+
+        isThemeDictionary.GetValue(rd).Should().Be(false);
     }
 }


### PR DESCRIPTION
Fixes #11714 

## Description

Application.Resources (and Window/FrameworkElement.Resources) could be incorrectly marked as a theme dictionary, after which any dictionary merged into it inherited the same flag. This led to wrong resources being cached in `SystemResources` and, in some cases, a `NullReferenceException` in `StyleHelper.GetInstanceValue()` when a misclassified style was applied to a container.

Root cause: the `ResourceDictionary` constructor inherits `IsThemeDictionary` from the ambient `SystemResources.IsSystemResourcesParsing` flag. The Resources property getters lazily construct their dictionary on first access, so if that first access happens while system resources are being parsed, the dictionary is permanently flagged as a theme dictionary.

Fix: in `ResourceDictionary.AddOwner`, clear I`sThemeDictionary` when the owner is an Application, FrameworkElement, or FrameworkContentElement. The getters call `AddOwner` immediately after construction, so the flag is corrected before it can be observed or propagated. The `IsThemeDictionary` setter already propagates the cleared value to merged dictionaries.

## Customer Impact

Applications can crash with a `NullReferenceException` during normal UI operations (e.g. adding items to an `ItemsControl`) whenever the application/window resource dictionary happens to be created while system resources are being parsed. The failure is timing-dependent and hard to diagnose, and there is no reliable workaround.

## Regression

Yes, it is regressed in .NET 9. The constructor heuristic and the lazy getters are unchanged from previous releases, but the .NET 9 Fluent theming feature (ThemeMode /  ThemeManager) introduced new reads of the public `Application.Current.Resources` / `Window.Resources` getters from within resource-change/theme-sync handling. These getters can now run while system resources are parsing and lazily create the dictionary at the wrong moment, exposing the latent misclassification. It does not reproduce on .NET 8.

## Testing

Tested against the issue's minimal repro. The debug assertion that Application.Resources had become a theme dictionary no longer fires, and the button click no longer throws.

## Risk

Low. The change is a single, narrowly scoped assignment at the point an Application / FrameworkElement / FrameworkContentElement becomes an owner. For the common case the flag is already false, so the setter's change-guard makes it a no-op with negligible overhead. Genuine theme/generic dictionaries are unaffected because they never receive these owner types. The setter's existing propagation to merged dictionaries keeps state consistent.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11727)