### PR TITLE
Fix Popup/ContextMenu flicker caused by repositioning a fading out root

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
@@ -1517,7 +1517,10 @@ namespace System.Windows.Controls.Primitives
             // This ensures that a recycled HWND that is moving from one display
             // to another does not undergo a WM_DPICHANGED event and thus cause a
             // cascading failure.
-            if (PopupInitialPlacementHelper.IsPerMonitorDpiScalingActive)
+            // Also create a new window if the popup animation is set to Fade,
+            // otherwise reusing the same window will interrupt the fade-out animation,
+            // causing together with the call to SetWindowPos a brief flicker instead of smooth fade-in.
+            if (PopupInitialPlacementHelper.IsPerMonitorDpiScalingActive || PopupAnimation is PopupAnimation.Fade)
             {
                 DestroyWindowImpl();
                 _positionInfo = null;


### PR DESCRIPTION
Fixes #11741 

## Description

When you have an app without PMA enabled (still common nowadays) and define a `ContextMenu` that uses `Fade` animation (the system default), upon attempting to reopen the `ContextMenu` at a different location in succession, you will observe flicker upon repositioning. This has been issue since early NETFX days, difference being that nowadays a PMA-enabled app will not observe it anymore as the window is not reused but a new one is always created due to other issues within WPF but also DWM.

This is caused by the fact that the window is reused and interrupted midst an ongoing fade-out animation, together with a call to `SetWindowPos` causing a repositioning, resulting in an ugly flicker. 

There are two ways to fix this:
- Disable **fade out** animation, which would be in-line with how Win32 (native) controls handle it, a context menu e.g. on Windows 10 only has a fade-in animation, not a fade out one, same case for pure menu strips.
   - However this introduces a visual change to the WPF ecosystem, and affects other derived controls such as `Menu` for no reason, potentially breaking user expectations.
 - Unconditionally use a new window even when not having a PMA-enabled app when using `Fade` animation.
    - This should be without side-effects, it has worked great on our apps for years.

## Customer Impact

Customers will finally get their fix after 15 years / won't need to disable animations.

https://github.com/syncfusion/wpf-demos/issues/23 (see video if you don't know what its about)
https://www.reddit.com/r/csharp/comments/1l8mb9o/wpf_contextmenu_flickering_issue/
https://stackoverflow.com/questions/13553456/contextmenu-of-tabcontrol-blinks-when-opened-a-second-time

## Regression

No, this has been issue pretty much since the dark days.

## Testing

Few years of user-facing commercial apps.

## Risk

Shouldn't cause any issues, this is a path that's hit regularly with PMA-enabled apps already.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11735)