### PR TITLE
Remove C4995 suppression

### DIFF
--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -96,8 +96,6 @@
     <ManagedCxxSuppressions>$(ManagedCxxSuppressions);4945</ManagedCxxSuppressions>
     <!-- Type marked as obsolete. -->
     <ManagedCxxSuppressions>$(ManagedCxxSuppressions);4947</ManagedCxxSuppressions>
-    <!-- Type marked as #pragma deprecated. -->
-    <ManagedCxxSuppressions>$(ManagedCxxSuppressions);4995</ManagedCxxSuppressions>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/inc/XpsDeviceSimulatingInteropPrinterHandler.hpp
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/inc/XpsDeviceSimulatingInteropPrinterHandler.hpp
@@ -114,7 +114,10 @@ namespace PrintWin32Thunk
 
             Stream^         spoolerStream;
 
+#pragma warning ( push )
+#pragma warning ( disable:4995 )
             IXpsPrintJob*   xpsPrintJob;
+#pragma warning ( pop )
 
             int             jobIdentifier;
     };    

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/src/XpsDeviceSimulatingInteropPrinterHandler.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/src/XpsDeviceSimulatingInteropPrinterHandler.cpp
@@ -176,7 +176,10 @@ ThunkStartDocPrinter(
         InternalPrintSystemException::ThrowIfNotCOMSuccess(hr);
     }
 
+#pragma warning ( push )
+#pragma warning ( disable:4995 )
     xpsPrintJob = (IXpsPrintJob *)tempJob;
+#pragma warning ( pop )
     spoolerStream = gcnew XpsPrintJobStream((IXpsPrintJobStream *)tempDocStream, tempCompletedEvent, false, true);
 
     if(printTicket != nullptr)
@@ -188,7 +191,10 @@ ThunkStartDocPrinter(
     }
 
     // Get the job ID, which may or may not be available.
+#pragma warning ( push )
+#pragma warning ( disable:4995 )
     XPS_JOB_STATUS status = {0};
+#pragma warning ( pop )
     hr = xpsPrintJob->GetJobStatus(&status);
     InternalPrintSystemException::ThrowIfNotCOMSuccess(hr);
 
@@ -316,7 +322,10 @@ get(
 {
     if(xpsPrintJob != NULL && jobIdentifier != 0)
     {
+#pragma warning ( push )
+#pragma warning ( disable:4995 )
         XPS_JOB_STATUS status = {0};
+#pragma warning ( pop )
         ::HRESULT hr = xpsPrintJob->GetJobStatus(&status);
 
         InternalPrintSystemException::ThrowIfNotCOMSuccess(hr);
@@ -347,5 +356,4 @@ ThunkReportJobProgress(
 {
     return 0;
 }
-
 


### PR DESCRIPTION
## Description

Remove the global managed C++ suppression for warning C4995. This prevents /wd4995 from being applied to DirectWriteForwarder and resolves the BinSkim BA2007 result tracked by dotnet/dotnet#8042.

## Validation

Built DirectWriteForwarder in Release for x86, x64, and arm64 with zero warnings and zero errors in the dotnet/dotnet VMR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11807)