### PR TITLE
Fix Binding errors when Ribbon is outside of RibbonWindow

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Themes/Generic.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Themes/Generic.xaml
@@ -2841,13 +2841,13 @@ To automatically copy the files, set the environment variable
                     </Trigger>
                     <MultiDataTrigger>
                         <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ribbon:RibbonWindow}, Path=IsActive}" Value="False"/>
 
                             <Condition Binding="{Binding Path=(SystemParameters.IsGlassEnabled)}" Value="False"/>
 
 
 
                             <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsHostedInRibbonWindow}" Value="True" />
+                            <Condition Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ribbon:RibbonWindow}, Path=IsActive}" Value="False"/>
                         </MultiDataTrigger.Conditions>
                         <Setter TargetName="PART_TitleHost" Property="TextElement.Foreground" Value="{DynamicResource {x:Static SystemColors.InactiveCaptionTextBrushKey}}" />
                     </MultiDataTrigger>
@@ -2900,6 +2900,7 @@ To automatically copy the files, set the environment variable
 
 
 
+                            <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsHostedInRibbonWindow}" Value="True" />
                             <Condition Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ribbon:RibbonWindow}, Path=WindowState}" Value="Maximized"/>
                         </MultiDataTrigger.Conditions>
                         <Setter TargetName="QatTopHost" Property="Margin" Value="0"/>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Themes/Generic.xaml.sdk
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Themes/Generic.xaml.sdk
@@ -2717,13 +2717,13 @@ Theme Styles For Windows Presentation Foundation Version 
                     </Trigger>
                     <MultiDataTrigger>
                         <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ribbon:RibbonWindow}, Path=IsActive}" Value="False"/>
 
                             <Condition Binding="{Binding Path=(SystemParameters.IsGlassEnabled)}" Value="False"/>
 
 
 
                             <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsHostedInRibbonWindow}" Value="True" />
+                            <Condition Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ribbon:RibbonWindow}, Path=IsActive}" Value="False"/>
                         </MultiDataTrigger.Conditions>
                         <Setter TargetName="PART_TitleHost" Property="TextElement.Foreground" Value="{DynamicResource {x:Static SystemColors.InactiveCaptionTextBrushKey}}" />
                     </MultiDataTrigger>
@@ -2775,6 +2775,7 @@ Theme Styles For Windows Presentation Foundation Version 
 
 
 
+                            <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsHostedInRibbonWindow}" Value="True" />
                             <Condition Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ribbon:RibbonWindow}, Path=WindowState}" Value="Maximized"/>
                         </MultiDataTrigger.Conditions>
                         <Setter TargetName="QatTopHost" Property="Margin" Value="0"/>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Themes/XAML/Ribbon.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Themes/XAML/Ribbon.xaml
@@ -327,13 +327,13 @@
                     </Trigger>
                     <MultiDataTrigger>
                         <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ribbon:RibbonWindow}, Path=IsActive}" Value="False"/>
 #ifdef Net45
                             <Condition Binding="{Binding Path=(SystemParameters.IsGlassEnabled)}" Value="False"/>
 #else
                             <Condition Binding="{Binding Path=IsGlassEnabled, Source={x:Static windows:SystemParameters2.Current}}" Value="False"/>
 #endif
                             <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsHostedInRibbonWindow}" Value="True" />
+                            <Condition Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ribbon:RibbonWindow}, Path=IsActive}" Value="False"/>
                         </MultiDataTrigger.Conditions>
                         <Setter TargetName="PART_TitleHost" Property="TextElement.Foreground" Value="{DynamicResource {x:Static SystemColors.InactiveCaptionTextBrushKey}}" />
                     </MultiDataTrigger>
@@ -386,6 +386,7 @@
 #else
                             <Condition Binding="{Binding Path=UxThemeName, Source={x:Static windows:SystemParameters2.Current}}" Value="Aero"/>
 #endif
+                            <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsHostedInRibbonWindow}" Value="True" />
                             <Condition Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ribbon:RibbonWindow}, Path=WindowState}" Value="Maximized"/>
                         </MultiDataTrigger.Conditions>
                         <Setter TargetName="QatTopHost" Property="Margin" Value="0"/>


### PR DESCRIPTION
Fixes #11860

## Description

The Binding errors happened when using the default template for the Ribbon. It has two conditions that may try to bind to the parent RibbonWindow but it did not check if there was a parent RibbonWindow before, so the two Bindings ended up failing if the Ribbon was outside of a RibbonWindow.

This fix ensures that the Ribbon is hosted in a RibbonWindow before binding to the parent RibbonWidow by having a condition that binds to `IsHostedInRibbonWindow` first. if `IsHostedInRibbonWindow == false`, the following conditions are not evaluated.

FYI, this was already done this way [there](https://github.com/dotnet/wpf/blob/1cfc37f708f91ff4556bd25af414546c446f3a16/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Themes/Generic.xaml#L2742) (and [there](https://github.com/dotnet/wpf/blob/1cfc37f708f91ff4556bd25af414546c446f3a16/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Themes/XAML/Ribbon.xaml#L228)).

## Customer Impact

Without this PR, there will still be the Binding errors as described in #11860.

## Regression

No (or at least not that I am aware of).

## Testing

For now, I only tested with the simple case linked in #11860.

## Risk

I believe that there are no real risks given the changes I made but correct me if I am wrong.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11864)