### PR TITLE
Delete dead item group

### DIFF
--- a/src/Microsoft.DotNet.Wpf/tests/IntegrationTests/MultiTargeting.props
+++ b/src/Microsoft.DotNet.Wpf/tests/IntegrationTests/MultiTargeting.props
@@ -7,12 +7,4 @@
     <PackageReference Include="System.Reflection.Emit" Version="$(SystemReflectionEmitPackageVersion)" />
   </ItemGroup>
 
-  <!--
-       When IsUnitTestProject is set by Arcade, these ProjectReferences are implicitly included. Many of our
-       tests don't require xUnit. So a non-unit test that does require xUnit has to set the IsXUnitProject property
-       to true.
-  -->
-  <ItemGroup Condition="'$(IsUnitTestProject)'!='true' and '$(IsXUnitProject)'=='true'">
-    <PackageReference Include="xunit.v3" Version="$(XUnitV3Version)" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
`IsXUnitProject` isn't set anywhere in this repo. So the condition is always false today. Everything is handled correctly and automatically by Arcade.