### PR TITLE
Fix NaN regression in double parameter validation

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Media;
@@ -460,12 +460,19 @@ namespace MS.Internal.TextFormatting
 
             double realMaxFontRenderingEmSize = Constants.RealInfiniteWidth / Constants.GreatestMutiplierOfEm;
 
-            ArgumentOutOfRangeException.ThrowIfNegative(paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize, "paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize");
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize, realMaxFontRenderingEmSize, "paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize");
+            if (    paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize < 0
+                ||  paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize > realMaxFontRenderingEmSize)
+            {
+                throw new ArgumentOutOfRangeException("paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize", SR.Format(SR.ParameterMustBeBetween, 0, realMaxFontRenderingEmSize));
+            }
+
             ArgumentOutOfRangeException.ThrowIfGreaterThan(paragraphProperties.Indent, Constants.RealInfiniteWidth, "paragraphProperties.Indent");
             ArgumentOutOfRangeException.ThrowIfGreaterThan(paragraphProperties.LineHeight, Constants.RealInfiniteWidth, "paragraphProperties.LineHeight");
-            ArgumentOutOfRangeException.ThrowIfNegative(paragraphProperties.DefaultIncrementalTab, "paragraphProperties.DefaultIncrementalTab");
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(paragraphProperties.DefaultIncrementalTab, Constants.RealInfiniteWidth, "paragraphProperties.DefaultIncrementalTab");
+            if (   paragraphProperties.DefaultIncrementalTab < 0
+                || paragraphProperties.DefaultIncrementalTab > Constants.RealInfiniteWidth)
+            {
+                throw new ArgumentOutOfRangeException("paragraphProperties.DefaultIncrementalTab", SR.Format(SR.ParameterMustBeBetween, 0, Constants.RealInfiniteWidth));
+            }
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1816,6 +1816,15 @@
   <data name="PaginatorNegativePageNumber" xml:space="preserve">
     <value>Page number cannot be negative.</value>
   </data>
+  <data name="ParameterCannotBeNegative" xml:space="preserve">
+    <value>Parameter must be greater than or equal to zero.</value>
+  </data>
+  <data name="ParameterMustBeBetween" xml:space="preserve">
+    <value>The parameter value must be between '{0}' and '{1}'.</value>
+  </data>
+  <data name="ParameterMustBeGreaterThanZero" xml:space="preserve">
+    <value>The parameter value must be greater than zero.</value>
+  </data>
   <data name="Parsers_IllegalToken" xml:space="preserve">
     <value>Token is not valid.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">Číslo stránky nemůže být záporné.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Nalezena nesprávná forma {0} při analýze řetězce {1}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">Die Seitenzahl kann nicht negativ sein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Beim Analysieren der Zeichenfolge "{1}" wurde die ungültige Form "{0}" gefunden.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">El número de página no puede ser negativo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Se encontró un formato incorrecto "{0}" al analizar la cadena "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">Le numéro de page ne peut pas être négatif.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Forme '{0}' incorrecte trouvée durant l'analyse de la chaîne '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">Il numero di pagina non può essere negativo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">È stato trovato un formato non corretto '{0}' durante l'analisi della stringa '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">ページ番号は負の数にできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' 文字列の解析中に無効なフォーム '{0}' が見つかりました。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">페이지 번호는 음수일 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' 문자열을 구문 분석하는 동안 잘못된 '{0}' 형식이 검색되었습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">Numer strony nie może być ujemny.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Znaleziono nieprawidłową formę „{0}” podczas analizy ciągu „{1}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">O número da página não pode ser negativo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Forma incorreta de '{0}' encontrada na análise da cadeia de caracteres '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">Номер страницы не может быть отрицательным.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">При синтаксическом анализе строки "{1}" обнаружена неправильная форма "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">Sayfa numarası negatif olamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' dizesi ayrıştırılırken yanlış '{0}' biçimi bulundu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">页码不能为负数。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">解析“{1}”字符串时发现格式“{0}”错误。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -2517,6 +2517,21 @@
         <target state="translated">頁碼不能為負數。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParameterCannotBeNegative">
+        <source>Parameter must be greater than or equal to zero.</source>
+        <target state="new">Parameter must be greater than or equal to zero.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeBetween">
+        <source>The parameter value must be between '{0}' and '{1}'.</source>
+        <target state="new">The parameter value must be between '{0}' and '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParameterMustBeGreaterThanZero">
+        <source>The parameter value must be greater than zero.</source>
+        <target state="new">The parameter value must be greater than zero.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">剖析 '{1}' 字串時發現不正確的格式 '{0}'。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
@@ -55,8 +55,15 @@ namespace System.Windows.Interop
         public D3DImage(double dpiX, double dpiY)
         {
 
-            ArgumentOutOfRangeException.ThrowIfNegative(dpiX);
-            ArgumentOutOfRangeException.ThrowIfNegative(dpiY);
+            if (dpiX < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(dpiX), SR.ParameterMustBeGreaterThanZero);
+            }
+
+            if (dpiY < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(dpiY), SR.ParameterMustBeGreaterThanZero);
+            }
 
             _canWriteEvent = new ManualResetEvent(true);
             _availableCallback = Callback;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
@@ -57,12 +57,12 @@ namespace System.Windows.Interop
 
             if (dpiX < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(dpiX), SR.ParameterMustBeGreaterThanZero);
+                throw new ArgumentOutOfRangeException(nameof(dpiX), SR.ParameterCannotBeNegative);
             }
 
             if (dpiY < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(dpiY), SR.ParameterMustBeGreaterThanZero);
+                throw new ArgumentOutOfRangeException(nameof(dpiY), SR.ParameterCannotBeNegative);
             }
 
             _canWriteEvent = new ManualResetEvent(true);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
@@ -270,7 +270,9 @@ namespace System.Windows.Media
 
         private static void ValidateFontSize(double emSize)
         {
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(emSize);
+            if (emSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(emSize), SR.ParameterMustBeGreaterThanZero);
+
             ArgumentOutOfRangeException.ThrowIfGreaterThan(emSize, MaxFontEmSize);
             ArgumentOutOfRangeException.ThrowIfEqual(emSize, double.NaN);
         }
@@ -1223,7 +1225,8 @@ namespace System.Windows.Media
         {
             set
             {
-                ArgumentOutOfRangeException.ThrowIfNegative(value);
+                if (value < 0)
+                    throw new ArgumentOutOfRangeException(nameof(value), SR.ParameterCannotBeNegative);
 
                 _defaultParaProps.SetLineHeight(value);
                 InvalidateMetrics();
@@ -1246,7 +1249,8 @@ namespace System.Windows.Media
         {
             set
             {
-                ArgumentOutOfRangeException.ThrowIfNegative(value);
+                if (value < 0)
+                    throw new ArgumentOutOfRangeException(nameof(value), SR.ParameterCannotBeNegative);
                 _maxTextWidth = value;
                 InvalidateMetrics();
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextCharacters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextCharacters.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -19,7 +19,7 @@ namespace System.Windows.Media.TextFormatting
 {
     /// <summary>
     /// A specialized TextSymbols implemented by TextFormatter to produces 
-    /// a collection of TextCharacterShape � each represents a collection of 
+    /// a collection of TextCharacterShape – each represents a collection of 
     /// character glyphs from distinct physical typeface.
     /// </summary>
     public class TextCharacters : TextRun, ITextSymbols, IShapeableTextCollector
@@ -119,7 +119,10 @@ namespace System.Windows.Media.TextFormatting
                 throw new ArgumentNullException("textRunProperties.CultureInfo");
             }
 
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(textRunProperties.FontRenderingEmSize, "textRunProperties.FontRenderingEmSize");
+            if (textRunProperties.FontRenderingEmSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException("textRunProperties.FontRenderingEmSize", SR.ParameterMustBeGreaterThanZero);
+            }
 
             _characterBufferReference = characterBufferReference;
             _length = length;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Interop/D3DImage.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Interop/D3DImage.Tests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Interop;
+
+public sealed class D3DImageTests
+{
+    [Fact]
+    public void Constructor_NaN_Dpi_DoesNotThrow()
+    {
+        // NaN DPI should not throw - it passes through the "< 0" check
+        // because NaN < 0 is false per IEEE 754.
+        _ = new D3DImage(double.NaN, double.NaN);
+    }
+
+    [Fact]
+    public void Constructor_NegativeDpiX_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new D3DImage(-1.0, 96.0));
+    }
+
+    [Fact]
+    public void Constructor_NegativeDpiY_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new D3DImage(96.0, -1.0));
+    }
+
+    [Fact]
+    public void Constructor_ValidDpi_DoesNotThrow()
+    {
+        _ = new D3DImage(96.0, 96.0);
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/FormattedText.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/FormattedText.Tests.cs
@@ -16,7 +16,7 @@ public sealed class FormattedTextTests
             new Typeface("Arial"),
             12.0,
             System.Windows.Media.Brushes.Black,
-            96.0);
+            1.0);
     }
 
     [Fact]

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/FormattedText.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/FormattedText.Tests.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+
+namespace System.Windows.Media;
+
+public sealed class FormattedTextTests
+{
+    private static FormattedText CreateFormattedText(string text = "Test")
+    {
+        return new FormattedText(
+            text,
+            CultureInfo.InvariantCulture,
+            FlowDirection.LeftToRight,
+            new Typeface("Arial"),
+            12.0,
+            System.Windows.Media.Brushes.Black,
+            96.0);
+    }
+
+    [Fact]
+    public void LineHeight_SetNaN_DoesNotThrow()
+    {
+        FormattedText ft = CreateFormattedText();
+
+        ft.LineHeight = double.NaN;
+    }
+
+    [Fact]
+    public void LineHeight_SetNegative_ThrowsArgumentOutOfRangeException()
+    {
+        FormattedText ft = CreateFormattedText();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ft.LineHeight = -1.0);
+    }
+
+    [Fact]
+    public void LineHeight_SetZero_DoesNotThrow()
+    {
+        FormattedText ft = CreateFormattedText();
+
+        ft.LineHeight = 0.0;
+    }
+
+    [Fact]
+    public void MaxTextWidth_SetNaN_DoesNotThrow()
+    {
+        FormattedText ft = CreateFormattedText();
+
+        ft.MaxTextWidth = double.NaN;
+    }
+
+    [Fact]
+    public void MaxTextWidth_SetNegative_ThrowsArgumentOutOfRangeException()
+    {
+        FormattedText ft = CreateFormattedText();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ft.MaxTextWidth = -1.0);
+    }
+
+    [Fact]
+    public void MaxTextWidth_SetZero_DoesNotThrow()
+    {
+        FormattedText ft = CreateFormattedText();
+
+        ft.MaxTextWidth = 0.0;
+    }
+}


### PR DESCRIPTION
Fixes #11317 

## Description

Reverts `ArgumentOutOfRangeException.ThrowIfNegative`/`ThrowIfNegativeOrZero` usage on `double` parameters introduced in PR #8408. The `ThrowIfNegative` helper internally uses `double.IsNegative()` which returns `true` for `NaN` (because `NaN` has the sign bit set), while the original `value < 0` check returns `false` per IEEE 754 semantics. This caused properties like `FormattedText.LineHeight` to reject `NaN` values that were previously valid (e.g., the default `TextBox.LineHeight` is `NaN`).
 
Affected files:
- `FormattedText.cs` - `ValidateFontSize`, `LineHeight` setter, `MaxTextWidth` setter
- `D3DImage.cs` - `dpiX`, `dpiY` constructor parameters
- `TextFormatterImp.cs` - `FontRenderingEmSize`, `DefaultIncrementalTab` validation
 
Also restores removed resource strings (`ParameterCannotBeNegative`, `ParameterMustBeBetween`, `ParameterMustBeGreaterThanZero`) and their xlf translation entries.

## Customer Impact

Applications that pass `NaN` to double properties (most commonly `FormattedText.LineHeight = textBox.LineHeight` where the default is `NaN`) now throw `ArgumentOutOfRangeException` unexpectedly. This breaks existing code that worked in .NET Framework and up to .NET 8.

## Regression

Yes. This is a regression introduced in .NET 9 by PR #8408. The behavior worked correctly in .NET Framework and all versions through .NET 8.

## Testing
 
Added unit tests in PresentationCore.Tests covering the NaN regression:
- `FormattedTextTests`: Verifies `LineHeight` and `MaxTextWidth` accept `double.NaN` and `0.0` without throwing, while negative values still throw `ArgumentOutOfRangeException`.
- `D3DImageTests`: Verifies constructor accepts `double.NaN` for DPI parameters without throwing, while negative values still throw `ArgumentOutOfRangeException`.

## Risk

Low. This is a targeted revert of the specific `ThrowIfNegative` calls on `double` parameters back to the original manual comparison pattern. Integer-parameter usages of `ThrowIfNegative` (which have no `NaN` concern) are left unchanged. The fix restores the exact validation semantics from .NET 8 and earlier.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11731)