### PR TITLE
[DO NOT MERGE] CI validation for #11893 (dotnet12 feeds vs codeflow #11869)

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -17,6 +17,8 @@
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
     <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" />
     <add key="dotnet11-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11-transport/nuget/v3/index.json" />
+    <add key="dotnet12" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet12/nuget/v3/index.json" />
+    <add key="dotnet12-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet12-transport/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
   <auditSources>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -8,29 +8,29 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-dotnet dependencies -->
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26427.102</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26427.102</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26427.102</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26427.102</MicrosoftDotNetHelixSdkPackageVersion>
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26427.102</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26427.102</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26427.102</MicrosoftPrivateWinformsPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26427.131</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26427.131</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26427.131</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26427.131</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26427.131</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26427.131</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26427.131</MicrosoftPrivateWinformsPackageVersion>
     <MicrosoftSourceLinkAzureReposGitPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkAzureReposGitPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkGitHubPackageVersion>
-    <SystemCodeDomPackageVersion>11.0.0-rc.1.26427.102</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26427.102</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26427.102</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26427.102</SystemDirectoryServicesPackageVersion>
-    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26427.102</SystemDrawingCommonPackageVersion>
-    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26427.102</SystemFormatsNrbfPackageVersion>
-    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26427.102</SystemIOPackagingPackageVersion>
-    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26427.102</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26427.102</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26427.102</SystemResourcesExtensionsPackageVersion>
-    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26427.102</SystemRuntimeSerializationFormattersPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26427.102</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26427.102</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26427.102</SystemWindowsExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>11.0.0-rc.1.26427.131</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26427.131</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26427.131</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26427.131</SystemDirectoryServicesPackageVersion>
+    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26427.131</SystemDrawingCommonPackageVersion>
+    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26427.131</SystemFormatsNrbfPackageVersion>
+    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26427.131</SystemIOPackagingPackageVersion>
+    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26427.131</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26427.131</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26427.131</SystemResourcesExtensionsPackageVersion>
+    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26427.131</SystemRuntimeSerializationFormattersPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26427.131</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26427.131</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26427.131</SystemWindowsExtensionsPackageVersion>
     <!-- dotnet-wpf-int dependencies -->
     <MicrosoftDotNetWpfDncEngPackageVersion>11.0.0-preview.2.26270.1</MicrosoftDotNetWpfDncEngPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -8,29 +8,29 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-dotnet dependencies -->
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetHelixSdkPackageVersion>
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26431.109</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26431.109</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26431.109</MicrosoftPrivateWinformsPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26451.109</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26451.109</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26451.109</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26451.109</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26451.109</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26451.109</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26451.109</MicrosoftPrivateWinformsPackageVersion>
     <MicrosoftSourceLinkAzureReposGitPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkAzureReposGitPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkGitHubPackageVersion>
-    <SystemCodeDomPackageVersion>11.0.0-rc.1.26431.109</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26431.109</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26431.109</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26431.109</SystemDirectoryServicesPackageVersion>
-    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26431.109</SystemDrawingCommonPackageVersion>
-    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26431.109</SystemFormatsNrbfPackageVersion>
-    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26431.109</SystemIOPackagingPackageVersion>
-    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26431.109</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26431.109</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26431.109</SystemResourcesExtensionsPackageVersion>
-    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26431.109</SystemRuntimeSerializationFormattersPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26431.109</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26431.109</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26431.109</SystemWindowsExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>11.0.0-rc.1.26451.109</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26451.109</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26451.109</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26451.109</SystemDirectoryServicesPackageVersion>
+    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26451.109</SystemDrawingCommonPackageVersion>
+    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26451.109</SystemFormatsNrbfPackageVersion>
+    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26451.109</SystemIOPackagingPackageVersion>
+    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26451.109</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26451.109</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26451.109</SystemResourcesExtensionsPackageVersion>
+    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26451.109</SystemRuntimeSerializationFormattersPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26451.109</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26451.109</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26451.109</SystemWindowsExtensionsPackageVersion>
     <!-- dotnet-wpf-int dependencies -->
     <MicrosoftDotNetWpfDncEngPackageVersion>11.0.0-preview.2.26270.1</MicrosoftDotNetWpfDncEngPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -8,29 +8,29 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-dotnet dependencies -->
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26430.103</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26430.103</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26430.103</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26430.103</MicrosoftDotNetHelixSdkPackageVersion>
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26430.103</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26430.103</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26430.103</MicrosoftPrivateWinformsPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26431.109</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26431.109</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26431.109</MicrosoftPrivateWinformsPackageVersion>
     <MicrosoftSourceLinkAzureReposGitPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkAzureReposGitPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkGitHubPackageVersion>
-    <SystemCodeDomPackageVersion>11.0.0-rc.1.26430.103</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26430.103</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26430.103</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26430.103</SystemDirectoryServicesPackageVersion>
-    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26430.103</SystemDrawingCommonPackageVersion>
-    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26430.103</SystemFormatsNrbfPackageVersion>
-    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26430.103</SystemIOPackagingPackageVersion>
-    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26430.103</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26430.103</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26430.103</SystemResourcesExtensionsPackageVersion>
-    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26430.103</SystemRuntimeSerializationFormattersPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26430.103</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26430.103</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26430.103</SystemWindowsExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>11.0.0-rc.1.26431.109</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26431.109</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26431.109</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26431.109</SystemDirectoryServicesPackageVersion>
+    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26431.109</SystemDrawingCommonPackageVersion>
+    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26431.109</SystemFormatsNrbfPackageVersion>
+    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26431.109</SystemIOPackagingPackageVersion>
+    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26431.109</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26431.109</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26431.109</SystemResourcesExtensionsPackageVersion>
+    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26431.109</SystemRuntimeSerializationFormattersPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26431.109</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26431.109</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26431.109</SystemWindowsExtensionsPackageVersion>
     <!-- dotnet-wpf-int dependencies -->
     <MicrosoftDotNetWpfDncEngPackageVersion>11.0.0-preview.2.26270.1</MicrosoftDotNetWpfDncEngPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -8,29 +8,29 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-dotnet dependencies -->
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26426.111</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26426.111</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26426.111</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26426.111</MicrosoftDotNetHelixSdkPackageVersion>
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26426.111</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26426.111</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26426.111</MicrosoftPrivateWinformsPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26427.102</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26427.102</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26427.102</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26427.102</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26427.102</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26427.102</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26427.102</MicrosoftPrivateWinformsPackageVersion>
     <MicrosoftSourceLinkAzureReposGitPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkAzureReposGitPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkGitHubPackageVersion>
-    <SystemCodeDomPackageVersion>11.0.0-rc.1.26426.111</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26426.111</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26426.111</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26426.111</SystemDirectoryServicesPackageVersion>
-    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26426.111</SystemDrawingCommonPackageVersion>
-    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26426.111</SystemFormatsNrbfPackageVersion>
-    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26426.111</SystemIOPackagingPackageVersion>
-    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26426.111</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26426.111</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26426.111</SystemResourcesExtensionsPackageVersion>
-    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26426.111</SystemRuntimeSerializationFormattersPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26426.111</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26426.111</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26426.111</SystemWindowsExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>11.0.0-rc.1.26427.102</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26427.102</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26427.102</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26427.102</SystemDirectoryServicesPackageVersion>
+    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26427.102</SystemDrawingCommonPackageVersion>
+    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26427.102</SystemFormatsNrbfPackageVersion>
+    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26427.102</SystemIOPackagingPackageVersion>
+    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26427.102</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26427.102</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26427.102</SystemResourcesExtensionsPackageVersion>
+    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26427.102</SystemRuntimeSerializationFormattersPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26427.102</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26427.102</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26427.102</SystemWindowsExtensionsPackageVersion>
     <!-- dotnet-wpf-int dependencies -->
     <MicrosoftDotNetWpfDncEngPackageVersion>11.0.0-preview.2.26270.1</MicrosoftDotNetWpfDncEngPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -8,29 +8,29 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-dotnet dependencies -->
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetHelixSdkPackageVersion>
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26424.125</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26424.125</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26424.125</MicrosoftPrivateWinformsPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26426.111</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26426.111</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26426.111</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26426.111</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26426.111</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26426.111</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26426.111</MicrosoftPrivateWinformsPackageVersion>
     <MicrosoftSourceLinkAzureReposGitPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkAzureReposGitPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkGitHubPackageVersion>
-    <SystemCodeDomPackageVersion>11.0.0-rc.1.26424.125</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26424.125</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26424.125</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26424.125</SystemDirectoryServicesPackageVersion>
-    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26424.125</SystemDrawingCommonPackageVersion>
-    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26424.125</SystemFormatsNrbfPackageVersion>
-    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26424.125</SystemIOPackagingPackageVersion>
-    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26424.125</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26424.125</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26424.125</SystemResourcesExtensionsPackageVersion>
-    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26424.125</SystemRuntimeSerializationFormattersPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26424.125</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26424.125</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26424.125</SystemWindowsExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>11.0.0-rc.1.26426.111</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26426.111</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26426.111</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26426.111</SystemDirectoryServicesPackageVersion>
+    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26426.111</SystemDrawingCommonPackageVersion>
+    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26426.111</SystemFormatsNrbfPackageVersion>
+    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26426.111</SystemIOPackagingPackageVersion>
+    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26426.111</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26426.111</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26426.111</SystemResourcesExtensionsPackageVersion>
+    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26426.111</SystemRuntimeSerializationFormattersPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26426.111</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26426.111</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26426.111</SystemWindowsExtensionsPackageVersion>
     <!-- dotnet-wpf-int dependencies -->
     <MicrosoftDotNetWpfDncEngPackageVersion>11.0.0-preview.2.26270.1</MicrosoftDotNetWpfDncEngPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -8,29 +8,29 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-dotnet dependencies -->
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26451.109</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26451.109</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26451.109</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26451.109</MicrosoftDotNetHelixSdkPackageVersion>
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26451.109</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26451.109</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26451.109</MicrosoftPrivateWinformsPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26452.110</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26452.110</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26452.110</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26452.110</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26452.110</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26452.110</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26452.110</MicrosoftPrivateWinformsPackageVersion>
     <MicrosoftSourceLinkAzureReposGitPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkAzureReposGitPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkGitHubPackageVersion>
-    <SystemCodeDomPackageVersion>11.0.0-rc.1.26451.109</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26451.109</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26451.109</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26451.109</SystemDirectoryServicesPackageVersion>
-    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26451.109</SystemDrawingCommonPackageVersion>
-    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26451.109</SystemFormatsNrbfPackageVersion>
-    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26451.109</SystemIOPackagingPackageVersion>
-    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26451.109</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26451.109</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26451.109</SystemResourcesExtensionsPackageVersion>
-    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26451.109</SystemRuntimeSerializationFormattersPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26451.109</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26451.109</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26451.109</SystemWindowsExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>11.0.0-rc.1.26452.110</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26452.110</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26452.110</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26452.110</SystemDirectoryServicesPackageVersion>
+    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26452.110</SystemDrawingCommonPackageVersion>
+    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26452.110</SystemFormatsNrbfPackageVersion>
+    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26452.110</SystemIOPackagingPackageVersion>
+    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26452.110</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26452.110</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26452.110</SystemResourcesExtensionsPackageVersion>
+    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26452.110</SystemRuntimeSerializationFormattersPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26452.110</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26452.110</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26452.110</SystemWindowsExtensionsPackageVersion>
     <!-- dotnet-wpf-int dependencies -->
     <MicrosoftDotNetWpfDncEngPackageVersion>11.0.0-preview.2.26270.1</MicrosoftDotNetWpfDncEngPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -8,29 +8,29 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-dotnet dependencies -->
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26411.119</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26411.119</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26411.119</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26411.119</MicrosoftDotNetHelixSdkPackageVersion>
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26411.119</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26411.119</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26411.119</MicrosoftPrivateWinformsPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26424.125</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26424.125</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26424.125</MicrosoftPrivateWinformsPackageVersion>
     <MicrosoftSourceLinkAzureReposGitPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkAzureReposGitPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkGitHubPackageVersion>
-    <SystemCodeDomPackageVersion>11.0.0-rc.1.26411.119</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26411.119</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26411.119</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26411.119</SystemDirectoryServicesPackageVersion>
-    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26411.119</SystemDrawingCommonPackageVersion>
-    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26411.119</SystemFormatsNrbfPackageVersion>
-    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26411.119</SystemIOPackagingPackageVersion>
-    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26411.119</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26411.119</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26411.119</SystemResourcesExtensionsPackageVersion>
-    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26411.119</SystemRuntimeSerializationFormattersPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26411.119</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26411.119</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26411.119</SystemWindowsExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>11.0.0-rc.1.26424.125</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26424.125</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26424.125</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26424.125</SystemDirectoryServicesPackageVersion>
+    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26424.125</SystemDrawingCommonPackageVersion>
+    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26424.125</SystemFormatsNrbfPackageVersion>
+    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26424.125</SystemIOPackagingPackageVersion>
+    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26424.125</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26424.125</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26424.125</SystemResourcesExtensionsPackageVersion>
+    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26424.125</SystemRuntimeSerializationFormattersPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26424.125</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26424.125</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26424.125</SystemWindowsExtensionsPackageVersion>
     <!-- dotnet-wpf-int dependencies -->
     <MicrosoftDotNetWpfDncEngPackageVersion>11.0.0-preview.2.26270.1</MicrosoftDotNetWpfDncEngPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -8,29 +8,29 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-dotnet dependencies -->
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26429.101</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26429.101</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26429.101</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26429.101</MicrosoftDotNetHelixSdkPackageVersion>
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26429.101</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26429.101</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26429.101</MicrosoftPrivateWinformsPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26430.103</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26430.103</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26430.103</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26430.103</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26430.103</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26430.103</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26430.103</MicrosoftPrivateWinformsPackageVersion>
     <MicrosoftSourceLinkAzureReposGitPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkAzureReposGitPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkGitHubPackageVersion>
-    <SystemCodeDomPackageVersion>11.0.0-rc.1.26429.101</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26429.101</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26429.101</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26429.101</SystemDirectoryServicesPackageVersion>
-    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26429.101</SystemDrawingCommonPackageVersion>
-    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26429.101</SystemFormatsNrbfPackageVersion>
-    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26429.101</SystemIOPackagingPackageVersion>
-    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26429.101</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26429.101</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26429.101</SystemResourcesExtensionsPackageVersion>
-    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26429.101</SystemRuntimeSerializationFormattersPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26429.101</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26429.101</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26429.101</SystemWindowsExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>11.0.0-rc.1.26430.103</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26430.103</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26430.103</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26430.103</SystemDirectoryServicesPackageVersion>
+    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26430.103</SystemDrawingCommonPackageVersion>
+    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26430.103</SystemFormatsNrbfPackageVersion>
+    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26430.103</SystemIOPackagingPackageVersion>
+    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26430.103</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26430.103</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26430.103</SystemResourcesExtensionsPackageVersion>
+    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26430.103</SystemRuntimeSerializationFormattersPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26430.103</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26430.103</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26430.103</SystemWindowsExtensionsPackageVersion>
     <!-- dotnet-wpf-int dependencies -->
     <MicrosoftDotNetWpfDncEngPackageVersion>11.0.0-preview.2.26270.1</MicrosoftDotNetWpfDncEngPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -8,29 +8,29 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-dotnet dependencies -->
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26427.131</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26427.131</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26427.131</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26427.131</MicrosoftDotNetHelixSdkPackageVersion>
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26427.131</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26427.131</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26427.131</MicrosoftPrivateWinformsPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26429.101</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26429.101</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26429.101</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26429.101</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-rc.1.26429.101</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26429.101</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftPrivateWinformsPackageVersion>11.0.0-rc.1.26429.101</MicrosoftPrivateWinformsPackageVersion>
     <MicrosoftSourceLinkAzureReposGitPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkAzureReposGitPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkGitHubPackageVersion>
-    <SystemCodeDomPackageVersion>11.0.0-rc.1.26427.131</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26427.131</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26427.131</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26427.131</SystemDirectoryServicesPackageVersion>
-    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26427.131</SystemDrawingCommonPackageVersion>
-    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26427.131</SystemFormatsNrbfPackageVersion>
-    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26427.131</SystemIOPackagingPackageVersion>
-    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26427.131</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26427.131</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26427.131</SystemResourcesExtensionsPackageVersion>
-    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26427.131</SystemRuntimeSerializationFormattersPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26427.131</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26427.131</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26427.131</SystemWindowsExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>11.0.0-rc.1.26429.101</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-rc.1.26429.101</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>11.0.0-rc.1.26429.101</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDirectoryServicesPackageVersion>11.0.0-rc.1.26429.101</SystemDirectoryServicesPackageVersion>
+    <SystemDrawingCommonPackageVersion>11.0.0-rc.1.26429.101</SystemDrawingCommonPackageVersion>
+    <SystemFormatsNrbfPackageVersion>11.0.0-rc.1.26429.101</SystemFormatsNrbfPackageVersion>
+    <SystemIOPackagingPackageVersion>11.0.0-rc.1.26429.101</SystemIOPackagingPackageVersion>
+    <SystemPrivateWindowsCoreTestUtilitiesPackageVersion>11.0.0-rc.1.26429.101</SystemPrivateWindowsCoreTestUtilitiesPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-rc.1.26429.101</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>11.0.0-rc.1.26429.101</SystemResourcesExtensionsPackageVersion>
+    <SystemRuntimeSerializationFormattersPackageVersion>11.0.0-rc.1.26429.101</SystemRuntimeSerializationFormattersPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-rc.1.26429.101</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>11.0.0-rc.1.26429.101</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26429.101</SystemWindowsExtensionsPackageVersion>
     <!-- dotnet-wpf-int dependencies -->
     <MicrosoftDotNetWpfDncEngPackageVersion>11.0.0-preview.2.26270.1</MicrosoftDotNetWpfDncEngPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="2c56808e389d7564c2585d0ab535da5724f0ffbd" BarId="328822" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="68347f89e60a3a413bccd05edd9008f50b6a2936" BarId="328926" />
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="11.0.0-preview.2.26270.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>a6da41e859712fcb3f2e5ed3474bdf86b4e5046a</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build.Framework" Version="15.9.20">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -80,21 +80,21 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26426.111">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26426.111">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26426.111">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26426.111">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
     <!-- TODO: Unpin sourcelink dependencies: https://github.com/dotnet/wpf/issues/11042 -->
     <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0-beta.23409.2" Pinned="true">
@@ -105,9 +105,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>e9f665e52848a3615736c099e5631af531b66a5c</Sha>
     </Dependency>
-    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26426.111">
+    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26427.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
+      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="4f8bdb66a033b551cc724f902111718ef5ca986c" BarId="329546" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="f2b969981e123579eb8a779dc05aa8138569dff9" BarId="329840" />
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="11.0.0-preview.2.26270.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>a6da41e859712fcb3f2e5ed3474bdf86b4e5046a</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build.Framework" Version="15.9.20">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -80,21 +80,21 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26431.109">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26431.109">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26431.109">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26431.109">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
     <!-- TODO: Unpin sourcelink dependencies: https://github.com/dotnet/wpf/issues/11042 -->
     <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0-beta.23409.2" Pinned="true">
@@ -105,9 +105,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>e9f665e52848a3615736c099e5631af531b66a5c</Sha>
     </Dependency>
-    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="1ec061ee82223a1fff7f84bd78726d18914ebf87" BarId="329383" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="4f8bdb66a033b551cc724f902111718ef5ca986c" BarId="329546" />
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="11.0.0-preview.2.26270.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>a6da41e859712fcb3f2e5ed3474bdf86b4e5046a</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build.Framework" Version="15.9.20">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -80,21 +80,21 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26430.103">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26430.103">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26430.103">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26430.103">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
     <!-- TODO: Unpin sourcelink dependencies: https://github.com/dotnet/wpf/issues/11042 -->
     <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0-beta.23409.2" Pinned="true">
@@ -105,9 +105,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>e9f665e52848a3615736c099e5631af531b66a5c</Sha>
     </Dependency>
-    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26430.103">
+    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="68347f89e60a3a413bccd05edd9008f50b6a2936" BarId="328926" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="4381489990ac3dac9331dcc1b178d2c5ced98de4" BarId="329115" />
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="11.0.0-preview.2.26270.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>a6da41e859712fcb3f2e5ed3474bdf86b4e5046a</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build.Framework" Version="15.9.20">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -80,21 +80,21 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26427.102">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26427.102">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26427.102">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26427.102">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
     <!-- TODO: Unpin sourcelink dependencies: https://github.com/dotnet/wpf/issues/11042 -->
     <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0-beta.23409.2" Pinned="true">
@@ -105,9 +105,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>e9f665e52848a3615736c099e5631af531b66a5c</Sha>
     </Dependency>
-    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26427.102">
+    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26427.131">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>68347f89e60a3a413bccd05edd9008f50b6a2936</Sha>
+      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="4381489990ac3dac9331dcc1b178d2c5ced98de4" BarId="329115" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="3d633fc408573f455fdb0dd73704196674fc4f27" BarId="329316" />
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="11.0.0-preview.2.26270.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>a6da41e859712fcb3f2e5ed3474bdf86b4e5046a</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build.Framework" Version="15.9.20">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -80,21 +80,21 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26427.131">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26427.131">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26427.131">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26427.131">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
     <!-- TODO: Unpin sourcelink dependencies: https://github.com/dotnet/wpf/issues/11042 -->
     <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0-beta.23409.2" Pinned="true">
@@ -105,9 +105,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>e9f665e52848a3615736c099e5631af531b66a5c</Sha>
     </Dependency>
-    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26427.131">
+    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26429.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4381489990ac3dac9331dcc1b178d2c5ced98de4</Sha>
+      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="f2b969981e123579eb8a779dc05aa8138569dff9" BarId="329840" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="11e3a8dcce675974e3e3a3d942309ac07f0d77cc" BarId="330140" />
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="11.0.0-preview.2.26270.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>a6da41e859712fcb3f2e5ed3474bdf86b4e5046a</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build.Framework" Version="15.9.20">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -80,21 +80,21 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26451.109">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26451.109">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26451.109">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26451.109">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
     <!-- TODO: Unpin sourcelink dependencies: https://github.com/dotnet/wpf/issues/11042 -->
     <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0-beta.23409.2" Pinned="true">
@@ -105,9 +105,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>e9f665e52848a3615736c099e5631af531b66a5c</Sha>
     </Dependency>
-    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26451.109">
+    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26452.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f2b969981e123579eb8a779dc05aa8138569dff9</Sha>
+      <Sha>11e3a8dcce675974e3e3a3d942309ac07f0d77cc</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="3d633fc408573f455fdb0dd73704196674fc4f27" BarId="329316" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="1ec061ee82223a1fff7f84bd78726d18914ebf87" BarId="329383" />
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="11.0.0-preview.2.26270.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>a6da41e859712fcb3f2e5ed3474bdf86b4e5046a</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build.Framework" Version="15.9.20">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -80,21 +80,21 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26429.101">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26429.101">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26429.101">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26429.101">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
     <!-- TODO: Unpin sourcelink dependencies: https://github.com/dotnet/wpf/issues/11042 -->
     <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0-beta.23409.2" Pinned="true">
@@ -105,9 +105,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>e9f665e52848a3615736c099e5631af531b66a5c</Sha>
     </Dependency>
-    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26429.101">
+    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26430.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d633fc408573f455fdb0dd73704196674fc4f27</Sha>
+      <Sha>1ec061ee82223a1fff7f84bd78726d18914ebf87</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="7cdb217445905f3342bbb0266a4497b9a014389a" BarId="326717" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="18aca855818ca5e09075637626229cd6d73011b9" BarId="328502" />
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="11.0.0-preview.2.26270.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>a6da41e859712fcb3f2e5ed3474bdf86b4e5046a</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build.Framework" Version="15.9.20">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -80,21 +80,21 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26411.119">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26411.119">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26411.119">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26411.119">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
     <!-- TODO: Unpin sourcelink dependencies: https://github.com/dotnet/wpf/issues/11042 -->
     <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0-beta.23409.2" Pinned="true">
@@ -105,9 +105,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>e9f665e52848a3615736c099e5631af531b66a5c</Sha>
     </Dependency>
-    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26411.119">
+    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7cdb217445905f3342bbb0266a4497b9a014389a</Sha>
+      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="18aca855818ca5e09075637626229cd6d73011b9" BarId="328502" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="wpf" Sha="2c56808e389d7564c2585d0ab535da5724f0ffbd" BarId="328822" />
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="Microsoft.Private.Winforms" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.Windows.Extensions" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="11.0.0-preview.2.26270.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>a6da41e859712fcb3f2e5ed3474bdf86b4e5046a</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.Resources.Extensions" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.Runtime.Serialization.Formatters" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.CodeDom" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.DirectoryServices" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.Formats.Nrbf" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.IO.Packaging" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.Security.Permissions" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.Drawing.Common" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build.Framework" Version="15.9.20">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -80,21 +80,21 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26424.125">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26424.125">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26424.125">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26424.125">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
     <!-- TODO: Unpin sourcelink dependencies: https://github.com/dotnet/wpf/issues/11042 -->
     <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0-beta.23409.2" Pinned="true">
@@ -105,9 +105,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>e9f665e52848a3615736c099e5631af531b66a5c</Sha>
     </Dependency>
-    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26424.125">
+    <Dependency Name="System.Private.Windows.Core.TestUtilities" Version="11.0.0-rc.1.26426.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+      <Sha>2c56808e389d7564c2585d0ab535da5724f0ffbd</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -110,19 +110,20 @@ $headers = @{
 
 Write-Host "Looking up installation for '$InstallationOwner'..."
 try {
-    $installations = @()
+    $installations = [System.Collections.Generic.List[object]]::new()
     $page = 1
     do {
-        # Assign the response before wrapping it in @(). PowerShell otherwise
-        # preserves a top-level JSON array as one nested pipeline object.
         $pageResponse = Invoke-RestMethod `
             -Uri "https://api.github.com/app/installations?per_page=100&page=$page" `
             -Headers $headers `
             -Method Get
-        $pageInstallations = @($pageResponse)
-        $installations += $pageInstallations
+        $pageInstallationCount = 0
+        foreach ($installation in $pageResponse) {
+            $installations.Add($installation)
+            $pageInstallationCount++
+        }
         $page++
-    } while ($pageInstallations.Count -eq 100)
+    } while ($pageInstallationCount -eq 100)
 }
 catch {
     Write-PipelineTelemetryError -Category 'Build' -Message "Failed to list GitHub App installations: $_. The signed JWT may be invalid or the App's Client ID ('$AppClientId') may be incorrect."

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -113,10 +113,13 @@ try {
     $installations = @()
     $page = 1
     do {
-        $pageInstallations = @(Invoke-RestMethod `
+        # Assign the response before wrapping it in @(). PowerShell otherwise
+        # preserves a top-level JSON array as one nested pipeline object.
+        $pageResponse = Invoke-RestMethod `
             -Uri "https://api.github.com/app/installations?per_page=100&page=$page" `
             -Headers $headers `
-            -Method Get)
+            -Method Get
+        $pageInstallations = @($pageResponse)
         $installations += $pageInstallations
         $page++
     } while ($pageInstallations.Count -eq 100)
@@ -125,12 +128,19 @@ catch {
     Write-PipelineTelemetryError -Category 'Build' -Message "Failed to list GitHub App installations: $_. The signed JWT may be invalid or the App's Client ID ('$AppClientId') may be incorrect."
     exit 1
 }
-$installation = $installations | Where-Object { $_.account.login -ieq $InstallationOwner } | Select-Object -First 1
-if (-not $installation) {
+$matchingInstallations = @($installations | Where-Object { $_.account.login -ieq $InstallationOwner })
+if ($matchingInstallations.Count -eq 0) {
     $found = ($installations | ForEach-Object { $_.account.login }) -join ', '
     Write-PipelineTelemetryError -Category 'Build' -Message "No installation found for '$InstallationOwner'. App is installed on: $found"
     exit 1
 }
+if ($matchingInstallations.Count -ne 1) {
+    $matchingIds = ($matchingInstallations | ForEach-Object { $_.id }) -join ', '
+    Write-PipelineTelemetryError -Category 'Build' -Message "Found multiple installations for '$InstallationOwner': $matchingIds"
+    exit 1
+}
+$installation = $matchingInstallations[0]
+Write-Host "Using installation $($installation.id) for '$($installation.account.login)'."
 
 try {
     $tokenResponse = Invoke-RestMethod `

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -173,7 +173,7 @@ if ($disabledSources -ne $null) {
     Write-Host "Checking for any darc-int disabled package sources in the disabledPackageSources node"
     EnableMaestroInternalPackageSources -DisabledPackageSources $disabledSources -Creds $creds -Credential $feedCredential
 }
-$dotnetVersions = @('5','6','7','8','9','10')
+$dotnetVersions = @('5','6','7','8','9','10','11')
 
 foreach ($dotnetVersion in $dotnetVersions) {
     $feedPrefix = "dotnet" + $dotnetVersion;

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -169,7 +169,7 @@ if [ "$?" == "0" ]; then
     EnableMaestroInternalPackageSources
 fi
 
-DotNetVersions=('5' '6' '7' '8' '9' '10')
+DotNetVersions=('5' '6' '7' '8' '9' '10' '11')
 
 for DotNetVersion in ${DotNetVersions[@]} ; do
     FeedPrefix="dotnet${DotNetVersion}";

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -84,6 +84,15 @@ parameters:
   type: boolean
   default: false
 
+# Controls per-test output attachments. Defaults to Failed.
+- name: testResultAttachmentMode
+  type: string
+  default: Failed
+  values:
+  - Failed
+  - All
+  - None
+
 # Advanced: optional pipeline artifact (produced earlier in this run) that contains the tool
 # nupkg. When set, the artifact is downloaded and the tool is installed from the nupkg into
 # a local tool-path; this bypasses the repo's .config/dotnet-tools.json manifest and is
@@ -210,6 +219,7 @@ jobs:
 
       organization='${{ parameters.organization }}'
       repository='${{ parameters.repository }}'
+      testResultAttachmentMode='${{ parameters.testResultAttachmentMode }}'
 
       # Fall back to Azure DevOps-provided environment variables when the caller did not
       # supply organization / repository explicitly. BUILD_REPOSITORY_NAME is typically
@@ -232,6 +242,9 @@ jobs:
 
       if [ -n "$organization" ]; then toolArgs+=( --organization "$organization" ); fi
       if [ -n "$repository" ];   then toolArgs+=( --repository   "$repository" );   fi
+      if [ -n "$testResultAttachmentMode" ]; then
+        toolArgs+=( --test-result-attachment-mode "$testResultAttachmentMode" )
+      fi
 
       # Build.Reason and Build.SourceBranch are required to derive the Helix source filter
       # the same way the Helix SDK submitter does (PR -> 'pr', internal -> 'official',

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -62,6 +62,12 @@ parameters:
   type: number
   default: 30
 
+# Maximum number of work items whose results may be downloaded, parsed, and
+# uploaded concurrently.
+- name: testResultUploadParallelism
+  type: number
+  default: 48
+
 # When 'true' (the default), Helix work items that exit 0 but have failed AzDO test results
 # are treated as failed: they count toward the monitor's exit code and are resubmitted by a
 # later invocation's retry pass. Set to 'false' to fall back to exit-code-only outcomes.
@@ -215,6 +221,8 @@ jobs:
         --max-wait-minutes            "$((${{ parameters.timeoutInMinutes }} - 5))" # Set the tool's timeout slightly lower than the Azure DevOps job timeout to allow it to exit gracefully.
         --stage-name                  '$(System.StageName)'
         --stage-attempt               '$(System.StageAttempt)'
+        --job-attempt                 '$(System.JobAttempt)'
+        --test-result-upload-parallelism '${{ parameters.testResultUploadParallelism }}'
       )
 
       organization='${{ parameters.organization }}'

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -14,10 +14,11 @@ parameters:
   # exist, and any pipeline that sets this to '' fall back to PAT-based auth via the CeapexPat parameter.
   CeapexServiceConnection: 'dnceng-onelocbuild-ceapex'
 
-  # GitHub App authentication for the OneLoc check-in PR (dnceng/internal only).
-  # The infrastructure identifiers are centralized here and the App path is enabled by default.
-  # DevDiv requires its own project-scoped service connection before this path can be enabled there.
+  # GitHub App authentication for the OneLoc check-in PR.
+  # dnceng/internal and DevDiv/DevDiv are enabled by default with their project-scoped service
+  # connections. Other projects must explicitly opt in after provisioning equivalent infrastructure.
   UseGitHubAppAuthentication: true
+  UseGitHubAppAuthenticationInOtherProjects: false
   GitHubAppServiceConnection: 'dnceng-oneloc-githubapp'
   GitHubAppClientId: 'Iv23lijBU8x3gc9lDOc9'
   GitHubAppKeyVaultName: 'EngKeyVault'
@@ -98,13 +99,16 @@ jobs:
           outputVariableName: 'CeapexEntraToken'
           condition: ${{ parameters.condition }}
 
-    # Mint a short-lived GitHub App installation token for the loc check-in PR (dnceng/internal only).
-    # All other projects fall back to PAT-based auth, since the app service connection is scoped to dnceng/internal.
-    - ${{ if and(eq(parameters.RepoType, 'gitHub'), eq(parameters.UseGitHubAppAuthentication, true), eq(variables['System.TeamProject'], 'internal')) }}:
+    # Mint a short-lived GitHub App installation token for the loc check-in PR. Use the connection
+    # provisioned in each supported project; other projects must explicitly opt in and override it.
+    - ${{ if and(eq(parameters.RepoType, 'gitHub'), eq(parameters.UseGitHubAppAuthentication, true), or(eq(variables['System.TeamProject'], 'internal'), eq(variables['System.TeamProject'], 'DevDiv'), eq(parameters.UseGitHubAppAuthenticationInOtherProjects, true))) }}:
       - template: /eng/common/core-templates/steps/get-github-app-token.yml
         parameters:
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
-          azureSubscription: ${{ parameters.GitHubAppServiceConnection }}
+          ${{ if and(eq(variables['System.TeamProject'], 'DevDiv'), eq(parameters.GitHubAppServiceConnection, 'dnceng-oneloc-githubapp')) }}:
+            azureSubscription: 'devdiv-oneloc-githubapp'
+          ${{ else }}:
+            azureSubscription: ${{ parameters.GitHubAppServiceConnection }}
           keyVaultName: ${{ parameters.GitHubAppKeyVaultName }}
           keyName: ${{ parameters.GitHubAppKeyName }}
           appClientId: ${{ parameters.GitHubAppClientId }}
@@ -133,9 +137,9 @@ jobs:
           patVariable: ${{ parameters.CeapexPat }}
         ${{ if eq(parameters.RepoType, 'gitHub') }}:
           repoType: ${{ parameters.RepoType }}
-          ${{ if and(eq(parameters.UseGitHubAppAuthentication, true), eq(variables['System.TeamProject'], 'internal')) }}:
+          ${{ if and(eq(parameters.UseGitHubAppAuthentication, true), or(eq(variables['System.TeamProject'], 'internal'), eq(variables['System.TeamProject'], 'DevDiv'), eq(parameters.UseGitHubAppAuthenticationInOtherProjects, true))) }}:
             gitHubPatVariable: "$(GitHubAppInstallationToken)"
-          ${{ if or(eq(parameters.UseGitHubAppAuthentication, false), ne(variables['System.TeamProject'], 'internal')) }}:
+          ${{ else }}:
             gitHubPatVariable: "${{ parameters.GithubPat }}"
         ${{ if ne(parameters.MirrorRepo, '') }}:
           isMirrorRepoSelected: true

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -9,9 +9,8 @@ parameters:
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
   # Service connection for WIF-based Entra authentication to ceapex feeds (replaces CeapexPat).
-  # When set, dnceng/internal builds acquire a federated Entra token instead of using a PAT.
-  # All other projects (e.g. DevDiv, public), where this dnceng-scoped service connection does not
-  # exist, and any pipeline that sets this to '' fall back to PAT-based auth via the CeapexPat parameter.
+  # dnceng/internal and DevDiv/DevDiv have same-named, project-scoped connections. Other projects,
+  # and any pipeline that sets this to '', fall back to PAT-based auth via the CeapexPat parameter.
   CeapexServiceConnection: 'dnceng-onelocbuild-ceapex'
 
   # GitHub App authentication for the OneLoc check-in PR.
@@ -90,9 +89,8 @@ jobs:
         displayName: Generate LocProject.json
         condition: ${{ parameters.condition }}
 
-    # Acquire an Entra token for ceapex feed access via WIF (dnceng/internal only).
-    # All other projects use PAT-based auth, since the ceapex service connection is scoped to dnceng/internal.
-    - ${{ if and(ne(parameters.CeapexServiceConnection, ''), eq(variables['System.TeamProject'], 'internal')) }}:
+    # Acquire an Entra token for ceapex feed access in the supported internal and DevDiv projects.
+    - ${{ if and(ne(parameters.CeapexServiceConnection, ''), or(eq(variables['System.TeamProject'], 'internal'), eq(variables['System.TeamProject'], 'DevDiv'))) }}:
       - template: /eng/common/templates/steps/get-federated-access-token.yml
         parameters:
           federatedServiceConnection: ${{ parameters.CeapexServiceConnection }}
@@ -131,9 +129,9 @@ jobs:
           isUseLfLineEndingsSelected: ${{ parameters.UseLfLineEndings }}
           isShouldReusePrSelected: ${{ parameters.ReusePr }}
         packageSourceAuth: patAuth
-        ${{ if and(ne(parameters.CeapexServiceConnection, ''), eq(variables['System.TeamProject'], 'internal')) }}:
+        ${{ if and(ne(parameters.CeapexServiceConnection, ''), or(eq(variables['System.TeamProject'], 'internal'), eq(variables['System.TeamProject'], 'DevDiv'))) }}:
           patVariable: $(CeapexEntraToken)
-        ${{ if or(eq(parameters.CeapexServiceConnection, ''), ne(variables['System.TeamProject'], 'internal')) }}:
+        ${{ if or(eq(parameters.CeapexServiceConnection, ''), and(ne(variables['System.TeamProject'], 'internal'), ne(variables['System.TeamProject'], 'DevDiv'))) }}:
           patVariable: ${{ parameters.CeapexPat }}
         ${{ if eq(parameters.RepoType, 'gitHub') }}:
           repoType: ${{ parameters.RepoType }}

--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -12,6 +12,7 @@ jobs:
 - job: SourceIndexStage1
   dependsOn: ${{ parameters.dependsOn }}
   condition: ${{ parameters.condition }}
+  continueOnError: true
   variables:
   - name: BinlogPath
     value: ${{ parameters.binlogPath }}
@@ -38,9 +39,11 @@ jobs:
 
   - ${{ each preStep in parameters.preSteps }}:
     - ${{ preStep }}
-  - script: ${{ parameters.sourceIndexBuildCommand }}
-    displayName: Build Repository
+  - ${{ if ne(parameters.sourceIndexBuildCommand, '') }}:
+    - script: ${{ parameters.sourceIndexBuildCommand }}
+      displayName: Build Repository
 
   - template: /eng/common/core-templates/steps/source-index-stage1-publish.yml
     parameters:
       binLogPath: ${{ parameters.binLogPath }}
+      runAsPublic: ${{ parameters.runAsPublic }}

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -236,6 +236,7 @@ stages:
           StageLabel: 'Validation'
           JobLabel: 'Signing'
           BinlogToolVersion: $(BinlogToolVersion)
+          enableInternalRuntimes: false
 
     # SourceLink validation has been removed — the underlying CLI tool
     # (targeting netcoreapp2.1) has not functioned for years.

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -5,6 +5,7 @@ parameters:
   # A default - in case value from eng/common/core-templates/post-build/common-variables.yml is not passed
   BinlogToolVersion: '1.0.11'
   is1ESPipeline: false
+  enableInternalRuntimes: true
 
 steps:
 - task: Powershell@2
@@ -25,13 +26,20 @@ steps:
     # Sensitive data can as well be added to $(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
     #  If the file exists - sensitive data for redaction will be sourced from it
     #  (single entry per line, lines starting with '# ' are considered comments and skipped)
-    arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs' 
-      -BinlogToolVersion '${{parameters.BinlogToolVersion}}'
-      -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
-      -runtimeSourceFeed https://ci.dot.net/internal 
-      -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
-      '$(System.AccessToken)'
-      ${{parameters.CustomSensitiveDataList}}
+    ${{ if and(eq(parameters.enableInternalRuntimes, true), ne(variables['System.TeamProject'], 'public')) }}:
+      arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs'
+        -BinlogToolVersion '${{parameters.BinlogToolVersion}}'
+        -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
+        -runtimeSourceFeed https://ci.dot.net/internal
+        -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
+        '$(System.AccessToken)'
+        ${{parameters.CustomSensitiveDataList}}
+    ${{ else }}:
+      arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs'
+        -BinlogToolVersion '${{parameters.BinlogToolVersion}}'
+        -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
+        '$(System.AccessToken)'
+        ${{parameters.CustomSensitiveDataList}}
   continueOnError: true
   condition: always()
 

--- a/eng/common/core-templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/core-templates/steps/source-index-stage1-publish.yml
@@ -1,7 +1,9 @@
 parameters:
-  sourceIndexUploadPackageVersion: 2.0.0-20260521.2
-  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260521.2
+  runAsPublic: false
+  sourceIndexUploadPackageVersion: '2.0.0-20260521.2'
+  sourceIndexComplogPackageVersion: '*'
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+  sourceIndexPublicPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
   binlogPath: artifacts/log/Debug/Build.binlog
 
 steps:
@@ -14,14 +16,17 @@ steps:
     workingDirectory: $(Agent.TempDirectory)
 
 - script: |
-    $(Agent.TempDirectory)/dotnet/dotnet tool install BinLogToSln --version ${{parameters.sourceIndexProcessBinlogPackageVersion}} --source ${{parameters.sourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
-    $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version ${{parameters.sourceIndexUploadPackageVersion}} --source ${{parameters.sourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
-  displayName: "Source Index: Download netsourceindex Tools"
+    $(Agent.TempDirectory)/dotnet/dotnet tool install complog --version "${{parameters.sourceIndexComplogPackageVersion}}" --source ${{parameters.sourceIndexPublicPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
+    $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version "${{parameters.sourceIndexUploadPackageVersion}}" --source ${{parameters.sourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
+  displayName: "Source Index: Download Tools"
   # Set working directory to temp directory so 'dotnet' doesn't try to use global.json and use the repo's sdk.
   workingDirectory: $(Agent.TempDirectory)
 
-- script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i ${{parameters.BinlogPath}} -r $(System.DefaultWorkingDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
-  displayName: "Source Index: Process Binlog into indexable sln"
+- script: |
+    mkdir ".source-index/stage1output"
+    git rev-parse HEAD > .source-index/stage1output/hash
+    $(Agent.TempDirectory)/.source-index/tools/complog create ${{parameters.BinlogPath}} -o .source-index/stage1output/build.complog
+  displayName: "Source Index: Process Binlog into Complog"
 
 - ${{ if and(ne(parameters.runAsPublic, 'true'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - task: AzureCLI@2

--- a/global.json
+++ b/global.json
@@ -27,8 +27,8 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26451.109",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26451.109",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26452.110",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26452.110",
     "Microsoft.Build.NoTargets": "3.7.56"
   },
   "native-tools": {

--- a/global.json
+++ b/global.json
@@ -27,8 +27,8 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26424.125",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26424.125",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26426.111",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26426.111",
     "Microsoft.Build.NoTargets": "3.7.56"
   },
   "native-tools": {

--- a/global.json
+++ b/global.json
@@ -27,8 +27,8 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26427.102",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26427.102",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26427.131",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26427.131",
     "Microsoft.Build.NoTargets": "3.7.56"
   },
   "native-tools": {

--- a/global.json
+++ b/global.json
@@ -27,8 +27,8 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26431.109",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26431.109",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26451.109",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26451.109",
     "Microsoft.Build.NoTargets": "3.7.56"
   },
   "native-tools": {

--- a/global.json
+++ b/global.json
@@ -27,8 +27,8 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26426.111",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26426.111",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26427.102",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26427.102",
     "Microsoft.Build.NoTargets": "3.7.56"
   },
   "native-tools": {

--- a/global.json
+++ b/global.json
@@ -27,8 +27,8 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26427.131",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26427.131",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26429.101",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26429.101",
     "Microsoft.Build.NoTargets": "3.7.56"
   },
   "native-tools": {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.6.26359.118",
+    "version": "11.0.100-rc.1.26420.103",
     "allowPrerelease": true,
     "rollForward": "latestFeature",
     "paths": [
@@ -10,7 +10,7 @@
     "errorMessage": "The required .NET SDK wasn't found. Please run ./eng/common/dotnet.cmd/sh to install it."
   },
   "tools": {
-    "dotnet": "11.0.100-preview.6.26359.118",
+    "dotnet": "11.0.100-rc.1.26420.103",
     "runtimes": {
       "dotnet/x64": [
         "$(MicrosoftNETCoreAppRefVersion)"
@@ -27,8 +27,8 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26411.119",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26411.119",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26424.125",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26424.125",
     "Microsoft.Build.NoTargets": "3.7.56"
   },
   "native-tools": {

--- a/global.json
+++ b/global.json
@@ -27,8 +27,8 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26429.101",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26429.101",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26430.103",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26430.103",
     "Microsoft.Build.NoTargets": "3.7.56"
   },
   "native-tools": {

--- a/global.json
+++ b/global.json
@@ -27,8 +27,8 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26430.103",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26430.103",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26431.109",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26431.109",
     "Microsoft.Build.NoTargets": "3.7.56"
   },
   "native-tools": {


### PR DESCRIPTION
**Do not merge.** CI-only validation branch for #11893, to be closed once green.

## Why this exists

#11893 adds the `dotnet12` / `dotnet12-transport` feeds to `NuGet.config`. Its own CI run cannot actually prove the fix, because `main` currently pins `11.0.0-rc.1.26411.119`, which is still available on `dotnet11` — so #11893 going green only demonstrates that adding the feeds causes no regression.

This branch is **codeflow PR #11869 + the `NuGet.config` change from #11893**, so CI here restores the exact versions that are failing today (`11.0.0-rc.1.26452.110`). A green run is direct evidence that the feed addition fixes the `NU1102` failures on #11869.

## What is being reproduced

#11869 fails on all six legs with:

```
Tools.proj : error NU1102: Unable to find package Microsoft.NETCore.App.Ref
             with version (= 11.0.0-rc.1.26452.110)
```

plus `Microsoft.NETCore.App.Runtime.win-{x86,x64,arm64}` and `Microsoft.NETCore.App.Host.win-{x86,x64,arm64}`. Those assets are published to `dotnet12` / `dotnet12-transport`, which WPF does not currently consume.

Locally, `Restore.cmd -ci` with this branch succeeds for x86, x64 and arm64 with 0 errors, and all seven packages resolve from `dotnet12`. This PR confirms the same in real CI.

See #11893 for the full analysis and the change actually proposed for merge.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/11894)