### PR TITLE
Implement CA1036: Add missing comparison operators to IComparable<T> types

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Shaping/OpenTypeLayoutCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Shaping/OpenTypeLayoutCache.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -1126,6 +1126,25 @@ namespace MS.Internal.Shaping
             public static bool operator !=(GlyphLookupRecord value1, GlyphLookupRecord value2)
             {
                 return !value1.Equals(value2);
+            }
+            public static bool operator <(GlyphLookupRecord left, GlyphLookupRecord right)
+            {
+                return left.CompareTo(right) < 0;
+            }
+
+            public static bool operator >(GlyphLookupRecord left, GlyphLookupRecord right)
+            {
+                return left.CompareTo(right) > 0;
+            }
+
+            public static bool operator <=(GlyphLookupRecord left, GlyphLookupRecord right)
+            {
+                return left.CompareTo(right) <= 0;
+            }
+
+            public static bool operator >=(GlyphLookupRecord left, GlyphLookupRecord right)
+            {
+                return left.CompareTo(right) >= 0;
             }
             public override bool Equals(object value)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextStore.cs
@@ -590,6 +590,51 @@ namespace MS.Internal.TextFormatting
                 // Starting edge is always in front.
                 return IsStart ? -1 : 1;
             }
+
+            public bool Equals(TextEffectBoundary other)
+            {
+                return _position == other._position && _isStart == other._isStart;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is TextEffectBoundary other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(_position, _isStart);
+            }
+
+            public static bool operator ==(TextEffectBoundary left, TextEffectBoundary right)
+            {
+                return left.Equals(right);
+            }
+
+            public static bool operator !=(TextEffectBoundary left, TextEffectBoundary right)
+            {
+                return !left.Equals(right);
+            }
+
+            public static bool operator <(TextEffectBoundary left, TextEffectBoundary right)
+            {
+                return left.CompareTo(right) < 0;
+            }
+
+            public static bool operator >(TextEffectBoundary left, TextEffectBoundary right)
+            {
+                return left.CompareTo(right) > 0;
+            }
+
+            public static bool operator <=(TextEffectBoundary left, TextEffectBoundary right)
+            {
+                return left.CompareTo(right) <= 0;
+            }
+
+            public static bool operator >=(TextEffectBoundary left, TextEffectBoundary right)
+            {
+                return left.CompareTo(right) >= 0;
+            }
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
@@ -358,9 +358,54 @@ namespace MS.Internal.IO.Packaging
             {
                 return Compare(otherPartUri) == 0;
             }
-             
-            #endregion IEqualityComparer Methods
 
+            #endregion IEqualityComparer Methods
+            public override bool Equals(object obj)
+            {
+                return obj is ValidatedPartUri other && Compare(other) == 0;
+            }
+
+            public override int GetHashCode()
+            {
+                return NormalizedPartUriString.GetHashCode();
+            }
+
+            public static bool operator ==(ValidatedPartUri left, ValidatedPartUri right)
+            {
+                if (left is null)
+                    return right is null;
+                return left.Equals(right);
+            }
+
+            public static bool operator !=(ValidatedPartUri left, ValidatedPartUri right) => !(left == right);
+
+            public static bool operator <(ValidatedPartUri left, ValidatedPartUri right)
+            {
+                if (left is null)
+                    return right is not null;
+                return left.Compare(right) < 0; 
+            }
+
+            public static bool operator >(ValidatedPartUri left, ValidatedPartUri right)
+            {
+                if (left is null)
+                    return false;
+                return left.Compare(right) > 0;
+            }
+
+            public static bool operator <=(ValidatedPartUri left, ValidatedPartUri right)
+            {
+                if (left is null)
+                    return true;
+                return left.Compare(right) <= 0;
+            }
+
+            public static bool operator >=(ValidatedPartUri left, ValidatedPartUri right)
+            {
+                if (left is null)
+                    return right is null;
+                return left.Compare(right) >= 0;
+            }
             #region Internal Properties
 
             //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/SparseMemoryStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/SparseMemoryStream.cs
@@ -872,8 +872,7 @@ namespace MS.Internal.IO.Packaging
                 }
             }
         }
-
-        int IComparable<MemoryStreamBlock>.CompareTo(MemoryStreamBlock other)
+        private int Compare(MemoryStreamBlock other)
         {
             if (other == null)
                 return 1;
@@ -895,7 +894,71 @@ namespace MS.Internal.IO.Packaging
                     return -1;
             }
         }
+        int IComparable<MemoryStreamBlock>.CompareTo(MemoryStreamBlock other)
+        {
+            return Compare(other);
+        }
+        public bool Equals(MemoryStreamBlock other)
+        {
+            if (other == null)
+                return false;
 
+            if (_offset == other.Offset)
+                return true;
+            if (_offset >= other.Offset && _offset < other.EndOffset)
+                return true;
+            if (other.Offset >= _offset && other.Offset < EndOffset)
+                return true;
+
+            return false;
+        }
+        public override bool Equals(object obj)
+        {
+            return obj is MemoryStreamBlock other && Equals(other);
+        }
+        public override int GetHashCode()
+        {
+            return _offset.GetHashCode();
+        }
+        public static bool operator ==(MemoryStreamBlock left, MemoryStreamBlock right)
+        {
+            if (left is null)
+                return right is null;
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(MemoryStreamBlock left, MemoryStreamBlock right)
+        {
+            return !(left == right);
+        }
+
+        public static bool operator <(MemoryStreamBlock left, MemoryStreamBlock right)
+        {
+            if (left is null)
+                return right is not null;
+            return left.Compare(right) < 0;
+        }
+
+        public static bool operator >(MemoryStreamBlock left, MemoryStreamBlock right)
+        {
+            if (left is null)
+                return false;
+            return left.Compare(right) > 0;
+        }
+
+        public static bool operator <=(MemoryStreamBlock left, MemoryStreamBlock right)
+        {
+            if (left is null)
+                return true;
+            return left.Compare(right) <= 0;
+        }
+
+        public static bool operator >=(MemoryStreamBlock left, MemoryStreamBlock right)
+        {
+            if (left is null)
+                return right is null;
+            return left.Compare(right) >= 0;
+        }
         private MemoryStream _stream;
         private long _offset;
     }


### PR DESCRIPTION
This PR addresses issue #10271 by implementing CA1036 (Override methods on comparable types) for the following types:

- **GlyphLookupRecord**: Added `<`, `>`, `<=`, `>=` operators
- **TextEffectBoundary**: Added , `Equals`, `GetHashCode`, and comparison operators
- **ValidatedPartUri**: Added `Equals`, `GetHashCode`, and comparison operators
- **MemoryStreamBlock**: Added , `Equals`, `GetHashCode`, and comparison operators

All implementations follow the CA1036 rule requirements:
- Provide `Equals(object)` and `GetHashCode()`
- Provide `==`, `!=`, `<`, `>`, `<=`, `>=` operators

Fixes #10271

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11733)