### PR TITLE
Fix WindowCollection removal and non-materialized window objects hanging Application

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -1591,7 +1591,7 @@ namespace System.Windows
             // in the function that calls us.
 
             // We use a while loop like this because closing a window will modify the windows list.
-            while(WindowsInternal.Count > 0)
+            while (WindowsInternal.Count > 0)
             {
                 if (!WindowsInternal[0].IsDisposed)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -4511,16 +4511,9 @@ namespace System.Windows
                     App.WindowsInternal.Remove(this);
 
                     // Check to see if app should shut down--this behavior really belongs in Application
-                    if (!_appShuttingDown)
+                    if (!_appShuttingDown && ShouldCloseApplication())
                     {
-                        // If this is the last window that's closing and shutdownmode is onlastwindowclose, or
-                        // if this is the main window closing and shutdownmode is onmainwindowclose, shutdown
-                        // the app
-                        if (((App.Windows.Count == 0) && (App.ShutdownMode == ShutdownMode.OnLastWindowClose))
-                         || ((App.MainWindow == this) && (App.ShutdownMode == ShutdownMode.OnMainWindowClose)))
-                        {
-                            App.CriticalShutdown(0);
-                        }
+                        App.CriticalShutdown(0);
                     }
 
                     TryClearingMainWindow();
@@ -4530,7 +4523,33 @@ namespace System.Windows
                     App.NonAppWindowsInternal.Remove(this);
                 }
             }
-}
+        }
+
+        private bool ShouldCloseApplication()
+        {
+            if (App.ShutdownMode is ShutdownMode.OnLastWindowClose)
+            {
+                // 1) If this is the last window and shutdown mode is OnLastWindowClose, then we can close the app
+                // 2) We should also close the app if all of the remaining windows are windows that were created,
+                // -- but never shown (excludes inits via EnsureHandle via WindowInteropHelper, such windows are considered shown). 
+                lock (App.WindowsInternal.SyncRoot)
+                {
+                    for (int i = App.WindowsInternal.Count - 1; i >= 0; i--)
+                    {
+                        if (!App.WindowsInternal[i].IsSourceWindowNull)
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            }
+
+            // If this is the main window and shutdown mode is OnMainWindowClose, then we can close the app
+            return App.ShutdownMode is ShutdownMode.OnMainWindowClose && App.MainWindow == this;
+        }
+
         private bool  WmDestroy()
         {
             // For WS_CHILD window, WM_SIZE, WM_MOVE (and maybe others) are called

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/WindowCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/WindowCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -167,11 +167,11 @@ namespace System.Windows
         {
             lock (_list.SyncRoot)
             {
-                _list.Remove(index);
+                _list.RemoveAt(index);
             }
         }
 
-        internal int Add (Window win)
+        internal int Add(Window win)
         {
             lock (_list.SyncRoot)
             {
@@ -201,7 +201,7 @@ namespace System.Windows
         //
         //------------------------------------------------------
         #region Private Fields
-        private ArrayList _list;
+        private readonly ArrayList _list;
         #endregion Private Fields
     }
 


### PR DESCRIPTION
Fixes #4204 
Fixes #11610 

## Description

Fixes removal of `Window` objects during explicit app shutdown (forced either via `Dispatcher` callback or when an app-shutdown condition is detected) and also alters behaviour to shutdown the app when there are non-materialized window objects (windows that don't have / never had a `HWND`) to stop the process from hanging on a programmer's error.

## Customer Impact

I guess customers will be happier this time around that the LLM's poor job is saved by complementary logic? Even though it locks  per each closing window now, previously it was an allocation to check the `Count` (since `App.Windows` creates a copy), so there's no real difference. Bail is expected on first item in the loop.

## Regression

Both has been there since the dark days, so, no.

## Testing

Repro in both issues.

## Risk

Unlike others, this is a newly crafted fix, so besides the repros it's untested. It changes the behaviour; if you were using `OnLastWindowClose` (default) and created a `Window` to hang your app without actually calling `EnsureHandle` (which you should do), then after merging this you'll be surprised.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11766)