### PR TITLE
Change MS.Internal.Span (ItemSpan.h) to value struct to reduce text related internal allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/ItemSpan.h
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/ItemSpan.h
@@ -8,7 +8,7 @@
 #include "Common.h"
 namespace MS { namespace Internal
 {
-    private ref struct Span sealed
+    private value struct Span
     {
         /// <summary>
         /// Constructor
@@ -20,12 +20,12 @@ namespace MS { namespace Internal
         /// <summary>
         /// Span element
         /// </summary>
-        Object^  element;
+        initonly Object^  element;
 
         /// <summary>
         /// Span length
         /// </summary>
-        int      length;
+        initonly int      length;
     };
 }}//MS::Internal
 #endif //_ITEM_SPAN_H

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextAnalyzer.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextAnalyzer.cpp
@@ -16,7 +16,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
         _textAnalyzer = gcnew NativeIUnknownWrapper<IDWriteTextAnalyzer>(textAnalyzer);
     }
 
-    IList<Span^>^ TextAnalyzer::Itemize(
+    IList<Span>^ TextAnalyzer::Itemize(
         __in_ecount(length) const WCHAR* text,
         UINT32                           length,
         CultureInfo^                     culture,
@@ -46,7 +46,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
             try
             {
                 hr = pDWriteFactory->CreateTextAnalyzer(&pTextAnalyzer);
-                ConvertHresultToException(hr, "List<Span^>^ TextAnalyzer::Itemize");
+                ConvertHresultToException(hr, "List<Span>^ TextAnalyzer::Itemize");
                 
                 pin_ptr<const WCHAR> pNumberSubstitutionLocaleNamePinned;
 
@@ -73,7 +73,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
                                                                       ignoreUserOverride,
                                                                       numberSubstitutionMethod,
                                                                       (void**)&pTextAnalysisSource));
-                ConvertHresultToException(hr, "List<Span^>^ TextAnalyzer::Itemize");
+                ConvertHresultToException(hr, "List<Span>^ TextAnalyzer::Itemize");
 
             
                 pTextAnalysisSink = (IDWriteTextAnalysisSink*)pfnCreateTextAnalysisSink();
@@ -83,14 +83,14 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
                                                  0,
                                                  length,
                                                  pTextAnalysisSink);
-                ConvertHresultToException(hr, "List<Span^>^ TextAnalyzer::Itemize");
+                ConvertHresultToException(hr, "List<Span>^ TextAnalyzer::Itemize");
 
                 // Analyze the number substitution ranges.
                 hr = pTextAnalyzer->AnalyzeNumberSubstitution(pTextAnalysisSource,
                                                             0,
                                                             length,
                                                             pTextAnalysisSink);
-                ConvertHresultToException(hr, "List<Span^>^ TextAnalyzer::Itemize");
+                ConvertHresultToException(hr, "List<Span>^ TextAnalyzer::Itemize");
 
                 DWriteTextAnalysisNode<DWRITE_SCRIPT_ANALYSIS>*     dwriteScriptAnalysisNode     = (DWriteTextAnalysisNode<DWRITE_SCRIPT_ANALYSIS>*)pfnGetScriptAnalysisList((void*)pTextAnalysisSink);
                 DWriteTextAnalysisNode<IDWriteNumberSubstitution*>* dwriteNumberSubstitutionNode = (DWriteTextAnalysisNode<IDWriteNumberSubstitution*>*)pfnGetNumberSubstitutionList((void*)pTextAnalysisSink);
@@ -114,7 +114,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
 
     }
 
-    IList<Span^>^ TextAnalyzer::AnalyzeExtendedAndItemize(
+    IList<Span>^ TextAnalyzer::AnalyzeExtendedAndItemize(
         TextItemizer^ textItemizer, 
         __in_ecount(length) const WCHAR *text, 
         UINT32 length, 

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextAnalyzer.h
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextAnalyzer.h
@@ -120,7 +120,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
                 }
             }
 
-            static IList<Span^>^ AnalyzeExtendedAndItemize(
+            static IList<Span>^ AnalyzeExtendedAndItemize(
                 TextItemizer^ textItemizer, 
                 __in_ecount(length) const WCHAR *text, 
                 UINT32 length, 
@@ -147,7 +147,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
                 IDWriteTextAnalyzer* textAnalyzer
                 );
 
-            static IList<Span^>^ Itemize(
+            static IList<Span>^ Itemize(
                 __in_ecount(length) const WCHAR* text,
                 UINT32                     length,
                 CultureInfo^               culture,

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextItemizer.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextItemizer.cpp
@@ -58,7 +58,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
 
     }
 
-    __declspec(noinline) IList<Span^>^ TextItemizer::Itemize(CultureInfo^ numberCulture, __in_ecount(textLength) CharAttributeType* pCharAttribute, UINT32 textLength)
+    __declspec(noinline) IList<Span>^ TextItemizer::Itemize(CultureInfo^ numberCulture, __in_ecount(textLength) CharAttributeType* pCharAttribute, UINT32 textLength)
     {
         DWriteTextAnalysisNode<DWRITE_SCRIPT_ANALYSIS>*     pScriptAnalysisListPrevious     = _pScriptAnalysisListHead;
         DWriteTextAnalysisNode<DWRITE_SCRIPT_ANALYSIS>*     pScriptAnalysisListCurrent      = _pScriptAnalysisListHead;
@@ -79,7 +79,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
                                       &pNumberSubstitutionListCurrent, numberSubstitutionRangeIndex,
                                       isDigitIndex, isDigitRangeIndex);
 
-        List<Span^>^ spanVector = gcnew List<Span^>();
+        List<Span>^ spanVector = gcnew List<Span>();
         while (
             rangeEnd != textLength 
             && (pScriptAnalysisListCurrent != NULL
@@ -193,10 +193,10 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
                     isLatin
                     );
 
-            spanVector->Add(gcnew Span(itemProps, (int)(rangeEnd - rangeStart)));
+            spanVector->Add(Span(itemProps, (int)(rangeEnd - rangeStart)));
         }
 
-        return spanVector;
+            return spanVector;
     }  
 
     void TextItemizer::SetIsDigit(

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextItemizer.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextItemizer.cpp
@@ -196,7 +196,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
             spanVector->Add(Span(itemProps, (int)(rangeEnd - rangeStart)));
         }
 
-            return spanVector;
+        return spanVector;
     }  
 
     void TextItemizer::SetIsDigit(

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextItemizer.h
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextItemizer.h
@@ -66,7 +66,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
             TextItemizer(DWriteTextAnalysisNode<DWRITE_SCRIPT_ANALYSIS>*     pScriptAnalysisListHead,
                          DWriteTextAnalysisNode<IDWriteNumberSubstitution*>* pNumberSubstitutionListHead);
 
-            IList<Span^>^ Itemize(CultureInfo^ numberCulture, __in_ecount(textLength) CharAttributeType* pCharAttribute, UINT32 textLength);
+            IList<Span>^ Itemize(CultureInfo^ numberCulture, __in_ecount(textLength) CharAttributeType* pCharAttribute, UINT32 textLength);
 
             void SetIsDigit(
                 UINT32 textPosition,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Span.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Span.cs
@@ -51,7 +51,7 @@ namespace MS.Internal
         /// <summary>
         /// Add a new span to vector
         /// </summary>
-        private void Add(Span span)
+        private void Add(in Span span)
         {
             _spans.Add(span);
         }
@@ -87,6 +87,13 @@ namespace MS.Internal
         }
 
         #region Public operation
+        /// <summary>
+        //// Place item into the store at index
+        /// </summary>
+        public void SetAt(int index, in Span span)
+        {
+            _spans.SetAt(index, span);
+        }
 
         /// <summary>
         /// Finds the span that contains the specified character position.
@@ -164,7 +171,7 @@ namespace MS.Internal
             // Return true if the span is in range.
             return spanIndex != spanCount;
         }
-        
+
 
         /// <summary>
         /// Set an element as a value to a character range
@@ -226,19 +233,23 @@ namespace MS.Internal
                     Add(new Span(_defaultObject, first - fc));
                 }
 
-                if (   Count > 0 
-                    && equals(_spans[Count-1].element, element))
+                bool addElement = true;
+                if (Count > 0)
                 {
-                    // New Element matches end Element, just extend end Element
-                    _spans[Count - 1].length += length;
-
-                    // Make sure fs and fc still agree
-                    if (fs == Count)
+                    var span = _spans[Count - 1];
+                    if (equals(span.element, element))
                     {
-                        fc += length;
+                        // New Element matches end Element, just extend end Element
+                        _spans[Count - 1] = new(span.element, span.length + length);
+                        addElement = false;
+                        // Make sure fs and fc still agree
+                        if (fs == Count)
+                        {
+                            fc += length;
+                        }
                     }
                 }
-                else
+                if (addElement)
                 {
                     Add(new Span(element, length));
                 }
@@ -314,7 +325,8 @@ namespace MS.Internal
                             if (!Resize(fs + 2))
                                 throw new OutOfMemoryException();
                         }
-                        _spans[fs].length = first - fc;
+                        var oldFsSpan = _spans[fs];
+                        _spans[fs] = new Span(oldFsSpan.element, first - fc);
                         _spans[fs + 1] = new Span(element, length);
                     }
                     else
@@ -370,7 +382,8 @@ namespace MS.Internal
 
                     if (fc < first)
                     {
-                        _spans[fs].length = first - fc;
+                        var oldFsSpan = _spans[fs];
+                        _spans[fs] = new Span(oldFsSpan.element, first - fc);
                         fs++;
                         fc = first;
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Span.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Span.cs
@@ -88,7 +88,7 @@ namespace MS.Internal
 
         #region Public operation
         /// <summary>
-        //// Place item into the store at index
+        /// Place item into the store at index
         /// </summary>
         public void SetAt(int index, in Span span)
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextStore.cs
@@ -1076,7 +1076,8 @@ namespace MS.Internal.TextFormatting
                         if (lsrun.Type == Plsrun.Text && cp + lsrun.Length > cpLimit)
                         {
                             lsrun.Truncate(cpLimit - cp);
-                            span.length = lsrun.Length;
+                            span = new(span.element, lsrun.Length);
+                            _plsrunVector.SetAt(i, span);
                         }
 
                         _lscchUpTo = lscp + lsrun.Length;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
@@ -2223,7 +2223,13 @@ namespace MS.Utility
 
         public void SetAt(int index, T value)
         {
-            _listStore.SetAt(index, value);
+            if ((_listStore is not null) && ((index < _listStore.Count) && (index >= 0)))
+            {
+                _listStore.SetAt(index, value);
+                return;
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         public bool Remove(T value)

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
@@ -2221,6 +2221,11 @@ namespace MS.Utility
             throw new ArgumentOutOfRangeException(nameof(index));
         }
 
+        public void SetAt(int index, T value)
+        {
+            _listStore.SetAt(index, value);
+        }
+
         public bool Remove(T value)
         {
             if ((_listStore is not null) && (_listStore.Count > 0))


### PR DESCRIPTION
For years I have observed `MS.Internal.Span` turn up as top 10 object being allocated in WPF app. Here I suggest to finally address this by turning the very small and simple `Span(object element, int length)` into a value type instead of reference type to reduce GC pressure and total memory use. I do not know how WPF does benchmarks or what metric is used to verify this change. I understand it changes a long standing internal type and hope the work is not seen as futile or irrelevant.

Example object allocation count for a WPF app that continuously updates simple `TextBlock`s with counts or similar. Span is almost always number one in any of our WPF apps. With other WPF allocs top too. Perhaps if this PR is accepted those can be addressed too. 

<img width="1032" height="528" alt="image" src="https://github.com/user-attachments/assets/0d5ee9b1-398c-4b76-8162-e5f342a8c149" />

## Description

Changes internal Span type from reference type to value to reduce text related managed heap allocations and GC pressure. To ensure correctness type also changed to readonly/initonly and minor necessary related code changed related to this.

## Customer Impact

Reduced GC pressure.

## Risk

Minor breaking internal change which may cause unexpected usage or similar.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11747)