### PR TITLE
fix/11848: BAML assembly resolution to respect AssemblyLoadContext

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006SchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006SchemaContext.cs
@@ -460,6 +460,31 @@ namespace System.Windows.Baml2006
             }
 
             AssemblyName assemblyName = new AssemblyName(bamlAssembly.Name);
+
+#if NETCOREAPP
+            // Try to resolve the requested assembly in the same AssemblyLoadContext as the local assembly which requests it.
+            if (_localAssembly != null)
+            {
+                System.Runtime.Loader.AssemblyLoadContext alc = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(_localAssembly);
+
+                if (alc != null)
+                {
+                    try
+                    {
+                        bamlAssembly.Assembly = alc.LoadFromAssemblyName(assemblyName);
+                        if (bamlAssembly.Assembly != null)
+                        {
+                            return bamlAssembly.Assembly;
+                        }
+                    }
+                    catch
+                    {
+                        // Fallback to legacy resolution logic.
+                    }
+                }
+            }
+#endif
+
             bamlAssembly.Assembly = MS.Internal.WindowsBase.SafeSecurityHelper.GetLoadedAssembly(assemblyName);
             if (bamlAssembly.Assembly == null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006SchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006SchemaContext.cs
@@ -477,7 +477,9 @@ namespace System.Windows.Baml2006
                             return bamlAssembly.Assembly;
                         }
                     }
-                    catch
+                    catch (System.Exception ex) when (ex is System.IO.FileNotFoundException ||
+                                                     ex is System.IO.FileLoadException ||
+                                                     ex is System.BadImageFormatException)
                     {
                         // Fallback to legacy resolution logic.
                     }


### PR DESCRIPTION
Fixes [#11848](https://github.com/dotnet/wpf/issues/11848)

## Description

A BAML reference normally identifies an assembly by its name and version. If more than one loaded assembly in the global appdomain satisfies that criteria, it becomes ambiguous. Selecting the last loaded matching assembly from a process-wide set of loaded assemblies can bind BAML to a type from an unrelated ALC.

The parser must instead resolve the reference in the loading context appropriate to the BAML-owning assembly. This preserves the normal rule that code and the BAML it owns refer to the same component-local types.

## Customer Impact

This issue has impact on both companies that develop and ship products and on their clientes that load different products simultaneously into a single host application.

## Regression

This issue was not present in .NET Framework because it did not allow assemblies with the same combination of name and version to be loaded more than once.

## Testing

The fix has been validated locally using this project: https://github.com/cunhamauro/XamlParserTypeIdentityMismatch

<img width="691" height="286" alt="image" src="https://github.com/user-attachments/assets/a6955e51-3be5-4322-af1e-b7f739bb3455" />

## Risk

The implementation risk is minimal because the fix follows the CLR’s existing assembly-loading semantics: a dependency is resolved in the AssemblyLoadContext of the assembly that requests it.
In most applications, this change will not produce any observable difference because assemblies are loaded into the default AssemblyLoadContext. The change only affects scenarios where the same assembly identity is loaded in multiple ALCs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11849)
 
 Read more about this @:
- https://github.com/dotnet/wpf/issues/1700
- https://github.com/dotnet/wpf/issues/11848
- https://forums.autodesk.com/t5/revit-api-forum/revit-2027-manifestsettings-deduplication-mechanism-from-revit/td-p/14105252