### PR TITLE
Fix Nullable<T> detection inside MetadataLoadContext to emit proper BamlRecordType

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -46,7 +46,9 @@ namespace System.Xaml
 #if PBTCOMPILER
         // System.Reflection.MetadataLoadContext instance
         private static MetadataLoadContext _metadataLoadContext = null;
-
+#if !NET11_0_OR_GREATER
+        private static Type s_nullableType = null;
+#endif
         // MetadataLoadContext Assembly cache
         private static Dictionary<string, Assembly> _cachedMetadataLoadContextAssemblies = null;
         private static Dictionary<string, Assembly> _cachedMetadataLoadContextAssembliesByNameNoExtension = null;
@@ -122,7 +124,10 @@ namespace System.Xaml
 #if NET11_0_OR_GREATER
             return type.GetNullableUnderlyingType() is not null;
 #else
-            return type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(Nullable<>));
+            s_nullableType ??= _metadataLoadContext.CoreAssembly?.GetType("System.Nullable`1");
+            Debug.Assert(s_nullableType is not null, "System.Nullable`1 type not found in MetadataLoadContext");
+
+            return type.IsGenericType && s_nullableType.Equals(type.GetGenericTypeDefinition());
 #endif
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -119,7 +119,11 @@ namespace System.Xaml
 
         internal static bool IsNullableType(Type type)
         {
-            return (type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(Nullable<>)));
+#if NET11_0_OR_GREATER
+            return type.GetNullableUnderlyingType() is not null;
+#else
+            return type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(Nullable<>));
+#endif
         }
 
         internal static bool IsInternalType(Type type)

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -46,9 +46,7 @@ namespace System.Xaml
 #if PBTCOMPILER
         // System.Reflection.MetadataLoadContext instance
         private static MetadataLoadContext _metadataLoadContext = null;
-#if !NET11_0_OR_GREATER
-        private static Type s_nullableType = null;
-#endif
+
         // MetadataLoadContext Assembly cache
         private static Dictionary<string, Assembly> _cachedMetadataLoadContextAssemblies = null;
         private static Dictionary<string, Assembly> _cachedMetadataLoadContextAssembliesByNameNoExtension = null;
@@ -124,10 +122,10 @@ namespace System.Xaml
 #if NET11_0_OR_GREATER
             return type.GetNullableUnderlyingType() is not null;
 #else
-            s_nullableType ??= _metadataLoadContext.CoreAssembly?.GetType("System.Nullable`1");
-            Debug.Assert(s_nullableType is not null, "System.Nullable`1 type not found in MetadataLoadContext");
+            Type nullableType = _metadataLoadContext.CoreAssembly?.GetType("System.Nullable`1");
+            Debug.Assert(nullableType is not null, "System.Nullable`1 type not found in MetadataLoadContext");
 
-            return type.IsGenericType && s_nullableType.Equals(type.GetGenericTypeDefinition());
+            return type.IsGenericType && nullableType == type.GetGenericTypeDefinition();
 #endif
         }
 


### PR DESCRIPTION
Fixes #11815 

## Description

Fixes detection of Nullable<T> types on SDK-style builds where a new API for detecting `Nullable<T>` types was added (https://github.com/dotnet/runtime/issues/124216). `GetNullableUnderlyingType` checks the `IsGenericType` for us.

## Customer Impact

Well, the customer impact depends on how many years does it take for a PR to land in dotnet/wpf.

## Regression

Regression for SDK-style projects. Otherwise this has been the case since `MetadataLoadContext` is available (which is the time when WPF was opensourced).

## Testing

The repro included in the original issue. Using `dotnet build` for any TFM after swapping PBT in SDK.

Also verified builds in Visual Studio which use the net472 build of PBT.

## Risk

There shouldn't be any, though I'm unsure at the moment if we can surface a non-in-box `Type` to check on inside WPF code so that such code would need to override this new method to not receive a random `NotSupportedException`. Eitherway, all inbox types ship with overrides and if a custom type override wants to work with nullables, they should override it.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11816)