### PR TITLE
Add CodeQL comments to clarify trusted input handling in ResourcesGen…

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Build.Tasks.Windows
 
                 strFileName = inputFile.ItemSpec;
 
-                if (!File.Exists(TaskHelper.CreateFullFilePath(strFileName, SourceDir)))
+                if (!File.Exists(TaskHelper.CreateFullFilePath(strFileName, SourceDir))) // CodeQL [SM00414] Trusted build-time input: ItemSpec is developer-authored MSBuild markup, not attacker-controlled
                 {
                     bValid = false;
                     Log.LogErrorWithCodeFromResources(nameof(SR.FileNotFound), strFileName);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/ResourcesGenerator.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Build.Tasks.Windows
 
                 strFileName = inputFile.ItemSpec;
 
-                if (!File.Exists(TaskHelper.CreateFullFilePath(strFileName, SourceDir))) // CodeQL [SM00414] Trusted build-time input: ItemSpec is developer-authored MSBuild markup, not attacker-controlled
+                if (!File.Exists(TaskHelper.CreateFullFilePath(strFileName, SourceDir))) // CodeQL [SM00414] Trusted build-time input, not attacker-controlled
                 {
                     bValid = false;
                     Log.LogErrorWithCodeFromResources(nameof(SR.FileNotFound), strFileName);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -476,7 +476,7 @@ namespace Microsoft.Build.Tasks.Windows
         {
             UidCollector collector = new UidCollector(fileName  );
 
-            using (Stream xamlStream = File.OpenRead(fileName))
+            using (Stream xamlStream = File.OpenRead(fileName)) // CodeQL [SM00414] Trusted build-time input: ItemSpec is developer-authored MSBuild markup, not attacker-controlled
             {
                 XmlNamespaceManager nsmgr = new XmlNamespaceManager(new NameTable());
                 XmlParserContext context  = new XmlParserContext(

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Build.Tasks.Windows
 
                                 using (Stream uidStream = new FileStream(tempFile, FileMode.Create))
                                 {
-                                    using (Stream source = File.OpenRead(inputFile.ItemSpec)) // CodeQL [SM00414] Trusted build-time input: ItemSpec is developer-authored MSBuild markup, not attacker-controlled
+                                    using (Stream source = File.OpenRead(inputFile.ItemSpec)) // CodeQL [SM00414] Trusted build-time input, not attacker-controlled
                                     {
                                         UidWriter writer = new UidWriter(collector, source, uidStream);
                                         writer.UpdateUidWrite();
@@ -297,7 +297,7 @@ namespace Microsoft.Build.Tasks.Windows
 
                                 using (Stream uidStream = new FileStream(tempFile, FileMode.Create))
                                 {
-                                    using (Stream source = File.OpenRead(inputFile.ItemSpec)) // CodeQL [SM00414] Trusted build-time input: ItemSpec is developer-authored MSBuild markup, not attacker-controlled
+                                    using (Stream source = File.OpenRead(inputFile.ItemSpec)) // CodeQL [SM00414] Trusted build-time input, not attacker-controlled
                                     {
                                         UidWriter writer = new UidWriter(collector, source, uidStream);
                                         writer.RemoveUidWrite();
@@ -371,9 +371,9 @@ namespace Microsoft.Build.Tasks.Windows
 
         private void RemoveFile(string fileName)
         {
-            if (File.Exists(fileName)) // CodeQL [SM00414] Trusted build-time input: path derived from developer-authored MSBuild ItemSpec, not attacker-controlled
+            if (File.Exists(fileName)) // CodeQL [SM00414] Trusted build-time path, not attacker-controlled
             {
-                File.Delete(fileName); // CodeQL [SM00414] Trusted build-time input: path derived from developer-authored MSBuild ItemSpec, not attacker-controlled
+                File.Delete(fileName); // CodeQL [SM00414] Trusted build-time path, not attacker-controlled
             }
         }
 
@@ -476,7 +476,7 @@ namespace Microsoft.Build.Tasks.Windows
         {
             UidCollector collector = new UidCollector(fileName  );
 
-            using (Stream xamlStream = File.OpenRead(fileName)) // CodeQL [SM00414] Trusted build-time input: ItemSpec is developer-authored MSBuild markup, not attacker-controlled
+            using (Stream xamlStream = File.OpenRead(fileName)) // CodeQL [SM00414] Trusted build-time input, not attacker-controlled
             {
                 XmlNamespaceManager nsmgr = new XmlNamespaceManager(new NameTable());
                 XmlParserContext context  = new XmlParserContext(

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/UidManager.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Build.Tasks.Windows
 
                                 using (Stream uidStream = new FileStream(tempFile, FileMode.Create))
                                 {
-                                    using (Stream source = File.OpenRead(inputFile.ItemSpec))
+                                    using (Stream source = File.OpenRead(inputFile.ItemSpec)) // CodeQL [SM00414] Trusted build-time input: ItemSpec is developer-authored MSBuild markup, not attacker-controlled
                                     {
                                         UidWriter writer = new UidWriter(collector, source, uidStream);
                                         writer.UpdateUidWrite();
@@ -297,7 +297,7 @@ namespace Microsoft.Build.Tasks.Windows
 
                                 using (Stream uidStream = new FileStream(tempFile, FileMode.Create))
                                 {
-                                    using (Stream source = File.OpenRead(inputFile.ItemSpec))
+                                    using (Stream source = File.OpenRead(inputFile.ItemSpec)) // CodeQL [SM00414] Trusted build-time input: ItemSpec is developer-authored MSBuild markup, not attacker-controlled
                                     {
                                         UidWriter writer = new UidWriter(collector, source, uidStream);
                                         writer.RemoveUidWrite();
@@ -371,9 +371,9 @@ namespace Microsoft.Build.Tasks.Windows
 
         private void RemoveFile(string fileName)
         {
-            if (File.Exists(fileName))
+            if (File.Exists(fileName)) // CodeQL [SM00414] Trusted build-time input: path derived from developer-authored MSBuild ItemSpec, not attacker-controlled
             {
-                File.Delete(fileName);
+                File.Delete(fileName); // CodeQL [SM00414] Trusted build-time input: path derived from developer-authored MSBuild ItemSpec, not attacker-controlled
             }
         }
 


### PR DESCRIPTION
Adds a suppression comment for CodeQL finding SM00414.

After investigation, the reported data flows were determined to be build-time only and originate from trusted MSBuild inputs (ITaskItem.ItemSpec values such as ResourceFiles, OutputResourcesFile, and _markupFiles). These values are supplied by the project file and build items authored by the developer performing the build, not by untrusted external users or runtime application input.

This area can be re-evaluated in the future if these tasks begin accepting untrusted or externally supplied input.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11763)