### PR TITLE
Filter re-resolved analyzers from the WPF temporary project

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -516,8 +516,7 @@
         Condition: _WpfTempProjectIncludesPackageReferences == true
   -->
   <Target Name="FilterTemporaryAssemblyAnalyzers"
-          AfterTargets="RemoveDuplicateAnalyzers"
-          BeforeTargets="CoreCompile"
+          BeforeTargets="RemoveDuplicateAnalyzers;CoreCompile"
           Condition="'$(_WpfTempProjectIncludesPackageReferences)' == 'true'">
     <ItemGroup>
         <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.WpfTempProjectAnalyzers)' != 'true'" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -503,6 +503,27 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    ================================================================
+                                   FilterTemporaryAssemblyAnalyzers
+    ================================================================
+
+        Name : FilterTemporaryAssemblyAnalyzers
+
+        This target runs only inside the temporary project, where it drops analyzers re-resolved on their own
+         (those lacking the parent's WpfTempProjectAnalyzers marker), keeping only the set flowed from the parent.
+
+        Condition: _WpfTempProjectIncludesPackageReferences == true
+  -->
+  <Target Name="FilterTemporaryAssemblyAnalyzers"
+          AfterTargets="RemoveDuplicateAnalyzers"
+          BeforeTargets="CoreCompile"
+          Condition="'$(_WpfTempProjectIncludesPackageReferences)' == 'true'">
+    <ItemGroup>
+        <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.WpfTempProjectAnalyzers)' != 'true'" />
+    </ItemGroup>
+  </Target>
+
 <!--
     ================================================================
                                    SatelliteOnlyMarkupCompilePass2

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Build.Tasks.Windows
                 AddNewItems(xmlProjectDoc, CompileTypeName, GeneratedCodeFiles);
 
                 // Add Analyzers to Analyzer item list.
-                AddNewItems(xmlProjectDoc, AnalyzerTypeName, Analyzers);
+                AddNewItems(xmlProjectDoc, AnalyzerTypeName, Analyzers, true);
 
                 // Replace implicit SDK imports with explicit SDK imports
                 ReplaceImplicitImports(xmlProjectDoc);
@@ -275,6 +275,7 @@ namespace Microsoft.Build.Tasks.Windows
                     ( nameof(BaseIntermediateOutputPath), BaseIntermediateOutputPath ),
                     ( nameof(MSBuildProjectExtensionsPath), MSBuildProjectExtensionsPath ),
                     ( "_TargetAssemblyProjectName", Path.GetFileNameWithoutExtension(CurrentProject) ),
+                    ( "_WpfTempProjectIncludesPackageReferences", "true" ),
                     ( nameof(RootNamespace), RootNamespace ),
                 };
 
@@ -694,7 +695,7 @@ namespace Microsoft.Build.Tasks.Windows
         //
         // Add a list of files into an Item in the project file, the ItemName is specified by sItemName.
         //
-        private void AddNewItems(XmlDocument xmlProjectDoc, string sItemName, ITaskItem[] pItemList)
+        private void AddNewItems(XmlDocument xmlProjectDoc, string sItemName, ITaskItem[] pItemList, bool tagWpfTempProjectAnalyzers = false)
         {
             if (xmlProjectDoc == null || String.IsNullOrEmpty(sItemName) || pItemList == null)
             {
@@ -742,6 +743,13 @@ namespace Microsoft.Build.Tasks.Windows
                     embedItem = xmlProjectDoc.CreateElement(ALIASES, root.NamespaceURI);
                     embedItem.InnerText = aliases;
                     nodeItem.AppendChild(embedItem);
+                }
+
+                if (tagWpfTempProjectAnalyzers)
+                {
+                    XmlElement metadataItem = xmlProjectDoc.CreateElement(WPFTEMPPROJECTANALYZERS, root.NamespaceURI);
+                    metadataItem.InnerText = "true";
+                    nodeItem.AppendChild(metadataItem);
                 }
 
                 // Add current item node into the children list of ItemGroup
@@ -935,6 +943,8 @@ namespace Microsoft.Build.Tasks.Windows
         private const string INCLUDE_ATTR_NAME = "Include";
 
         private const string WPFTMP = "wpftmp";
+
+        private const string WPFTEMPPROJECTANALYZERS = "WpfTempProjectAnalyzers";
 
         private static readonly char[] s_semicolonChar = [';'];
 


### PR DESCRIPTION
Fixes #9660 

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description
When a XAML file references a locally defined type, `GenerateTemporaryTargetAssembly` generates and builds a temporary `*_wpftmp` project to resolve those types. That temporary project re-runs analyzer resolution (`ResolveLockFileAnalyzers`) and re-adds analyzers from NuGet packages, without importing those packages' build targets that would normally remove them. In the Visual Studio in-process build, this reintroduces the `Microsoft.Extensions.Configuration.Binder` source generator - which requires C#12 - into the temporary compilation, failing it with `SYSLIB1102`.

This change tags every analyzer flowed from the parent project with `WpfTempProjectAnalyzers` metadata and sets a `_WpfTempProjectIncludesPackageReferences` marker property on the temporary project. A new `FilterTemporaryAssemblyAnalyzers` target (running only inside that temporary project, after `RemoveDuplicateAnalyzers` and before `CoreCompile`) then removes any analyzer lacking the marker, restoring the authoritative analyzer set the parent project already resolved.

## Customer Impact
WPF customers cannot publish (or, in some cases, build) self-contained apps from Visual Studio when they reference `Microsoft.Extensions.Configuration.Binder` (8.0.x) and use config binding such as `config.Get<T>()`. Publish fails with a generic "Publish has encountered an error" backed by `SYSLIB1102`. There is no straightforward workaround other than avoiding the package or forcing `LangVersion`, both undesirable.

## Regression
Yes - this regressed for customers when the `Microsoft.Extensions.Configuration.Binder` package introduced its C#12 source generator (.NET 8 timeframe), combined with the Visual Studio 17.10 in-process build pipeline. It does not reproduce via `dotnet build / publish` from the command line, only through the Visual Studio in-process Publish path.

## Testing
- Reproduced the original failure: a WPF app referencing `Microsoft.Extensions.Configuration.Binder` 8.0.2 with a local type referenced in XAML, published self-contained from Visual Studio 17.10 (SDK 8.0.401) - failed with `SYSLIB1102` in the `*_wpftmp` compilation.
- Built `PresentationBuildTasks` from the corresponding release branch with this fix, staged it plus the updated targets into the local SDK, and re-ran the same Visual Studio Publish - succeeds, `SYSLIB1102` is gone.
- The new target is gated on `_WpfTempProjectIncludesPackageReferences`, which is set only in the package-reference temporary-build path, so normal (non-temp) builds and the legacy markup-compilation path are unaffected.

## Risk
Low. The behavior change is scoped tightly:
- The filtering target only runs inside the generated temporary project (guarded by the new `_WpfTempProjectIncludesPackageReferences` property), so it cannot affect normal builds or the legacy path.
- It only removes analyzers that lack the parent-applied marker - i.e., duplicates the temporary project re-resolved on its own. All analyzers the parent project legitimately resolved are preserved, so it does not silently disable analyzers/generators a customer relies on.
- The metadata-stamping is additive and inert outside the new target. The change is small (33 added / 2 removed lines across two files).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11739)