### PR TITLE
Scope IME display attribute enumeration to the edited ranges

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesDisplayAttributePropertyRanges.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesDisplayAttributePropertyRanges.cs
@@ -77,13 +77,9 @@ namespace System.Windows.Documents
         {
             Guid displayAttributeGuid;
             UnsafeNativeMethods.ITfProperty displayAttributeProperty;
-            UnsafeNativeMethods.IEnumTfRanges attributeRangeEnumerator;
-            UnsafeNativeMethods.ITfRange[] attributeRanges;
+            UnsafeNativeMethods.IEnumTfRanges updatedRangeEnumerator;
+            UnsafeNativeMethods.ITfRange[] updatedRanges;
             int fetched;
-            int guidAtom;
-            TextServicesDisplayAttribute displayAttribute;
-            ITextPointer start;
-            ITextPointer end;
 
             //
             // Remove any existing display attribute highlights.
@@ -111,25 +107,92 @@ namespace System.Windows.Documents
             // Get the DisplayAttributeProperty.
             displayAttributeGuid = Guid;
             context.GetProperty(ref displayAttributeGuid, out displayAttributeProperty);
-            // Get a range enumerator for the property.
-            if (displayAttributeProperty.EnumRanges(ecReadOnly, out attributeRangeEnumerator, null) == NativeMethods.S_OK)
+
+            //
+            // Only look at the ranges this edit actually changed.
+            //
+            // Passing null as the target range of EnumRanges enumerates the display
+            // attribute property over the WHOLE document. The property accumulates a
+            // range per previously composed run, so the enumeration - and the COM
+            // round trip it costs per range - grows with the length of the document,
+            // on every single keystroke.
+            //
+            // Measured with a modern Korean TSF IME on a 1,200 character document:
+            // 1,077 ranges returned, of which exactly one carried an attribute, for
+            // roughly 3 seconds of blocked UI thread on one keystroke. Restricting
+            // the enumeration to the updated ranges removes the stalls entirely.
+            //
+            // This mirrors what the base class TextServicesPropertyRanges.OnEndEdit
+            // already does; this override had lost that scoping.
+            //
+            updatedRangeEnumerator = GetPropertyUpdate(editRecord);
+            if (updatedRangeEnumerator != null)
             {
-                attributeRanges = new UnsafeNativeMethods.ITfRange[1];
+                updatedRanges = new UnsafeNativeMethods.ITfRange[1];
 
-                // Walk each range.
-                while (attributeRangeEnumerator.Next(1, attributeRanges, out fetched) == NativeMethods.S_OK)
+                while (updatedRangeEnumerator.Next(1, updatedRanges, out fetched) == NativeMethods.S_OK)
                 {
-                    // Get a DisplayAttribute for this range.
-                    guidAtom = GetInt32Value(ecReadOnly, displayAttributeProperty, attributeRanges[0]);
-                    displayAttribute = GetDisplayAttribute(guidAtom);
+                    AddAttributeRanges(ecReadOnly, displayAttributeProperty, updatedRanges[0]);
+                    Marshal.ReleaseComObject(updatedRanges[0]);
+                }
 
-                    if (displayAttribute != null && !displayAttribute.IsEmptyAttribute())
+                Marshal.ReleaseComObject(updatedRangeEnumerator);
+            }
+
+#if UNUSED_IME_HIGHLIGHT_LAYER
+            if (_highlightLayer != null)
+            {
+                this.TextStore.TextContainer.Highlights.AddLayer(_highlightLayer);
+            }
+#endif
+
+            if (_compositionAdorner != null)
+            {
+                // Update the layout to get the acurated rectangle from calling GetRectangleFromTextPosition
+                this.TextStore.RenderScope.UpdateLayout();
+
+                // Invalidate the composition adorner to render the composition attribute ranges.
+                _compositionAdorner.InvalidateAdorner();
+            }
+
+            Marshal.ReleaseComObject(displayAttributeProperty);
+        }
+
+        /// <summary>
+        ///     Adds every display attribute range found inside targetRange to the
+        ///     composition adorner.
+        /// </summary>
+        private void AddAttributeRanges(
+            int ecReadOnly,
+            UnsafeNativeMethods.ITfProperty displayAttributeProperty,
+            UnsafeNativeMethods.ITfRange targetRange)
+        {
+            UnsafeNativeMethods.IEnumTfRanges attributeRangeEnumerator;
+
+            if (displayAttributeProperty.EnumRanges(ecReadOnly, out attributeRangeEnumerator, targetRange) != NativeMethods.S_OK)
+            {
+                return;
+            }
+
+            UnsafeNativeMethods.ITfRange[] attributeRanges = new UnsafeNativeMethods.ITfRange[1];
+            int fetched;
+
+            // Walk each range.
+            while (attributeRangeEnumerator.Next(1, attributeRanges, out fetched) == NativeMethods.S_OK)
+            {
+                // Get a DisplayAttribute for this range.
+                int guidAtom = GetInt32Value(ecReadOnly, displayAttributeProperty, attributeRanges[0]);
+                TextServicesDisplayAttribute displayAttribute = GetDisplayAttribute(guidAtom);
+
+                if (displayAttribute != null && !displayAttribute.IsEmptyAttribute())
+                {
+                    // Set a matching highlight for the attribute range.
+                    ITextPointer start;
+                    ITextPointer end;
+                    ConvertToTextPosition(attributeRanges[0], out start, out end);
+
+                    if (start != null)
                     {
-                        // Set a matching highlight for the attribute range.
-                        ConvertToTextPosition(attributeRanges[0], out start, out end);
-
-                        if (start != null)
-                        {
 #if UNUSED_IME_HIGHLIGHT_LAYER
                         // Demand create the highlight layer.
                         if (_highlightLayer == null)
@@ -138,45 +201,26 @@ namespace System.Windows.Documents
                         }
 #endif
 
-                            if (_compositionAdorner == null)
-                            {
-                                _compositionAdorner = new CompositionAdorner(this.TextStore.TextView);
-                                _compositionAdorner.Initialize(this.TextStore.TextView);
-                            }
+                        if (_compositionAdorner == null)
+                        {
+                            _compositionAdorner = new CompositionAdorner(this.TextStore.TextView);
+                            _compositionAdorner.Initialize(this.TextStore.TextView);
+                        }
 
 #if UNUSED_IME_HIGHLIGHT_LAYER
                         // Need to pass the foreground and background color of the composition
                         _highlightLayer.Add(start, end, /*TextDecorationCollection:*/null);
 #endif
 
-                            // Add the attribute range into CompositionAdorner.
-                            _compositionAdorner.AddAttributeRange(start, end, displayAttribute);
-                        }
+                        // Add the attribute range into CompositionAdorner.
+                        _compositionAdorner.AddAttributeRange(start, end, displayAttribute);
                     }
-
-                    Marshal.ReleaseComObject(attributeRanges[0]);
                 }
 
-#if UNUSED_IME_HIGHLIGHT_LAYER
-                if (_highlightLayer != null)
-                {
-                    this.TextStore.TextContainer.Highlights.AddLayer(_highlightLayer);
-                }
-#endif
-
-                if (_compositionAdorner != null)
-                {
-                    // Update the layout to get the acurated rectangle from calling GetRectangleFromTextPosition
-                    this.TextStore.RenderScope.UpdateLayout();
-
-                    // Invalidate the composition adorner to render the composition attribute ranges.
-                    _compositionAdorner.InvalidateAdorner();
-                }
-
-                Marshal.ReleaseComObject(attributeRangeEnumerator);
+                Marshal.ReleaseComObject(attributeRanges[0]);
             }
 
-            Marshal.ReleaseComObject(displayAttributeProperty);
+            Marshal.ReleaseComObject(attributeRangeEnumerator);
         }
 
         // Callback from TextServicesProperty.OnLayoutUpdated.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesDisplayAttributePropertyRanges.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesDisplayAttributePropertyRanges.cs
@@ -77,9 +77,6 @@ namespace System.Windows.Documents
         {
             Guid displayAttributeGuid;
             UnsafeNativeMethods.ITfProperty displayAttributeProperty;
-            UnsafeNativeMethods.IEnumTfRanges updatedRangeEnumerator;
-            UnsafeNativeMethods.ITfRange[] updatedRanges;
-            int fetched;
 
             //
             // Remove any existing display attribute highlights.
@@ -109,34 +106,35 @@ namespace System.Windows.Documents
             context.GetProperty(ref displayAttributeGuid, out displayAttributeProperty);
 
             //
-            // Only look at the ranges this edit actually changed.
+            // Enumerate the display attribute property only where display attributes
+            // can currently be, instead of over the whole document.
             //
-            // Passing null as the target range of EnumRanges enumerates the display
-            // attribute property over the WHOLE document. The property accumulates a
-            // range per previously composed run, so the enumeration - and the COM
-            // round trip it costs per range - grows with the length of the document,
-            // on every single keystroke.
+            // Passing null as the target range of EnumRanges enumerates the property
+            // across the entire document. The property keeps a range for every run the
+            // input method has composed, so on a long document this is a COM round trip
+            // per historical range, on every keystroke. Measured with the Windows 11
+            // Korean TSF IME on a 1,200 character document, a single OnEndEdit
+            // enumerated 1,077 ranges of which exactly one carried an attribute, and
+            // blocked the UI thread for roughly three seconds.
             //
-            // Measured with a modern Korean TSF IME on a 1,200 character document:
-            // 1,077 ranges returned, of which exactly one carried an attribute, for
-            // roughly 3 seconds of blocked UI thread on one keystroke. Restricting
-            // the enumeration to the updated ranges removes the stalls entirely.
+            // Display attributes are decorations the input method places on text it is
+            // composing, so they can only be (a) inside an active composition or
+            // (b) on a range this edit just changed (which also covers ranges an ending
+            // composition just cleared). Enumerating the smallest span that covers both
+            // finds every range the whole-document scan would find - for any IME,
+            // including ones whose composition holds several attribute ranges at once,
+            // such as Japanese clause conversion, and edits that touch only some of
+            // them - while keeping the cost proportional to the composition rather than
+            // to the document.
             //
-            // This mirrors what the base class TextServicesPropertyRanges.OnEndEdit
-            // already does; this override had lost that scoping.
-            //
-            updatedRangeEnumerator = GetPropertyUpdate(editRecord);
-            if (updatedRangeEnumerator != null)
+            if (TryGetAttributeScanWindow(context, ecReadOnly, editRecord, out int scanStart, out int scanEnd))
             {
-                updatedRanges = new UnsafeNativeMethods.ITfRange[1];
+                context.GetStart(ecReadOnly, out UnsafeNativeMethods.ITfRange scanRange);
+                ((UnsafeNativeMethods.ITfRangeACP)scanRange).SetExtent(scanStart, scanEnd - scanStart);
 
-                while (updatedRangeEnumerator.Next(1, updatedRanges, out fetched) == NativeMethods.S_OK)
-                {
-                    AddAttributeRanges(ecReadOnly, displayAttributeProperty, updatedRanges[0]);
-                    Marshal.ReleaseComObject(updatedRanges[0]);
-                }
+                AddAttributeRanges(ecReadOnly, displayAttributeProperty, scanRange);
 
-                Marshal.ReleaseComObject(updatedRangeEnumerator);
+                Marshal.ReleaseComObject(scanRange);
             }
 
 #if UNUSED_IME_HIGHLIGHT_LAYER
@@ -156,6 +154,79 @@ namespace System.Windows.Documents
             }
 
             Marshal.ReleaseComObject(displayAttributeProperty);
+        }
+
+        /// <summary>
+        ///     Computes the smallest ACP span covering every active composition and
+        ///     every range whose display attribute this edit changed. Returns false
+        ///     when there is nothing to scan.
+        /// </summary>
+        private bool TryGetAttributeScanWindow(
+            UnsafeNativeMethods.ITfContext context,
+            int ecReadOnly,
+            UnsafeNativeMethods.ITfEditRecord editRecord,
+            out int scanStart,
+            out int scanEnd)
+        {
+            scanStart = int.MaxValue;
+            scanEnd = int.MinValue;
+            int fetched;
+
+            // (a) Active compositions.
+            if (context is UnsafeNativeMethods.ITfContextComposition contextComposition)
+            {
+                contextComposition.EnumCompositions(out UnsafeNativeMethods.IEnumITfCompositionView compositionEnumerator);
+                if (compositionEnumerator != null)
+                {
+                    UnsafeNativeMethods.ITfCompositionView[] views = new UnsafeNativeMethods.ITfCompositionView[1];
+                    while (compositionEnumerator.Next(1, views, out fetched) == NativeMethods.S_OK && fetched == 1)
+                    {
+                        views[0].GetRange(out UnsafeNativeMethods.ITfRange compositionRange);
+                        if (compositionRange != null)
+                        {
+                            ExtendScanWindow(compositionRange, ref scanStart, ref scanEnd);
+                            Marshal.ReleaseComObject(compositionRange);
+                        }
+                        Marshal.ReleaseComObject(views[0]);
+                    }
+                    Marshal.ReleaseComObject(compositionEnumerator);
+                }
+            }
+
+            // (b) Ranges whose display attribute changed in this edit.
+            UnsafeNativeMethods.IEnumTfRanges updatedRanges = GetPropertyUpdate(editRecord);
+            if (updatedRanges != null)
+            {
+                UnsafeNativeMethods.ITfRange[] updated = new UnsafeNativeMethods.ITfRange[1];
+                while (updatedRanges.Next(1, updated, out fetched) == NativeMethods.S_OK && fetched == 1)
+                {
+                    ExtendScanWindow(updated[0], ref scanStart, ref scanEnd);
+                    Marshal.ReleaseComObject(updated[0]);
+                }
+                Marshal.ReleaseComObject(updatedRanges);
+            }
+
+            return scanStart <= scanEnd;
+        }
+
+        private static void ExtendScanWindow(UnsafeNativeMethods.ITfRange range, ref int scanStart, ref int scanEnd)
+        {
+            ((UnsafeNativeMethods.ITfRangeACP)range).GetExtent(out int start, out int count);
+
+            // Cicero can report a negative length; ConvertToTextPosition guards the same way.
+            if (count < 0)
+            {
+                return;
+            }
+
+            if (start < scanStart)
+            {
+                scanStart = start;
+            }
+            if (start + count > scanEnd)
+            {
+                scanEnd = start + count;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesPropertyRanges.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesPropertyRanges.cs
@@ -147,8 +147,11 @@ namespace System.Windows.Documents
         /// <summary>
         ///    Get ranges that the property is changed.
         /// </summary>
-        private UnsafeNativeMethods.IEnumTfRanges GetPropertyUpdate(
-                                UnsafeNativeMethods.ITfEditRecord editRecord) 
+        // 파생 클래스도 쓸 수 있도록 protected 로 승격.
+        // TextServicesDisplayAttributePropertyRanges 가 OnEndEdit 을 오버라이드하면서
+        // 이 범위 한정을 놓치고 문서 전체를 열거하는 문제가 있어 필요하다.
+        protected UnsafeNativeMethods.IEnumTfRanges GetPropertyUpdate(
+                                UnsafeNativeMethods.ITfEditRecord editRecord)
         {
             UnsafeNativeMethods.IEnumTfRanges ranges;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesPropertyRanges.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextServicesPropertyRanges.cs
@@ -147,9 +147,8 @@ namespace System.Windows.Documents
         /// <summary>
         ///    Get ranges that the property is changed.
         /// </summary>
-        // 파생 클래스도 쓸 수 있도록 protected 로 승격.
-        // TextServicesDisplayAttributePropertyRanges 가 OnEndEdit 을 오버라이드하면서
-        // 이 범위 한정을 놓치고 문서 전체를 열거하는 문제가 있어 필요하다.
+        // Promoted from private to protected so TextServicesDisplayAttributePropertyRanges
+        // can reuse it to scope its enumeration to the ranges an edit actually changed.
         protected UnsafeNativeMethods.IEnumTfRanges GetPropertyUpdate(
                                 UnsafeNativeMethods.ITfEditRecord editRecord)
         {


### PR DESCRIPTION
Fixes the typing lag reported in #7397.

## Cause

`TextServicesDisplayAttributePropertyRanges.OnEndEdit` enumerates the display attribute property with a **null target range**, which enumerates it over the whole document:

```csharp
displayAttributeProperty.EnumRanges(ecReadOnly, out attributeRangeEnumerator, null);
```

The property accumulates a range per previously composed run, so both the enumeration and the COM round trip it costs per range grow with document length — on every keystroke.

Only IMEs that set display attributes hit this (for example the modern Korean TSF IME, which underlines the composition). Measured on a 1,200 character `RichTextBox`, a single `OnEndEdit` enumerated **1,077 ranges of which exactly 1 carried an attribute**, blocking the UI thread for ~3 seconds.

## Fix

Use `GetPropertyUpdate(editRecord)` to obtain the ranges this edit actually changed and enumerate the property within each of them — which is what the base class `TextServicesPropertyRanges.OnEndEdit` already does. This override had lost that scoping.

`GetPropertyUpdate` is promoted from `private` to `protected` so the override can reuse it.

## Measurement

`SendInput` macro typing `안녕하세요 ` 300 times into a `RichTextBox` (Windows 11 10.0.26200, .NET 8, x64 Release):

| | mean / iteration | max | UI thread stalls |
|---|---|---|---|
| before | 181.3 ms | 3577.6 ms | 13, totalling 15,898 ms |
| **after** | **100.9 ms** | **127.4 ms** | **1, of 53 ms** |
| legacy IME (reference) | 101.5 ms | 173.1 ms | none |

The same harness with the IME in English mode showed no stalls before or after, confirming the cost is in the composition path.

Composition underline and the Hanja candidate window continue to render correctly, including mid-document, while scrolled, and immediately after fast typing.

## Notes

- The same code is present on .NET Framework (`PresentationFramework` 4.8.9340.0), consistent with the original report that 4.8 is affected.
- Root cause was located with WPF's own IME tracer (`IMECompositionTraceTarget`) plus stack sampling during the stalls; analysis was done with the help of Claude Code, and every number above is a measurement from an actual run on my machine.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11872)