### PR TITLE
Restoring autoConvert behavior in Clipboard APIs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
@@ -487,7 +487,7 @@ public static class Clipboard
             return false;
         }
 
-        return dataObject.TryGetData(format, out data);
+        return dataObject.TryGetData(format, autoConvert: false, out data);
     }
 
     /// <inheritdoc cref="DataObject.SetDataAsJson{T}(string, T)"/>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
@@ -83,8 +83,8 @@ public static class Clipboard
     private static T? GetTypedDataIfAvailable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string format)
     {
         IDataObject? data = GetDataObject();
-
         bool autoConvert = IsDataFormatAutoConvert(format);
+
         if (data is ITypedDataObject typed)
         {
             return typed.TryGetData(format, autoConvert, out T? value) ? value : default;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
@@ -83,14 +83,16 @@ public static class Clipboard
     private static T? GetTypedDataIfAvailable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string format)
     {
         IDataObject? data = GetDataObject();
+
+        bool autoConvert = IsDataFormatAutoConvert(format);
         if (data is ITypedDataObject typed)
         {
-            return typed.TryGetData(format, autoConvert: true, out T? value) ? value : default;
+            return typed.TryGetData(format, autoConvert, out T? value) ? value : default;
         }
 
         if (data is IDataObject dataObject)
         {
-            return dataObject.GetData(format, autoConvert: true) is T value ? value : default;
+            return dataObject.GetData(format, autoConvert) is T value ? value : default;
         }
 
         return default;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/ClipboardTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/ClipboardTests.cs
@@ -225,6 +225,27 @@ public class ClipboardTests
         result2.Should().Be(testData2);
     }
 
+    [WpfTheory]
+    [InlineData(TextDataFormat.Text, TextDataFormat.UnicodeText)]
+    [InlineData(TextDataFormat.UnicodeText, TextDataFormat.Text)]
+    public void GetText_AutoConvertibleFormat_DoesNotAutoConvert(
+        TextDataFormat sourceFormat,
+        TextDataFormat requestedFormat)
+    {
+        const string text = "Hello, World!";
+        string sourceDataFormat = DataFormats.ConvertToDataFormats(sourceFormat);
+        string requestedDataFormat = DataFormats.ConvertToDataFormats(requestedFormat);
+        DataObject dataObject = new();
+        dataObject.SetData(sourceDataFormat, text, autoConvert: true);
+
+        dataObject.GetData(requestedDataFormat, autoConvert: true).Should().Be(text);
+        dataObject.GetData(requestedDataFormat, autoConvert: false).Should().BeNull();
+
+        Clipboard.SetDataObject(dataObject);
+
+        Clipboard.GetText(requestedFormat).Should().BeEmpty();
+    }
+
     [WpfFact]
     public void SetData_Text_Format_AllUpper()
     {


### PR DESCRIPTION
Fixes one issue in https://github.com/dotnet/winforms/issues/14322

## Description

Till .NET 9.0, `autoConvert` was set to true only for `FileDrop` and `Bitmap` scenarios. However, since .NET 10, it is being set to true for `GetAudioStream`, `GetFileDropList`, `GetImage`, and `GetText` APIs inside the private method `GetTypedDataIfAvailable`. This causes issues with GetText API with mojibake characters as described in bug https://github.com/dotnet/winforms/issues/14322

## Customer Impact

There is no way for the app to know whether the clipboard contents were corrupted or if there is any problem with the API as it didn't get the desired data.

## Regression

Yes - from .NET 9.0

## Testing

Created a WPF app to write unicode data on the clipboard and another app to read it. Before the changes, the reader app returned several hits for mojibake characters. After fix, there were none.

## Risk

This should be a very low risk change as this behavior was working fine in 9.0 and previous versions.
 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11837)